### PR TITLE
Fix/model dts object/definition not stripped

### DIFF
--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -42,7 +42,7 @@ class ModelRoleType(ModelObject):
     @property
     def definitionNotStripped(self):
         definition = XmlUtil.child(self, XbrlConst.link, "definition")
-        return definition.textNotStripped if definition is not None else None
+        return XmlUtil.textNotStripped(definition) if definition is not None else None
     
     @property
     def usedOns(self): 


### PR DESCRIPTION
Throws exception because ModelObject doesn't have a 'textNotStripped' property. Use XmlUtil.textNotStripped() instead.
