### PR TITLE
added flag to Cntlr and FileSource which disables non-local fetching

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -80,6 +80,7 @@ class Cntlr:
         self.hasFileSystem = True # no file system on Google App Engine servers
         self.isGAE = False
         self.isCGI = False
+        self.localOnly = False # if true, webCAche will not try to fetch any non local files
         self.systemWordSize = int(round(math.log(sys.maxsize, 2)) + 1) # e.g., 32 or 64
 
         self.moduleDir = os.path.dirname(__file__)

--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -513,7 +513,7 @@ def openFileStream(cntlr, filepath, mode='r', encoding=None):
     if isHttpUrl(filepath) and cntlr:
         filepath = cntlr.webCache.getfilename(filepath)
     # file path may be server (or memcache) or local file system
-    if filepath.startswith(SERVER_WEB_CACHE) and cntlr:
+    if filepath.startswith(SERVER_WEB_CACHE) and cntlr and not cntlr.localOnly:
         filestream = None
         cacheKey = filepath[len(SERVER_WEB_CACHE) + 1:].replace("\\","/")
         if cntlr.isGAE: # check if in memcache
@@ -540,6 +540,9 @@ def openFileStream(cntlr, filepath, mode='r', encoding=None):
         return io.open(filepath, mode=mode, encoding=encoding)
     else:
         # local file system
+        if cntlr and cntlr.isGAE and cntlr.localOnly and filepath[0] == '/':
+            # can't do an absolute path here, so presume it is a relative to the path of the app source
+            filepath = '.%s' % filepath
         return io.open(filepath, mode=mode, encoding=encoding)
     
 def openXmlFileStream(cntlr, filepath, stripDeclaration=False):


### PR DESCRIPTION
@hefischer, while working on some GAE tasks I was looking for a way to disable all http requests and force Arelle to look only into the cache directory.  Not seeing how to do this I added a flag to the `Cntlr` class and the associated code.  I'm not at all married to this code, but wanted to show you so we could discuss how to enable "local only" behavior.  The result of this code is if the file is not cached it will fail and give a message with the file that's missed.
