### PR TITLE
[FIX] Avoid saving twice an XML instance.

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -438,8 +438,6 @@ class ModelXbrl:
         :param overrideFilepath: specify to override saving in instance's modelDocument.filepath
         """
         self.modelDocument.save(overrideFilepath)
-        with open( (overrideFilepath or self.modelDocument.filepath), "w", encoding='utf-8') as fh:
-            XmlUtil.writexml(fh, self.modelDocument.xmlDocument, encoding="utf-8")
             
     @property    
     def prefixedNamespaces(self):


### PR DESCRIPTION
In the GUI, when you save an XBRL instance, it is actually saved twice.
By applying this pull request, it is only saved once.
