### PR TITLE
Align right empty cells if they should contain a numeric value.

### DIFF
--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -695,7 +695,11 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                 for aspect, aspectValue in cellAspectValues.items():
                                     if isinstance(aspectValue, str) and aspectValue.startswith(OPEN_ASPECT_ENTRY_SURROGATE):
                                         self.factPrototypeAspectEntryObjectIds[objectId].add(aspectValue) 
-                            gridCell(self.gridBody, self.dataFirstCol + i, row, value, justify=justify, 
+                            modelConcept = fp.concept
+                            if (justify is None) and modelConcept is not None:
+                                justify = "right" if modelConcept.isNumeric else "left"
+                            gridCell(self.gridBody, self.dataFirstCol + i, row, value,
+                                     justify=justify, 
                                      width=ENTRY_WIDTH_IN_CHARS, # width is in characters, not screen units
                                      objectId=objectId, onClick=self.onClick)
                         else:


### PR DESCRIPTION
In the GUI, when displaying a table, I have noticed that when a cell does not contain a value yet, it is always left-aligned.

With this pull request, cells become right-aligned as soon as they are aimed at containing a numeric value even before the actual value is provided.
