### PR TITLE
fixed pg8000 module access in xbrldb plugin.

### DIFF
--- a/arelle/plugin/xbrlDB/SqlDb.py
+++ b/arelle/plugin/xbrlDB/SqlDb.py
@@ -18,12 +18,12 @@ def noop(*args, **kwargs): return
 class NoopException(Exception):
     pass
 try:
-    import pg8000, pg8000.errors
+    import pg8000
     hasPostgres = True
-    pgConnect = pg8000.DBAPI.connect
-    pgOperationalError = pg8000.errors.OperationalError
-    pgProgrammingError = pg8000.errors.ProgrammingError
-    pgInterfaceError = pg8000.errors.InterfaceError
+    pgConnect = pg8000.connect
+    pgOperationalError = pg8000.OperationalError
+    pgProgrammingError = pg8000.ProgrammingError
+    pgInterfaceError = pg8000.InterfaceError
 except ImportError:
     hasPostgres = False
     pgConnect = noop
@@ -267,7 +267,7 @@ class SqlDbConnection():
     def rollback(self):
         try:
             self.conn.rollback()
-        except (pg8000.errors.ConnectionClosedError):
+        except (pg8000.ConnectionClosedError):
             pass
         
     def dropTemporaryTable(self):


### PR DESCRIPTION
The location of connect and error items in the pg8000 module has changed slightly. There is no DBAPI or errors files any more. All of these items are accessed directly through pg8000.

You can checkout https://github.com/mfenniak/pg8000/blob/master/pg8000/__init__.py for the current pg8000 code I used to update SqlDB.py.
