### PR TITLE
Correct display of multiple open structural nodes in a single axis

### DIFF
--- a/arelle/RenderingResolver.py
+++ b/arelle/RenderingResolver.py
@@ -307,7 +307,10 @@ def expandDefinition(view, structuralNode, breakdownNode, definitionNode, depth,
                                 structuralNode.childStructuralNodes.append(childStructuralNode)
                         if axisDisposition != "z":
                             expandDefinition(view, childStructuralNode, breakdownNode, childDefinitionNode, depth+ordDepth, axisDisposition, facts, i, tblAxisRels) #recurse
-                            cartesianProductExpander(childStructuralNode, *cartesianProductNestedArgs)
+                            if not (isinstance(childStructuralNode.definitionNode, ModelFilterDefinitionNode)
+                                    and any([node.isEntryPrototype(default=False) for node in childStructuralNode.childStructuralNodes])) :
+                                # To be computed only if the structural node is not an open node
+                                cartesianProductExpander(childStructuralNode, *cartesianProductNestedArgs)
                         else:
                             childStructuralNode.indent = depth - 1
                             if structuralNode.choiceStructuralNodes is not None:


### PR DESCRIPTION
For a DTS with a table linkbase, whenever there is an axis with more than one open structural nodes, the corresponding table is not correctly displayed. There are spurious new rows or nodes.
For instance, in the COREP EBA 2.0.1 you can find the following table:
![arelle](https://cloud.githubusercontent.com/assets/8653205/4522814/24d45946-4d2f-11e4-8a08-520c90570dde.png)
With this pull request, the situation is greatly improved. The same example becomes:
![arelle2](https://cloud.githubusercontent.com/assets/8653205/4522992/a85650ec-4d31-11e4-88b9-83335e5f75e4.png)

Many thanks in advance for integrating this change request in your master branch if you find it correct and useful!
