### PR TITLE
Create inexistent facts only

### DIFF
--- a/arelle/FactIndex.py
+++ b/arelle/FactIndex.py
@@ -1,0 +1,265 @@
+"""
+:mod:`arelle.FactIndex`
+~~~~~~~~~~~~~~~~~~~
+
+.. py:module:: arelle.FactIndex
+   :copyright: Copyright 2014 Acsone S. A., All rights reserved.
+   :license: Apache-2.
+   :synopsis: fast and compact way to find facts based on a property
+"""
+
+from arelle import ModelValue
+
+from sqlalchemy import create_engine, Table, \
+    Column, Integer, String, \
+    Sequence, MetaData, ForeignKey, \
+    Boolean
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.sql import select, and_
+
+TYPED_VALUE = '#TYPED_VALUE#'
+DEFAULT = 'default'
+NONDEFAULT = 'nondefault'
+
+class FactIndex(object):
+    def __init__(self):
+        self.engine = create_engine('sqlite://',
+                    connect_args={'check_same_thread':False},
+                    poolclass=StaticPool)
+        self.metadata = MetaData()
+        self.facts = Table('facts', self.metadata,
+                           Column('id', Integer, Sequence('facts_seq'), primary_key = True),
+                           Column('isNil', Boolean, nullable = False, unique = False, index = True),
+                           Column('qName', String(256), nullable = False, unique = False, index = True),
+                           Column('datatype', String(256), nullable = False, unique = False, index = True),
+                           Column('periodType', String(48), nullable = False, unique = False, index = True),
+                           Column('objectId', Integer, nullable = False, unique = True, index = True)
+                           )
+        self.dimensions = Table('dimensions', self.metadata,
+                                    Column('id', Integer, Sequence('dimensions_seq'), primary_key = True),
+                                    Column('qName', String(256), nullable = False, unique = False, index = True),
+                                    Column('isDefault', Boolean, nullable = False, unique = False, index = True),
+                                    Column('dimValue', String(256), nullable = True, unique = False, index = True),
+                                    Column('factId', Integer, ForeignKey('facts.id', ondelete="CASCADE"))
+                                )
+        self.metadata.create_all(self.engine)
+        self.connection = self.engine.connect()
+
+    def close(self):
+        self.connection.close()
+
+    def insertFact(self, fact):
+        concept = fact.concept
+        context = fact.context
+        factIsNil = fact.isNil
+        factQName = str(fact.qname)
+        factDatatype = str(concept.typeQname)
+        factPeriodType = str(concept.periodType)
+        factObjectId = fact.objectIndex
+        factsInsert = self.facts.insert().values(isNil = factIsNil,
+                                                 qName = factQName,
+                                                 datatype = factDatatype,
+                                                 periodType = factPeriodType,
+                                                 objectId = factObjectId)
+        factsInsert.bind = self.engine
+        result = self.connection.execute(factsInsert)
+        newFactId = result.inserted_primary_key
+        result.close()
+        if fact.isItem and len(context.qnameDims)>0:
+            for dim in context.qnameDims.keys():
+                dimValue = context.dimValue(dim)
+                dimValueString = None
+                if isinstance(dimValue, ModelValue.QName): # explicit dimension default value
+                    dimValueString = str(ModelValue.QName)
+                    dimValueIsDefault = True
+                elif dimValue is not None: # not default
+                    dimValueIsDefault = False
+                    if dimValue.isExplicit:
+                        dimValueString = str(dimValue.memberQname)
+                else: # default typed dimension, no value
+                    dimValueIsDefault = True
+                if dimValueString is None:
+                    dimensionsInsert = self.dimensions.insert().values(qName = str(dim),
+                                                                       isDefault = dimValueIsDefault,
+                                                                       factId = newFactId[0]
+                                                                       )
+                else:
+                    dimensionsInsert = self.dimensions.insert().values(qName = str(dim),
+                                                                       isDefault = dimValueIsDefault,
+                                                                       dimValue = dimValueString,
+                                                                       factId = newFactId[0]
+                                                                       )
+                dimensionsInsert.bind = self.engine
+                result = self.connection.execute(dimensionsInsert)
+                result.close()
+
+    def deleteFact(self, fact):
+        factObjectId = fact.objectIndex
+        delStatement = self.facts.delete().where(self.facts.c.objectId == factObjectId)
+        delStatement.bind = self.engine
+        result = self.connection.execute(delStatement)
+        numberOfDeletedRows = result.rowcount
+        result.close()
+        return numberOfDeletedRows
+
+    def nonNilFacts(self, modelXbrl):
+        selectStmt = select([self.facts.c.objectId]).where(self.facts.c.isNil == False)
+        result = self.connection.execute(selectStmt)
+        resultSet = set(modelXbrl.modelObjects[row[self.facts.c.objectId]] for row in result)
+        result.close()
+        return resultSet
+
+    def factsByQname(self, qName, modelXbrl, defaultValue=None):
+        selectStmt = select([self.facts.c.objectId]).where(self.facts.c.qName == str(qName))
+        result = self.connection.execute(selectStmt)
+        resultSet = set(modelXbrl.modelObjects[row[self.facts.c.objectId]] for row in result)
+        result.close()
+        if (len(resultSet)>0):
+            return resultSet
+        else:
+            return defaultValue
+
+    def factsByDatatype(self, typeQname, modelXbrl):
+        selectStmt = select([self.facts.c.objectId]).where(self.facts.c.datatype == str(typeQname))
+        result = self.connection.execute(selectStmt)
+        resultSet = set(modelXbrl.modelObjects[row[self.facts.c.objectId]] for row in result)
+        result.close()
+        return resultSet
+
+    def factsByPeriodType(self, periodType, modelXbrl):
+        selectStmt = select([self.facts.c.objectId]).where(self.facts.c.periodType == str(periodType))
+        result = self.connection.execute(selectStmt)
+        resultSet = set(modelXbrl.modelObjects[row[self.facts.c.objectId]] for row in result)
+        result.close()
+        return resultSet
+
+    def factsByDimMemQname(self, dimQname, modelXbrl, memQname=None):
+        if memQname is None:
+            selectStmt = select([self.facts.c.objectId]).select_from(self.facts.join(self.dimensions)).\
+                where(self.dimensions.c.qName == str(dimQname))
+        elif memQname == DEFAULT:
+            selectStmt = select([self.facts.c.objectId]).select_from(self.facts.join(self.dimensions)).\
+                where(and_(self.dimensions.c.qName == str(dimQname), self.dimensions.c.isDefault == True))
+        elif memQname == NONDEFAULT:
+            selectStmt = select([self.facts.c.objectId]).select_from(self.facts.join(self.dimensions)).\
+                where(and_(self.dimensions.c.qName == str(dimQname), self.dimensions.c.isDefault == False))
+        else:
+            selectStmt = select([self.facts.c.objectId]).select_from(self.facts.join(self.dimensions)).\
+                where(and_(self.dimensions.c.qName == str(dimQname), self.dimensions.c.dimValue == str(memQname)))
+        result = self.connection.execute(selectStmt)
+        resultSet = set(modelXbrl.modelObjects[row[self.facts.c.objectId]] for row in result)
+        result.close()
+        return resultSet
+
+def testAll():
+    class ModelConcept(object):
+        def __init__(self, typeQname, periodType):
+            self.typeQname = typeQname
+            self.periodType = periodType
+    
+    class ModelContext(object):
+        def __init__(self):
+            self.qnameDims = set()
+        def dimValue(self, dimQname):
+            """Caution: copied from ModelInstanceObject!"""
+            try:
+                return self.qnameDims[dimQname]
+            except KeyError:
+                try:
+                    return self.modelXbrl.qnameDimensionDefaults[dimQname]
+                except KeyError:
+                    return None
+
+    class Fact(object):
+        def __init__(self, concept, context, isNil, qname, objectId, isItem):
+            self.concept = concept
+            self.context = context
+            self.isNil = isNil
+            self.qname = qname
+            self.objectIndex = objectId
+            self.isItem = isItem
+
+    class ModelXbrl(object):
+        def __init__(self):
+            self.modelObjects = dict()
+    class DimensionValue(object):
+        def __init__(self, isExplicit, value):
+            self.isExplicit = isExplicit
+            self.memberQname = value 
+        def __str__(self):
+            return self.memberQname
+    def assertEquals(expectedValue, actualValue):
+        try:
+            assert expectedValue == actualValue
+        except AssertionError:
+            print('Expected %s got %s' % (expectedValue, actualValue))
+    modelXbrl = ModelXbrl()
+    concept1d = ModelConcept('type1', 'duration')
+    concept1i = ModelConcept('type1', 'instant')
+    concept2d = ModelConcept('type2', 'duration')
+    concept2i = ModelConcept('type2', 'instant')
+    dimVal1 = DimensionValue(True, 'val1')
+    dimVal2 = DimensionValue(True, 'val2')
+    dimVal3 = DimensionValue(True, 'val3')
+    dimVal4 = DimensionValue(True, 'val4')
+    dimVal5 = DimensionValue(True, 'val5')
+    dimVal6 = DimensionValue(True, 'val6')
+    context1 = ModelContext()
+    context1.qnameDims = {'dim1': dimVal1, 'dim2': dimVal2, 'dim3': dimVal3}
+    context2 = ModelContext()
+    context2.qnameDims = {'dim1': dimVal1, 'dim7': None}
+    context3 = ModelContext()
+    context3.qnameDims = {'dim4': dimVal4, 'dim5': dimVal5, 'dim6': dimVal6, 'dim7': None}
+
+    fact1 = Fact(concept1d, context1, False, '{ns}name1', 1, True)
+    fact2 = Fact(concept1i, context2, False, '{ns}name1', 2, True)
+    fact3 = Fact(concept2d, context3, False, '{ns}name2', 3, True)
+    fact4 = Fact(concept2i, context3, False, '{ns}name2', 4, True)
+    fact5 = Fact(concept2i, context3, True, '{ns}name3', 5, True)
+    fact6 = Fact(concept2d, context3, True, '{ns}name4', 6, False)
+    modelXbrl.modelObjects[fact1.objectIndex] = fact1
+    modelXbrl.modelObjects[fact2.objectIndex] = fact2
+    modelXbrl.modelObjects[fact3.objectIndex] = fact3
+    modelXbrl.modelObjects[fact4.objectIndex] = fact4
+    modelXbrl.modelObjects[fact5.objectIndex] = fact5
+    modelXbrl.modelObjects[fact6.objectIndex] = fact6
+
+    factIndex = FactIndex()
+    factIndex.insertFact(fact1)
+    factIndex.insertFact(fact2)
+    factIndex.insertFact(fact3)
+    factIndex.insertFact(fact4)
+    factIndex.insertFact(fact5)
+    factIndex.insertFact(fact6)
+    dataResult = factIndex.nonNilFacts(modelXbrl)
+    assertEquals({fact1, fact2, fact3, fact4}, dataResult)
+    expectedResult = 'NiceJob'
+    dataResult = factIndex.factsByQname('doesNotExist', modelXbrl, expectedResult)
+    assertEquals(expectedResult, dataResult)
+    dataResult = factIndex.factsByQname('{ns}name1', modelXbrl, None)
+    assertEquals({fact1, fact2}, dataResult)
+    dataResult = factIndex.factsByQname('{ns}name3', modelXbrl, None)
+    assertEquals({fact5}, dataResult)
+    dataResult = factIndex.factsByDatatype('doesNotExist', modelXbrl)
+    assertEquals(set(), dataResult)
+    dataResult = factIndex.factsByDatatype('type2', modelXbrl)
+    assertEquals({fact3, fact4, fact5, fact6}, dataResult)
+    dataResult = factIndex.factsByPeriodType('doesNotExist', modelXbrl)
+    assertEquals(set(), dataResult)
+    dataResult = factIndex.factsByPeriodType('instant', modelXbrl)
+    assertEquals({fact2, fact4, fact5}, dataResult)
+    dataResult = factIndex.factsByDimMemQname('doesNotExist', modelXbrl, None)
+    assertEquals(set(), dataResult)
+    dataResult = factIndex.factsByDimMemQname('dim1', modelXbrl, None)
+    assertEquals({fact1, fact2}, dataResult)
+    dataResult = factIndex.factsByDimMemQname('dim2', modelXbrl, 'val2')
+    assertEquals({fact1}, dataResult)
+    dataResult = factIndex.factsByDimMemQname('dim1', modelXbrl, 'val1')
+    assertEquals({fact1, fact2}, dataResult)
+    dataResult = factIndex.factsByDimMemQname('dim1', modelXbrl, NONDEFAULT)
+    assertEquals({fact1, fact2}, dataResult)
+    dataResult = factIndex.factsByDimMemQname('dim7', modelXbrl, DEFAULT)
+    assertEquals({fact2, fact3, fact4, fact5}, dataResult) # fact6 is not an item!
+    factIndex.close()
+if __name__ == '__main__':
+    testAll()

--- a/arelle/FactIndex.py
+++ b/arelle/FactIndex.py
@@ -263,6 +263,14 @@ def testAll():
     assertEquals({fact1, fact2}, dataResult)
     dataResult = factIndex.factsByDimMemQname('dim7', modelXbrl, DEFAULT)
     assertEquals({fact2, fact3, fact4, fact5}, dataResult) # fact6 is not an item!
+    numberOfDeletedFacts = factIndex.deleteFact(fact1)
+    assertEquals(1, numberOfDeletedFacts)
+    dataResult = factIndex.nonNilFacts(modelXbrl)
+    assertEquals({fact2, fact3, fact4}, dataResult)
+    dataResult = factIndex.factsByDimMemQname('dim1', modelXbrl, None)
+    assertEquals({fact2}, dataResult)
+    dataResult = factIndex.factsByDimMemQname('dim2', modelXbrl, None)
+    assertEquals(set(), dataResult)
     factIndex.close()
 if __name__ == '__main__':
     testAll()

--- a/arelle/FactIndex.py
+++ b/arelle/FactIndex.py
@@ -48,7 +48,7 @@ class FactIndex(object):
     def close(self):
         self.connection.close()
 
-    def insertFact(self, fact):
+    def insertFact(self, fact, modelXbrl):
         concept = fact.concept
         context = fact.context
         factIsNil = fact.isNil
@@ -66,11 +66,12 @@ class FactIndex(object):
         newFactId = result.inserted_primary_key
         result.close()
         if fact.isItem and len(context.qnameDims)>0:
-            for dim in context.qnameDims.keys():
+            allDimensions = context.qnameDims.keys()|modelXbrl.qnameDimensionDefaults.keys()
+            for dim in allDimensions:
                 dimValue = context.dimValue(dim)
                 dimValueString = None
                 if isinstance(dimValue, ModelValue.QName): # explicit dimension default value
-                    dimValueString = str(ModelValue.QName)
+                    dimValueString = str(dimValue)
                     dimValueIsDefault = True
                 elif dimValue is not None: # not default
                     dimValueIsDefault = False
@@ -182,6 +183,8 @@ def testAll():
     class ModelXbrl(object):
         def __init__(self):
             self.modelObjects = dict()
+            self.qnameDimensionDefaults = dict()
+
     class DimensionValue(object):
         def __init__(self, isExplicit, value):
             self.isExplicit = isExplicit
@@ -225,12 +228,12 @@ def testAll():
     modelXbrl.modelObjects[fact6.objectIndex] = fact6
 
     factIndex = FactIndex()
-    factIndex.insertFact(fact1)
-    factIndex.insertFact(fact2)
-    factIndex.insertFact(fact3)
-    factIndex.insertFact(fact4)
-    factIndex.insertFact(fact5)
-    factIndex.insertFact(fact6)
+    factIndex.insertFact(fact1, modelXbrl)
+    factIndex.insertFact(fact2, modelXbrl)
+    factIndex.insertFact(fact3, modelXbrl)
+    factIndex.insertFact(fact4, modelXbrl)
+    factIndex.insertFact(fact5, modelXbrl)
+    factIndex.insertFact(fact6, modelXbrl)
     dataResult = factIndex.nonNilFacts(modelXbrl)
     assertEquals({fact1, fact2, fact3, fact4}, dataResult)
     expectedResult = 'NiceJob'

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -9,7 +9,8 @@ from collections import defaultdict
 from lxml import etree
 from xml.sax import SAXParseException
 from arelle import (PackageManager, XbrlConst, XmlUtil, UrlUtil, ValidateFilingText, 
-                    XhtmlValidate, XmlValidate, XmlValidateSchema)
+                    XhtmlValidate, XmlValidate, XmlValidateSchema,
+    ValidateXbrlDimensions)
 from arelle.ModelObject import ModelObject, ModelComment
 from arelle.ModelValue import qname
 from arelle.ModelDtsObject import ModelLink, ModelResource, ModelRelationship
@@ -997,6 +998,7 @@ class ModelDocument:
         if not self.skipDTS:
             self.linkbaseDiscover(xbrlElement,inInstance=True) # for role/arcroleRefs and footnoteLinks
         XmlValidate.validate(self.modelXbrl, xbrlElement) # validate instance elements (xValid may be UNKNOWN if skipDTS)
+        ValidateXbrlDimensions.loadDimensionDefaults(self.modelXbrl)
         self.instanceContentsDiscover(xbrlElement)
 
     def instanceContentsDiscover(self,xbrlElement):
@@ -1103,7 +1105,7 @@ class ModelDocument:
         if isinstance(modelFact, ModelFact):
             parentModelFacts.append( modelFact )
             self.modelXbrl.factsInInstance.add( modelFact )
-            self.modelXbrl.factIndex.insertFact( modelFact )
+            self.modelXbrl.factIndex.insertFact( modelFact, self.modelXbrl )
             tupleElementSequence = 0
             for tupleElement in modelFact:
                 if isinstance(tupleElement,ModelObject):
@@ -1244,7 +1246,7 @@ def inlineIxdsDiscover(modelXbrl):
             for modelInlineFact in htmlElement.iterdescendants(tag=tag):
                 if isinstance(modelInlineFact,ModelInlineFact):
                     mdlDoc.modelXbrl.factsInInstance.add( modelInlineFact )
-                    self.modelXbrl.factIndex.insertFact( modelInlineFact )
+                    mdlDoc.modelXbrl.factIndex.insertFact( modelInlineFact, mdlDoc.modelXbrl )
                     locateFactInTuple(modelInlineFact, tuplesByTupleID, ixNStag)
                     locateContinuation(modelInlineFact)
                     for r in modelInlineFact.footnoteRefs:

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -1103,6 +1103,7 @@ class ModelDocument:
         if isinstance(modelFact, ModelFact):
             parentModelFacts.append( modelFact )
             self.modelXbrl.factsInInstance.add( modelFact )
+            self.modelXbrl.factIndex.insertFact( modelFact )
             tupleElementSequence = 0
             for tupleElement in modelFact:
                 if isinstance(tupleElement,ModelObject):
@@ -1243,6 +1244,7 @@ def inlineIxdsDiscover(modelXbrl):
             for modelInlineFact in htmlElement.iterdescendants(tag=tag):
                 if isinstance(modelInlineFact,ModelInlineFact):
                     mdlDoc.modelXbrl.factsInInstance.add( modelInlineFact )
+                    self.modelXbrl.factIndex.insertFact( modelInlineFact )
                     locateFactInTuple(modelInlineFact, tuplesByTupleID, ixNStag)
                     locateContinuation(modelInlineFact)
                     for r in modelInlineFact.footnoteRefs:

--- a/arelle/ModelFormulaObject.py
+++ b/arelle/ModelFormulaObject.py
@@ -1119,7 +1119,7 @@ class ModelConceptName(ModelFilter):
     
     def filter(self, xpCtx, varBinding, facts, cmplmt):
         if not self.qnameExpressionProgs: # optimize if simple
-            qnamedFacts = set.union(*[inst.factsByQname(qn)
+            qnamedFacts = set.union(*[inst.factsByQname(qn, set())
                                       for inst in varBinding.instances
                                       for qn in self.conceptQnames])
             return (facts - qnamedFacts) if cmplmt else (facts & qnamedFacts)            

--- a/arelle/ModelFormulaObject.py
+++ b/arelle/ModelFormulaObject.py
@@ -1119,7 +1119,7 @@ class ModelConceptName(ModelFilter):
     
     def filter(self, xpCtx, varBinding, facts, cmplmt):
         if not self.qnameExpressionProgs: # optimize if simple
-            qnamedFacts = set.union(*[inst.factsByQname[qn]
+            qnamedFacts = set.union(*[inst.factsByQname(qn)
                                       for inst in varBinding.instances
                                       for qn in self.conceptQnames])
             return (facts - qnamedFacts) if cmplmt else (facts & qnamedFacts)            

--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -164,6 +164,10 @@ class ModelFact(ModelObject):
         """(str) -- unitRef attribute"""
         return self.get("unitRef")
     
+    @unitID.setter
+    def unitID(self, identifier):
+        self.set("unitRef", identifier)
+
     @property
     def utrEntries(self):
         """(set(UtrEntry)) -- set of UtrEntry objects that match this fact and unit"""

--- a/arelle/ModelRenderingObject.py
+++ b/arelle/ModelRenderingObject.py
@@ -132,7 +132,15 @@ class StructuralNode:
                 (inherit and
                  self.parentStructuralNode is not None and 
                  self.parentStructuralNode.hasAspect(aspect, inherit)))
-    
+
+    def ownOrInheritedAspect(self, aspect):
+        if aspect in self.aspects:
+            return self.aspects[aspect]
+        elif self.parentStructuralNode is not None:
+            return self.parentStructuralNode.ownOrInheritedAspect(aspect)
+        else:
+            return None
+
     def aspectValue(self, aspect, inherit=True, dims=None, depth=0, tagSelectors=None):
         xc = self._rendrCntx
         if False: # TEST: self.choiceStructuralNodes:  # use aspects from choice structural node
@@ -164,6 +172,15 @@ class StructuralNode:
             return dims
         if aspect in aspects:
             return aspects[aspect]
+        if not inherit:
+            if aspect in aspects:
+                foundAspect = aspects[aspect]
+            else:
+                foundAspect = None
+        else:
+            foundAspect = self.ownOrInheritedAspect(aspect);
+        if foundAspect is not None:
+            return foundAspect
         elif constraintSet is not None and constraintSet.hasAspect(self, aspect):
             if isinstance(definitionNode, ModelSelectionDefinitionNode):
                 # result is in the indicated variable of ordCntx

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -680,12 +680,12 @@ class ModelXbrl:
         _nonNilFactsInInstance = self.factIndex.nonNilFacts(self)
         return _nonNilFactsInInstance
         
-    def factsByQname(self, qname, defaultValue=None): # indexed by fact (concept) qname
+    def factsByQname(self, qname, defaultValue=None, cntxtId=None): # indexed by fact (concept) qname
         """Facts in the instance indexed by their QName, cached
         
         :returns: dict -- indexes are QNames, values are ModelFacts
         """
-        return self.factIndex.factsByQname(qname, self, defaultValue)
+        return self.factIndex.factsByQname(qname, self, defaultValue=defaultValue, cntxtId=cntxtId)
 
     def factsByQnameAll(self):
         """Facts in the instance indexed by their QName, cached
@@ -730,6 +730,15 @@ class ModelXbrl:
         """
         return self.factIndex.factsByDimMemQname(dimQname, self, memQname)
         
+    def factAlreadyExists(self, factQName, contextId):
+        """Find matching fact by QName and c-equality.
+        :type factQName: QName
+        :type contextId: str
+        :rtype bool -- True if fact already exists, False otherwise
+        """
+        matchingFacts = self.factsByQname(factQName, defaultValue=[], cntxtId=contextId)
+        return len(matchingFacts)>0
+
     def matchFact(self, otherFact, unmatchedFactsStack=None, deemP0inf=False):
         """Finds matching fact, by XBRL 2.1 duplicate definition (if tuple), or by
         QName and VEquality (if an item), lang and accuracy equality, as in formula and test case usage

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -672,11 +672,8 @@ class ModelXbrl:
         
         :returns: set -- non-nil facts in instance
         """
-        try:
-            return self._nonNilFactsInInstance
-        except AttributeError:
-            self._nonNilFactsInInstance = set(f for f in self.factsInInstance if not f.isNil)
-            return self._nonNilFactsInInstance
+        _nonNilFactsInInstance = set(f for f in self.factsInInstance if not f.isNil)
+        return _nonNilFactsInInstance
         
     def factsByQname(self, qname, defaultValue=None): # indexed by fact (concept) qname
         """Facts in the instance indexed by their QName, cached
@@ -695,18 +692,12 @@ class ModelXbrl:
         :type notStrict: bool
         :returns: set -- ModelFacts that have specified type or (if nonStrict) derived from specified type
         """
-        try:
-            return self._factsByDatatype[notStrict, typeQname]
-        except AttributeError:
-            self._factsByDatatype = {}
-            return self.factsByDatatype(notStrict, typeQname)
-        except KeyError:
-            self._factsByDatatype[notStrict, typeQname] = fbdt = set()
-            for f in self.factsInInstance:
-                c = f.concept
-                if c.typeQname == typeQname or (notStrict and c.type.isDerivedFrom(typeQname)):
-                    fbdt.add(f)
-            return fbdt
+        fbdt = set()
+        for f in self.factsInInstance:
+            c = f.concept
+            if c.typeQname == typeQname or (notStrict and c.type.isDerivedFrom(typeQname)):
+                fbdt.add(f)
+        return fbdt
         
     def factsByPeriodType(self, periodType): # indexed by fact (concept) qname
         """Facts in the instance indexed by periodType, cached
@@ -715,18 +706,13 @@ class ModelXbrl:
         :type periodType: str
         :returns: set -- ModelFacts that have specified periodType
         """
-        try:
-            return self._factsByPeriodType[periodType]
-        except AttributeError:
-            self._factsByPeriodType = fbpt = defaultdict(set)
-            for f in self.factsInInstance:
-                p = f.concept.periodType
-                if p:
-                    fbpt[p].add(f)
-            return self.factsByPeriodType(periodType)
-        except KeyError:
-            return set()  # no facts for this period type
-        
+        fbpt = set()
+        for f in self.factsInInstance:
+            p = f.concept.periodType
+            if p == periodType:
+                fbpt.add(f)
+            return fbpt
+
     def factsByDimMemQname(self, dimQname, memQname=None): # indexed by fact (concept) qname
         """Facts in the instance indexed by their Dimension  and Member QName, cached
         

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -687,7 +687,13 @@ class ModelXbrl:
         """
         return self.factIndex.factsByQname(qname, self, defaultValue)
 
+    def factsByQnameAll(self):
+        """Facts in the instance indexed by their QName, cached
         
+        :returns: list(tuple(str, set(ModelFact))) -- indexes are QNames (as string), values are ModelFacts
+        """
+        return self.factIndex.factsByQnameAll(self)
+
     def factsByDatatype(self, notStrict, typeQname): # indexed by fact (concept) qname
         """Facts in the instance indexed by data type QName, cached as types are requested
 

--- a/arelle/RenderingResolver.py
+++ b/arelle/RenderingResolver.py
@@ -221,6 +221,8 @@ def expandDefinition(view, structuralNode, breakdownNode, definitionNode, depth,
                     if widestWordLen > view.rowNonAbstractHdrSpanMin[structuralNode.depth]:
                         view.rowNonAbstractHdrSpanMin[structuralNode.depth] = widestWordLen
                         
+    if axisDisposition == "z" and structuralNode.aspects is None:
+        structuralNode.aspects = view.zOrdinateChoices.get(definitionNode, None)
     if structuralNode and isinstance(definitionNode, (ModelBreakdown, ModelEuAxisCoord, ModelDefinitionNode)):
         try:
             #cartesianProductNestedArgs = (view, depth, axisDisposition, facts, tblAxisRels, i)

--- a/arelle/TableStructure.py
+++ b/arelle/TableStructure.py
@@ -124,7 +124,7 @@ def evaluateRoleTypesTableCodes(modelXbrl):
             # for Registration and resubmission allow detecting multiple of code
             detectMultipleOfCode = any(v and any(v.startswith(dt) for dt in ('S-', 'F-', '8-K', '6-K'))
                                        for docTypeConcept in modelXbrl.nameConcepts.get('DocumentType', ())
-                                       for docTypeFact in modelXbrl.factsByQname.get(docTypeConcept.qname, ())
+                                       for docTypeFact in modelXbrl.factsByQname(docTypeConcept.qname, ())
                                        for v in (docTypeFact.value,))
         elif disclosureSystem.HMRC:
             tableCodes = list( HMRCtableCodes ) # separate copy of list so entries can be deleted
@@ -226,13 +226,12 @@ def evaluateTableIndex(modelXbrl):
             from arelle import ValidateXbrlDimensions
             ValidateXbrlDimensions.loadDimensionDefaults(modelXbrl)
         reportedFacts = set() # facts which were shown in a higher-numbered ELR table
-        factsByQname = modelXbrl.factsByQname
         reportingPeriods = set()
         nextEnd = None
         deiFact = {}
         for conceptName in ("DocumentPeriodEndDate", "DocumentType", "CurrentFiscalPeriodEndDate"):
             for concept in modelXbrl.nameConcepts[conceptName]:
-                for fact in factsByQname[concept.qname]:
+                for fact in  modelXbrl.factsByQname(concept.qname):
                     deiFact[conceptName] = fact
                     if fact.context is not None:
                         reportingPeriods.add((None, fact.context.endDatetime)) # for instant

--- a/arelle/UiUtil.py
+++ b/arelle/UiUtil.py
@@ -216,7 +216,7 @@ class gridCell(Entry):
         self.isChanged = True
     
 class gridCombobox(_Combobox): 
-    def __init__(self, master, x, y, value="", values=(), width=None, objectId=None, columnspan=None, selectindex=None, comboboxselected=None): 
+    def __init__(self, master, x, y, value="", values=(), width=None, objectId=None, columnspan=None, selectindex=None, comboboxselected=None, state=[], onClick=None): 
         _Combobox.__init__(self, master=master) 
         self.valueVar = StringVar() 
         self.valueVar.trace('w', self.valueChanged)
@@ -249,7 +249,11 @@ class gridCombobox(_Combobox):
         if comboboxselected:
             self.bind("<<ComboboxSelected>>", comboboxselected)
         self.isChanged = False
-        
+        if state != None and len(state)>0: 
+            self.state(state)
+        if onClick:
+            self.bind("<1>", onClick)
+
     @property
     def value(self):
         return self.valueVar.get()

--- a/arelle/UiUtil.py
+++ b/arelle/UiUtil.py
@@ -216,7 +216,7 @@ class gridCell(Entry):
         self.isChanged = True
     
 class gridCombobox(_Combobox): 
-    def __init__(self, master, x, y, value="", values=(), width=None, objectId=None, columnspan=None, selectindex=None, comboboxselected=None, state=[], onClick=None): 
+    def __init__(self, master, x, y, value="", values=(), width=None, objectId=None, columnspan=None, selectindex=None, comboboxselected=None, state=[], onClick=None, codes=dict()): 
         _Combobox.__init__(self, master=master) 
         self.valueVar = StringVar() 
         self.valueVar.trace('w', self.valueChanged)
@@ -226,6 +226,7 @@ class gridCombobox(_Combobox):
                     width=width
                     ) 
         self["values"] = values
+        self.codes = codes
         if isinstance(master.master.master, scrolledHeaderedFrame):
             x = x * 2
             y = y * 2

--- a/arelle/ValidateFiling.py
+++ b/arelle/ValidateFiling.py
@@ -1725,7 +1725,7 @@ class ValidateFiling(ValidateXbrl.ValidateXbrl):
             if not hasPresentationRelationship:
                 self.modelXbrl.error(("EFM.6.12.03", "GFM.1.6.3"),
                     _("Concept used in instance %(concept)s does not participate in an effective presentation relationship"),
-                    modelObject=[concept] + list(modelXbrl.factsByQname(concept.qname)), concept=concept.qname)
+                    modelObject=[concept] + list(modelXbrl.factsByQname(concept.qname, [])), concept=concept.qname)
                 
         for fromIndx, toIndxs in usedCalcsPresented.items():
             for toIndx in toIndxs:

--- a/arelle/ValidateXbrlDimensions.py
+++ b/arelle/ValidateXbrlDimensions.py
@@ -489,22 +489,23 @@ def findUsableMembersInDomainELR(val, rels, ELR, usableMembers, unusableMembers,
             findUsableMembersInDomainELR(val, domMbrRels, toELR, usableMembers, unusableMembers, toConceptELRs)
             toELRs.discard(toELR)
 
-def enumerationMemberUsable(val, enumConcept, memConcept):
-    if enumConcept is None or memConcept is None:
-        return False
+def usableEnumerationMembers(val, enumConcept):
+    if enumConcept is None:
+        return set()
     try:
         enumerationMembersUsable = val.enumerationMembersUsable
     except AttributeError:
         enumerationMembersUsable = val.enumerationMembersUsable = {}
     try:
-        return memConcept in enumerationMembersUsable[enumConcept]
+        return enumerationMembersUsable[enumConcept]
     except KeyError:
         domConcept = enumConcept.enumDomain
         usableMembers = set()
         unusableMembers = set()
         enumerationMembersUsable[enumConcept] = usableMembers
         if domConcept is None:
-            return False
+            usableMembers = set()
+            return usableMembers
         if enumConcept.isEnumDomainUsable:
             usableMembers.add(domConcept)
         # build set of usable members in dimension/domain/ELR
@@ -512,8 +513,13 @@ def enumerationMemberUsable(val, enumConcept, memConcept):
         findUsableMembersInDomainELR(val, val.modelXbrl.relationshipSet(XbrlConst.domainMember, domELR).fromModelObject(domConcept),
                                      domELR, usableMembers, unusableMembers, defaultdict(set))
         usableMembers -= unusableMembers
-        return memConcept in usableMembers
-    
+        return usableMembers
+
+def enumerationMemberUsable(val, enumConcept, memConcept):
+    if enumConcept is None or memConcept is None:
+        return False
+    else:
+        return memConcept in usableEnumerationMembers(val, enumConcept)
 ''' removed to cache all members usability for domain
 def dimensionMemberState(val, dimConcept, memConcept, domELR):
     try:

--- a/arelle/ViewFileRenderedGrid.py
+++ b/arelle/ViewFileRenderedGrid.py
@@ -693,7 +693,7 @@ class ViewRenderedGrid(ViewFile.View):
                         fp = FactPrototype(self, cellAspectValues)
                         if conceptNotAbstract:
                             # reduce set of matchable facts to those with pri item qname and have dimension aspects
-                            facts = self.modelXbrl.factsByQname(priItemQname) if priItemQname else self.modelXbrl.factsInInstance
+                            facts = self.modelXbrl.factsByQname(priItemQname, set()) if priItemQname else self.modelXbrl.factsInInstance
                             if self.hasTableFilters:
                                 facts = self.modelTable.filterFacts(self.rendrCntx, facts)
                             for aspect in matchableAspects:  # trim down facts with explicit dimensions match or just present

--- a/arelle/ViewFileRenderedGrid.py
+++ b/arelle/ViewFileRenderedGrid.py
@@ -693,7 +693,7 @@ class ViewRenderedGrid(ViewFile.View):
                         fp = FactPrototype(self, cellAspectValues)
                         if conceptNotAbstract:
                             # reduce set of matchable facts to those with pri item qname and have dimension aspects
-                            facts = self.modelXbrl.factsByQname[priItemQname] if priItemQname else self.modelXbrl.factsInInstance
+                            facts = self.modelXbrl.factsByQname(priItemQname) if priItemQname else self.modelXbrl.factsInInstance
                             if self.hasTableFilters:
                                 facts = self.modelTable.filterFacts(self.rendrCntx, facts)
                             for aspect in matchableAspects:  # trim down facts with explicit dimensions match or just present

--- a/arelle/ViewFileRenderedGrid.py
+++ b/arelle/ViewFileRenderedGrid.py
@@ -711,6 +711,8 @@ class ViewRenderedGrid(ViewFile.View):
                                     else:
                                         dimMemQname = None # match facts that report this dimension
                                     facts = facts & self.modelXbrl.factsByDimMemQname(aspect, dimMemQname)
+                                    if len(facts)==0:
+                                        break;
                             for fact in facts:
                                 if (all(aspectMatches(self.rendrCntx, fact, fp, aspect) 
                                         for aspect in matchableAspects) and

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -656,7 +656,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                         fp = FactPrototype(self, cellAspectValues)
                         if conceptNotAbstract:
                             # reduce set of matchable facts to those with pri item qname and have dimension aspects
-                            facts = self.modelXbrl.factsByQname[priItemQname] if priItemQname else self.modelXbrl.factsInInstance
+                            facts = self.modelXbrl.factsByQname(priItemQname, set()) if priItemQname else self.modelXbrl.factsInInstance
                             if self.hasTableFilters:
                                 facts = self.modelTable.filterFacts(self.rendrCntx, facts)
                             for aspect in matchableAspects:  # trim down facts with explicit dimensions match or just present

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -8,7 +8,7 @@ Note speed of using tkinter appears to be slow to render with tkinter (see profi
 Typical example is an instance takes 3 secs for view() for an open table and 
 subsequently after Python operations concluded, tkinter takes additional 27 secs to render
 '''
-import os, threading, time
+import os, threading, time, logging
 from tkinter import Menu, BooleanVar, font as tkFont
 from arelle import (ViewWinGrid, ModelDocument, ModelDtsObject, ModelInstanceObject, XbrlConst, 
                     ModelXbrl, XmlValidate, XmlUtil, Locale, FunctionXfi,
@@ -961,6 +961,9 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                 qnameDims, [], [])
                             if prevCntx is not None:
                                 cntxId = prevCntx.id
+                                if self.modelXbrl.factAlreadyExists(concept.qname, cntxId):
+                                    self.modelXbrl.modelManager.addToLog(_("Value %s will not be saved, because fact '%s' already exists somewhere else") % (value, concept.label()), level=logging.ERROR)
+                                    continue
                             else:
                                 newCntx = instance.createContext(entityIdentScheme, entityIdentValue, 
                                     periodType, periodStart, periodEndInstant, 

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -681,6 +681,8 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                     else:
                                         dimMemQname = None # match facts that report this dimension
                                     facts = facts & self.modelXbrl.factsByDimMemQname(aspect, dimMemQname)
+                                    if len(facts)==0:
+                                        break;
                             for fact in facts:
                                 if (all(aspectMatches(self.rendrCntx, fact, fp, aspect) 
                                         for aspect in matchableAspects) and

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -34,6 +34,7 @@ from arelle.XbrlConst import eurofilingModelNamespace, eurofilingModelPrefix
 emptyList = []
 
 ENTRY_WIDTH_IN_CHARS = 12 # width of a data column entry cell in characters (nominal)
+ENTRY_WIDTH_SCREEN_UNITS = 100
 PADDING = 20 # screen units of padding between entry cells
 
 def viewRenderedGrid(modelXbrl, tabWin, lang=None):
@@ -426,7 +427,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                     isLabeled = xStructuralNode.isLabeled
                     nonAbstract = not xStructuralNode.isAbstract and isLabeled
                     if nonAbstract and isLabeled:
-                        width += 100 # width for this label, in screen units
+                        width += ENTRY_WIDTH_SCREEN_UNITS # width for this label, in screen units
                     widthToSpanParent += width
                     if childrenFirst:
                         thisCol = rightCol
@@ -448,6 +449,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                 columnspan=(rightCol - leftCol + (1 if nonAbstract else 0)),
                                 rowspan=(row - topRow + 1) if leafNode else 1,
                                 wraplength=width, # screen units
+                                minwidth=width,
                                 objectId=xStructuralNode.objectId(),
                                 onClick=self.onClick)
                         if nonAbstract:
@@ -457,7 +459,8 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                 gridHdr(self.gridColHdr, thisCol, self.dataFirstRow - len(self.colHdrNonStdRoles) + i, 
                                         xStructuralNode.header(role=role, lang=self.lang), 
                                         anchor="center",
-                                        wraplength=100, # screen units
+                                        wraplength=ENTRY_WIDTH_SCREEN_UNITS, # screen units
+                                        minwidth=ENTRY_WIDTH_SCREEN_UNITS,
                                         objectId=xStructuralNode.objectId(),
                                         onClick=self.onClick)
                             ''' was
@@ -468,7 +471,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                         xStructuralNode.header(role="http://www.xbrl.org/2008/role/documentation",
                                                                lang=self.lang), 
                                         anchor="center",
-                                        wraplength=100, # screen units
+                                        wraplength=ENTRY_WIDTH_SCREEN_UNITS, # screen units
                                         objectId=xStructuralNode.objectId(),
                                         onClick=self.onClick)
                             if self.colHdrCodeRow:
@@ -477,7 +480,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                 gridHdr(self.gridColHdr, thisCol, self.dataFirstRow - 1, 
                                         xStructuralNode.header(role="http://www.eurofiling.info/role/2010/coordinate-code"),
                                         anchor="center",
-                                        wraplength=100, # screen units
+                                        wraplength=ENTRY_WIDTH_SCREEN_UNITS, # screen units
                                         objectId=xStructuralNode.objectId(),
                                         onClick=self.onClick)
                             '''
@@ -562,7 +565,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                 gridHdr(self.gridRowHdr, docCol, row, 
                                         yStructuralNode.header(role=role, lang=self.lang), 
                                         anchor="c" if isCode else "w",
-                                        wraplength=40 if isCode else 100, # screen units
+                                        wraplength=40 if isCode else ENTRY_WIDTH_SCREEN_UNITS, # screen units
                                         objectId=yStructuralNode.objectId(),
                                         onClick=self.onClick)
                             ''' was:
@@ -574,7 +577,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                         yStructuralNode.header(role="http://www.xbrl.org/2008/role/documentation",
                                                              lang=self.lang), 
                                         anchor="w",
-                                        wraplength=100, # screen units
+                                        wraplength=ENTRY_WIDTH_SCREEN_UNITS, # screen units
                                         objectId=yStructuralNode.objectId(),
                                         onClick=self.onClick)
                             if self.rowHdrCodeCol:
@@ -715,6 +718,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                              self.dataFirstCol + i, row,
                                              value=effectiveValue,
                                              values=enumerationValues,
+                                             width=ENTRY_WIDTH_IN_CHARS,
                                              objectId=objectId,
                                              selectindex=selectedIdx,
                                              state=["readonly"],
@@ -767,6 +771,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                                  self.dataFirstCol + i, row,
                                                  value=effectiveValue,
                                                  values=qNameValues,
+                                                 width=ENTRY_WIDTH_IN_CHARS,
                                                  objectId=objectId,
                                                  selectindex=selectedIdx,
                                                  state=["readonly"],
@@ -786,6 +791,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                              self.dataFirstCol + i, row,
                                              value=effectiveValue,
                                              values=booleanValues,
+                                             width=ENTRY_WIDTH_IN_CHARS,
                                              objectId=objectId,
                                              selectindex=selectedIdx,
                                              state=["readonly"],

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -1021,7 +1021,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                             if fact.value != str(value):
                                 if fact.isNil != (not value):
                                     fact.isNil = not value
-                                if not fact.isNil: # if nil, there is no need to update these values
+                                if fact.concept.isNumeric and (not fact.isNil): # if nil, there is no need to update these values
                                     fact.decimals = decimals
                                     prevUnit = instance.matchUnit([unitMeasure], [])
                                     if prevUnit is not None:

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -1023,6 +1023,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                             if fact.value != str(value):
                                 if fact.isNil != (not value):
                                     fact.isNil = not value
+                                    instance.factIndex.updateFact(fact) # for the time being, only the isNil value can change
                                 if fact.concept.isNumeric and (not fact.isNil): # if nil, there is no need to update these values
                                     fact.decimals = decimals
                                     prevUnit = instance.matchUnit([unitMeasure], [])

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -214,6 +214,7 @@ validation = "http://xbrl.org/2008/validation"
 qnAssertion = qname("{http://xbrl.org/2008/validation}validation:assertion")
 qnVariableSetAssertion = qname("{http://xbrl.org/2008/validation}validation:variableSetAssertion")
 qnAssertionSet = qname("{http://xbrl.org/2008/validation}validation:assertionSet")
+qnAssertionSeverity = qname("{http://xbrl.org/PWD/2014-08-13/assertion-severity}severity")
 assertionSet = "http://xbrl.org/arcrole/2008/assertion-set"
 assertionSatisfiedSeverity = "http://xbrl.org/arcrole/2014/assertion-satisfied-severity"
 assertionUnsatisfiedSeverity = "http://xbrl.org/arcrole/2014/assertion-unsatisfied-severity"

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -520,7 +520,12 @@ def isNumericXsdType(xsdType):
     return xsdType in {"integer", "positiveInteger", "negativeInteger", "nonNegativeInteger", "nonPositiveInteger",
                        "long", "unsignedLong", "int", "unsignedInt", "short", "unsignedShort",
                        "byte", "unsignedByte", "decimal", "float", "double"}
-    
+
+def isIntegerXsdType(xsdType):
+    return xsdType in {"integer", "positiveInteger", "negativeInteger", "nonNegativeInteger", "nonPositiveInteger",
+                       "long", "unsignedLong", "int", "unsignedInt", "short", "unsignedShort",
+                       "byte", "unsignedByte"}
+
 standardLabelRoles = {
                     "http://www.xbrl.org/2003/role/label",
                     "http://www.xbrl.org/2003/role/terseLabel",

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -28,6 +28,8 @@ qnXbrliStringItemType = qname("{http://www.xbrl.org/2003/instance}xbrli:stringIt
 qnXbrliMonetaryItemType = qname("{http://www.xbrl.org/2003/instance}xbrli:monetaryItemType")
 qnXbrliDateItemType = qname("{http://www.xbrl.org/2003/instance}xbrli:dateItemType")
 qnXbrliDurationItemType = qname("{http://www.xbrl.org/2003/instance}xbrli:durationItemType")
+qnXbrliBooleanItemType = qname("{http://www.xbrl.org/2003/instance}xbrli:booleanItemType")
+qnXbrliQNameItemType = qname("{http://www.xbrl.org/2003/instance}xbrli:QNameItemType")
 qnXbrliPure = qname("{http://www.xbrl.org/2003/instance}xbrli:pure")
 qnXbrliShares = qname("{http://www.xbrl.org/2003/instance}xbrli:shares")
 qnInvalidMeasure = qname("{http://arelle.org}arelle:invalidMeasureQName")
@@ -438,6 +440,9 @@ qnTableRuleAxis2011 = qname("{http://xbrl.org/2011/table}table:ruleAxis")
 qnTablePredefinedAxis2011 = qname("{http://xbrl.org/2011/table}table:predefinedAxis")
 qnTableSelectionAxis2011 = qname("{http://xbrl.org/2011/table}table:selectionAxis")
 qnTableTupleAxis2011 = qname("{http://xbrl.org/2011/table}table:tupleAxis")
+
+booleanValueTrue = "true"
+booleanValueFalse = "false"
 
 # Eurofiling 2010 table linkbase
 euRend = "http://www.eurofiling.info/2010/rendering"

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -14,6 +14,8 @@ builtinAttributes = {qnXsiNil,
                      ,qname(xsi,"xsi:noNamespaceSchemaLocation")}
 xml = "http://www.w3.org/XML/1998/namespace"
 xbrli = "http://www.xbrl.org/2003/instance"
+eurofilingModelNamespace = "http://www.eurofiling.info/xbrl/ext/model"
+eurofilingModelPrefix = "model"
 qnNsmap = qname("nsmap") # artificial parent for insertion of xmlns in saving xml documents
 qnXbrliXbrl = qname("{http://www.xbrl.org/2003/instance}xbrli:xbrl")
 qnXbrliItem = qname("{http://www.xbrl.org/2003/instance}xbrli:item")

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -214,7 +214,6 @@ validation = "http://xbrl.org/2008/validation"
 qnAssertion = qname("{http://xbrl.org/2008/validation}validation:assertion")
 qnVariableSetAssertion = qname("{http://xbrl.org/2008/validation}validation:variableSetAssertion")
 qnAssertionSet = qname("{http://xbrl.org/2008/validation}validation:assertionSet")
-qnAssertionSeverity = qname("{http://xbrl.org/PWD/2014-08-13/assertion-severity}severity")
 assertionSet = "http://xbrl.org/arcrole/2008/assertion-set"
 assertionSatisfiedSeverity = "http://xbrl.org/arcrole/2014/assertion-satisfied-severity"
 assertionUnsatisfiedSeverity = "http://xbrl.org/arcrole/2014/assertion-unsatisfied-severity"

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -503,6 +503,9 @@ def addChild(parent, childName1, childName2=None, attributes=None, text=None, af
                 child.set(name, xsString(None, None, value) )
     if text is not None:
         child.text = xsString(None, None, text)
+        # check if the text is a QName and add the namespace if needed!
+        if isinstance(text, QName):
+            addQnameValue(modelDocument, text)
     child.init(modelDocument)
     return child
 

--- a/arelle/examples/plugin/streamingExtensions.py
+++ b/arelle/examples/plugin/streamingExtensions.py
@@ -284,6 +284,7 @@ def dropFact(modelXbrl, fact, facts):
     while fact.modelTupleFacts:
         dropFact(modelXbrl, fact.modelTupleFacts[0], fact.modelTupleFacts)
     modelXbrl.factsInInstance.discard(fact)
+    modelXbrl.factIndex.deleteFact(fact)
     facts.remove(fact)
     modelXbrl.modelObjects[fact.objectIndex] = None # objects found by index, can't remove position from list
     fact.modelDocument.modelObjects.remove(fact)

--- a/arelle/plugin/EbaCompliance/FactWalkingAction.py
+++ b/arelle/plugin/EbaCompliance/FactWalkingAction.py
@@ -1,0 +1,41 @@
+'''
+Created on 25 sept. 2014
+
+@author: gmo
+'''
+from arelle.ModelInstanceObject import ModelFact
+
+defaultENLanguage = "en"
+filingIndicatorCodeRole = "http://www.eurofiling.info/xbrl/role/filing-indicator-code";
+
+class FactWalkingAction:
+    '''
+    Action executed by the walker whenever a fact is met
+    '''
+
+    def __init__(self, modelXbrl):
+        '''
+        Constructor
+        :type modelXbrl: ModelXbrl
+        '''
+        self.modelXbrl = modelXbrl
+        self.allFilingIndicatorCodes = set();
+
+    def onFactEvent(self, fact, value, modelTable):
+        '''
+        Action executed for every met fact.
+        :type fact: ModelFact
+        :type value: str
+        :type modelTable: ModelTable
+        '''
+        if not fact.isNil:
+            filingIndicatorCode = modelTable.genLabel(role=filingIndicatorCodeRole,
+                                                      lang=defaultENLanguage)
+            if not filingIndicatorCode in self.allFilingIndicatorCodes:
+                self.allFilingIndicatorCodes.add(filingIndicatorCode)
+                self.modelXbrl.modelManager.cntlr.addToLog("Filing indicator code %s has been added" % filingIndicatorCode)
+    def afterAllFactsEvent(self):
+        '''
+        Action executed at the end, when all facts have been executed
+        '''
+        pass

--- a/arelle/plugin/EbaCompliance/ViewWalkerRenderedGrid.py
+++ b/arelle/plugin/EbaCompliance/ViewWalkerRenderedGrid.py
@@ -1,0 +1,253 @@
+'''
+Created on Sep 25, 2014
+
+@author: Gregorio Mongelli (Acsone S. A.)
+(c) Copyright 2014 Acsone S. A., All rights reserved.
+'''
+
+from arelle.RenderingResolver import resolveAxesStructure
+from arelle.ModelFormulaObject import Aspect, aspectModels, aspectModelAspect
+from arelle.FormulaEvaluator import aspectMatches
+from arelle.ModelInstanceObject import ModelDimensionValue
+from arelle.ModelValue import QName
+from arelle.ModelXbrl import DEFAULT
+from arelle.ModelRenderingObject import (ModelClosedDefinitionNode, ModelEuAxisCoord)
+from arelle.PrototypeInstanceObject import FactPrototype
+
+from arelle import XbrlConst
+from collections import defaultdict
+
+emptySet = set()
+emptyList = []
+
+def viewWalkerRenderedGrid(modelXbrl, factWalkingAction, lang=None, viewTblELR=None, sourceView=None):
+    '''
+    Constructor
+    :type modelXbrl: ModelXbrl
+    :type factWalkingAction: FactWalkingAction
+    :type lang: str
+    '''
+    modelXbrl.modelManager.showStatus(_("walking through tables"))
+    view = ViewRenderedGrid(modelXbrl, lang, factWalkingAction)
+    
+    if sourceView is not None:
+        viewTblELR = sourceView.tblELR
+        view.ignoreDimValidity.set(sourceView.ignoreDimValidity.get())
+        view.xAxisChildrenFirst.set(sourceView.xAxisChildrenFirst.get())
+        view.yAxisChildrenFirst.set(sourceView.yAxisChildrenFirst.get())
+    view.view(viewTblELR)
+    modelXbrl.modelManager.showStatus(_("rendering for walk terminated"), clearAfter=5000)
+    
+class ViewRenderedGrid:
+    def __init__(self, modelXbrl, lang, factWalkingAction):
+        '''
+        Constructor
+        :type modelXbrl: ModelXbrl
+        :type lang: str
+        :type factWalkingAction: FactWalkingAction
+        '''
+        # find table model namespace based on table namespace
+        self.tableModelNamespace = XbrlConst.tableModel
+        for xsdNs in modelXbrl.namespaceDocs.keys():
+            if xsdNs in (XbrlConst.tableMMDD, XbrlConst.table, XbrlConst.table201305, XbrlConst.table201301, XbrlConst.table2011):
+                self.tableModelNamespace = xsdNs + "/model"
+                break
+        class nonTkBooleanVar():
+            def __init__(self, value=True):
+                self.value = value
+            def set(self, value):
+                self.value = value
+            def get(self):
+                return self.value
+        # context menu boolean vars (non-tkinter boolean
+        self.modelXbrl = modelXbrl
+        self.lang = lang
+        self.ignoreDimValidity = nonTkBooleanVar(value=True)
+        self.xAxisChildrenFirst = nonTkBooleanVar(value=True)
+        self.yAxisChildrenFirst = nonTkBooleanVar(value=False)
+        self.factWalkingAction = factWalkingAction 
+
+    def tableModelQName(self, localName):
+        return '{' + self.tableModelNamespace + '}' + localName
+
+    def view(self, viewTblELR=None):
+        if viewTblELR is not None:
+            tblELRs = (viewTblELR,)
+        else:
+            tblELRs = self.modelXbrl.relationshipSet("Table-rendering").linkRoleUris
+        for tblELR in tblELRs:
+            self.zOrdinateChoices = {}
+            
+                
+            for discriminator in range(1, 65535):  # @UnusedVariable
+                # each table z production
+                tblAxisRelSet, xTopStructuralNode, yTopStructuralNode, zTopStructuralNode = resolveAxesStructure(self, tblELR)  # @UnusedVariable
+                self.hasTableFilters = bool(self.modelTable.filterRelationships)
+                
+                self.zStrNodesWithChoices = []
+                if tblAxisRelSet:
+                    zAspectStructuralNodes = defaultdict(set)
+                    self.zAxis(1, zTopStructuralNode, zAspectStructuralNodes, False)
+                    xStructuralNodes = []
+                    self.xAxis(self.dataFirstCol, self.colHdrTopRow, self.colHdrTopRow + self.colHdrRows - 1, 
+                               xTopStructuralNode, xStructuralNodes, self.xAxisChildrenFirst.get(), True, True)
+                    self.bodyCells(self.dataFirstRow, yTopStructuralNode, xStructuralNodes, zAspectStructuralNodes, self.yAxisChildrenFirst.get(), tblELR)
+                # find next choice structural node
+                moreDiscriminators = False
+                for zStrNodeWithChoices in self.zStrNodesWithChoices:
+                    currentIndex = zStrNodeWithChoices.choiceNodeIndex + 1
+                    if currentIndex < len(zStrNodeWithChoices.choiceStructuralNodes):
+                        zStrNodeWithChoices.choiceNodeIndex = currentIndex
+                        self.zOrdinateChoices[zStrNodeWithChoices.definitionNode] = currentIndex
+                        moreDiscriminators = True
+                        break
+                    else:
+                        zStrNodeWithChoices.choiceNodeIndex = 0
+                        self.zOrdinateChoices[zStrNodeWithChoices.definitionNode] = 0
+                        # continue incrementing next outermore z choices index
+                if not moreDiscriminators:
+                    break
+        self.factWalkingAction.afterAllFactsEvent()
+
+            
+    def zAxis(self, row, zStructuralNode, zAspectStructuralNodes, discriminatorsTable):
+        if zStructuralNode is not None:
+            label = zStructuralNode.header(lang=self.lang)
+            choiceLabel = None
+            effectiveStructuralNode = zStructuralNode
+            if zStructuralNode.choiceStructuralNodes: # same as combo box selection in GUI mode
+                if not discriminatorsTable:
+                    self.zStrNodesWithChoices.insert(0, zStructuralNode) # iteration from last is first
+                try:
+                    effectiveStructuralNode = zStructuralNode.choiceStructuralNodes[zStructuralNode.choiceNodeIndex]
+                    choiceLabel = effectiveStructuralNode.header(lang=self.lang)
+                    if not label and choiceLabel:
+                        label = choiceLabel # no header for choice
+                        choiceLabel = None
+                except KeyError:
+                    pass
+
+            for aspect in aspectModels[self.aspectModel]:
+                if effectiveStructuralNode.hasAspect(aspect, inherit=True): #implies inheriting from other z axes
+                    if aspect == Aspect.DIMENSIONS:
+                        for dim in (effectiveStructuralNode.aspectValue(Aspect.DIMENSIONS, inherit=True) or emptyList):
+                            zAspectStructuralNodes[dim].add(effectiveStructuralNode)
+                    else:
+                        zAspectStructuralNodes[aspect].add(effectiveStructuralNode)
+            for zStructuralNode in zStructuralNode.childStructuralNodes:
+                self.zAxis(row + 1, zStructuralNode, zAspectStructuralNodes, discriminatorsTable)
+
+    def xAxis(self, leftCol, topRow, rowBelow, xParentStructuralNode, xStructuralNodes, childrenFirst, renderNow, atTop):
+        if xParentStructuralNode is not None:
+            parentRow = rowBelow
+            noDescendants = True
+            rightCol = leftCol
+            widthToSpanParent = 0
+            for xStructuralNode in xParentStructuralNode.childStructuralNodes:
+                noDescendants = False
+                rightCol, row, width, leafNode = self.xAxis(leftCol, topRow + 1, rowBelow, xStructuralNode, xStructuralNodes, # nested items before totals
+                                                            childrenFirst, childrenFirst, False)
+                if row - 1 < parentRow:
+                    parentRow = row - 1
+                #if not leafNode: 
+                #    rightCol -= 1
+                nonAbstract = not xStructuralNode.isAbstract
+                if nonAbstract:
+                    width += 100 # width for this label
+                widthToSpanParent += width
+                if renderNow and nonAbstract:
+                    xStructuralNodes.append(xStructuralNode)
+                if nonAbstract:
+                    rightCol += 1
+                if renderNow and not childrenFirst:
+                    self.xAxis(leftCol + (1 if nonAbstract else 0), topRow + 1, rowBelow, xStructuralNode, xStructuralNodes, childrenFirst, True, False) # render on this pass
+                leftCol = rightCol
+            return (rightCol, parentRow, widthToSpanParent, noDescendants)
+
+    def bodyCells(self, row, yParentStructuralNode, xStructuralNodes, zAspectStructuralNodes, yChildrenFirst, tblELR):
+        if yParentStructuralNode is not None:
+            dimDefaults = self.modelXbrl.qnameDimensionDefaults
+            for yStructuralNode in yParentStructuralNode.childStructuralNodes:
+                if yChildrenFirst:
+                    row = self.bodyCells(row, yStructuralNode, xStructuralNodes, zAspectStructuralNodes, yChildrenFirst, tblELR)
+                if not (yStructuralNode.isAbstract or 
+                        (yStructuralNode.childStructuralNodes and
+                         not isinstance(yStructuralNode.definitionNode, (ModelClosedDefinitionNode, ModelEuAxisCoord)))) and yStructuralNode.isLabeled:
+                    yAspectStructuralNodes = defaultdict(set)
+                    for aspect in aspectModels[self.aspectModel]:
+                        if yStructuralNode.hasAspect(aspect):
+                            if aspect == Aspect.DIMENSIONS:
+                                for dim in (yStructuralNode.aspectValue(Aspect.DIMENSIONS) or emptyList):
+                                    yAspectStructuralNodes[dim].add(yStructuralNode)
+                            else:
+                                yAspectStructuralNodes[aspect].add(yStructuralNode)
+                    yTagSelectors = yStructuralNode.tagSelectors
+                    # data for columns of rows
+                    for _, xStructuralNode in enumerate(xStructuralNodes):
+                        xAspectStructuralNodes = defaultdict(set)
+                        for aspect in aspectModels[self.aspectModel]:
+                            if xStructuralNode.hasAspect(aspect):
+                                if aspect == Aspect.DIMENSIONS:
+                                    for dim in (xStructuralNode.aspectValue(Aspect.DIMENSIONS) or emptyList):
+                                        xAspectStructuralNodes[dim].add(xStructuralNode)
+                                else:
+                                    xAspectStructuralNodes[aspect].add(xStructuralNode)
+                        cellTagSelectors = yTagSelectors | xStructuralNode.tagSelectors
+                        cellAspectValues = {}
+                        matchableAspects = set()
+                        for aspect in _DICT_SET(xAspectStructuralNodes.keys()) | _DICT_SET(yAspectStructuralNodes.keys()) | _DICT_SET(zAspectStructuralNodes.keys()):  # @UndefinedVariable
+                            aspectValue = xStructuralNode.inheritedAspectValue(yStructuralNode,
+                                               self, aspect, cellTagSelectors, 
+                                               xAspectStructuralNodes, yAspectStructuralNodes, zAspectStructuralNodes)
+                            # value is None for a dimension whose value is to be not reported in this slice
+                            if (isinstance(aspect, _INT) or  # not a dimension @UndefinedVariable
+                                dimDefaults.get(aspect) != aspectValue or # explicit dim defaulted will equal the value
+                                aspectValue is not None): # typed dim absent will be none
+                                cellAspectValues[aspect] = aspectValue
+                            matchableAspects.add(aspectModelAspect.get(aspect,aspect)) #filterable aspect from rule aspect
+                        cellDefaultedDims = _DICT_SET(dimDefaults) - _DICT_SET(cellAspectValues.keys())  # @UndefinedVariable
+                        priItemQname = cellAspectValues.get(Aspect.CONCEPT)
+                            
+                        concept = self.modelXbrl.qnameConcepts.get(priItemQname)
+                        conceptNotAbstract = concept is None or not concept.isAbstract
+                        fact = None
+                        value = None
+                        fp = FactPrototype(self, cellAspectValues)
+                        if conceptNotAbstract:
+                            # reduce set of matchable facts to those with pri item qname and have dimension aspects
+                            facts = self.modelXbrl.factsByQname(priItemQname, set()) if priItemQname else self.modelXbrl.factsInInstance
+                            if self.hasTableFilters:
+                                facts = self.modelTable.filterFacts(self.rendrCntx, facts)
+                            for aspect in matchableAspects:  # trim down facts with explicit dimensions match or just present
+                                if isinstance(aspect, QName):
+                                    aspectValue = cellAspectValues.get(aspect, None)
+                                    if isinstance(aspectValue, ModelDimensionValue):
+                                        if aspectValue.isExplicit:
+                                            dimMemQname = aspectValue.memberQname # match facts with this explicit value
+                                        else:
+                                            dimMemQname = None  # match facts that report this dimension
+                                    elif isinstance(aspectValue, QName): 
+                                        dimMemQname = aspectValue  # match facts that have this explicit value
+                                    elif aspectValue is None: # match typed dims that don't report this value
+                                        dimMemQname = DEFAULT
+                                    else:
+                                        dimMemQname = None # match facts that report this dimension
+                                    facts = facts & self.modelXbrl.factsByDimMemQname(aspect, dimMemQname)
+                            for fact in facts:
+                                if (all(aspectMatches(self.rendrCntx, fact, fp, aspect) 
+                                        for aspect in matchableAspects) and
+                                    all(fact.context.dimMemberQname(dim,includeDefaults=True) in (dimDefaults[dim], None)
+                                        for dim in cellDefaultedDims)):
+                                    if yStructuralNode.hasValueExpression(xStructuralNode):
+                                        value = yStructuralNode.evalValueExpression(fact, xStructuralNode)
+                                    else:
+                                        value = fact.effectiveValue
+                                    self.factWalkingAction.onFactEvent(fact, value, tblELR)
+                                    break
+
+                        fp.clear()  # dereference
+                    row += 1
+                if not yChildrenFirst:
+                    row = self.bodyCells(row, yStructuralNode, xStructuralNodes, zAspectStructuralNodes, yChildrenFirst, tblELR)
+        return row
+            

--- a/arelle/plugin/EbaCompliance/ViewWalkerRenderedGrid.py
+++ b/arelle/plugin/EbaCompliance/ViewWalkerRenderedGrid.py
@@ -233,6 +233,8 @@ class ViewRenderedGrid:
                                     else:
                                         dimMemQname = None # match facts that report this dimension
                                     facts = facts & self.modelXbrl.factsByDimMemQname(aspect, dimMemQname)
+                                    if len(facts)==0:
+                                        break;
                             for fact in facts:
                                 if (all(aspectMatches(self.rendrCntx, fact, fp, aspect) 
                                         for aspect in matchableAspects) and

--- a/arelle/plugin/EbaCompliance/__init__.py
+++ b/arelle/plugin/EbaCompliance/__init__.py
@@ -12,8 +12,8 @@ from arelle.ModelValue import qname
 from arelle.DialogNewFactItem import getNewFactItemOptions
 from lxml import etree
 from arelle.ViewWinRenderedGrid import ViewRenderedGrid
-from arelle.plugin.EbaCompliance.ViewWalkerRenderedGrid import viewWalkerRenderedGrid
-from arelle.plugin.EbaCompliance.FactWalkingAction import FactWalkingAction
+from .ViewWalkerRenderedGrid import viewWalkerRenderedGrid
+from .FactWalkingAction import FactWalkingAction
 
 EbaURL = "www.eba.europa.eu/xbrl"
 qnFindFilingIndicators = qname("{http://www.eurofiling.info/xbrl/ext/filing-indicators}find:fIndicators")
@@ -165,7 +165,7 @@ def getFactItemOptions(dts, cntlr):
             break
     return newFactItemOptions
 
-def improveEbaComplianceMenuEntender(cntlr, menu):
+def improveEbaComplianceMenuExtender(cntlr, menu):
     # Extend menu with an item for the improve compliance menu
     menu.add_command(label=_("Improve EBA compliance"), 
                      underline=0, 
@@ -193,5 +193,5 @@ __pluginInfo__ = {
     'author': 'Gregorio Mongelli (Acsone S. A.)',
     'copyright': '(c) Copyright 2014 Acsone S. A.',
     # classes of mount points (required)
-    'CntlrWinMain.Menu.Tools': improveEbaComplianceMenuEntender
+    'CntlrWinMain.Menu.Tools': improveEbaComplianceMenuExtender
 }

--- a/arelle/plugin/EbaCompliance/__init__.py
+++ b/arelle/plugin/EbaCompliance/__init__.py
@@ -19,7 +19,7 @@ from .FactWalkingAction import FactWalkingAction
 EbaURL = "www.eba.europa.eu/xbrl"
 qnFindFilingIndicators = qname("{http://www.eurofiling.info/xbrl/ext/filing-indicators}find:fIndicators")
 qnFindFilingIndicator = qname("{http://www.eurofiling.info/xbrl/ext/filing-indicators}find:filingIndicator")
-
+qnPercentItemType = qname("{http://www.xbrl.org/dtr/type/numeric}num:percentItemType")
 
 def improveEbaCompliance(dts, cntlr, lang="en"):
     ':type dts: ModelXbrl'
@@ -226,18 +226,22 @@ def ebaDecimals(locale, value, concept, defaultDecimals):
     :type defaultDecimals: str
     :rtype (boolean, str)
     '''
-    isPure = not(concept.isMonetary) and not(concept.isShares)
+    isPercent = concept.typeQname == qnPercentItemType
     isInteger = XbrlConst.isIntegerXsdType(concept.type.baseXsdType)
+    isMonetary = concept.isMonetary
     decimalsFound, decimals = decimalsComputer(locale, value, concept, defaultDecimals)
     if not(decimalsFound) or decimals == 'INF':
         return (decimalsFound, decimals)
     else:
-        lowerBound = -3
+        # the default values are for non-monetary items
+        lowerBound = -20
         upperBound = 20
         decimalsAsInteger = int(decimals)
-        if isInteger:
+        if isMonetary:
+            lowerBound = -3
+        elif isInteger:
             lowerBound = upperBound = 0
-        elif isPure: # percent or ratio values
+        elif isPercent: # percent values
             lowerBound = 4
             upperBound = 20
         if decimalsAsInteger<lowerBound:

--- a/arelle/plugin/EbaCompliance/__init__.py
+++ b/arelle/plugin/EbaCompliance/__init__.py
@@ -131,12 +131,14 @@ def removeUselessFilingIndicatorsInModel(dts):
     filingIndicatorsElements = dts.factsByQname(qnFindFilingIndicators, set())
     for fact in filingIndicatorsElements:
         dts.factsInInstance.remove(fact)
+        dts.factIndex.deleteFact(fact)
         dts.facts.remove(fact)
         if fact in dts.undefinedFacts:
             dts.undefinedFacts.remove(fact)
     filingIndicatorElements = dts.factsByQname(qnFindFilingIndicator, set())
     for fact in filingIndicatorElements:
         dts.factsInInstance.remove(fact)
+        dts.factIndex.deleteFact(fact)
         # non-top-level elements are not in 'facts'
 
 def createFilingIndicatorsElement(dts, newFactItemOptions):

--- a/arelle/plugin/EbaCompliance/improveEBACompliance.py
+++ b/arelle/plugin/EbaCompliance/improveEBACompliance.py
@@ -1,0 +1,185 @@
+'''
+Improve the EBA compliance of the currently loaded facts.
+
+For the time being, there is only one improvement that is implemented:
+1. The filing indicators are regenerated using a fixed context with ID "c".
+
+(c) Copyright 2014 Acsone S. A., All rights reserved.
+'''
+
+from arelle import ModelDocument, XmlValidate, ModelXbrl
+from arelle.ModelValue import qname
+from arelle.DialogNewFactItem import getNewFactItemOptions
+from lxml import etree
+from arelle.ViewWinRenderedGrid import ViewRenderedGrid
+from arelle.plugin.EbaCompliance.ViewWalkerRenderedGrid import viewWalkerRenderedGrid
+from arelle.plugin.EbaCompliance.FactWalkingAction import FactWalkingAction
+
+EbaURL = "www.eba.europa.eu/xbrl"
+qnFindFilingIndicators = qname("{http://www.eurofiling.info/xbrl/ext/filing-indicators}find:fIndicators")
+qnFindFilingIndicator = qname("{http://www.eurofiling.info/xbrl/ext/filing-indicators}find:filingIndicator")
+
+
+def improveEbaCompliance(dts, cntlr, lang="en"):
+    ':type dts: ModelXbrl'
+    try:
+        if not isEbaInstance(dts):
+            dts.modelManager.showStatus(_("Only applicable to EBA instances"), 5000)
+            return
+        dts.modelManager.showStatus(_("Improving the EBA compliance"))
+        factWalkingAction = FactWalkingAction(dts)
+        newFactItemOptions = getFactItemOptions(dts, cntlr)
+        if not newFactItemOptions:
+            return
+        from arelle import XbrlConst
+        from arelle.ModelRenderingObject import ModelEuTable, ModelTable
+        
+        class nonTkBooleanVar():
+            def __init__(self, value=True):
+                self.value = value
+            def set(self, value):
+                self.value = value
+            def get(self):
+                return self.value
+        class View():
+            def __init__(self, tableOrELR, ignoreDimValidity, xAxisChildrenFirst, yAxisChildrenFirst):
+                self.tblELR = tableOrELR
+                # context menu boolean vars (non-tkinter boolean)
+                self.ignoreDimValidity = nonTkBooleanVar(value=ignoreDimValidity)
+                self.xAxisChildrenFirst = nonTkBooleanVar(value=xAxisChildrenFirst)
+                self.yAxisChildrenFirst = nonTkBooleanVar(value=yAxisChildrenFirst)
+
+        groupTableRels = dts.modelXbrl.relationshipSet(XbrlConst.euGroupTable)
+        modelTables = []
+
+
+        def viewTable(modelTable, factWalkingAction):
+            if isinstance(modelTable, (ModelEuTable, ModelTable)):
+                # status
+                dts.modelManager.cntlr.addToLog("improving: " + modelTable.id)
+
+                viewWalkerRenderedGrid(dts,
+                                       factWalkingAction,
+                                       lang=lang,
+                                       viewTblELR=modelTable,
+                                       sourceView=View(modelTable, False, False, True))
+
+            for rel in groupTableRels.fromModelObject(modelTable):
+                viewTable(rel.toModelObject, factWalkingAction)
+
+    
+        for rootConcept in groupTableRels.rootConcepts:
+            sourceline = 0
+            for rel in dts.modelXbrl.relationshipSet(XbrlConst.euGroupTable).fromModelObject(rootConcept):
+                sourceline = rel.sourceline
+                break
+            modelTables.append((rootConcept, sourceline))
+            
+        for modelTable, order in sorted(modelTables, key=lambda x: x[1]):  # @UnusedVariable
+            viewTable(modelTable, factWalkingAction)
+
+        createOrReplaceFilingIndicators(dts, factWalkingAction.allFilingIndicatorCodes, newFactItemOptions)
+        dts.modelManager.showStatus(_("EBA compliance improved"), 5000)
+    except Exception as ex:
+        dts.error("exception",
+            _("EBA compliance improvements generation exception: %(error)s"), error=ex,
+            modelXbrl=dts,
+            exc_info=True)
+
+def isEbaInstance(dts):
+    if dts.modelDocument.type == ModelDocument.Type.INSTANCE:
+        doc = dts.modelDocument.xmlDocument
+        for el in doc.iter("*"):
+            if isinstance(el, etree._Element):
+                for _, NS in _DICT_SET(el.nsmap.items()):  # @UndefinedVariable
+                    if EbaURL in NS:
+                        return True;
+        return False
+    else:
+        return False
+
+def createOrReplaceFilingIndicators(dts, allFilingIndicatorCodes, newFactItemOptions):
+    filingIndicatorsElements = dts.factsByQname(qnFindFilingIndicators, set())
+    if len(filingIndicatorsElements)>0:
+        filingIndicatorsElement = filingIndicatorsElements.pop()
+    else:
+        filingIndicatorsElement = None
+    if filingIndicatorsElement is not None:
+        parent = filingIndicatorsElement.getparent()
+        parent.remove(filingIndicatorsElement)
+        removeUselessFilingIndicatorContext(dts)
+        XmlValidate.validate(dts, parent) # must validate after content is deleted
+    if len(allFilingIndicatorCodes)>0:
+        filingIndicatorsElement = createFilingIndicatorsElement(dts, newFactItemOptions)
+        for filingIndicatorCode in allFilingIndicatorCodes:
+            dts.createFact(qnFindFilingIndicator, 
+                           parent=filingIndicatorsElement,
+                           attributes={"contextRef": "c"}, 
+                           text=filingIndicatorCode,
+                           validate=False)
+        XmlValidate.validate(dts, filingIndicatorsElement) # must validate after content is created
+
+def removeUselessFilingIndicatorContext(dts):
+    ''':type dts: ModelXbrl'''
+    context = dts.contexts["c"]
+    parent = context.getparent()
+    parent.remove(context)
+    del dts.contexts["c"]
+
+def createFilingIndicatorsElement(dts, newFactItemOptions):
+    dts.createContext(newFactItemOptions.entityIdentScheme,
+        newFactItemOptions.entityIdentValue,
+        'instant',
+        None,
+        newFactItemOptions.endDateDate,
+        None, # no dimensional validity checking (like formula does)
+        {}, [], [],
+        id='c',
+        afterSibling=ModelXbrl.AUTO_LOCATE_ELEMENT)
+    filingIndicatorsTuple = dts.createFact(qnFindFilingIndicators,
+                                           validate=False)
+    return filingIndicatorsTuple
+
+def getFactItemOptions(dts, cntlr):
+    newFactItemOptions = None
+    for view in dts.views:
+        if isinstance(view, ViewRenderedGrid):
+            if (not view.newFactItemOptions.entityIdentScheme or  # not initialized yet
+            not view.newFactItemOptions.entityIdentValue or
+            not view.newFactItemOptions.startDateDate or not view.newFactItemOptions.endDateDate):
+                if not getNewFactItemOptions(cntlr, view.newFactItemOptions):
+                    return None
+            newFactItemOptions = view.newFactItemOptions
+            break
+    return newFactItemOptions
+
+def improveEbaComplianceMenuEntender(cntlr, menu):
+    # Extend menu with an item for the improve compliance menu
+    menu.add_command(label=_("Improve EBA compliance"), 
+                     underline=0, 
+                     command=lambda: improveEbaComplianceMenuCommand(cntlr) )
+
+def improveEbaComplianceMenuCommand(cntlr):
+    # improve EBA compliance menu item has been invoked
+    if cntlr.modelManager is None or cntlr.modelManager.modelXbrl is None:
+        cntlr.addToLog("No DTS loaded.")
+        return
+    dts = cntlr.modelManager.modelXbrl
+    getFactItemOptions(dts, cntlr)
+    import threading
+    thread = threading.Thread(target=lambda 
+                                  _dts=dts: 
+                                        improveEbaCompliance(_dts, cntlr))
+    thread.daemon = True
+    thread.start()
+
+__pluginInfo__ = {
+    'name': 'Improve EBA compliance of XBRL instances',
+    'version': '1.0',
+    'description': "This module regenerates EBA filing indicators if needed.",
+    'license': 'Apache-2',
+    'author': 'Gregorio Mongelli (Acsone S. A.)',
+    'copyright': '(c) Copyright 2014 Acsone S. A.',
+    # classes of mount points (required)
+    'CntlrWinMain.Menu.Tools': improveEbaComplianceMenuEntender
+}

--- a/arelle/plugin/sphinx/SphinxContext.py
+++ b/arelle/plugin/sphinx/SphinxContext.py
@@ -268,7 +268,7 @@ class HyperspaceBinding:
             if hsAxis.restriction:
                 restriction = evaluate(hsAxis.restriction, self.sCtx, value=True)
                 if aspect == Aspect.CONCEPT:
-                    aspectQualifiedFacts = [modelXbrl.factsByQname[qn]
+                    aspectQualifiedFacts = [modelXbrl.factsByQname(qn)
                                             for qn in restriction
                                             if isinstance(qn, QName)]
                     facts = facts & set.union(*aspectQualifiedFacts) if aspectQualifiedFacts else set()

--- a/arelle/plugin/streamingExtensions.py
+++ b/arelle/plugin/streamingExtensions.py
@@ -494,6 +494,7 @@ def dropFact(modelXbrl, fact, facts):
     while fact.modelTupleFacts:
         dropFact(modelXbrl, fact.modelTupleFacts[0], fact.modelTupleFacts)
     modelXbrl.factsInInstance.discard(fact)
+    modelXbrl.factIndex.deleteFact(fact)
     facts.remove(fact)
     modelXbrl.modelObjects[fact.objectIndex] = None # objects found by index, can't remove position from list
     fact.modelDocument.modelObjects.remove(fact)

--- a/arelle/plugin/validateEBA.py
+++ b/arelle/plugin/validateEBA.py
@@ -150,187 +150,147 @@ def final(val):
                             _("Successful XBRL facts sum of md5s."),
                             modelObject=modelXbrl)
             
-            numFilingIndicatorTuples = len(modelXbrl.factsByQname(qnFIndicators, ()))
-            if numFilingIndicatorTuples > 1:
-                modelXbrl.info("EBA.1.6.2",                            
-                        _('Multiple filing indicators tuples when not in streaming mode (info).'),
-                        modelObject=modelXbrl.factsByQname(qnFIndicators))
-                        
-            # note EBA 2.1 is in ModelDocument.py
-            
-            cntxIDs = set()
-            cntxEntities = set()
-            cntxDates = defaultdict(list)
-            timelessDatePattern = re.compile(r"\s*([0-9]{4})-([0-9]{2})-([0-9]{2})\s*$")
-            for cntx in modelXbrl.contexts.values():
-                cntxIDs.add(cntx.id)
-                cntxEntities.add(cntx.entityIdentifier)
-                dateElts = XmlUtil.descendants(cntx, XbrlConst.xbrli, ("startDate","endDate","instant"))
-                if any(not timelessDatePattern.match(e.textValue) for e in dateElts):
-                    modelXbrl.error("EBA.2.10",
-                            _('Period dates must be whole dates without time or timezone: %(dates)s.'),
-                            modelObject=cntx, dates=", ".join(e.text for e in dateElts))
-                if cntx.isForeverPeriod:
-                    modelXbrl.error("EBA.2.11",
-                            _('Forever context period is not allowed.'),
-                            modelObject=cntx)
-                elif cntx.isStartEndPeriod:
-                    modelXbrl.error("EBA.2.13",
-                            _('Start-End (flow) context period is not allowed.'),
-                            modelObject=cntx)
-                elif cntx.isInstantPeriod:
-                    cntxDates[cntx.instantDatetime].append(cntx)
-                if XmlUtil.hasChild(cntx, XbrlConst.xbrli, "segment"):
-                    modelXbrl.error("EBA.2.14",
-                        _("The segment element not allowed in context Id: %(context)s"),
-                        modelObject=cntx, context=cntx.contextID)
-                for scenElt in XmlUtil.descendants(cntx, XbrlConst.xbrli, "scenario"):
-                    childTags = ", ".join([child.prefixedName for child in scenElt.iterchildren()
-                                           if isinstance(child,ModelObject) and 
-                                           child.tag != "{http://xbrl.org/2006/xbrldi}explicitMember" and
-                                           child.tag != "{http://xbrl.org/2006/xbrldi}typedMember"])
-                    if len(childTags) > 0:
-                        modelXbrl.error("EBA.2.15",
-                            _("Scenario of context Id %(context)s has disallowed content: %(content)s"),
-                            modelObject=cntx, context=cntx.id, content=childTags)
-            if len(cntxDates) > 1:
-                modelXbrl.error("EBA.2.13",
-                        _('Contexts must have the same date: %(dates)s.'),
-                        modelObject=[_cntx for _cntxs in cntxDates.values() for _cntx in _cntxs], 
-                        dates=', '.join(XmlUtil.dateunionValue(_dt, subtractOneDay=True)
-                                                               for _dt in cntxDates.keys()))
-                
-            unusedCntxIDs = cntxIDs - {fact.contextID 
-                                       for fact in modelXbrl.factsInInstance
-                                       if fact.contextID} # skip tuples
-            if unusedCntxIDs:
-                modelXbrl.warning("EBA.2.7",
-                        _('Unused xbrli:context nodes SHOULD NOT be present in the instance: %(unusedContextIDs)s.'),
-                        modelObject=[modelXbrl.contexts[unusedCntxID] for unusedCntxID in unusedCntxIDs], 
-                        unusedContextIDs=", ".join(sorted(unusedCntxIDs)))
-    
-            if len(cntxEntities) > 1:
-                modelXbrl.warning("EBA.2.9",
-                        _('All entity identifiers and schemes must be the same, %(count)s found: %(entities)s.'),
-                        modelObject=modelDocument, count=len(cntxEntities), 
-                        entities=", ".join(sorted(str(cntxEntity) for cntxEntity in cntxEntities)))
-                
-            otherFacts = {} # (contextHash, unitHash, xmlLangHash) : fact
-            nilFacts = []
-            stringFactsWithoutXmlLang = []
-            nonMonetaryNonPureFacts = []
-            unitIDsUsed = set()
-            currenciesUsed = {}
-            for qnameString, facts in modelXbrl.factsByQnameAll():
-                for f in facts:
-                    if modelXbrl.skipDTS:
-                        c = f.qname.localName[0]
-                        isNumeric = c in ('m', 'p', 'i')
-                        isMonetary = c == 'm'
-                        isInteger = c == 'i'
-                        isPercent = c == 'p'
-                        isString = c == 's'
-                    else:
-                        concept = f.concept
-                        if concept is not None:
-                            isNumeric = concept.isNumeric
-                            isMonetary = concept.isMonetary
-                            isInteger = concept.baseXbrliType in integerItemTypes
-                            isPercent = concept.typeQname == qnPercentItemType
-                            isString = concept.baseXbrliType in ("stringItemType", "normalizedStringItemType")
-                        else:
-                            isNumeric = isString = False # error situation
-                    k = (f.getparent().objectIndex,
-                         f.qname,
-                         f.context.contextDimAwareHash if f.context is not None else None,
-                         f.unit.hash if f.unit is not None else None,
-                         hash(f.xmlLang))
-                    if f.qname == qnFIndicators and val.validateEIOPA:
-                        pass
-                    elif k not in otherFacts:
-                        otherFacts[k] = {f}
-                    else:
-                        matches = [o
-                                   for o in otherFacts[k]
-                                   if (f.getparent().objectIndex == o.getparent().objectIndex and
-                                       f.qname == o.qname and
-                                       f.context.isEqualTo(o.context) if f.context is not None and o.context is not None else True) and
-                                      (f.unit.isEqualTo(o.unit) if f.unit is not None and o.unit is not None else True) and
-                                      (f.xmlLang == o.xmlLang)]
-                        if matches:
-                            contexts = [f.contextID] + [o.contextID for o in matches]
-                            modelXbrl.error("EBA.2.16",
-                                            _('Facts are duplicates %(fact)s contexts %(contexts)s.'),
-                                            modelObject=[f] + matches, fact=f.qname, contexts=', '.join(contexts))
-                        else:
-                            otherFacts[k].add(f)
-                    if isNumeric:
-                        if f.precision:
-                            modelXbrl.error("EBA.2.17",
-                                _("Numeric fact %(fact)s of context %(contextID)s has a precision attribute '%(precision)s'"),
-                                modelObject=f, fact=f.qname, contextID=f.contextID, precision=f.precision)
-                        if f.decimals and f.decimals != "INF":
+        otherFacts = {} # (contextHash, unitHash, xmlLangHash) : fact
+        nilFacts = []
+        stringFactsWithoutXmlLang = []
+        nonMonetaryNonPureFacts = []
+        unitIDsUsed = set()
+        currenciesUsed = {}
+        for f in modelXbrl.factsInInstance:
+            concept = f.concept
+            k = (f.getparent().objectIndex,
+                 f.concept.objectIndex,
+                 f.context.contextDimAwareHash if f.context is not None else None,
+                 f.unit.hash if f.unit is not None else None,
+                 hash(f.xmlLang))
+            if concept.qname == qnFilingIndicator and val.validateEIOPA:
+                pass
+            elif k not in otherFacts:
+                otherFacts[k] = {f}
+            else:
+                matches = [o
+                           for o in otherFacts[k]
+                           if (f.getparent().objectIndex == o.getparent().objectIndex and
+                               f.concept.objectIndex == o.concept.objectIndex and
+                               f.context.isEqualTo(o.context) if f.context is not None and o.context is not None else True) and
+                              (f.unit.isEqualTo(o.unit) if f.unit is not None and o.unit is not None else True) and
+                              (f.xmlLang == o.xmlLang)]
+                if matches:
+                    contexts = [f.contextID] + [o.contextID for o in matches]
+                    modelXbrl.error("EBA.2.16",
+                                    _('Facts are duplicates %(fact)s contexts %(contexts)s.'),
+                                    modelObject=[f] + matches, fact=f.qname, contexts=', '.join(contexts))
+                else:
+                    otherFacts[k].add(f)    
+            if concept is not None:
+                if concept.isNumeric:
+                    if f.precision:
+                        modelXbrl.error("EBA.2.17",
+                            _("Numeric fact %(fact)s of context %(contextID)s has a precision attribute '%(precision)s'"),
+                            modelObject=f, fact=f.qname, contextID=f.contextID, precision=f.precision)
+                    if f.decimals and f.decimals != "INF":
+                        try:
+                            dec = int(f.decimals)
+                            if concept.isMonetary:
+                                if dec < -3:
+                                    modelXbrl.error("EBA.2.17",
+                                        _("Monetary fact %(fact)s of context %(contextID)s has a decimal attribute < -3: '%(decimals)s'"),
+                                        modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
+                            elif concept.baseXbrliType in integerItemTypes:
+                                if dec != 0:
+                                    modelXbrl.error("EBA.2.17",
+                                        _("Integer fact %(fact)s of context %(contextID)s has a decimal attribute \u2260 0: '%(decimals)s'"),
+                                        modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
+                            elif concept.typeQname == qnPercentItemType:
+                                if dec < 4:
+                                    modelXbrl.error("EBA.2.17",
+                                        _("Percent fact %(fact)s of context %(contextID)s has a decimal attribute < 4: '%(decimals)s'"),
+                                        modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
+                        except ValueError:
+                            pass # should have been reported as a schema error by loader
+                        '''' (not intended by EBA 2.18)
+                        if not f.isNil and getattr(f,"xValid", 0) == 4:
                             try:
-                                dec = int(f.decimals)
-                                if isMonetary:
-                                    if dec < -3:
-                                        modelXbrl.error("EBA.2.17",
-                                            _("Monetary fact %(fact)s of context %(contextID)s has a decimal attribute < -3: '%(decimals)s'"),
-                                            modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
-                                elif isInteger:
-                                    if dec != 0:
-                                        modelXbrl.error("EBA.2.17",
-                                            _("Integer fact %(fact)s of context %(contextID)s has a decimal attribute \u2260 0: '%(decimals)s'"),
-                                            modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
-                                elif isPercent:
-                                    if dec < 4:
-                                        modelXbrl.error("EBA.2.17",
-                                            _("Percent fact %(fact)s of context %(contextID)s has a decimal attribute < 4: '%(decimals)s'"),
-                                            modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
-                            except ValueError:
-                                pass # should have been reported as a schema error by loader
-                            '''' (not intended by EBA 2.18, paste here is from EFM)
-                            if not f.isNil and getattr(f,"xValid", 0) == 4:
-                                try:
-                                    insignificance = insignificantDigits(f.xValue, decimals=f.decimals)
-                                    if insignificance: # if not None, returns (truncatedDigits, insiginficantDigits)
-                                        modelXbrl.error(("EFM.6.05.37", "GFM.1.02.26"),
-                                            _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s has nonzero digits in insignificant portion %(insignificantDigits)s."),
-                                            modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, 
-                                            value=f1.xValue, truncatedDigits=insignificance[0], insignificantDigits=insignificance[1])
-                                except (ValueError,TypeError):
-                                    modelXbrl.error(("EBA.2.18"),
-                                        _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s causes Value Error exception."),
-                                        modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, value=f1.value)
-                            '''
-                        unit = f.unit
-                        if unit is not None:
-                            if isMonetary:
-                                if unit.measures[0]:
-                                    currenciesUsed[unit.measures[0][0]] = unit
-                            elif not unit.isSingleMeasure or unit.measures[0][0] != XbrlConst.qnXbrliPure:
-                                nonMonetaryNonPureFacts.append(f)
-                    elif isString: 
-                        if not f.xmlLang:
-                            stringFactsWithoutXmlLang.append(f)
-                                
-                    if f.unitID is not None:
-                        unitIDsUsed.add(f.unitID)
-                    if f.isNil:
-                        nilFacts.append(f)
+                                insignificance = insignificantDigits(f.xValue, decimals=f.decimals)
+                                if insignificance: # if not None, returns (truncatedDigits, insiginficantDigits)
+                                    modelXbrl.error(("EFM.6.05.37", "GFM.1.02.26"),
+                                        _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s has nonzero digits in insignificant portion %(insignificantDigits)s."),
+                                        modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, 
+                                        value=f1.xValue, truncatedDigits=insignificance[0], insignificantDigits=insignificance[1])
+                            except (ValueError,TypeError):
+                                modelXbrl.error(("EBA.2.18"),
+                                    _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s causes Value Error exception."),
+                                    modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, value=f1.value)
+                        '''
+                    unit = f.unit
+                    if unit is not None:
+                        if concept.isMonetary:
+                            if unit.measures[0]:
+                                currenciesUsed[unit.measures[0][0]] = unit
+                        elif not unit.isSingleMeasure or unit.measures[0][0] != XbrlConst.qnXbrliPure:
+                            nonMonetaryNonPureFacts.append(f)
+                elif concept.baseXbrliType in ("stringItemType", "normalizedStringItemType"): 
+                    if not f.xmlLang:
+                        stringFactsWithoutXmlLang.append(f)
                         
-            if nilFacts:
-                modelXbrl.error("EBA.2.19",
-                        _('Nil facts MUST NOT be present in the instance: %(nilFacts)s.'),
-                        modelObject=nilFacts, nilFacts=", ".join(str(f.qname) for f in nilFacts))
-            if stringFactsWithoutXmlLang:
-                modelXbrl.error("EBA.2.20",
-                                _("String facts need to report xml:lang: '%(langLessFacts)s'"),
-                                modelObject=stringFactsWithoutXmlLang, langLEssFacts=", ".join(str(f.qname) for f in stringFactsWithoutXmlLang))
-            if nonMonetaryNonPureFacts:
-                modelXbrl.error("EBA.3.2",
-                                _("Non monetary (numeric) facts MUST use the pure unit: '%(langLessFacts)s'"),
-                                modelObject=nonMonetaryNonPureFacts, langLessFacts=", ".join(str(f.qname) for f in nonMonetaryNonPureFacts))
+            if f.unitID is not None:
+                unitIDsUsed.add(f.unitID)
+            if f.isNil:
+                nilFacts.append(f)
+                
+        if nilFacts:
+            modelXbrl.error("EBA.2.19",
+                    _('Nil facts MUST NOT be present in the instance: %(nilFacts)s.'),
+                    modelObject=nilFacts, nilFacts=", ".join(str(f.qname) for f in nilFacts))
+        if stringFactsWithoutXmlLang:
+            modelXbrl.error("EBA.2.20",
+                            _("String facts need to report xml:lang: '%(langLessFacts)s'"),
+                            modelObject=stringFactsWithoutXmlLang, langLEssFacts=", ".join(str(f.qname) for f in stringFactsWithoutXmlLang))
+        if nonMonetaryNonPureFacts:
+            modelXbrl.error("EBA.3.2",
+                            _("Non monetary (numeric) facts MUST use the pure unit: '%(langLessFacts)s'"),
+                            modelObject=nonMonetaryNonPureFacts, langLessFacts=", ".join(str(f.qname) for f in nonMonetaryNonPureFacts))
+            
+        unusedUnitIDs = modelXbrl.units.keys() - unitIDsUsed
+        if unusedUnitIDs:
+            modelXbrl.warning("EBA.2.21",
+                    _('Unused xbrli:unit nodes SHOULD NOT be present in the instance: %(unusedUnitIDs)s.'),
+                    modelObject=[modelXbrl.units[unusedUnitID] for unusedUnitID in unusedUnitIDs], 
+                    unusedUnitIDs=", ".join(sorted(unusedUnitIDs)))
+                    
+        unitHashes = {}
+        for unit in modelXbrl.units.values():
+            h = hash(unit)
+            if h in unitHashes and unit.isEqualTo(unitHashes[h]):
+                modelXbrl.warning("EBA.2.32",
+                    _("Duplicate units SHOULD NOT be reported, units %(unit1)s and %(unit2)s have same measures.'"),
+                    modelObject=(unit, unitHashes[h]), unit1=unit.id, unit2=unitHashes[h].id)
+            else:
+                unitHashes[h] = unit
+        if len(currenciesUsed) > 1:
+            modelXbrl.error("EBA.3.1",
+                _("There MUST be only one currency but %(numCurrencies)s were found: %(currencies)s.'"),
+                modelObject=currenciesUsed.values(), numCurrencies=len(currenciesUsed), currencies=", ".join(str(c) for c in currenciesUsed.keys()))
+            
+        namespacePrefixesUsed = defaultdict(set)
+        prefixesUnused = set(modelDocument.xmlRootElement.keys()).copy()
+        for elt in modelDocument.xmlRootElement.iter():
+            if isinstance(elt, ModelObject): # skip comments and processing instructions
+                namespacePrefixesUsed[elt.qname.namespaceURI].add(elt.qname.prefix)
+                prefixesUnused.discard(elt.qname.prefix)
+        if prefixesUnused:
+            modelXbrl.warning("EBA.3.4",
+                _("There SHOULD be no unused prefixes but these were declared: %(unusedPrefixes)s.'"),
+                modelObject=modelDocument, unusedPrefixes=', '.join(sorted(prefixesUnused)))
+        for ns, prefixes in namespacePrefixesUsed.items():
+            nsDocs = modelXbrl.namespaceDocs.get(ns)
+            if nsDocs:
+                for nsDoc in nsDocs:
+                    nsDocPrefix = XmlUtil.xmlnsprefix(nsDoc.xmlRootElement, ns)
+                    if any(prefix != nsDocPrefix for prefix in prefixes if prefix is not None):
+                        modelXbrl.warning("EBA.3.5",
+                            _("Prefix for namespace %(namespace)s is %(declaredPrefix)s but these were found %(foundPrefixes)s"),
+                            modelObject=modelDocument, namespace=ns, declaredPrefix=nsDocPrefix, foundPrefixes=', '.join(sorted(prefixes - {None})))                        
                 
             unusedUnitIDs = modelXbrl.units.keys() - unitIDsUsed
             if unusedUnitIDs:

--- a/arelle/plugin/validateEBA.py
+++ b/arelle/plugin/validateEBA.py
@@ -113,8 +113,7 @@ def final(val):
                     modelObject=schemaRefElts, entryPointCount=len(schemaRefElts))
         filingIndicators = {}
         for fIndicator in modelXbrl.factsByQname(qnFilingIndicator):
-            _value = (fIndicator.xValue or fIndicator.value) # use validated xValue if DTS else value for skipDTS 
-            if _value in filingIndicators:
+            if fIndicator.xValue in filingIndicators:
                 modelXbrl.error("EBA.1.6.1",
                         _('Multiple filing indicators facts for indicator %(filingIndicator)s.'),
                         modelObject=(fIndicator, filingIndicators[_value]), filingIndicator=_value)

--- a/arelle/plugin/validateEBA.py
+++ b/arelle/plugin/validateEBA.py
@@ -117,8 +117,8 @@ def final(val):
             if _value in filingIndicators:
                 modelXbrl.error("EBA.1.6.1",
                         _('Multiple filing indicators facts for indicator %(filingIndicator)s.'),
-                        modelObject=(fIndicator, filingIndicators[_value]), filingIndicator=_value)
-            filingIndicators[_value] = fIndicator
+                        modelObject=(fIndicator, filingIndicators[fIndicator.xValue]), filingIndicator=fIndicator.xValue)
+            filingIndicators[fIndicator.xValue] = fIndicator
         
         if not filingIndicators:
             modelXbrl.error("EBA.1.6",

--- a/arelle/plugin/validateEBA.py
+++ b/arelle/plugin/validateEBA.py
@@ -112,7 +112,7 @@ def final(val):
                     _('Any reported XBRL instance document MUST contain only one xbrli:xbrl/link:schemaRef node, but %(entryPointCount)s.'),
                     modelObject=schemaRefElts, entryPointCount=len(schemaRefElts))
         filingIndicators = {}
-        for fIndicator in modelXbrl.factsByQname(qnFilingIndicator):
+        for fIndicator in modelXbrl.factsByQname(qnFilingIndicator, ()):
             if fIndicator.xValue in filingIndicators:
                 modelXbrl.error("EBA.1.6.1",
                         _('Multiple filing indicators facts for indicator %(filingIndicator)s.'),
@@ -124,7 +124,7 @@ def final(val):
                     _('Missing filing indicators.  Reported XBRL instances MUST include appropriate filing indicator elements'),
                     modelObject=modelDocument)
             
-        numFilingIndicatorTuples = len(modelXbrl.factsByQname(qnFilingIndicators))
+        numFilingIndicatorTuples = len(modelXbrl.factsByQname(qnFilingIndicators, ()))
         if numFilingIndicatorTuples > 1 and not getattr(modelXbrl, "isStreamingMode", False):
             modelXbrl.info("EBA.1.6.2",                            
                     _('Multiple filing indicators tuples when not in streaming mode (info).'),
@@ -179,199 +179,57 @@ def final(val):
         unitIDsUsed = set()
         currenciesUsed = {}
         for facts in modelXbrl.factsInInstance:
-            for f in facts:
-                concept = f.concept
-                k = (f.context.contextDimAwareHash if f.context is not None else None,
-                     f.unit.hash if f.unit is not None else None,
-                     hash(f.xmlLang))
-                if k not in otherFacts:
-                    otherFacts[k] = {f}
+            f = facts
+            concept = f.concept
+            k = (f.context.contextDimAwareHash if f.context is not None else None,
+                 f.unit.hash if f.unit is not None else None,
+                 hash(f.xmlLang))
+            if k not in otherFacts:
+                otherFacts[k] = {f}
+            else:
+                matches = [o
+                           for o in otherFacts[k]
+                           if f.qname == o.qname and
+                              (f.context.isEqualTo(o.context) if f.context is not None and o.context is not None else True) and
+                              (f.unit.isEqualTo(o.unit) if f.unit is not None and o.unit is not None else True) and
+                              (f.xmlLang == o.xmlLang)]
+                if matches:
+                    modelXbrl.error("EBA.2.16",
+                                    _('Facts are duplicates %(fact)s and %(otherFacts)s.'),
+                                    modelObject=[f] + matches, fact=f.qname, otherFacts=', '.join(str(f.qname) for f in matches))
                 else:
-                    modelXbrl.info("info",
-                            _("Successful XBRL facts sum of md5s."),
-                            modelObject=modelXbrl)
-            
-            numFilingIndicatorTuples = len(modelXbrl.factsByQname[qnFIndicators])
-            if numFilingIndicatorTuples > 1:
-                modelXbrl.info("EBA.1.6.2",                            
-                        _('Multiple filing indicators tuples when not in streaming mode (info).'),
-                        modelObject=modelXbrl.factsByQname[qnFIndicators])
-                        
-            # note EBA 2.1 is in ModelDocument.py
-            
-            cntxIDs = set()
-            cntxEntities = set()
-            cntxDates = defaultdict(list)
-            timelessDatePattern = re.compile(r"\s*([0-9]{4})-([0-9]{2})-([0-9]{2})\s*$")
-            for cntx in modelXbrl.contexts.values():
-                cntxIDs.add(cntx.id)
-                cntxEntities.add(cntx.entityIdentifier)
-                dateElts = XmlUtil.descendants(cntx, XbrlConst.xbrli, ("startDate","endDate","instant"))
-                if any(not timelessDatePattern.match(e.textValue) for e in dateElts):
-                    modelXbrl.error("EBA.2.10",
-                            _('Period dates must be whole dates without time or timezone: %(dates)s.'),
-                            modelObject=cntx, dates=", ".join(e.text for e in dateElts))
-                if cntx.isForeverPeriod:
-                    modelXbrl.error("EBA.2.11",
-                            _('Forever context period is not allowed.'),
-                            modelObject=cntx)
-                elif cntx.isStartEndPeriod:
-                    modelXbrl.error("EBA.2.13",
-                            _('Start-End (flow) context period is not allowed.'),
-                            modelObject=cntx)
-                elif cntx.isInstantPeriod:
-                    cntxDates[cntx.instantDatetime].append(cntx)
-                if XmlUtil.hasChild(cntx, XbrlConst.xbrli, "segment"):
-                    modelXbrl.error("EBA.2.14",
-                        _("The segment element not allowed in context Id: %(context)s"),
-                        modelObject=cntx, context=cntx.contextID)
-                for scenElt in XmlUtil.descendants(cntx, XbrlConst.xbrli, "scenario"):
-                    childTags = ", ".join([child.prefixedName for child in scenElt.iterchildren()
-                                           if isinstance(child,ModelObject) and 
-                                           child.tag != "{http://xbrl.org/2006/xbrldi}explicitMember" and
-                                           child.tag != "{http://xbrl.org/2006/xbrldi}typedMember"])
-                    if len(childTags) > 0:
-                        modelXbrl.error("EBA.2.15",
-                            _("Scenario of context Id %(context)s has disallowed content: %(content)s"),
-                            modelObject=cntx, context=cntx.id, content=childTags)
-            if len(cntxDates) > 1:
-                modelXbrl.error("EBA.2.13",
-                        _('Contexts must have the same date: %(dates)s.'),
-                        modelObject=[_cntx for _cntxs in cntxDates.values() for _cntx in _cntxs], 
-                        dates=', '.join(XmlUtil.dateunionValue(_dt, subtractOneDay=True)
-                                                               for _dt in cntxDates.keys()))
+                    otherFacts[k].add(f)    
+            if concept is not None and concept.isNumeric:
+                if f.precision:
+                    modelXbrl.error("EBA.2.17",
+                        _("Numeric fact %(fact)s of context %(contextID)s has a precision attribute '%(precision)s'"),
+                        modelObject=f, fact=f.qname, contextID=f.contextID, precision=f.precision)
+                '''' (not intended by EBA 2.18)
+                if f.decimals and f.decimals != "INF" and not f.isNil and getattr(f,"xValid", 0) == 4:
+                    try:
+                        insignificance = insignificantDigits(f.xValue, decimals=f.decimals)
+                        if insignificance: # if not None, returns (truncatedDigits, insiginficantDigits)
+                            modelXbrl.error(("EFM.6.05.37", "GFM.1.02.26"),
+                                _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s has nonzero digits in insignificant portion %(insignificantDigits)s."),
+                                modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, 
+                                value=f1.xValue, truncatedDigits=insignificance[0], insignificantDigits=insignificance[1])
+                    except (ValueError,TypeError):
+                        modelXbrl.error(("EFM.6.05.37", "GFM.1.02.26"),
+                            _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s causes Value Error exception."),
+                            modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, value=f1.value)
+                '''
+                unit = f.unit
+                if concept.isMonetary and unit is not None and unit.measures[0]:
+                    currenciesUsed[unit.measures[0][0]] = unit
+            if f.unitID is not None:
+                unitIDsUsed.add(f.unitID)
+            if f.isNil:
+                nilFacts.append(f)
                 
-            unusedCntxIDs = cntxIDs - {fact.contextID 
-                                       for fact in modelXbrl.factsInInstance
-                                       if fact.contextID} # skip tuples
-            if unusedCntxIDs:
-                modelXbrl.warning("EBA.2.7",
-                        _('Unused xbrli:context nodes SHOULD NOT be present in the instance: %(unusedContextIDs)s.'),
-                        modelObject=[modelXbrl.contexts[unusedCntxID] for unusedCntxID in unusedCntxIDs], 
-                        unusedContextIDs=", ".join(sorted(unusedCntxIDs)))
-    
-            if len(cntxEntities) > 1:
-                modelXbrl.warning("EBA.2.9",
-                        _('All entity identifiers and schemes must be the same, %(count)s found: %(entities)s.'),
-                        modelObject=modelDocument, count=len(cntxEntities), 
-                        entities=", ".join(sorted(str(cntxEntity) for cntxEntity in cntxEntities)))
-                
-            otherFacts = {} # (contextHash, unitHash, xmlLangHash) : fact
-            nilFacts = []
-            stringFactsWithoutXmlLang = []
-            nonMonetaryNonPureFacts = []
-            unitIDsUsed = set()
-            currenciesUsed = {}
-            for qname, facts in modelXbrl.factsByQname.items():
-                for f in facts:
-                    if modelXbrl.skipDTS:
-                        c = f.qname.localName[0]
-                        isNumeric = c in ('m', 'p', 'i')
-                        isMonetary = c == 'm'
-                        isInteger = c == 'i'
-                        isPercent = c == 'p'
-                        isString = c == 's'
-                    else:
-                        concept = f.concept
-                        if concept is not None:
-                            isNumeric = concept.isNumeric
-                            isMonetary = concept.isMonetary
-                            isInteger = concept.baseXbrliType in integerItemTypes
-                            isPercent = concept.typeQname == qnPercentItemType
-                            isString = concept.baseXbrliType in ("stringItemType", "normalizedStringItemType")
-                        else:
-                            isNumeric = isString = False # error situation
-                    k = (f.getparent().objectIndex,
-                         f.qname,
-                         f.context.contextDimAwareHash if f.context is not None else None,
-                         f.unit.hash if f.unit is not None else None,
-                         hash(f.xmlLang))
-                    if f.qname == qnFIndicators and val.validateEIOPA:
-                        pass
-                    elif k not in otherFacts:
-                        otherFacts[k] = {f}
-                    else:
-                        matches = [o
-                                   for o in otherFacts[k]
-                                   if (f.getparent().objectIndex == o.getparent().objectIndex and
-                                       f.qname == o.qname and
-                                       f.context.isEqualTo(o.context) if f.context is not None and o.context is not None else True) and
-                                      (f.unit.isEqualTo(o.unit) if f.unit is not None and o.unit is not None else True) and
-                                      (f.xmlLang == o.xmlLang)]
-                        if matches:
-                            contexts = [f.contextID] + [o.contextID for o in matches]
-                            modelXbrl.error("EBA.2.16",
-                                            _('Facts are duplicates %(fact)s contexts %(contexts)s.'),
-                                            modelObject=[f] + matches, fact=f.qname, contexts=', '.join(contexts))
-                        else:
-                            otherFacts[k].add(f)
-                    if isNumeric:
-                        if f.precision:
-                            modelXbrl.error("EBA.2.17",
-                                _("Numeric fact %(fact)s of context %(contextID)s has a precision attribute '%(precision)s'"),
-                                modelObject=f, fact=f.qname, contextID=f.contextID, precision=f.precision)
-                        if f.decimals and f.decimals != "INF":
-                            try:
-                                dec = int(f.decimals)
-                                if isMonetary:
-                                    if dec < -3:
-                                        modelXbrl.error("EBA.2.17",
-                                            _("Monetary fact %(fact)s of context %(contextID)s has a decimal attribute < -3: '%(decimals)s'"),
-                                            modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
-                                elif isInteger:
-                                    if dec != 0:
-                                        modelXbrl.error("EBA.2.17",
-                                            _("Integer fact %(fact)s of context %(contextID)s has a decimal attribute \u2260 0: '%(decimals)s'"),
-                                            modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
-                                elif isPercent:
-                                    if dec < 4:
-                                        modelXbrl.error("EBA.2.17",
-                                            _("Percent fact %(fact)s of context %(contextID)s has a decimal attribute < 4: '%(decimals)s'"),
-                                            modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
-                            except ValueError:
-                                pass # should have been reported as a schema error by loader
-                            '''' (not intended by EBA 2.18, paste here is from EFM)
-                            if not f.isNil and getattr(f,"xValid", 0) == 4:
-                                try:
-                                    insignificance = insignificantDigits(f.xValue, decimals=f.decimals)
-                                    if insignificance: # if not None, returns (truncatedDigits, insiginficantDigits)
-                                        modelXbrl.error(("EFM.6.05.37", "GFM.1.02.26"),
-                                            _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s has nonzero digits in insignificant portion %(insignificantDigits)s."),
-                                            modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, 
-                                            value=f1.xValue, truncatedDigits=insignificance[0], insignificantDigits=insignificance[1])
-                                except (ValueError,TypeError):
-                                    modelXbrl.error(("EBA.2.18"),
-                                        _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s causes Value Error exception."),
-                                        modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, value=f1.value)
-                            '''
-                        unit = f.unit
-                        if unit is not None:
-                            if isMonetary:
-                                if unit.measures[0]:
-                                    currenciesUsed[unit.measures[0][0]] = unit
-                            elif not unit.isSingleMeasure or unit.measures[0][0] != XbrlConst.qnXbrliPure:
-                                nonMonetaryNonPureFacts.append(f)
-                    elif isString: 
-                        if not f.xmlLang:
-                            stringFactsWithoutXmlLang.append(f)
-                                
-                    if f.unitID is not None:
-                        unitIDsUsed.add(f.unitID)
-                    if f.isNil:
-                        nilFacts.append(f)
-                        
-            if nilFacts:
-                modelXbrl.error("EBA.2.19",
-                        _('Nil facts MUST NOT be present in the instance: %(nilFacts)s.'),
-                        modelObject=nilFacts, nilFacts=", ".join(str(f.qname) for f in nilFacts))
-            if stringFactsWithoutXmlLang:
-                modelXbrl.error("EBA.2.20",
-                                _("String facts need to report xml:lang: '%(langLessFacts)s'"),
-                                modelObject=stringFactsWithoutXmlLang, langLEssFacts=", ".join(str(f.qname) for f in stringFactsWithoutXmlLang))
-            if nonMonetaryNonPureFacts:
-                modelXbrl.error("EBA.3.2",
-                                _("Non monetary (numeric) facts MUST use the pure unit: '%(langLessFacts)s'"),
-                                modelObject=nonMonetaryNonPureFacts, langLessFacts=", ".join(str(f.qname) for f in nonMonetaryNonPureFacts))
+        if nilFacts:
+            modelXbrl.warning("EBA.2.19",
+                    _('Nil facts SHOULD NOT be present in the instance: %(nilFacts)s.'),
+                    modelObject=nilFacts, nilFacts=", ".join(str(f.qname) for f in nilFacts))
                 
             unusedUnitIDs = modelXbrl.units.keys() - unitIDsUsed
             if unusedUnitIDs:

--- a/arelle/plugin/validateEBA.py
+++ b/arelle/plugin/validateEBA.py
@@ -117,8 +117,8 @@ def final(val):
             if _value in filingIndicators:
                 modelXbrl.error("EBA.1.6.1",
                         _('Multiple filing indicators facts for indicator %(filingIndicator)s.'),
-                        modelObject=(fIndicator, filingIndicators[fIndicator.xValue]), filingIndicator=fIndicator.xValue)
-            filingIndicators[fIndicator.xValue] = fIndicator
+                        modelObject=(fIndicator, filingIndicators[_value]), filingIndicator=_value)
+            filingIndicators[_value] = fIndicator
         
         if not filingIndicators:
             modelXbrl.error("EBA.1.6",
@@ -150,147 +150,187 @@ def final(val):
                             _("Successful XBRL facts sum of md5s."),
                             modelObject=modelXbrl)
             
-        otherFacts = {} # (contextHash, unitHash, xmlLangHash) : fact
-        nilFacts = []
-        stringFactsWithoutXmlLang = []
-        nonMonetaryNonPureFacts = []
-        unitIDsUsed = set()
-        currenciesUsed = {}
-        for f in modelXbrl.factsInInstance:
-            concept = f.concept
-            k = (f.getparent().objectIndex,
-                 f.concept.objectIndex,
-                 f.context.contextDimAwareHash if f.context is not None else None,
-                 f.unit.hash if f.unit is not None else None,
-                 hash(f.xmlLang))
-            if concept.qname == qnFilingIndicator and val.validateEIOPA:
-                pass
-            elif k not in otherFacts:
-                otherFacts[k] = {f}
-            else:
-                matches = [o
-                           for o in otherFacts[k]
-                           if (f.getparent().objectIndex == o.getparent().objectIndex and
-                               f.concept.objectIndex == o.concept.objectIndex and
-                               f.context.isEqualTo(o.context) if f.context is not None and o.context is not None else True) and
-                              (f.unit.isEqualTo(o.unit) if f.unit is not None and o.unit is not None else True) and
-                              (f.xmlLang == o.xmlLang)]
-                if matches:
-                    contexts = [f.contextID] + [o.contextID for o in matches]
-                    modelXbrl.error("EBA.2.16",
-                                    _('Facts are duplicates %(fact)s contexts %(contexts)s.'),
-                                    modelObject=[f] + matches, fact=f.qname, contexts=', '.join(contexts))
-                else:
-                    otherFacts[k].add(f)    
-            if concept is not None:
-                if concept.isNumeric:
-                    if f.precision:
-                        modelXbrl.error("EBA.2.17",
-                            _("Numeric fact %(fact)s of context %(contextID)s has a precision attribute '%(precision)s'"),
-                            modelObject=f, fact=f.qname, contextID=f.contextID, precision=f.precision)
-                    if f.decimals and f.decimals != "INF":
-                        try:
-                            dec = int(f.decimals)
-                            if concept.isMonetary:
-                                if dec < -3:
-                                    modelXbrl.error("EBA.2.17",
-                                        _("Monetary fact %(fact)s of context %(contextID)s has a decimal attribute < -3: '%(decimals)s'"),
-                                        modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
-                            elif concept.baseXbrliType in integerItemTypes:
-                                if dec != 0:
-                                    modelXbrl.error("EBA.2.17",
-                                        _("Integer fact %(fact)s of context %(contextID)s has a decimal attribute \u2260 0: '%(decimals)s'"),
-                                        modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
-                            elif concept.typeQname == qnPercentItemType:
-                                if dec < 4:
-                                    modelXbrl.error("EBA.2.17",
-                                        _("Percent fact %(fact)s of context %(contextID)s has a decimal attribute < 4: '%(decimals)s'"),
-                                        modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
-                        except ValueError:
-                            pass # should have been reported as a schema error by loader
-                        '''' (not intended by EBA 2.18)
-                        if not f.isNil and getattr(f,"xValid", 0) == 4:
-                            try:
-                                insignificance = insignificantDigits(f.xValue, decimals=f.decimals)
-                                if insignificance: # if not None, returns (truncatedDigits, insiginficantDigits)
-                                    modelXbrl.error(("EFM.6.05.37", "GFM.1.02.26"),
-                                        _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s has nonzero digits in insignificant portion %(insignificantDigits)s."),
-                                        modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, 
-                                        value=f1.xValue, truncatedDigits=insignificance[0], insignificantDigits=insignificance[1])
-                            except (ValueError,TypeError):
-                                modelXbrl.error(("EBA.2.18"),
-                                    _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s causes Value Error exception."),
-                                    modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, value=f1.value)
-                        '''
-                    unit = f.unit
-                    if unit is not None:
-                        if concept.isMonetary:
-                            if unit.measures[0]:
-                                currenciesUsed[unit.measures[0][0]] = unit
-                        elif not unit.isSingleMeasure or unit.measures[0][0] != XbrlConst.qnXbrliPure:
-                            nonMonetaryNonPureFacts.append(f)
-                elif concept.baseXbrliType in ("stringItemType", "normalizedStringItemType"): 
-                    if not f.xmlLang:
-                        stringFactsWithoutXmlLang.append(f)
+            numFilingIndicatorTuples = len(modelXbrl.factsByQname(qnFIndicators, ()))
+            if numFilingIndicatorTuples > 1:
+                modelXbrl.info("EBA.1.6.2",                            
+                        _('Multiple filing indicators tuples when not in streaming mode (info).'),
+                        modelObject=modelXbrl.factsByQname(qnFIndicators))
                         
-            if f.unitID is not None:
-                unitIDsUsed.add(f.unitID)
-            if f.isNil:
-                nilFacts.append(f)
+            # note EBA 2.1 is in ModelDocument.py
+            
+            cntxIDs = set()
+            cntxEntities = set()
+            cntxDates = defaultdict(list)
+            timelessDatePattern = re.compile(r"\s*([0-9]{4})-([0-9]{2})-([0-9]{2})\s*$")
+            for cntx in modelXbrl.contexts.values():
+                cntxIDs.add(cntx.id)
+                cntxEntities.add(cntx.entityIdentifier)
+                dateElts = XmlUtil.descendants(cntx, XbrlConst.xbrli, ("startDate","endDate","instant"))
+                if any(not timelessDatePattern.match(e.textValue) for e in dateElts):
+                    modelXbrl.error("EBA.2.10",
+                            _('Period dates must be whole dates without time or timezone: %(dates)s.'),
+                            modelObject=cntx, dates=", ".join(e.text for e in dateElts))
+                if cntx.isForeverPeriod:
+                    modelXbrl.error("EBA.2.11",
+                            _('Forever context period is not allowed.'),
+                            modelObject=cntx)
+                elif cntx.isStartEndPeriod:
+                    modelXbrl.error("EBA.2.13",
+                            _('Start-End (flow) context period is not allowed.'),
+                            modelObject=cntx)
+                elif cntx.isInstantPeriod:
+                    cntxDates[cntx.instantDatetime].append(cntx)
+                if XmlUtil.hasChild(cntx, XbrlConst.xbrli, "segment"):
+                    modelXbrl.error("EBA.2.14",
+                        _("The segment element not allowed in context Id: %(context)s"),
+                        modelObject=cntx, context=cntx.contextID)
+                for scenElt in XmlUtil.descendants(cntx, XbrlConst.xbrli, "scenario"):
+                    childTags = ", ".join([child.prefixedName for child in scenElt.iterchildren()
+                                           if isinstance(child,ModelObject) and 
+                                           child.tag != "{http://xbrl.org/2006/xbrldi}explicitMember" and
+                                           child.tag != "{http://xbrl.org/2006/xbrldi}typedMember"])
+                    if len(childTags) > 0:
+                        modelXbrl.error("EBA.2.15",
+                            _("Scenario of context Id %(context)s has disallowed content: %(content)s"),
+                            modelObject=cntx, context=cntx.id, content=childTags)
+            if len(cntxDates) > 1:
+                modelXbrl.error("EBA.2.13",
+                        _('Contexts must have the same date: %(dates)s.'),
+                        modelObject=[_cntx for _cntxs in cntxDates.values() for _cntx in _cntxs], 
+                        dates=', '.join(XmlUtil.dateunionValue(_dt, subtractOneDay=True)
+                                                               for _dt in cntxDates.keys()))
                 
-        if nilFacts:
-            modelXbrl.error("EBA.2.19",
-                    _('Nil facts MUST NOT be present in the instance: %(nilFacts)s.'),
-                    modelObject=nilFacts, nilFacts=", ".join(str(f.qname) for f in nilFacts))
-        if stringFactsWithoutXmlLang:
-            modelXbrl.error("EBA.2.20",
-                            _("String facts need to report xml:lang: '%(langLessFacts)s'"),
-                            modelObject=stringFactsWithoutXmlLang, langLEssFacts=", ".join(str(f.qname) for f in stringFactsWithoutXmlLang))
-        if nonMonetaryNonPureFacts:
-            modelXbrl.error("EBA.3.2",
-                            _("Non monetary (numeric) facts MUST use the pure unit: '%(langLessFacts)s'"),
-                            modelObject=nonMonetaryNonPureFacts, langLessFacts=", ".join(str(f.qname) for f in nonMonetaryNonPureFacts))
-            
-        unusedUnitIDs = modelXbrl.units.keys() - unitIDsUsed
-        if unusedUnitIDs:
-            modelXbrl.warning("EBA.2.21",
-                    _('Unused xbrli:unit nodes SHOULD NOT be present in the instance: %(unusedUnitIDs)s.'),
-                    modelObject=[modelXbrl.units[unusedUnitID] for unusedUnitID in unusedUnitIDs], 
-                    unusedUnitIDs=", ".join(sorted(unusedUnitIDs)))
-                    
-        unitHashes = {}
-        for unit in modelXbrl.units.values():
-            h = hash(unit)
-            if h in unitHashes and unit.isEqualTo(unitHashes[h]):
-                modelXbrl.warning("EBA.2.32",
-                    _("Duplicate units SHOULD NOT be reported, units %(unit1)s and %(unit2)s have same measures.'"),
-                    modelObject=(unit, unitHashes[h]), unit1=unit.id, unit2=unitHashes[h].id)
-            else:
-                unitHashes[h] = unit
-        if len(currenciesUsed) > 1:
-            modelXbrl.error("EBA.3.1",
-                _("There MUST be only one currency but %(numCurrencies)s were found: %(currencies)s.'"),
-                modelObject=currenciesUsed.values(), numCurrencies=len(currenciesUsed), currencies=", ".join(str(c) for c in currenciesUsed.keys()))
-            
-        namespacePrefixesUsed = defaultdict(set)
-        prefixesUnused = set(modelDocument.xmlRootElement.keys()).copy()
-        for elt in modelDocument.xmlRootElement.iter():
-            if isinstance(elt, ModelObject): # skip comments and processing instructions
-                namespacePrefixesUsed[elt.qname.namespaceURI].add(elt.qname.prefix)
-                prefixesUnused.discard(elt.qname.prefix)
-        if prefixesUnused:
-            modelXbrl.warning("EBA.3.4",
-                _("There SHOULD be no unused prefixes but these were declared: %(unusedPrefixes)s.'"),
-                modelObject=modelDocument, unusedPrefixes=', '.join(sorted(prefixesUnused)))
-        for ns, prefixes in namespacePrefixesUsed.items():
-            nsDocs = modelXbrl.namespaceDocs.get(ns)
-            if nsDocs:
-                for nsDoc in nsDocs:
-                    nsDocPrefix = XmlUtil.xmlnsprefix(nsDoc.xmlRootElement, ns)
-                    if any(prefix != nsDocPrefix for prefix in prefixes if prefix is not None):
-                        modelXbrl.warning("EBA.3.5",
-                            _("Prefix for namespace %(namespace)s is %(declaredPrefix)s but these were found %(foundPrefixes)s"),
-                            modelObject=modelDocument, namespace=ns, declaredPrefix=nsDocPrefix, foundPrefixes=', '.join(sorted(prefixes - {None})))                        
+            unusedCntxIDs = cntxIDs - {fact.contextID 
+                                       for fact in modelXbrl.factsInInstance
+                                       if fact.contextID} # skip tuples
+            if unusedCntxIDs:
+                modelXbrl.warning("EBA.2.7",
+                        _('Unused xbrli:context nodes SHOULD NOT be present in the instance: %(unusedContextIDs)s.'),
+                        modelObject=[modelXbrl.contexts[unusedCntxID] for unusedCntxID in unusedCntxIDs], 
+                        unusedContextIDs=", ".join(sorted(unusedCntxIDs)))
+    
+            if len(cntxEntities) > 1:
+                modelXbrl.warning("EBA.2.9",
+                        _('All entity identifiers and schemes must be the same, %(count)s found: %(entities)s.'),
+                        modelObject=modelDocument, count=len(cntxEntities), 
+                        entities=", ".join(sorted(str(cntxEntity) for cntxEntity in cntxEntities)))
+                
+            otherFacts = {} # (contextHash, unitHash, xmlLangHash) : fact
+            nilFacts = []
+            stringFactsWithoutXmlLang = []
+            nonMonetaryNonPureFacts = []
+            unitIDsUsed = set()
+            currenciesUsed = {}
+            for qnameString, facts in modelXbrl.factsByQnameAll():
+                for f in facts:
+                    if modelXbrl.skipDTS:
+                        c = f.qname.localName[0]
+                        isNumeric = c in ('m', 'p', 'i')
+                        isMonetary = c == 'm'
+                        isInteger = c == 'i'
+                        isPercent = c == 'p'
+                        isString = c == 's'
+                    else:
+                        concept = f.concept
+                        if concept is not None:
+                            isNumeric = concept.isNumeric
+                            isMonetary = concept.isMonetary
+                            isInteger = concept.baseXbrliType in integerItemTypes
+                            isPercent = concept.typeQname == qnPercentItemType
+                            isString = concept.baseXbrliType in ("stringItemType", "normalizedStringItemType")
+                        else:
+                            isNumeric = isString = False # error situation
+                    k = (f.getparent().objectIndex,
+                         f.qname,
+                         f.context.contextDimAwareHash if f.context is not None else None,
+                         f.unit.hash if f.unit is not None else None,
+                         hash(f.xmlLang))
+                    if f.qname == qnFIndicators and val.validateEIOPA:
+                        pass
+                    elif k not in otherFacts:
+                        otherFacts[k] = {f}
+                    else:
+                        matches = [o
+                                   for o in otherFacts[k]
+                                   if (f.getparent().objectIndex == o.getparent().objectIndex and
+                                       f.qname == o.qname and
+                                       f.context.isEqualTo(o.context) if f.context is not None and o.context is not None else True) and
+                                      (f.unit.isEqualTo(o.unit) if f.unit is not None and o.unit is not None else True) and
+                                      (f.xmlLang == o.xmlLang)]
+                        if matches:
+                            contexts = [f.contextID] + [o.contextID for o in matches]
+                            modelXbrl.error("EBA.2.16",
+                                            _('Facts are duplicates %(fact)s contexts %(contexts)s.'),
+                                            modelObject=[f] + matches, fact=f.qname, contexts=', '.join(contexts))
+                        else:
+                            otherFacts[k].add(f)
+                    if isNumeric:
+                        if f.precision:
+                            modelXbrl.error("EBA.2.17",
+                                _("Numeric fact %(fact)s of context %(contextID)s has a precision attribute '%(precision)s'"),
+                                modelObject=f, fact=f.qname, contextID=f.contextID, precision=f.precision)
+                        if f.decimals and f.decimals != "INF":
+                            try:
+                                dec = int(f.decimals)
+                                if isMonetary:
+                                    if dec < -3:
+                                        modelXbrl.error("EBA.2.17",
+                                            _("Monetary fact %(fact)s of context %(contextID)s has a decimal attribute < -3: '%(decimals)s'"),
+                                            modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
+                                elif isInteger:
+                                    if dec != 0:
+                                        modelXbrl.error("EBA.2.17",
+                                            _("Integer fact %(fact)s of context %(contextID)s has a decimal attribute \u2260 0: '%(decimals)s'"),
+                                            modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
+                                elif isPercent:
+                                    if dec < 4:
+                                        modelXbrl.error("EBA.2.17",
+                                            _("Percent fact %(fact)s of context %(contextID)s has a decimal attribute < 4: '%(decimals)s'"),
+                                            modelObject=f, fact=f.qname, contextID=f.contextID, decimals=f.decimals)
+                            except ValueError:
+                                pass # should have been reported as a schema error by loader
+                            '''' (not intended by EBA 2.18, paste here is from EFM)
+                            if not f.isNil and getattr(f,"xValid", 0) == 4:
+                                try:
+                                    insignificance = insignificantDigits(f.xValue, decimals=f.decimals)
+                                    if insignificance: # if not None, returns (truncatedDigits, insiginficantDigits)
+                                        modelXbrl.error(("EFM.6.05.37", "GFM.1.02.26"),
+                                            _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s has nonzero digits in insignificant portion %(insignificantDigits)s."),
+                                            modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, 
+                                            value=f1.xValue, truncatedDigits=insignificance[0], insignificantDigits=insignificance[1])
+                                except (ValueError,TypeError):
+                                    modelXbrl.error(("EBA.2.18"),
+                                        _("Fact %(fact)s of context %(contextID)s decimals %(decimals)s value %(value)s causes Value Error exception."),
+                                        modelObject=f1, fact=f1.qname, contextID=f1.contextID, decimals=f1.decimals, value=f1.value)
+                            '''
+                        unit = f.unit
+                        if unit is not None:
+                            if isMonetary:
+                                if unit.measures[0]:
+                                    currenciesUsed[unit.measures[0][0]] = unit
+                            elif not unit.isSingleMeasure or unit.measures[0][0] != XbrlConst.qnXbrliPure:
+                                nonMonetaryNonPureFacts.append(f)
+                    elif isString: 
+                        if not f.xmlLang:
+                            stringFactsWithoutXmlLang.append(f)
+                                
+                    if f.unitID is not None:
+                        unitIDsUsed.add(f.unitID)
+                    if f.isNil:
+                        nilFacts.append(f)
+                        
+            if nilFacts:
+                modelXbrl.error("EBA.2.19",
+                        _('Nil facts MUST NOT be present in the instance: %(nilFacts)s.'),
+                        modelObject=nilFacts, nilFacts=", ".join(str(f.qname) for f in nilFacts))
+            if stringFactsWithoutXmlLang:
+                modelXbrl.error("EBA.2.20",
+                                _("String facts need to report xml:lang: '%(langLessFacts)s'"),
+                                modelObject=stringFactsWithoutXmlLang, langLEssFacts=", ".join(str(f.qname) for f in stringFactsWithoutXmlLang))
+            if nonMonetaryNonPureFacts:
+                modelXbrl.error("EBA.3.2",
+                                _("Non monetary (numeric) facts MUST use the pure unit: '%(langLessFacts)s'"),
+                                modelObject=nonMonetaryNonPureFacts, langLessFacts=", ".join(str(f.qname) for f in nonMonetaryNonPureFacts))
                 
             unusedUnitIDs = modelXbrl.units.keys() - unitIDsUsed
             if unusedUnitIDs:

--- a/arelle/plugin/validateUSBestPractices.py
+++ b/arelle/plugin/validateUSBestPractices.py
@@ -386,8 +386,8 @@ def final(val, conceptsUsed):
                                         break
                                 if filingELR:
                                     # are there any compatible facts for this sum?
-                                    for totalFact in val.modelXbrl.factsByQname[totalConcept.qname]:
-                                        for itemFact in val.modelXbrl.factsByQname[itemQname]:
+                                    for totalFact in val.modelXbrl.factsByQname(totalConcept.qname, ()):
+                                        for itemFact in val.modelXbrl.factsByQname(itemQname):
                                             if (totalFact.context is not None and totalFact.context.isEqualTo(itemFact.context) and
                                                 totalFact.unit is not None and totalFact.unit.isEqualTo(itemFact.unit)):
                                                 foundFiledItemCalc = False

--- a/arelle/plugin/xbrlDB/entityInformation.py
+++ b/arelle/plugin/xbrlDB/entityInformation.py
@@ -133,7 +133,7 @@ def loadEntityInformation(dts, rssItem):
                                       ("DocumentFisalPeriodFocus", "fiscal-period-focus")):
             try:
                 concept = dts.nameConcepts[factName][0] # get qname irrespective of taxonomy year
-                facts = dts.factsByQname[concept.qname]
+                facts = dts.factsByQname(concept.qname)
                 for fact in facts:
                     if not fact.context.qnameDims: #default context
                         if factName in ("EntityPublicFloat",):

--- a/arelle/plugin/xbrlDB/tableFacts.py
+++ b/arelle/plugin/xbrlDB/tableFacts.py
@@ -44,13 +44,12 @@ def tableFacts(dts):
                      for roleType in dts.roleTypes.get(roleURI,())]
         roleTypes.sort(key=lambda roleType: roleType.definition)
         # find defined non-default axes in pre hierarchy for table
-        factsByQname = dts.factsByQname
         for roleType in roleTypes:
             roleURI = roleType.roleURI
             code = roleType.tableCode
             roleURIdims, priItemQNames = EFMlinkRoleURIstructure(dts, roleURI)
             for priItemQName in priItemQNames:
-                for fact in factsByQname[priItemQName]:
+                for fact in dts.factsByQname(priItemQName):
                     cntx = fact.context
                     # non-explicit dims must be default
                     if (cntx is not None and

--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,7 @@ if sys.platform in ('darwin', 'linux2', 'linux', 'sunos5'): # works on ubuntu wi
         
     includeLibs = ['lxml', 'lxml.etree', 'lxml._elementpath', 'lxml.html', 
                    'pg8000', 'pymysql', 'sqlite3',
+                   'SQLAlchemy',
                     # note cx_Oracle isn't here because it is version and machine specific, ubuntu not likely working
                     'rdflib', 'rdflib.extras', 'rdflib.tools', 
                     # more rdflib plugin modules may need to be added later
@@ -280,6 +281,7 @@ elif sys.platform == 'win32':
         #
         "includes": ['lxml', 'lxml.etree', 'lxml._elementpath', 'lxml.html',
                      'pg8000', 'pymysql', 'cx_Oracle', 'pyodbc', 'sqlite3',
+                     'SQLAlchemy',
                      'rdflib', 'rdflib.extras', 'rdflib.tools', 
                      # more rdflib plugin modules may need to be added later
                      'rdflib.plugins', 'rdflib.plugins.memory', 

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ if sys.platform in ('darwin', 'linux2', 'linux', 'sunos5'): # works on ubuntu wi
         
     includeLibs = ['lxml', 'lxml.etree', 'lxml._elementpath', 'lxml.html', 
                    'pg8000', 'pymysql', 'sqlite3',
-                   'SQLAlchemy',
+                   'SQLAlchemy', 'SQLAlchemy.dialects.sqlite',
                     # note cx_Oracle isn't here because it is version and machine specific, ubuntu not likely working
                     'rdflib', 'rdflib.extras', 'rdflib.tools', 
                     # more rdflib plugin modules may need to be added later
@@ -281,7 +281,7 @@ elif sys.platform == 'win32':
         #
         "includes": ['lxml', 'lxml.etree', 'lxml._elementpath', 'lxml.html',
                      'pg8000', 'pymysql', 'cx_Oracle', 'pyodbc', 'sqlite3',
-                     'SQLAlchemy',
+                     'SQLAlchemy', 'SQLAlchemy.dialects.sqlite',
                      'rdflib', 'rdflib.extras', 'rdflib.tools', 
                      # more rdflib plugin modules may need to be added later
                      'rdflib.plugins', 'rdflib.plugins.memory', 


### PR DESCRIPTION
Please only apply this pull request after having handled #38 (Performance improvement by using database indices). This pull request also contains all the changes from that pull request as it cannot work reliably without it.

For new facts with open dimensions, only really create them if they do not exist yet.
They exist if they are c-equal (context equal) and if they have the same QName.
