### PR TITLE
Table linkbase: z axis containing an aspect node filter along the axis 'descendant-or-self'

### DIFF
--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -1002,13 +1002,17 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                     header = memConcept.label(lang=self.lang)
                                     valueHeaders.add(header)
                                     headerValues[header] = memConcept
-                                elif memberModel.axis and memberModel.linkrole and memberModel.arcrole:
+                                if memberModel.axis and memberModel.linkrole and memberModel.arcrole:
+                                    if memberModel.axis.endswith('-or-self'):
+                                        searchAxis = memberModel.axis[:len(memberModel.axis)-len('-or-self')]
+                                    else:
+                                        searchAxis = memberModel.axis
                                     relationships = concept_relationships(self.rendrCntx, 
                                                          None, 
                                                          (memQname,
                                                           memberModel.linkrole,
                                                           memberModel.arcrole,
-                                                          memberModel.axis),
+                                                          searchAxis),
                                                          False) # return flat list
                                     for rel in relationships:
                                         if rel.isUsable:


### PR DESCRIPTION
The problem arises for instance in table C 15.00 of the COREP taxonomy 2.2.

It is due to the fact that for the z axis of table C15.00, the search axis 'descendant-or-self' is chosen:

``` xml
    <df:explicitDimension xlink:type="resource" xlink:label="eba_a3.root.filter" id="eba_a3.root.filter">
      <df:dimension>
        <df:qname>eba_dim:CEG</df:qname>
      </df:dimension>
      <df:member>
        <df:qname>eba_GA:x0</df:qname>
        <df:linkrole>http://www.eba.europa.eu/xbrl/crr/role/dict/dom/GA/GA5_1</df:linkrole>
        <df:arcrole>http://xbrl.org/int/dim/arcrole/domain-member</df:arcrole>
        <df:axis>descendant-or-self</df:axis>
      </df:member>
    </df:explicitDimension>
```

Until now `descendant-or-self` was not supported.

This fix tries to support all `df:axis` elements ending with '-or-self'.
