### PR TITLE
Table linkbase rendering: make z axis drop-down list read-only

### DIFF
--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -310,6 +310,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                              value=comboBoxValue,
                              selectindex=zStructuralNode.choiceNodeIndex if i >= 0 else None,
                              columnspan=2,
+                             state=["readonly"],
                              comboboxselected=self.onZComboBoxSelected)
                 combobox.zStructuralNode = zStructuralNode
                 combobox.zAxisIsOpenExplicitDimension = zAxisIsOpenExplicitDimension


### PR DESCRIPTION
# Justification
The z axis within a table may either be linked to an explicit dimension or to a typed dimension.

For explicit dimensions, adding new dimensions makes no sense.

For typed dimensions, the values for which there is a fact is nevertheless a specific set. If a new value should be added, it is done through the '(enter typed member)' entry.

Currently, giving the possibility of entering a _new_ value is misleading. The user thinks that the typed dimension has a value, but at saving time, the entered value is ignored.

The easiest solution is to make the drop-down list read-only.