### PR TITLE
Make intermediate nodes in dimension label hierarchies usable for z dimension

### DIFF
--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -1001,7 +1001,10 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                 if memConcept is not None and (not memberModel.axis or memberModel.axis.endswith('-self')):
                                     header = memConcept.label(lang=self.lang)
                                     valueHeaders.add(header)
-                                    headerValues[header] = memConcept
+                                    if rel.isUsable:
+                                        headerValues[header] = memQname
+                                    else:
+                                        headerValues[header] = memConcept
                                 elif memberModel.axis and memberModel.linkrole and memberModel.arcrole:
                                     relationships = concept_relationships(self.rendrCntx, 
                                                          None, 


### PR DESCRIPTION
In a label hierarchy for dimensions, there are nodes that have children and nodes that are leafs.

Without this change, labels for nodes with children are saved as ModelConcept and this makes it impossible to use them as domain members. No fact can be created that includes the node value in the z dimension.

For instance, this can be tested with the COREP 2.2 hierarchy, entry point corep_ind.xsd.

For table C 15.00, the z axis is a list of countries. The default value is 'Not available/all geographical areas'. The default value is an intermediate node. It is 'usable' but no cells are presented in the GUI without this fix. With this fix enabled, the cells are presented and the contexts are correctly saved: as  'Not available/all geographical areas' is the default values, the contexts attached to the facts do not bear any explicit value for the 'country' dimension, which is in line with the XBRL Dimensions specifications 1.0. When saved and read back, the facts are correctly displayed.

This pull request is related to pull request #42 . That pull request makes it possible to use the 'descendant-or-self' axis for node aspect filters.