### PR TITLE
Arelle with tkinter GUI: make sure the File menu is complete when there are plug-ins extending it

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -113,6 +113,7 @@ class CntlrWinMain (Cntlr.Cntlr):
             elif label == "PLUG-IN":
                 for pluginMenuExtender in pluginClassMethods(command):
                     pluginMenuExtender(self, self.fileMenu)
+                    self.fileMenuLength += 1
             else:
                 self.fileMenu.add_command(label=label, underline=0, command=command, accelerator=shortcut_text)
                 self.parent.bind(shortcut, command)


### PR DESCRIPTION
## Problem encountered
When the `File` menu is extended with by a plug-in, the menu entry `Quit` disappears.

This is caused by the fact the the dynamic `Recent Files` menu entry deletes the wrong place holder menu entry. The entries to delete are defined by a counter. The counter is not correctly incremented when there is a plug-in menu entry.  

## Solution description

The counter `self.fileMenuLength` should also be incremented whenever there is a plug-in that extends the `File` menu.