### PR TITLE
Replace 'Save...' by 'Save' and 'Save As...' in the GUI

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -98,7 +98,8 @@ class CntlrWinMain (Cntlr.Cntlr):
                 (_("Import File..."), self.importFileOpen, None, None),
                 (_("Import Web..."), self.importWebOpen, None, None),
                 ("PLUG-IN", "CntlrWinMain.Menu.File.Open", None, None),
-                (_("Save..."), self.fileSave, "Ctrl+S", "<Control-s>"),
+                (_("Save"), self.fileSaveExistingFile, "Ctrl+S", "<Control-s>"),
+                (_("Save As..."), self.fileSave, None, None),
                 (_("Save DTS Package"), self.saveDTSpackage, None, None),
                 ("PLUG-IN", "CntlrWinMain.Menu.File.Save", None, None),
                 (_("Close"), self.fileClose, "Ctrl+W", "<Control-w>"),
@@ -235,7 +236,7 @@ class CntlrWinMain (Cntlr.Cntlr):
                 #("images/toolbarNewFile.gif", self.fileNew),
                 ("toolbarOpenFile.gif", self.fileOpen, _("Open local file"), _("Open by choosing a local XBRL file, testcase, or archive file")),
                 ("toolbarOpenWeb.gif", self.webOpen, _("Open web file"), _("Enter an http:// URL of an XBRL file or testcase")),
-                ("toolbarSaveFile.gif", self.fileSave, _("Save file"), _("Saves currently selected local XBRL file")),
+                ("toolbarSaveFile.gif", self.fileSaveExistingFile, _("Save file"), _("Saves currently selected local XBRL file")),
                 ("toolbarClose.gif", self.fileClose, _("Close"), _("Closes currently selected instance/DTS or testcase(s)")),
                 (None,None,None,None),
                 ("toolbarFindMenu.gif", self.find, _("Find"), _("Find dialog for scope and method of searching")),
@@ -447,32 +448,46 @@ class CntlrWinMain (Cntlr.Cntlr):
             return self.fileSave()
         return True
         
-    def fileSave(self, view=None, fileType=None, *ignore):
+    def fileSave(self, view=None, fileType=None, filenameFromInstance=False, *ignore):
         if view is None:
             view = getattr(self, "currentView", None)
         if view is not None:
-            modelXbrl = view.modelXbrl
+            filename = None
+            modelXbrl = None
+            try:
+                modelXbrl = view.modelXbrl
+            except AttributeError:
+                pass
+            if filenameFromInstance:
+                try:
+                    modelXbrl = view.modelXbrl
+                    filename = modelXbrl.modelDocument.filepath
+                    if filename.endswith('.xsd'): # DTS entry point, no instance saved yet!
+                        filename = None
+                except AttributeError:
+                    pass
             if isinstance(view, ViewWinRenderedGrid.ViewRenderedGrid):
                 initialdir = os.path.dirname(modelXbrl.modelDocument.uri)
                 if fileType in ("html", "xml", None):
-                    if fileType == "html":
+                    if fileType == "html" and filename is None:
                         filename = self.uiFileDialog("save",
                                 title=_("arelle - Save HTML-rendered Table"),
                                 initialdir=initialdir,
                                 filetypes=[(_("HTML file .html"), "*.html"), (_("HTML file .htm"), "*.htm")],
                                 defaultextension=".html")
-                    elif fileType == "xml":
+                    elif fileType == "xml" and filename is None:
                         filename = self.uiFileDialog("save",
                                 title=_("arelle - Save Table Layout Model"),
                                 initialdir=initialdir,
                                 filetypes=[(_("Layout model file .xml"), "*.xml")],
                                 defaultextension=".xml")
                     else: # ask file type
-                        filename = self.uiFileDialog("save",
-                                title=_("arelle - Save XBRL Instance or HTML-rendered Table"),
-                                initialdir=initialdir,
-                                filetypes=[(_("XBRL instance .xbrl"), "*.xbrl"), (_("XBRL instance .xml"), "*.xml"), (_("HTML table .html"), "*.html"), (_("HTML table .htm"), "*.htm")],
-                                defaultextension=".html")
+                        if filename is None:
+                            filename = self.uiFileDialog("save",
+                                    title=_("arelle - Save XBRL Instance or HTML-rendered Table"),
+                                    initialdir=initialdir,
+                                    filetypes=[(_("XBRL instance .xbrl"), "*.xbrl"), (_("XBRL instance .xml"), "*.xml"), (_("HTML table .html"), "*.html"), (_("HTML table .htm"), "*.htm")],
+                                    defaultextension=".html")
                         if filename and (filename.endswith(".xbrl") or filename.endswith(".xml")):
                             view.saveInstance(filename)
                             return True
@@ -581,6 +596,9 @@ class CntlrWinMain (Cntlr.Cntlr):
         return True;
         '''
     
+    def fileSaveExistingFile(self, view=None, fileType=None, *ignore):
+        return self.fileSave(view, fileType, filenameFromInstance=True)
+
     def saveDTSpackage(self):
         self.modelManager.saveDTSpackage(allDTSes=True)
     

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -565,6 +565,7 @@ class ModelDocument:
         self.referencedNamespaces = set()
         self.inDTS = False
         self.definesUTR = False
+        self.isModified = False
 
 
     def objectId(self,refId=""):
@@ -636,6 +637,7 @@ class ModelDocument:
             self.filepath = overrideFilepath
             self.setTitleInBackground()
         self.updateFileHistoryIfNeeded()
+        self.isModified = False
     
     def close(self, visited=None, urlDocs=None):
         if visited is None: visited = []

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -624,7 +624,12 @@ class ModelDocument:
         myCntlr = self.modelXbrl.modelManager.cntlr
         updateFileHistory = getattr(myCntlr, 'updateFileHistory', None)
         if updateFileHistory:
-            updateFileHistory(self.filepath, False)
+            try:
+                cntlr = self.modelXbrl.modelManager.cntlr
+                uiThreadQueue = cntlr.uiThreadQueue
+                uiThreadQueue.put((updateFileHistory, [self.filepath, False]))
+            except AttributeError:
+                pass
 
     def save(self, overrideFilepath=None):
         """Saves current document file.

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -825,8 +825,23 @@ class ModelXbrl:
                 self._factsByPeriodType[newFact.concept.periodType].add(newFact)
             if hasattr(self, "_factsByDimQname"):
                 del self._factsByDimQname
+        self.setIsModified()
         return newFact    
         
+    def setIsModified(self):
+        """Records that the underlying document has been modified.
+        """
+        self.modelDocument.isModified = True
+
+    def isModified(self):
+        """Check if the underlying document has been modified.
+        """
+        md = self.modelDocument
+        if md is not None:
+            return md.isModified
+        else:
+            return False
+
     def modelObject(self, objectId):
         """Finds a model object by an ordinal ID which may be buried in a tkinter view id string (e.g., 'somedesignation_ordinalnumber').
         

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -904,6 +904,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
         cntlr.showStatus(_("Saving {0}").format(instance.modelDocument.basename))
         cntlr.waitForUiThreadQueue() # force status update
 
+        self.updateInstanceFromFactPrototypes()
         instance.saveInstance(newFilename) # may override prior filename for instance from main menu
         cntlr.showStatus(_("Saved {0}").format(instance.modelDocument.basename), clearAfter=3000)
         if onSaved is not None:

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -883,6 +883,8 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
             if not getNewFactItemOptions(self.modelXbrl.modelManager.cntlr, self.newFactItemOptions):
                 return # new instance not set
         # newFilename = None # only used when a new instance must be created
+        
+        self.updateInstanceFromFactPrototypes()
         if self.modelXbrl.modelDocument.type != ModelDocument.Type.INSTANCE and newFilename is None:
             newFilename = self.modelXbrl.modelManager.cntlr.fileSave(view=self, fileType="xbrl")
             if not newFilename:
@@ -902,7 +904,6 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
         cntlr.showStatus(_("Saving {0}").format(instance.modelDocument.basename))
         cntlr.waitForUiThreadQueue() # force status update
 
-        self.updateInstanceFromFactPrototypes()
         instance.saveInstance(newFilename) # may override prior filename for instance from main menu
         cntlr.showStatus(_("Saved {0}").format(instance.modelDocument.basename), clearAfter=3000)
         if onSaved is not None:

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -873,6 +873,7 @@ class ViewRenderedGrid(ViewWinGrid.ViewGrid):
                                                          if fact.concept.isMonetary else
                                                          self.newFactItemOptions.nonMonetaryDecimals)
                                 fact.text = value
+                                instance.setIsModified()
                                 XmlValidate.validate(instance, fact)
                             bodyCell.isChanged = False  # clear change flag
                         


### PR DESCRIPTION
This pull request suggests a new saving scheme.

The old 'Save...' has been split into a 'Save' and a 'Save As...' menu entry. 'Save' does not ask for a file name, it uses the current file name. If the file is new, a file name is asked nevertheless. The 'Save' icon now does the 'Save' operation. The 'Save As...' menu entry systematically asks for a new file name to save the current instance.

The name of the new file name replaces the old name in the current instance.

The file name visible in the window title is also updated.

Moreover, the recent files list is now also updated with the latest saved files.

Finally, before closing an instance, the program checks whether there is something to save. If there is, an alert message is displayed and the closing may be interrupted.