### PR TITLE
Corrected ModelXbrl to handle dictionary values.

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -1028,8 +1028,11 @@ class ModelXbrl:
                 elif isinstance(argValue,(float,Decimal)):
                     # need locale-dependent formatting
                     fmtArgs[argName] = format_string(self.modelManager.locale, '%f', argValue)
+                elif isinstance(argValue, dict):
+                    fmtArgs[argName] = argValue
                 else:
                     fmtArgs[argName] = str(argValue)
+
         if "refs" not in extras:
             try:
                 file = os.path.basename(self.modelDocument.uri)


### PR DESCRIPTION
There was a bug in the extraProperties for handling dictionaries in the fmtArgs. Specifically, dictionaries were falling through to the final else case, which caused them to be typecast to `str( )`. 

So I added a specific `elif` check for dictionaries, allowing other types to still fall through to the str case. This might be risky still, as str can have unusual behaviors, and it might be better to just have an exception be thrown if the argValue does not match any of the specified types that are known to have a conversion. 

This is still stronger for now, though, so I believe it is still a step in the right direction for now.
