### PR TITLE
Sort baseSet keys on ELR for consistent locators

### DIFF
--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -97,7 +97,7 @@ class ValidateXbrl:
         modelXbrl.qnameDimensionContextElement = {}
         # check base set cycles, dimensions
         modelXbrl.modelManager.showStatus(_("validating relationship sets"))
-        for baseSetKey in modelXbrl.baseSets.keys():
+        for baseSetKey in sorted(modelXbrl.baseSets.keys(), key=lambda b: b[1] or ""):
             arcrole, ELR, linkqname, arcqname = baseSetKey
             if arcrole.startswith("XBRL-") or ELR is None or \
                 linkqname is None or arcqname is None:


### PR DESCRIPTION
When running on python 3.4, it was discovered that the rules within the affected loop could fire on different locators across subsequent runs.  This is due to python 3.4's hash randomization, which causes the keys to be returned in different order across those runs.

The fix is to sort the baseSet keys on ELR.
