### PR TITLE
Possible workaround for Nonetype children on Typed Dimensions

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -1298,7 +1298,10 @@ class ModelDimensionValue(ModelObject):
         if self.isExplicit:
             return (str(self.dimensionQname),str(self.memberQname))
         else:
-            return (str(self.dimensionQname), XmlUtil.xmlstring( XmlUtil.child(self), stripXmlns=True, prettyPrint=True ) )
+            if XmlUtil.child(self):
+                return (str(self.dimensionQname), XmlUtil.xmlstring( XmlUtil.child(self), stripXmlns=True, prettyPrint=True ) )
+            else:
+                return (str(self.dimensionQname))
         
 def measuresOf(parent):
     if parent.xValid >= VALID: # has DTS and is validated


### PR DESCRIPTION
Hi Herm,

Not too sure how to proceed with this one.  I've got a document with typed dimensions, and it was breaking Arelle when attempting to serialize the child element in the removed line here.  I've put a workaround in place, and would like to discuss any better ways to proceed.  Contact the XS team for the document.

Thanks,
Jay
