### PR TITLE
Values of TypedDimension will now be returned instead of "None" using REST

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -977,10 +977,12 @@ class ModelContext(ModelObject):
         dimValue = self.dimValue(dimQname)
         if isinstance(dimValue, (ModelDimensionValue,DimValuePrototype)) and dimValue.isExplicit:
             return dimValue.memberQname
-        elif isinstance(dimValue, ModelValue.QName):
+        if isinstance(dimValue, ModelValue.QName):
             return dimValue
         if dimValue is None and includeDefaults and dimQname in self.modelXbrl.qnameDimensionDefaults:
             return self.modelXbrl.qnameDimensionDefaults[dimQname]
+        if dimValue is not None and dimValue.isTyped:
+            return dimValue.typedMember.sValue
         return None
     
     def dimAspects(self, defaultDimensionAspects=None):


### PR DESCRIPTION
We have the following problem:

We have a XBRL-file which has several dimensions. Some dimensions have a QName, some other are typed dimensions. Example:
```
<context id="c-160">
        <entity>
            <identifier scheme="http://www.bundesbank.de/ext/basis/identifiertyp/creditorNumber">11069999</identifier>
        </entity>
        <period>
            <instant>2016-06-30</instant>
        </period>
        <scenario>
            <xbrldi:explicitMember dimension="de_sprv_dim:COL">de_sprv_CL:x030</xbrldi:explicitMember>
            <xbrldi:typedMember dimension="de_sprv_dim:KNR">
                <de_sprv_typ:KN>1</de_sprv_typ:KN>
            </xbrldi:typedMember>
            <xbrldi:explicitMember dimension="de_sprv_dim:ROW">de_sprv_RO:x250</xbrldi:explicitMember>
            <xbrldi:explicitMember dimension="de_sprv_dim:TEM">de_sprv_TE:RDP-R</xbrldi:explicitMember>
        </scenario>
    </context>
```

The REST-Call using Arelle

  http://localhost:8080/rest/xbrl/c:/xbrl/test.xbrl/facts?media=json&factListCols=Label,unitRef,Dec,Value,EntityScheme,EntityIdentifier,Period,Dimensions

returns the following result (it is an excerpt) :
```
 [
      "item",
      {
        "name": "de_sprv_met:mi1"
      },
      {
        "entityIdentifier": "11069999",
        "label": "Monetär",
        "unitRef": "u-01",
        "dec": "2",
        "dimensions": {
          "de_sprv_dim:ROW": "de_sprv_RO:x250",
          "de_sprv_dim:TEM": "de_sprv_TE:RDP-R",
          "de_sprv_dim:KNR": "None",
          "de_sprv_dim:COL": "de_sprv_CL:x030"
        },
        "entityScheme": "http://www.bundesbank.de/ext/basis/identifiertyp/creditorNumber",
        "value": "100,00",
        "endInstant": "2016-06-30"
      }
    ]
```
I expect the value "1" for "de_sprv_dim:KNR", but I got "None". I haven't found any other REST-Calls which returns the value of a typed dimension. Thus, I presume that this behavior is a bug.

After I tried to fix this bug, the new outcome looks like the following:

   ```
 [
      "item",
      {
        "name": "de_sprv_met:mi1"
      },
      {
        "entityIdentifier": "11069999",
        "label": "Monetär",
        "unitRef": "u-01",
        "dec": "2",
        "dimensions": {
          "de_sprv_dim:ROW": "de_sprv_RO:x250",
          "de_sprv_dim:TEM": "de_sprv_TE:RDP-R",
          "de_sprv_dim:KNR": "1",
          "de_sprv_dim:COL": "de_sprv_CL:x030"
        },
        "entityScheme": "http://www.bundesbank.de/ext/basis/identifiertyp/creditorNumber",
        "value": "100,00",
        "endInstant": "2016-06-30"
      }
    ]
```

I will appreciate if someone review my fix. If these changes are convenient for you, I will also appreciate for accepting the pull request. 

Thank you very much,
Thomas