### PR TITLE
Add isodate to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lxml==3.4.4
 openPyXL==2.3.3
+isodate==0.5.4


### PR DESCRIPTION
isodate was not included. Allows pip installs to work with VCS install.