### PR TITLE
PackageManager command line initialization

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -240,7 +240,7 @@ class Cntlr:
         self.modelManager = ModelManager.initialize(self)
  
         # start taxonomy package server (requres web cache initialized, but not logger)
-        PackageManager.init(self, loadPackagesConfig=hasGui)
+        PackageManager.init(self)
  
         self.startLogging(logFileName, logFileMode, logFileEncoding, logFormat)
         


### PR DESCRIPTION
This addresses a bug when trying to import a package via the command line api, e.g.

```python3 arelleCmdLine.py --packages +UK-ALL-2009-09-01-package.zip```

At the moment the loadPackagesConfig arg passed to PackageManager.init() [here](https://github.com/Arelle/Arelle/blob/master/arelle/Cntlr.py#L243)  will be false when running from the command line.

Therefore [```packagesJsonFile = cntlr.userAppDir + os.sep + "taxonomyPackages.json"```](https://github.com/Arelle/Arelle/blob/master/arelle/PackageManager.py#L280)  will never be executed.

PackageManager.save(self) is called later from the [command line controller](https://github.com/Arelle/Arelle/blob/master/arelle/CntlrCmdLine.py#L631). 

It attempts to write to packagesJsonFile which will be None, thus throwing an error.

The fix is simply not to pass hasGui to init, as loadPackagesConfig defaults to true.

Perhaps this change will throw up unintended adverse consequences elsewhere but a manual test of the web and command line apis seemed ok.