### PR TITLE
Ignore error codes if "nonStandardErrorCodes" is specified.

### DIFF
--- a/arelle/ModelTestcaseObject.py
+++ b/arelle/ModelTestcaseObject.py
@@ -252,12 +252,12 @@ class ModelTestcaseVariation(ModelObject):
                 if schemaTestElement is not None:
                     return XmlUtil.descendantAttr(schemaTestElement, None, "expected", "validity")
         errorElement = XmlUtil.descendant(self, None, "error")
-        if errorElement is not None:
+        resultElement = XmlUtil.descendant(self, None, "result")
+        if errorElement is not None and not resultElement.get("nonStandardErrorCodes"):
             _errorText = XmlUtil.text(errorElement)
             if ' ' in _errorText: # list of tokens
                 return _errorText
             return ModelValue.qname(errorElement, _errorText)  # turn into a QName
-        resultElement = XmlUtil.descendant(self, None, "result")
         if resultElement is not None:
             expected = resultElement.get("expected")
             if expected:


### PR DESCRIPTION
The iXBRL conformance suite now has a "nonStandardErrorCodes" attribute, which is a flag saying that you can ignore the error codes and just get the pass/fail result right.  This commit adds support for the flag to Arelle.