### PR TITLE
Remove \m from regex in ValidateFilingText for Python 3.6

### DIFF
--- a/arelle/ValidateFilingText.py
+++ b/arelle/ValidateFilingText.py
@@ -16,7 +16,7 @@ XMLdeclaration = re.compile(r"<\?xml.*\?>", re.DOTALL)
 XMLpattern = re.compile(r".*(<|&lt;|&#x3C;|&#60;)[A-Za-z_]+[A-Za-z0-9_:]*[^>]*(/>|>|&gt;|/&gt;).*", re.DOTALL)
 CDATApattern = re.compile(r"<!\[CDATA\[(.+)\]\]")
 #EFM table 5-1 and all &xxx; patterns
-docCheckPattern = re.compile(r"&\w+;|[^0-9A-Za-z`~!@#$%&\*\(\)\.\-+ \[\]\{\}\|\\:;\"'<>,_?/=\t\n\r\m\f]") # won't match &#nnn;
+docCheckPattern = re.compile(r"&\w+;|[^0-9A-Za-z`~!@#$%&\*\(\)\.\-+ \[\]\{\}\|\\:;\"'<>,_?/=\t\n\r\f]") # won't match &#nnn;
 namedEntityPattern = re.compile("&[_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]"
                                 r"[_\-\.:" 
                                 "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040]*;")


### PR DESCRIPTION
Hello Herman Fischer,

While packaging Arelle for the NixOS Linux distribution, another contributor has come across what seem to be small problems preventing Arelle from working in Python 3.6. The fix in this PR seems to touch the actual validation code, but some further research seems to indicate that the behavior does not change. If you agree, you may merge this pull request.

If you're interested, our progress is here https://github.com/NixOS/nixpkgs/pull/29435

Below is the commit message with further info:

This removes what seems to be an escape sequence from a regular expressing that validates filing texts.
In support of this change, I have gathered the following information:
 - An \m escape results in an error in Python 3.6 
 - An \m escape is not in the Python 2 documentation
 - An \m escape does not seem to be suggested by the relevant part of the EFM specification table as mentioned in the comment
 - The backslash before an m in the pattern seems to be ignored by the re (regex) module until recent versions
 - The m character was matched by this regex anyway. It was redundant but has now become an error.