### PR TITLE
Fixes the saving and update of facts for table linkbase

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -167,6 +167,11 @@ class ModelFact(ModelObject):
         """(str) -- unitRef attribute"""
         return self.getStripped("unitRef")
     
+    @unitID.setter
+    def unitID(self, value):
+        """(str) -- unitRef attribute"""
+        self.set("unitRef", value)
+    
     @property
     def utrEntries(self):
         """(set(UtrEntry)) -- set of UtrEntry objects that match this fact and unit"""

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -1085,7 +1085,7 @@ class ViewRenderedGrid(ViewWinTkTable.ViewTkTable):
         cntlr.waitForUiThreadQueue() # force status update
 
         self.updateInstanceFromFactPrototypes()
-        instance.saveInstance(newFilename) # may override prior filename for instance from main menu
+        instance.saveInstance(overrideFilepath=newFilename) # may override prior filename for instance from main menu
         cntlr.addToLog(_("{0} saved").format(newFilename if newFilename is not None else instance.modelDocument.filepath))
         cntlr.showStatus(_("Saved {0}").format(instance.modelDocument.basename), clearAfter=3000)
         if onSaved is not None:


### PR DESCRIPTION
Small patch to correct the issues met by Luigi Carini and Mike van der Ploeg: [https://groups.google.com/forum/#!topic/arelle-users/XDwQwoUaLLY](https://groups.google.com/forum/#!topic/arelle-users/XDwQwoUaLLY)

The problems happened when the user want to save a report and when he wants to update a existing fact.

The first problem (the save) appends because the definition of `saveInstance` allows only keyword
From ModelXbrl.py, line 468: 
`def saveInstance(self, **kwargs):`

The second appends because unitID wasn't settable in `ModelFact ` and in ViewWinRenderedGrid.py the update of the fact want to set it (line 1051)