### PR TITLE
Add support for detecting JPEG images with Exif data (APP1 segment).

### DIFF
--- a/arelle/ValidateFilingText.py
+++ b/arelle/ValidateFilingText.py
@@ -866,7 +866,9 @@ def validateGraphicFile(elt, graphicFile):
     #normalizedUri = elt.modelXbrl.modelManager.cntlr.webCache.getfilename(normalizedUri)
     with elt.modelXbrl.fileSource.file(normalizedUri,binary=True)[0] as fh:
         data = fh.read(11)
-        if data[:4] == b'\xff\xd8\xff\xe0' and data[6:] == b'JFIF\0': 
+        # Support both JFIF APP0 (0xffe0 + 'JFIF') and APP1 Exif (0xffe1 + 'Exif') JPEG application segement types
+        if (data[:4] == b'\xff\xd8\xff\xe0' and data[6:] == b'JFIF\0') or \
+           (data[:4] == b'\xff\xd8\xff\xe1' and data[6:] == b'Exif\0'):
             return "jpg"
         if data[:3] == b"GIF" and data[3:6] in (b'89a', b'89b', b'87a'):
             return "gif"


### PR DESCRIPTION
Issue: EFM XBRL validation fails with a "EFM.5.02.05.graphicFileContent" error if the content references a JPEG image which contains Exif data. 

The Edgar Filer Manual doesn't specify, one way or the other, if Exif data is allowed in JPEG images.  But since it is only metadata added to an otherwise compliant image format and isn't active content, and since all modern browsers and software are able to display and manipulate such images, it would seem reasonable to allow it to pass Arelle's validation.  

Example SEC disseminated JPEG image file with Exif data: https://www.sec.gov/Archives/edgar/data/920760/000162828018000562/lennarlogo.jpg

References:
http://www.exif.org/Exif2-2.PDF (4.7 JPEG Marker Segments Used in Exif)
http://www.ozhiker.com/electronics/pjmt/jpeg_info/app_segments.html