### PR TITLE
Fix the 2014 DEI EntityFilerCategory check

### DIFF
--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -2336,4 +2336,4 @@ def deiParamEqual(deiName, xbrlVal, secVal):
                            "Not Applicable":("Non-accelerated Filer", "Smaller Reporting Company")}.get(secVal,())
     elif deiName == "2014EntityFilerCategory":
         return xbrlVal in {"true":("Smaller Reporting Company", "Smaller Reporting Accelerated Filer"),
-                           "false":("Non-accelerated Filer", "Accelerated Filer", "Large Accelerated Filer")}.get(secVal,())
+                           "false":("Non-accelerated Filer", "Accelerated Filer", "Large Accelerated Filer")}.get(secVal.lower(),())


### PR DESCRIPTION
Fix the 2014 DEI EntityFilerCategory check by making the key lookup case-insensitive

Example warning messages currently in EDGAR 18.3 with US-GAAP 2017 with smallBusinessFlag = False

```
WRN:  XBRL WARNING MESSAGE
MSG:  Warning: [dq-0540-Entity-Small-Business-Filer-Category-Consistency]
      dei:EntityFilerCategory value Large Accelerated Filer in the Required
      Context is inconsistent with the False of smallBusinessFlag in the
      Submission. foo-20180831.xml line 1234
LOC:  LINE NUMBER: 0
```

```
WRN:  XBRL WARNING MESSAGE
MSG:  Warning: [dq-0540-Entity-Small-Business-Filer-Category-Consistency] 
      dei:EntityFilerCategory value Non-accelerated Filer in the Required 
      Context is inconsistent with the False of smallBusinessFlag in the 
      Submission. foo-20171231.xml line 1234 
LOC:  LINE NUMBER: 0
```


And a test I did with 2017 / smallBusinessFlag = True
```
WRN:  XBRL WARNING MESSAGE
MSG:  Warning: [dq-0540-Entity-Small-Business-Filer-Category-Consistency] 
      dei:EntityFilerCategory value Smaller Reporting Company in the Required 
      Context is inconsistent with the True of smallBusinessFlag in the 
      Submission. foo-20171231.xml line 1234 
LOC:  LINE NUMBER: 0
```
