### PR TITLE
Fix the warning message for the DEI WKSI / Submission WKSI value mismatch

### DIFF
--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -863,7 +863,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
         if hasDeiFact("EntityWellKnownSeasonedIssuer") and "wellKnownSeasonedIssuerFlag" in val.params and not deiParamEqual(
             "EntityWellKnownSeasonedIssuer", deiItems["EntityWellKnownSeasonedIssuer"], val.params["wellKnownSeasonedIssuerFlag"]):
             modelXbrl.warning("EFM.6.05.40.entityWellKnownSeasonedIssuerValue",
-                _("dei:EntityWellKnownSeasonedIssuer value %(deiValue)s in the Required Context does not agree with submission voluntary filer flag value %(submissionValue)s."),
+                _("dei:EntityWellKnownSeasonedIssuer value %(deiValue)s in the Required Context does not agree with submission well known seasoned issuer flag value %(submissionValue)s."),
                 edgarCode="dq-0540-Entity-Well-Known-Seasoned-Issuer-Value",
                 modelObject=deiFacts["EntityWellKnownSeasonedIssuer"], submissionValue=val.params["wellKnownSeasonedIssuerFlag"], deiValue=deiItems["EntityWellKnownSeasonedIssuer"])
         if submissionType not in docTypesRequiringEntityWellKnownSeasonedIssuer and "wellKnownSeasonedIssuerFlag" in val.params:


### PR DESCRIPTION
A customer received the following XBRL Warning while test filing a 10-K today:

```
WRN:  XBRL WARNING MESSAGE
MSG:  Warning: [dq-0540-Entity-Well-Known-Seasoned-Issuer-Value] 
      dei:EntityWellKnownSeasonedIssuer value Yes in the Required Context does 
      not agree with submission voluntary filer flag value False. 
      foo-20180831.xml line 1234 
LOC:  LINE NUMBER: 0
```

I was confused until I looked at the Arelle code - the check appears to be correct but the error message is wrong.