### PR TITLE
Comprehensive dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ arelle/plugin/EdgarRendererWithBuiltinHtml
 arelle/plugin/validate/DQC_US_Rules
 arelle/plugin/validate/DQC_test
 arelle/plugin/xule
-
+Arelle.egg-info
+.eggs
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup_requires = ['lxml']
 # this also allows installation directly from the github repository 
 # (using 'pip install -e git+git://github.com/rheimbuchArelle.git#egg=Arelle') 
 # and the install_requires packages are auto-installed as well.
-install_requires = ['lxml']
+install_requires = ['lxml', 'isodate', 'openpyxl']
 options = {}
 scripts = []
 cxFreezeExecutables = []


### PR DESCRIPTION
When installing Arelle with use of either pip or setup.py two dependencies are missing:
* isodate 
* openpyxl

which forces the user to install them manually.
Also, egg directories are not excluded from the git.

This PR is fixing those two issues.