### PR TITLE
Expand valid years for 'regYr' and 'finYr' of filename regex

### DIFF
--- a/arelle/plugin/validate/CIPC/__init__.py
+++ b/arelle/plugin/validate/CIPC/__init__.py
@@ -23,7 +23,7 @@ from .Const import cpicModules, mandatoryElements
 cipcBlockedInlineHtmlElements = {
     'object', 'script'}
 
-namePattern = re.compile(r"^(.*) - (20[12][0-9]-[0-9]+-(06|07|08|09|10|12|20|21|22|23|24|25|26|30|31)) - (20[12][0-9])$")
+namePattern = re.compile(r"^(.*) - ((18|19|20)\d{2}-[0-9]+-(06|07|08|09|10|12|20|21|22|23|24|25|26|30|31)) - (20[1-9]\d)$")
 reportingModulePattern = re.compile(r"http://xbrl.cipc.co.za/taxonomy/.*/\w*(ca_fas|full_ifrs|ifrs_for_smes)\w*[_-]20[12][0-9]-[0-9]{2}-[0-9]{2}.xsd")
                 
 def dislosureSystemTypes(disclosureSystem, *args, **kwargs):


### PR DESCRIPTION
Changes:
regYr used to only accept years [2010 - 2029] that range has been expanded to [1800 - 2099]
finYr used to only accept years [2010 - 2029] that range has been expanded to [2010 - 2099]

Ultimate Problem:
Companies registered before 2010 throw a warning in arelle, but not on the cipc filing website.
     ex: 'Ceramic Industries Proprietary Limited - 1982-008520-07 - 2018.xhtml' filename generates no warnings from the cipc website but throws an error in arelle