### PR TITLE
Set User-Agent for web requests

### DIFF
--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -84,7 +84,7 @@ class WebCache:
         self._noCertificateCheck = False
         self.resetProxies(httpProxyTuple)
         
-        #self.opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+        self.opener.addheaders = [('User-agent', 'Mozilla/5.0')]
 
         #self.opener = WebCacheUrlOpener(cntlr, proxyDirFmt(httpProxyTuple)) # self.proxies)
         


### PR DESCRIPTION
There needs to be a way to allow the User-Agent header to be sent for web requests made by Arelle. Eg. the Indian MCA does not allow access to the taxonomy without a User-Agent header (http://www.mca.gov.in/XBRL/2016/07/26/Taxonomy/CnI/in-ci-ent-2016-03-31.xsd)