### PR TITLE
Provide a parsedValue property for ModelFact

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -40,6 +40,7 @@ from arelle.PrototypeInstanceObject import DimValuePrototype
 from math import isnan, isinf
 from arelle.ModelObject import ModelObject
 from decimal import Decimal, InvalidOperation
+from fractions import Fraction
 from hashlib import md5
 from arelle.HashUtil import md5hash, Md5Sum
 
@@ -414,7 +415,7 @@ class ModelFact(ModelObject):
         if concept is None or concept.isTuple or fact.isNil:
             return None
         if concept.isFraction:
-            num, den = map(fractions.Fraction, fact.fractionValue)
+            num, den = map(Fraction, fact.fractionValue)
             return num / den
         val = fact.value.strip()
         if concept.isInteger:


### PR DESCRIPTION
When using Arelle to parse and extract data from an XBRL instance, most of the time what you need is a Python value that you can then manipulate (eg. decimal.Decimal for numbers or True/False for booleans) rather than the string value which is what effectiveValue provides. The parsedValue property adds support for exactly that.