### PR TITLE
Load resource relationships into XBRL US Postgres DB

### DIFF
--- a/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
+++ b/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
@@ -517,7 +517,7 @@ class XbrlPostgresDatabaseConnection(SqlDbConnection):
                           self.dbNum(rel.weight), # none if no weight
                           sequence,
                           depth,
-                          self.qnameId.get(rel.preferredLabel) if rel.preferredLabel else None)
+                          self.uriId.get(rel.preferredLabel) if rel.preferredLabel else None)
                          for rel, sequence, depth, networkId in dbRels)
         del dbRels[:]   # dererefence
         table = self.getTable('relationship', 'relationship_id', 

--- a/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
+++ b/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
@@ -518,8 +518,7 @@ class XbrlPostgresDatabaseConnection(SqlDbConnection):
                           sequence,
                           depth,
                           self.qnameId.get(rel.preferredLabel) if rel.preferredLabel else None)
-                         for rel, sequence, depth, networkId in dbRels
-                         if isinstance(rel.fromModelObject, ModelConcept) and isinstance(rel.toModelObject, ModelConcept))
+                         for rel, sequence, depth, networkId in dbRels)
         del dbRels[:]   # dererefence
         table = self.getTable('relationship', 'relationship_id', 
                               ('network_id', 'from_element_id', 'to_element_id', 'reln_order', 


### PR DESCRIPTION
Hi Arelle folks,

I am not familiar with this codebase so apologies if my pull request is incorrect. However, it appears to solve my problem. My problem is that, when I load an XBRL SEC filing into my Postgres DB using the XBRL US schema, resource relationships are not populated: the from_resource_id and to_resource_id columns of the relationship table are always NULL. Fact data is properly stored, but I need these resource relationships to get the label associated with each element. (The filing I am testing with is a MSFT 10-Q at https://www.sec.gov/Archives/edgar/data/789019/000156459020019706/msft-10q_20200331_htm.xml, but I have observed this issue with every other filing I attempted as well.)

When I open the same filing in the Arelle GUI, I can see the labels, which suggests to me that the model objects are OK and the problem is likely isolated to the Postgres DB plugin. Without really knowing what I am doing, I opened up XbrlPublicPostgresDB.py and found the section that populates relationships within the insertNetworks() function. I noticed that, for these columns, it calls resourceResourceId() on rel.fromModelObject and rel.toModelObject, which requires them to be ModelResource instances before it will return data. However, the if expression on line 522 requires that both rel.fromModelObject and rel.toModelObject must always be ModelConcept instances, which seems to apply only for cases where from_element_id and to_element_id are populated. I reasoned that this must be filtering out those items in dbRels which are in fact ModelResource instances and would thus populate my from_resource_id and to_resource_id columns. So, as a total shot in the dark, I removed the if expression and reloaded my filing. It worked!

Incidentally, I noticed that the official XBRL US public database has the resource relationships populated correctly. I assume they are running a modified version of Arelle to populate their schema, which they have changed from the original that is described in xbrlPublicPostgresDB.ddl.

Thanks,
Jeff