### PR TITLE
update ESEF validation guidances 2.1.2, 2.5.3, 3.1.1, 3.4.5

### DIFF
--- a/arelle/plugin/validate/ESEF/DTS.py
+++ b/arelle/plugin/validate/ESEF/DTS.py
@@ -139,8 +139,9 @@ def checkFilingDTS(val, modelDocument, visited, hrefXlinkRole=None):
                                 modelObject=modelConcept, concept=modelConcept.qname, lc3names=", ".join(lc3names))
                         for (lang,labelrole),labels in langRoleLabels.items():
                             if len(labels) > 1:
-                                val.modelXbrl.warning("ESEF.3.4.5.extensionTaxonomyElementDuplicateLabels",
-                                    _("Extension taxonomy element name SHOULD not have multiple labels for lang %(lang)s and role %(labelrole)s: %(concept)s"),
+                                # Severity level and message changed (RM 3.4.5: "Each taxonomy extension element shall be defined with at most one label for any combination (...)"
+                                val.modelXbrl.error("ESEF.3.4.5.extensionTaxonomyElementDuplicateLabels",
+                                    _("Extension taxonomy element name SHALL not have multiple labels for lang %(lang)s and role %(labelrole)s: %(concept)s"),
                                     modelObject=[modelConcept]+labels, concept=modelConcept.qname, lang=lang, labelrole=labelrole)
                     langRoleLabels.clear()
             for modelType in modelDocument.xmlRootElement.iterdescendants(tag="{http://www.w3.org/2001/XMLSchema}complexType"):
@@ -270,7 +271,8 @@ def checkFilingDTS(val, modelDocument, visited, hrefXlinkRole=None):
             del prohibitingLbElts[:]
             del prohibitedBaseConcepts[:]
         if len(linkbasesFound) > 1:
-            val.modelXbrl.error("ESEF.3.1.1.extensionTaxonomyWrongFilesStructure",
+            # Set message code and severity level accordingly to message
+            val.modelXbrl.warning("ESEF.3.1.1.linkbasesNotSeparateFiles",
                 _("Each linkbase type SHOULD be provided in a separate linkbase file, found: %(linkbasesFound)s."),
                 modelObject=modelDocument.xmlRootElement, linkbasesFound=", ".join(sorted(linkbasesFound)))
             

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -342,8 +342,9 @@ def validateXbrlFinally(val, *args, **kwargs):
                                 
                             
                     if eltTag in ixTags and elt.get("target"):
-                        modelXbrl.warning("ESEF.2.5.3.targetAttributeUsed",
-                            _("Target attribute MUST not be used: element %(localName)s, target attribute %(target)s."),
+                        # Reporting Manual update - July 2020: message and severity level changed to account for local jurisdictions requirements
+                        modelXbrl.warning("ESEF.2.5.3.targetAttributeUsedForESEFContents",
+                            _("Target attribute SHOULD not be used unless explicitly required by local jurisdictions: element %(localName)s, target attribute %(target)s."),
                             modelObject=elt, localName=elt.elementQname, target=elt.get("target"))
                     if eltTag == ixTupleTag:
                         modelXbrl.error("ESEF.2.4.1.tupleElementUsed",
@@ -470,12 +471,14 @@ def validateXbrlFinally(val, *args, **kwargs):
                         _("The LEI context identifier has checksum error: %(identifier)s"),
                         modelObject=contextElts, identifier=contextIdentifier)
         if contextsWithPeriodTime:
-            modelXbrl.warning("ESEF.2.1.2.periodWithTimeContent",
-                _("Context period startDate, endDate and instant elements should be in whole days without time: %(contextIds)s"),
+            # Reporting Manual update - July 2020: message and severity level changed
+            modelXbrl.error("ESEF.2.1.2.periodWithTimeContent",
+                _("The xbrli:startDate, xbrli:endDate and xbrli:instant elements MUST identify periods using whole days (i.e. specified without a time content and time zone): %(contextIds)s"),
                 modelObject=contextsWithPeriodTime, contextIds=", ".join(c.id for c in contextsWithPeriodTime))
         if contextsWithPeriodTimeZone:
-            modelXbrl.warning("ESEF.2.1.2.periodWithTimeZone",
-                _("Context period startDate, endDate and instant elements should be in whole days without a timezone: %(contextIds)s"),
+            # Reporting Manual update - July 2020: message and severity level changed
+            modelXbrl.error("ESEF.2.1.2.periodWithTimeZone",
+                _("The xbrli:startDate, xbrli:endDate and xbrli:instant elements MUST identify periods using whole days (i.e. specified without a time content and time zone): %(contextIds)s"),
                 modelObject=contextsWithPeriodTimeZone, contextIds=", ".join(c.id for c in contextsWithPeriodTimeZone))
         
         # identify unique contexts and units


### PR DESCRIPTION
### Regarding ESEF validation:
updates four messages in regards to the latest update of the reporting manual.

* **G2.1.2**: changed message and severity level (to "error")
The latest update of the manual is stricter on this guidance

* **G2.5.3**: changed message and severity level (to "warning")
The latest update of the manual discourages but allows the use of the "target" attribute (if required by local jurisdictions)

* **G3.1.1**: changed severity level (to "warning") and message code in the case where several linkbases are in the same xml file (not the .xsd)
The message is: "Each linkbase type SHOULD be provided in a separate linkbase file"
The message code has been changed from "extensionTaxonomyWrongFilesStructure" to "linkbasesNotSeparateFiles", for which the manual sets the level to "warning"

* **G3.4.5**: changed severity level (to "error") and message ("SHOULD" to "SHALL").
While the manual does not explicitly set a severity level, it says that "Each taxonomy extension element **shall** be defined with at most one label for any combination (...)"