### PR TITLE
Add the value that couldn't be atomized to the error message

### DIFF
--- a/arelle/XPathContext.py
+++ b/arelle/XPathContext.py
@@ -690,7 +690,7 @@ class XPathContext:
             try:
                 x = Decimal(v)
             except InvalidOperation:
-                raise XPathException(p, 'err:FORG0001', _('Atomizing {0} to decimal does not have a proper value'))
+                raise XPathException(p, 'err:FORG0001', _('Atomizing {0} to decimal does not have a proper value').format(x))
         elif baseXsdType in ("integer",
                              "nonPositiveInteger","negativeInteger","nonNegativeInteger","positiveInteger",
                              "long","unsignedLong",


### PR DESCRIPTION
The error message misses the information what value could not be atomized.

Note: Unfortunately the contributor agreement linked to from https://arelle.atlassian.net/wiki/spaces/ARELLE/overview returns me a 404