### PR TITLE
Allow non-rec units to be loaded

### DIFF
--- a/arelle/ValidateUtr.py
+++ b/arelle/ValidateUtr.py
@@ -21,7 +21,17 @@ class UtrEntry(): # use slotted class for execution efficiency
         return "utrEntry({})".format(', '.join("{}={}".format(n, getattr(self,n))
                                                for n in self.__slots__))
 
-def loadUtr(modelXbrl, rec_units_only=True): # Build a dictionary of item types that are constrained by the UTR
+def loadUtr(modelXbrl, statusFilters=None): # Build a dictionary of item types that are constrained by the UTR
+    """
+    Parses the units from modelXbrl.modelManager.disclosureStystem.utrUrl, and sets them on
+    modelXbrl.modelManager.disclosureSystem.utrItemTypeEntries
+
+    :param modelXbrl: the loaded xbrl model
+    :param statusFilters: the list of status to keep. If unset, 'REC' status is the default filter
+    :return: None
+    """
+    if statusFilters is None:
+        statusFilters = ['REC']
     modelManager = modelXbrl.modelManager
     modelManager.disclosureSystem.utrItemTypeEntries = utrItemTypeEntries = defaultdict(dict)
     # print('UTR LOADED FROM '+utrUrl);
@@ -48,7 +58,7 @@ def loadUtr(modelXbrl, rec_units_only=True): # Build a dictionary of item types 
             u.isSimple = all(e is None for e in (u.numeratorItemType, u.nsNumeratorItemType, u.denominatorItemType, u.nsDenominatorItemType))
             u.symbol = unitElt.findtext("{http://www.xbrl.org/2009/utr}symbol")
             u.status = unitElt.findtext("{http://www.xbrl.org/2009/utr}status")
-            if not rec_units_only or u.status == "REC":
+            if u.status in statusFilters:
                 # TO DO: This indexing scheme assumes that there are no name clashes in item types of the registry.
                 (utrItemTypeEntries[u.itemType])[u.id] = u
             unitDupKey = (u.unitId, u.nsUnit, u.status)

--- a/arelle/ValidateUtr.py
+++ b/arelle/ValidateUtr.py
@@ -21,7 +21,7 @@ class UtrEntry(): # use slotted class for execution efficiency
         return "utrEntry({})".format(', '.join("{}={}".format(n, getattr(self,n))
                                                for n in self.__slots__))
 
-def loadUtr(modelXbrl): # Build a dictionary of item types that are constrained by the UTR
+def loadUtr(modelXbrl, rec_units_only=True): # Build a dictionary of item types that are constrained by the UTR
     modelManager = modelXbrl.modelManager
     modelManager.disclosureSystem.utrItemTypeEntries = utrItemTypeEntries = defaultdict(dict)
     # print('UTR LOADED FROM '+utrUrl);
@@ -48,7 +48,7 @@ def loadUtr(modelXbrl): # Build a dictionary of item types that are constrained 
             u.isSimple = all(e is None for e in (u.numeratorItemType, u.nsNumeratorItemType, u.denominatorItemType, u.nsDenominatorItemType))
             u.symbol = unitElt.findtext("{http://www.xbrl.org/2009/utr}symbol")
             u.status = unitElt.findtext("{http://www.xbrl.org/2009/utr}status")
-            if u.status == "REC":
+            if not rec_units_only or u.status == "REC":
                 # TO DO: This indexing scheme assumes that there are no name clashes in item types of the registry.
                 (utrItemTypeEntries[u.itemType])[u.id] = u
             unitDupKey = (u.unitId, u.nsUnit, u.status)


### PR DESCRIPTION
### Description
Arelle has a convenient util for parsing units, but it doesn't allow you to load all utr units. This adds a simple bool that allows all utr units to be loaded, not just the units with status "REC". The default behavior of only loading units with status "REC"  is unchanged

please review: @hefischer 