### PR TITLE
[ESEF] Fix severity level for three checks

### DIFF
--- a/arelle/plugin/validate/ESEF/DTS.py
+++ b/arelle/plugin/validate/ESEF/DTS.py
@@ -294,8 +294,8 @@ def checkFilingDTS(val, modelDocument, visited, hrefXlinkRole=None):
                     modelObject=modelDocument.xmlRootElement, linkbaseType=linkbaseRefType, extendedLinkElement=linkEltName)
                 
         elif len(linkbasesFound) > 1:
-            val.modelXbrl.warning("ESEF.3.1.1.linkbasesNotSeparateFiles",
-                _("Each linkbase type SHOULD be provided in a separate linkbase file, found: %(linkbasesFound)s."),
+            val.modelXbrl.error("ESEF.3.1.1.linkbasesNotSeparateFiles",
+                _("Each linkbase type MUST be provided in a separate linkbase file, found: %(linkbasesFound)s."),
                 modelObject=modelDocument.xmlRootElement, linkbasesFound=", ".join(sorted(linkbasesFound)))
             
         # check for any prohibiting dimensionArc's

--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -98,8 +98,8 @@ def checkFilingDimensions(val):
                concept not in elrPrimaryItems.get(LineItemsNotQualifiedLinkrole, set()) and
                concept not in elrPrimaryItems.get("*", set()))
     if i:
-        val.modelXbrl.warning("ESEF.3.4.2.extensionTaxonomyLineItemNotLinkedToAnyHypercube",
-            _("Dimensional line item reported non-dimensionally SHOULD be linked to \"not dimensionally qualified\" hypercube %(linkrole)s, primary item %(qnames)s"),
+        val.modelXbrl.error("ESEF.3.4.2.extensionTaxonomyLineItemNotLinkedToAnyHypercube",
+            _("Line items that do not require any dimensional information to tag data MUST be linked to the dedicated \"Line items not dimensionally qualified\" hypercube in %(linkrole)s declared in esef_cor.xsd, primary item %(qnames)s"),
             modelObject=i, linkrole=LineItemsNotQualifiedLinkrole, qnames=", ".join(sorted(str(c.qname) for c in i)))
     # pri items in LineItemsNotQualifiedLinkrole which are not used in report non-dimensionally
     # check no longer in Filer Manual as of 2021

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -884,7 +884,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                     checkMonetaryUnits(rootConcept, relSet, set())
             if pfsConceptsRootInELR and (len(pfsConceptsRootInELR) + len(nonPfsConceptsRootInELR) ) > 1:
                 roots = pfsConceptsRootInELR | nonPfsConceptsRootInELR
-                modelXbrl.warning("ESEF.3.4.7.singleExtendedLinkRoleUsedForAllPFSs",
+                modelXbrl.error("ESEF.3.4.7.singleExtendedLinkRoleUsedForAllPFSs",
                     _("Separate Extended Link Roles are required by %(elr)s for hierarchies: %(roots)s."),
                     modelObject=roots, elr=modelXbrl.roleTypeDefinition(ELR), roots=", ".join(sorted((str(c.qname) for c in roots))))
         for labelrole, concepts in missingConceptLabels.items():


### PR DESCRIPTION
#### Reason for Change

The current code for some errors do not reflect the latest changes (2021) of the reporting manual.

#### Description

Changes severity level from warning to error (and messages) for the following checks:

* 3.1.1 linkbasesNotSeparateFiles

![image](https://user-images.githubusercontent.com/57985290/147821828-d6c43366-8038-407b-b889-1828f34e44b9.png)

* 3.4.2 extensionTaxonomyLineItemNotLinkedToAnyHypercube

![image](https://user-images.githubusercontent.com/57985290/147821864-563c9d86-4051-4a79-bb39-39c7d55b30e4.png)

* 3.4.7 singleExtendedLinkRoleUsedForAllPFSs

The level is not specified in the Reporting Manual, but according to the criticality described in the [list of tests](https://www.esma.europa.eu/sites/default/files/library/esma32-60-795_esef_conformance_suite_2021.xlsx):

![image](https://user-images.githubusercontent.com/57985290/147821950-d01e1a93-bdb3-4c6e-a47c-005d957c7a5f.png)

#### Steps to Test

Run the relevant test cases from the ESEF Conformance Suite, I suppose.
This requires "manual" testing to check the messages, since automated run of the test suite does not differentiate warnings from errors, so tests "pass" either way.

**review**:
@hermfischer-wf
cc: @austinmatherne-wk @derekgengenbacher-wf @sagesmith-wf