### PR TITLE
schemaBaseTypeDerivedFrom - iter union children

### DIFF
--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -437,8 +437,8 @@ def schemaBaseTypeDerivedFrom(element):
             return child.get("base") 
         elif child.tag == "{http://www.w3.org/2001/XMLSchema}union":
             return (child.get("memberTypes") or "").split() + [
-                    schemaBaseTypeDerivedFrom(child)
-                    for child in element.iterchildren(tag="{http://www.w3.org/2001/XMLSchema}simpleType")]
+                    schemaBaseTypeDerivedFrom(_child)
+                    for _child in child.iterchildren(tag="{http://www.w3.org/2001/XMLSchema}simpleType")]
         elif child.tag in ("{http://www.w3.org/2001/XMLSchema}complexType",
                            "{http://www.w3.org/2001/XMLSchema}simpleType",
                            "{http://www.w3.org/2001/XMLSchema}complexContent",


### PR DESCRIPTION
# Description
ModelType attribute `qnameDerivedFrom` does not detect base types of simpleTypes defined within union element.

# Fixes
This PR fixes the issue by modifying `XmlUtil.schemaBaseTypeDerivedFrom` function to iterate over simpleTypes within union elements and detect base types.

# Tests
The issue described does not result in a visible bug that I am aware of, so there no direct test, but the issue and PR request can be demonstrated using [`xbrli`](https://www.xbrl.org/2003/xbrl-instance-2003-12-31.xsd) schema as follows:  

(Can be tested by checking that the return value of `ModelType.qnameDerivedFrom` - for a type extended using union - includes base for types defined inside union element)

Assuming we have modelXbrl loaded as follows:

```python
from arelle import Cntlr, FileSource
from arelle.ModelValue import QName

cntlr = Cntlr.Cntlr(logFileName="logToPring")
fs = FileSource.FileSource('https://www.xbrl.org/2003/xbrl-instance-2003-12-31.xsd', cntlr)

modelXbrl = cntlr.modelManager.load(fs)
```
### Checking value returned by `qnameDerivedFrom` for types `nonZeroDecimal`, `precisionType` as an example:
_**nonZeroDecimal**_
```python
non_zero_dec_qn = QName('xbrli','http://www.xbrl.org/2003/instance', 'nonZeroDecimal')
# qnameDerivedFrom is expected to return [decimal, decimal]
non_zero_dec_qn = QName('xbrli','http://www.xbrl.org/2003/instance', 'nonZeroDecimal')
# before PR returns
>>> [] # empty list
# After PR returns
>>> [decimal, decimal] # expected
```
_**precisionType**_
```python
precision_type_qn = QName('xbrli', 'http://www.xbrl.org/2003/instance', 'precisionType')
# qnameDerivedFrom is expected to return [nonNegativeInteger, string]
modelXbrl.qnameTypes[precision_type_qn].qnameDerivedFrom
# before PR returns
>>> [nonNegativeInteger] # only built-in type from attr memberTypes
# After PR returns
>>> [nonNegativeInteger, string] # expected
```

