### PR TITLE
[ESEF] Fix AttributeError in validation due to HTML entity

### DIFF
--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -28,7 +28,7 @@ except ImportError:
     import re
 from collections import defaultdict
 from math import isnan
-from lxml.etree import _ElementTree, _Comment, _ProcessingInstruction
+from lxml.etree import _ElementTree, _Comment, _ProcessingInstruction, EntityBase
 from arelle import LeiUtil, ModelDocument, XbrlConst, XhtmlValidate, XmlUtil
 from arelle.FunctionIxt import ixtNamespaces
 from arelle.ModelDtsObject import ModelResource
@@ -292,7 +292,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                 ixFractionTag = ixNStag + "fraction"
                 for elt, depth in etreeIterWithDepth(ixdsHtmlRootElt):
                     eltTag = elt.tag
-                    if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction)):
+                    if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, EntityBase)):
                         continue # comment or other non-parsed element
                     else:
                         eltTag = elt.tag


### PR DESCRIPTION
#### Reason for change

This fixes the following error that arise during ESEF validation due to the presence of a non-existing or unrecognised XML entity:

`AttributeError: 'cython_function_or_method' object has no attribute 'startswith'`

![image](https://user-images.githubusercontent.com/57985290/147923141-2ad3f455-a0a4-4a45-a272-dde373d6bbbb.png)

This problem was detected in command line operation (not present in GUI, I don't know about web server) while validating a "real" stand-alone XHTML that:
* **specified a doctype** 
* contained `&nbsp;` entities 
 
(It seems that iXBRL validation uses that code too but I didn't test that case).

#### Description

This PR adds XML entities (as modeled by lxml.etree.EntityBase) to types of element to ignore while validating the content of the XHTML file (guidance 2.5.x and 4.x.x)

#### Steps to test

1. Get or create a sample stand-alone XHTML report (meaning any XHTML document...) that specifies a doctype and contains illegal entities according to that doctype.  
For instance I used [this file](https://github.com/Arelle/Arelle/files/8115867/docTypeXhtml11InZipInvalid.zip) (unzipped) that is a copy of the file from the ESEF conformance suite to which I added some elements to test the XHTML validation.

![image](https://user-images.githubusercontent.com/57985290/155116587-92bb73fc-7faf-4b85-90a4-a998076c6443.png)

![image](https://user-images.githubusercontent.com/57985290/155116685-746b151a-44db-44ec-bf35-4ed5571c38b4.png)

2. Run the command: `arelleCmdLine.py -f [file path] --plugin "validate/ESEF" --validate --disclosureSystem "esef-unconsolidated"`

* Running it with the current version of Arelle should reproduce the problem;
* Running it with the suggested changes applied should not trigger the error:

![image](https://user-images.githubusercontent.com/57985290/155117698-dc4092a1-5408-43b8-a0fd-f07a07ba2585.png)

#### Off-topic note (kind of):

The need to validate ESEF stand-alone XHTML (unconsolidated) reports opens the door to a whole new dimension regarding XML and XHTML validation.

While Inline XBRL specification prescribes the XML schema that iXBRL instances must conform to, the RTS on ESEF (currently) don't impose a particular XHTML version (at least from what I know). And stand-alone XHTML are not subject to the iXBRL specification; thus it seem acceptable for an issuer to submit a XHTML file that specifies a doctype. In which case Arelle might produce false positives (which is exactly what happened to me and led me to write this PR).
