### PR TITLE
Fix insert of resource value in xbrlDB plugin for SQL database

### DIFF
--- a/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
@@ -811,7 +811,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                                      elementChildSequence(resource),
                                      resource.qname.clarkNotation,
                                      resource.role,
-                                     resource.textValue,
+                                     resource.stringValue,
                                      resource.xmlLang)
                                     for resource in uniqueResources.values()),
                               checkIfExisting=True)

--- a/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
+++ b/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
@@ -451,7 +451,7 @@ class XbrlPostgresDatabaseConnection(SqlDbConnection):
                               ('resource_id', 'label', 'xml_lang'), 
                               ('resource_id',), 
                               tuple((resourceId,
-                                     resource.textValue,
+                                     resource.stringValue,
                                      resource.xmlLang)
                                     for resourceId, resource in uniqueResources.items()),
                               checkIfExisting=True)

--- a/arelle/plugin/xbrlDB/XbrlSemanticSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlSemanticSqlDB.py
@@ -791,7 +791,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                                      elementChildSequence(resource),
                                      resource.qname.clarkNotation,
                                      resource.role,
-                                     resource.textValue,
+                                     resource.stringValue,
                                      resource.xmlLang)
                                     for resource in uniqueResources.values()),
                               checkIfExisting=True)


### PR DESCRIPTION
Insert value in resource table doesn't work for some kind of data when using textValue property because value is empty (for example with ruleNode of EBA taxonomy)
Semantic database other than SQL already used stringValue property for resource value