### PR TITLE
Fix precedence issue in XF parsing

### DIFF
--- a/arelle/plugin/formulaLoader.py
+++ b/arelle/plugin/formulaLoader.py
@@ -1481,14 +1481,16 @@ def compileXfsGrammar( cntlr, debugParsing ):
     
     dimensionFilter = ( 
         ZeroOrMore( Keyword("complemented") | Keyword("covering") | Keyword("non-covering") ) + 
-         (Keyword("explicit-dimension") + (qName | xpathExpression) + 
-            ZeroOrMore( Keyword("default-member") | 
-               (Keyword("member") + (variableRef | qName | xpathExpression) +
-                Optional(Keyword("linkrole") + quotedString) + 
-                Optional(Keyword("arcrole") + quotedString) +
-                Optional(Keyword("axis") + dimensionAxis))) + separator) |
-         (Keyword("typed-dimension") + (variableRef | qName | xpathExpression) + 
-            Optional( Keyword("test") + xpathExpression )  + separator)
+            (
+                (Keyword("explicit-dimension") + (qName | xpathExpression) + 
+                    ZeroOrMore( Keyword("default-member") | 
+                       (Keyword("member") + (variableRef | qName | xpathExpression) +
+                        Optional(Keyword("linkrole") + quotedString) + 
+                        Optional(Keyword("arcrole") + quotedString) +
+                        Optional(Keyword("axis") + dimensionAxis))) + separator) |
+                (Keyword("typed-dimension") + (variableRef | qName | xpathExpression) + 
+                    Optional( Keyword("test") + xpathExpression )  + separator)
+            )
         ).setParseAction(compileDimensionFilter).ignore(xfsComment).setName("dimension-filter").setDebug(debugParsing)
 
     unitFilter = ( 


### PR DESCRIPTION
This PR fixes the parsing of dimension filters in XF.

Prior to this, it was only possible to use `completed`, `covering` and `non-covering` with an explicit dimension as they were joined into the first branch of the `|` with `+`.

With this, these modifiers can be used with all dimensional filters.

Commit easier to review with whitespace changes hidden.

To test, use the following `test.xf` file:

```
namespace eg = "http://example.com/taxonomy";
assertion TestAssertion {
    variable $v1 {
        complemented typed-dimension eg:SomeDimension;
    };
    evaluation-count {.};
};
```

and the following command line:

```
python3 arelleCmdLine.py --plugin formulaLoader -f test.xf --save-formula-linkbase=test-formula.xml
```

Without this PR, this gives the following error:

```
[formulaSyntax:syntaxError] Parse error after line 1 col 1:
❋assertion TestAssertion {
    variable $v1 {
        complemented typed-dimension eg:SomeDimension; - test.xf 2
```

Editing the XF to either remove the `complemented` or change `typed-dimension` to `explicit-dimension` removes this error.

With this PR, the above `test.xf` should convert without error.
