### PR TITLE
Fix escaping of formula messages

### DIFF
--- a/arelle/FormulaEvaluator.py
+++ b/arelle/FormulaEvaluator.py
@@ -86,7 +86,8 @@ def evaluate(xpCtx, varSet, variablesInScope=False, uncoveredAspectFacts=None):
                 xpCtx.modelXbrl.log(
                     "INFO" if result else {"OK":"INFO", "WARNING":"WARNING", "ERROR":"ERROR"}[unsatSeverity],
                     "message:" + (varSet.id or varSet.xlinkLabel or  _("unlabeled variableSet")),
-                    msg.evaluate(xpCtx, contextItem=varSet.evaluationsCount),
+                    "%(formulaMessage)s",
+                    formulaMessage=msg.evaluate(xpCtx, contextItem=varSet.evaluationsCount),
                     modelObject=varSet,
                     label=varSet.logLabel(),
                     messageCodes=("message:{variableSetID|xlinkLabel}",))
@@ -217,7 +218,8 @@ def evaluateVar(xpCtx, varSet, varIndex, cachedFilteredFacts, uncoveredAspectFac
                     xpCtx.modelXbrl.log(
                         "INFO" if result else {"OK":"INFO", "WARNING":"WARNING", "ERROR":"ERROR"}[unsatSeverity],
                         "message:" + (varSet.id or varSet.xlinkLabel or  _("unlabeled variableSet")),
-                        msg.evaluate(xpCtx),
+                        "%(formulaMessage)s",
+                        formulaMessage=msg.evaluate(xpCtx),
                         modelObject=_modelObjects,
                         label=varSet.logLabel(),
                         messageCodes=("message:{variableSetID|xlinkLabel}",))


### PR DESCRIPTION
This PR fixes the escaping of taxonomy-supplied formula messages (and potentially user-supplied fact data).

Without this PR, any custom validation messages from a formula linkbase are used directly as the message that gets added to the log.  Python's `logging` applies `%` substitutions to these messages, to include any provided fields, and/or various standard fields.

For example, if you include `%-D` in a formula validation message, you will get the following output from Arelle:
```
Message log error: unsupported format character 'D' (0x44) at index 100
```
If the formula message includes the current fact value in the message, then this can be triggered by end-user supplied data. 

I originally noticed this because the error was causing an uncaught exception in Arelle, when validating a particular ESEF report (the ESEF duplicate facts formula rule includes the fact value) although I can't now reproduce the exception.  This bug does allow leaking of internal information, as any of the [standard LogRecord attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) can be inserted into messages.  

