### PR TITLE
Fix erroneous catalog.xml validation error in package validation

### DIFF
--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -342,6 +342,9 @@ class FileSource:
         for f in (self.dir or []):
             if f.endswith("/META-INF/taxonomyPackage.xml"): # must be in a sub directory in the zip
                 return [f]  # standard package
+        # If not found in subdirectory, start by checking if META-INF is at archive top-level (and contains target file)
+        if "META-INF/taxonomyPackage.xml" in self.dir:
+            return ["META-INF/taxonomyPackage.xml"]
         return [f for f in (self.dir or []) if os.path.split(f)[-1] in TAXONOMY_PACKAGE_FILE_NAMES]
     
     def isInArchive(self,filepath, checkExistence=False):

--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -383,7 +383,7 @@ def validateTaxonomyPackage(cntlr, filesource, packageFiles=[], errors=[]):
         if filesource.isZipBackslashed:
             cntlr.addToLog(_("Taxonomy package directory uses '\\' as fire separator"),
                            messageCode="tpe:invalidArchiveFormat",
-                           file=os.path.basename(filesource.url),
+                           file=os.path.basename(filesource.baseurl),
                            level=logging.ERROR)
             errors.append("tpe:invalidArchiveFormat")
             return False
@@ -396,7 +396,7 @@ def validateTaxonomyPackage(cntlr, filesource, packageFiles=[], errors=[]):
                            messageArgs={"count": len(topLevelFiles),
                                         "topLevelFiles": ', '.join(sorted(topLevelFiles))},
                            messageCode="tpe:invalidDirectoryStructure",
-                           file=os.path.basename(filesource.url),
+                           file=os.path.basename(filesource.baseurl),
                            level=logging.ERROR)
             errors.append("tpe:invalidDirectoryStructure")
         if len(topLevelDirectories) != 1:
@@ -404,7 +404,7 @@ def validateTaxonomyPackage(cntlr, filesource, packageFiles=[], errors=[]):
                            messageArgs={"count": len(topLevelDirectories),
                                         "topLevelDirectories": ', '.join(sorted(topLevelDirectories))},
                            messageCode="tpe:invalidDirectoryStructure",
-                           file=os.path.basename(filesource.url),
+                           file=os.path.basename(filesource.baseurl),
                            level=logging.ERROR)
             if not topLevelFiles:
                 errors.append("tpe:invalidDirectoryStructure")
@@ -421,7 +421,7 @@ def validateTaxonomyPackage(cntlr, filesource, packageFiles=[], errors=[]):
         else:
             cntlr.addToLog(_("Taxonomy package does not contain a metadata file */META-INF/taxonomyPackage.xml"),
                            messageCode="tpe:metadataFileNotFound",
-                           file=os.path.basename(filesource.url),
+                           file=os.path.basename(filesource.baseurl),
                            level=logging.ERROR)
             errors.append("tpe:metadataFileNotFound")
         return len(errors) == numErrorsOnEntry


### PR DESCRIPTION
#### Reason for Change

When opening / validating a report package that does not contain a single top-level directory (meaning the "META-INF" directory is at the package root) and the "META-INF" directory contains a "catalog.xml" file, Arelle signals (wrongly) an issue with said catalog:

![image](https://user-images.githubusercontent.com/57985290/151755959-5b1d3bb1-8749-44b0-b98f-4cc2be454f9c.png)

(Note the inconsistency between the error code `invalidMetaDataFile` and the actual file catalog.xml)

This problem happened with an actual ESEF report package validated by a national authority and can be reproduced (for instance) with an altered version of the  G2-6-1_1/TC2_invalid.zip test case from the ESEF conformance suite, by removing the top-level directory:

![image](https://user-images.githubusercontent.com/57985290/151756474-bfa1455f-f16a-44b1-bb85-a3c30ecf5573.png)

In `FileSource.taxonomyPackageMetadataFiles`:

In such cases, because we only check for the "taxonomyPackage.xml" file in subdirectories (marked by the leading '/' in the code below), the actual target file is not found and the `taxonomyPackageMetadataFiles` property instead returns the location of the "catalog.xml" file. Hence the error during package validation.

![image](https://user-images.githubusercontent.com/57985290/151757254-57076142-54f4-4303-b05b-65c69d18c1a0.png)

(Side note: I'm not sure which parts of this constitutes the "reason for change" and which belong in the "description" section. I personally would add a "suggested change / fix" section)

#### Description

Changes:

1. Fixing the problem

After the lookup for the "taxonomyPackage.xml" file in subdirectories but before looking for a file in `TAXONOMY_PACKAGE_FILE_NAMES`, looking specifically for the metadata file in a META-INF at the archive root.

So even if the file is not where it is supposed to be, it's better to still find it rather than validating the catalog in its place.

By looking for the META-INF directory at the archive root outside of the `for` loop checking subdirectories, we ensure that the correct one will be used if there are more than one "taxonomyPackage.xml" file (unlikely but who knows).

![image](https://user-images.githubusercontent.com/57985290/151758599-383e0ba2-f065-4a77-b923-8faeaf6ca09b.png)

2. Handling a subsequent exception

Loading the test report package after this change has been applied causes the following exception:

![image](https://user-images.githubusercontent.com/57985290/151758790-60f82228-f36a-40c4-938e-018869967303.png)

Because while writing error messages we use `filesource.url` which in this case is a list of a single element: the xhtml file.

In `PackageManager.validateTaxonomyPackage` I replaced all `filesource.url` in logging with `filesource.baseurl` as was already the case for the `invalidDirectoryStructure` message. That way the referenced file is the zip archive rather than the xhtml file, which makes more sense anyway.

#### Steps to Test

Loading the test report package described above gives the following result:

![image](https://user-images.githubusercontent.com/57985290/151759706-7f2cc206-5171-4307-adfe-f462d0c3fce3.png)

* No error message about the "catalog.xml" file
* No unhandled exception raised
* **Note** that when using the ESEF validation plugin as is the case in the screenshot, package validation messages appear twice.

**review**:
@hermfischer-wf
cc: @austinmatherne-wk @derekgengenbacher-wf @sagesmith-wf