### PR TITLE
Skip XMLSchema.xsd during particle validation

### DIFF
--- a/arelle/XmlValidateParticles.py
+++ b/arelle/XmlValidateParticles.py
@@ -15,7 +15,7 @@ from arelle.XmlValidate import validate
 
 def validateElementSequence(modelXbrl, compositor, children, ixFacts, iNextChild=0):
     if compositor.modelDocument.targetNamespace == xsd:
-        return None
+        return (iNextChild, True, None, None)
     particles = compositor.dereference().particles        
     iStartingChild = iNextChild
     errDesc = None

--- a/arelle/XmlValidateParticles.py
+++ b/arelle/XmlValidateParticles.py
@@ -9,9 +9,13 @@ from arelle.ModelDtsObject import (ModelConcept, ModelType, ModelGroupDefinition
                                    ModelAll, ModelChoice, ModelSequence, 
                                    ModelAny, anonymousTypeSuffix)
 from arelle.ModelObject import ModelObject, ModelAttribute
+from arelle.XbrlConst import xsd
 from arelle.XmlValidate import validate
 
+
 def validateElementSequence(modelXbrl, compositor, children, ixFacts, iNextChild=0):
+    if compositor.modelDocument.targetNamespace == xsd:
+        return None
     particles = compositor.dereference().particles        
     iStartingChild = iNextChild
     errDesc = None


### PR DESCRIPTION
#### Description:
Exclude validating XMLSchema.xsd during particle validation because it can cause issues when filing docs include extension concepts.

#### Reason:
The FRC 2022 taxonomy makes `http://www.w3.org/2001/XMLSchema.xsd` a discoverable part of the taxonomy. This causes issues in the Arelle xml validator. Because it is implied that everything derives from that schema there is no need to validate it.

#### Testing:
Use the following doc to validate. Validate it with a disclosure system of ESEF.Verify that the `XMLSchema:UnknownElements` error does not get fired with this fix. [UKSEF-2022.zip](https://github.com/Arelle/Arelle/files/7996958/UKSEF-2022.zip)

**review**:
@hermfischer-wf
cc: @austinmatherne-wk @derekgengenbacher-wf @sagesmith-wf