### PR TITLE
Fix unresolved reference 'modelXbrl' in validate/ESEF/DTS.py

### DIFF
--- a/arelle/plugin/validate/ESEF/DTS.py
+++ b/arelle/plugin/validate/ESEF/DTS.py
@@ -347,7 +347,7 @@ def checkFilingDTS(val, modelDocument, visited, hrefXlinkRole=None):
     if isExtensionDoc and val.authority == "UKFRC":
         if modelDocument.type == ModelDocument.Type.INLINEXBRL:
             if modelDocument.documentEncoding.lower() != "utf-8":
-                modelXbrl.error("UKFRC.1.1.instanceDocumentEncoding",
+                val.modelXbrl.error("UKFRC.1.1.instanceDocumentEncoding",
                     _("UKFRC instance documents should be UTF-8 encoded: %(encoding)s"),
                     modelObject=modelDocument, encoding=modelDocument.documentEncoding)
   


### PR DESCRIPTION
#### Reason for Change

![image](https://user-images.githubusercontent.com/57985290/154257544-8f187be7-01e7-4cad-9e41-ea0ad6f536d9.png)

#### Description

No local variable is defined for `modelXbrl`, instead the `modelXbrl` is accessed through `val.modelXbrl`:

![image](https://user-images.githubusercontent.com/57985290/154257778-4f6002b3-f946-47c3-9e51-360908531259.png)

#### Steps to Test

None on my part, I just run into this while doing a merge and I don't have test samples for the "UKFRC" authority.

**review**:
@hermfischer-wf
cc: @austinmatherne-wk @derekgengenbacher-wf @sagesmith-wf