### PR TITLE
Fix ESEF 3-4-3_2 test case

### DIFF
--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -165,7 +165,7 @@ def checkFilingDimensions(val):
                             val.modelXbrl.error("ESEF.3.4.3.extensionTaxonomyOverridesDefaultMembers",
                                 _("The extension taxonomy MUST not modify (prohibit and/or override) default members assigned to dimensions by the ESEF taxonomy."),
                                 modelObject=linkChild)
-                    if modelLink.role != "http://www.esma.europa.eu/xbrl/role/cor/ifrs- dim_role-990000":
+                    if modelLink.role != "http://www.esma.europa.eu/xbrl/role/cor/ifrs-dim_role-990000":
                         val.modelXbrl.error("ESEF.3.4.3.dimensionDefaultLinkrole",
                             _("Each dimension in an issuer specific extension taxonomy MUST be assigned to a default member in the ELR with role URI http://www.esma.europa.eu/xbrl/role/cor/ifrs-dim_role-990000, but linkrole used is %(linkrole)s."),
                             modelObject=linkChild, linkrole=modelLink.role)

--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -13,7 +13,7 @@ from arelle.ModelDtsObject import ModelConcept
 from arelle.ModelObject import ModelObject
 from arelle.PrototypeDtsObject import PrototypeObject
 from arelle import XbrlConst
-from .Const import LineItemsNotQualifiedLinkrole
+from .Const import LineItemsNotQualifiedLinkrole, DefaultDimensionLinkroles
 from .Util import isExtension, isInEsefTaxonomy
 try:
     import regex as re
@@ -165,7 +165,7 @@ def checkFilingDimensions(val):
                             val.modelXbrl.error("ESEF.3.4.3.extensionTaxonomyOverridesDefaultMembers",
                                 _("The extension taxonomy MUST not modify (prohibit and/or override) default members assigned to dimensions by the ESEF taxonomy."),
                                 modelObject=linkChild)
-                    if modelLink.role != "http://www.esma.europa.eu/xbrl/role/cor/ifrs-dim_role-990000":
+                    if modelLink.role not in DefaultDimensionLinkroles:
                         val.modelXbrl.error("ESEF.3.4.3.dimensionDefaultLinkrole",
                             _("Each dimension in an issuer specific extension taxonomy MUST be assigned to a default member in the ELR with role URI http://www.esma.europa.eu/xbrl/role/cor/ifrs-dim_role-990000, but linkrole used is %(linkrole)s."),
                             modelObject=linkChild, linkrole=modelLink.role)


### PR DESCRIPTION
#### Reason for Change

Arelle gives a false positive for ESEF test case 3-4-3_2/TC1_valid:

![image](https://user-images.githubusercontent.com/57985290/154262392-57d4a270-4487-4fd6-88ed-4279b228802f.png)

#### Description

There is a whitespace in the hard-coded value of the default dimension linkrole:

![image](https://user-images.githubusercontent.com/57985290/154264315-0696d86f-bdf6-4697-9da7-9b4db87eeecf.png)

This PR has two commits:

1. Removing the incriminated whitespace
2. I wondered if the URI was in the XbrlConst.py file; seems it isn't but I found it in the Const.py file of the plugin, so I thought it best to use that instead of a hard-coded value.

#### Steps to reproduce the problem

1. Checking that the disclosure system checks are enabled and that the selected disclosure system is "ESEF"
2. Loading the ESEF test suite G3-4-3_2/index.xml (or directly the G3-4-3_2/TC1_valid.zip test case)
3. Running the validation

#### Steps to Test

1. Going through the "Steps to reproduce the problem" 1 to 3
2. Checking that the error message is not present for the valid test case

**CAUTION:** when validating the test suite, the valid test case may still fail due to an exception, see pull request 143

#### Side note

I wonder about the relevance of this recently added check anyway. Is it not a duplicate of the `3.4.3.extensionTaxonomyDimensionNotAssignedDefaultMemberInDedicatedPlaceholder` (in DTS.py) ?

![image](https://user-images.githubusercontent.com/57985290/154266205-c1710a89-c99f-4495-b5d2-5b0c8f12b2af.png)

The message is very similar for the two of them:

![image](https://user-images.githubusercontent.com/57985290/154266529-6034b01c-b92b-446f-9d78-7618dd0c74cb.png)

Plus, the `dimensionDefaultLinkrole` is not in either the Reporting Manual or the Conformance Suite documentation.

![image](https://user-images.githubusercontent.com/57985290/154266771-e735e967-bcf2-47f1-b557-80507b72509d.png)

**review**:
@hermfischer-wf
cc: @austinmatherne-wk @derekgengenbacher-wf @sagesmith-wf