### PR TITLE
Fix uninitialized variable 'nsExclPat'

### DIFF
--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -906,11 +906,9 @@ def validateXbrlFinally(val, *args, **kwargs):
             if reportedEltsNotInLb and lbType == "presentation":
                 # reported pri items excluded from having to be in pre LB
                 nsExcl = val.authParam.get("lineItemsMustBeInPreLbExclusionNsPattern")
-                nsExclPat = None
                 if nsExcl:
                     nsExclPat = re.compile(nsExcl)
-                reportedEltsNotInLb -= set(c for c in reportedEltsNotInLb 
-                                           if nsExclPat and nsExclPat.match(c.qname.namespaceURI))
+                    reportedEltsNotInLb -= set(c for c in reportedEltsNotInLb if nsExclPat.match(c.qname.namespaceURI))
             if reportedEltsNotInLb and lbType != "calculation":
                 modelXbrl.error("ESEF.3.4.6.UsableConceptsNotAppliedByTaggedFacts",
                     _("All concepts used by tagged facts MUST be in extension taxonomy %(linkbaseType)s relationships: %(elements)s."),

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -906,10 +906,11 @@ def validateXbrlFinally(val, *args, **kwargs):
             if reportedEltsNotInLb and lbType == "presentation":
                 # reported pri items excluded from having to be in pre LB
                 nsExcl = val.authParam.get("lineItemsMustBeInPreLbExclusionNsPattern")
+                nsExclPat = None
                 if nsExcl:
                     nsExclPat = re.compile(nsExcl)
                 reportedEltsNotInLb -= set(c for c in reportedEltsNotInLb 
-                                           if nsExclPat.match(c.qname.namespaceURI))
+                                           if nsExclPat and nsExclPat.match(c.qname.namespaceURI))
             if reportedEltsNotInLb and lbType != "calculation":
                 modelXbrl.error("ESEF.3.4.6.UsableConceptsNotAppliedByTaggedFacts",
                     _("All concepts used by tagged facts MUST be in extension taxonomy %(linkbaseType)s relationships: %(elements)s."),


### PR DESCRIPTION
#### Reason for Change

Exception `NameError` raised while validating two test cases of the ESEF conformance suite:
(The tests are still marked as "passed" though)

![image](https://user-images.githubusercontent.com/57985290/154275650-c2fd7196-35ed-488d-a79e-c6842867c4ae.png)

#### Description

The variable `nsExclPat` is not declared:

![image](https://user-images.githubusercontent.com/57985290/154276004-f5534787-8017-4604-a45c-83f62c772e59.png)

#### Steps to Test

1. Loading the ESEF test cases G3-1-1_1/TC3_invalid, G3-1-1_1/TC5_invalid or the test suite G3-1-1_1/index.xml
2. Running the validation
3. Checking that the `NameError` exception is not raised

**review**:
@hermfischer-wf
cc: @austinmatherne-wk @derekgengenbacher-wf @sagesmith-wf