### PR TITLE
Fix TypeError: '<' not supported between instances of 'InvalidValue' and 'int'

### DIFF
--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -2790,7 +2790,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
             dqc0015 = ugtRels["DQC.US.0015"]
             warnedFactsByQn = defaultdict(list)
             for f in modelXbrl.facts:
-                if (f.qname in dqc0015.concepts and f.isNumeric and not f.isNil and f.xValue < 0 and (
+                if (f.qname in dqc0015.concepts and f.isNumeric and not f.isNil and f.xValid >= VALID and f.xValue < 0 and (
                     all(dim.isTyped or (
                         (dim.dimensionQname not in dqc0015.excludedAxesMembers or
                          ("*" not in dqc0015.excludedAxesMembers[dim.dimensionQname] and


### PR DESCRIPTION
#### Description:
Arelle throws a `'<' not supported between instances of 'InvalidValue' and 'int'` error when a monetary fact is tagged with something like `[XX]` when validating with the EFM disclosure. This PR fixes this issue.

#### Testing:
Validate with [type_error_validation.zip](https://github.com/Arelle/Arelle/files/8100007/type_error_validation.zip) and verify that an with `'<' not supported between instances of 'InvalidValue' and 'int'` is not generated.



**review**:
@hermfischer-wf
cc: @austinmatherne-wk @derekgengenbacher-wf @sagesmith-wf
