### PR TITLE
Exclude LEI formulas from ESEF UKFRC authority

### DIFF
--- a/arelle/ValidateFormula.py
+++ b/arelle/ValidateFormula.py
@@ -897,9 +897,10 @@ def validate(val, xpathContext=None, parametersOnly=False, statusMsg='', compile
             _runIdPattern = "|".join(formulaOptions.runIDs.split()) # whitespace separated IDs
         try: # should be a regex now
             runIDs = re.compile(_runIdPattern)
-            val.modelXbrl.info("formula:trace",
-                               _("Formula/assertion IDs restriction pattern: %(ids)s"), 
-                               modelXbrl=val.modelXbrl, ids=', '.join(_runIdPattern))
+            if formulaOptions.traceVariableSetExpressionResult:
+                val.modelXbrl.info("formula:trace",
+                                   _("Formula/assertion IDs restriction pattern: %(ids)s"), 
+                                   modelXbrl=val.modelXbrl, ids=', '.join(_runIdPattern))
         except:
             val.modelXbrl.info("formula:invalidRunIDsPattern",
                                _("Formula/assertion IDs pattern is invalid: %(runIdPattern)s"), 

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -170,7 +170,6 @@ def validateXbrlStart(val, parameters=None, *args, **kwargs):
         
     formulaOptions = val.modelXbrl.modelManager.formulaOptions
     # skip formula IDs as needed per authority if no formula runIDs provided by environment
-    val.priorFormulaOptionsRunIDs = formulaOptions.runIDs
     if not formulaOptions.runIDs and val.authParam["formulaRunIDs"]:
         formulaOptions.runIDs = val.authParam["formulaRunIDs"]
         
@@ -182,8 +181,6 @@ def validateXbrlFinally(val, *args, **kwargs):
     _xhtmlNs = "{{{}}}".format(xhtml)
     _xhtmlNsLen = len(_xhtmlNs)
     modelXbrl = val.modelXbrl
-    # reset environment formula run IDs
-    modelXbrl.modelManager.formulaOptions.runIDs = val.priorFormulaOptionsRunIDs
     modelDocument = modelXbrl.modelDocument
     if not modelDocument:
         return # never loaded properly

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -170,6 +170,7 @@ def validateXbrlStart(val, parameters=None, *args, **kwargs):
         
     formulaOptions = val.modelXbrl.modelManager.formulaOptions
     # skip formula IDs as needed per authority if no formula runIDs provided by environment
+    val.priorFormulaOptionsRunIDs = formulaOptions.runIDs
     if not formulaOptions.runIDs and val.authParam["formulaRunIDs"]:
         formulaOptions.runIDs = val.authParam["formulaRunIDs"]
         
@@ -1091,6 +1092,8 @@ def validateFormulaFinished(val, *args, **kwargs): # runs *after* formula (which
         return
 
     modelXbrl = val.modelXbrl
+    # reset environment formula run IDs
+    modelXbrl.modelManager.formulaOptions.runIDs = val.priorFormulaOptionsRunIDs
     sumWrnMsgs = sumErrMsgs = 0
     for e in modelXbrl.errors:
         if isinstance(e,dict):

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -273,6 +273,7 @@
             "https://www.w3.org/2001/",
             "http://xbrl.frc.org.uk/",
             "https://xbrl.frc.org.uk/"
-        ]
+        ],
+        "formulaRunIDs": "(?!con_IdentifierSchemeMustBeLEI|lei-identifier-scheme)"
     }
 }


### PR DESCRIPTION
#### Reason for Change

The Companies House identifier is used with UKSEF. This causes the ESEF run formulas to throw 2 errors for `con_IdentifierSchemeMustBeLEI` and `lei-identifier-scheme`. These 2 formulas need to be excluded from UKSEF validations.

#### Description
Configure the UKFRC authority to exclude the LEI formula IDs and stop resetting the formula `runIDs` before executing formulas.

#### Steps to Test

Verify that the LEI formulas no longer generate errors for [test-20220216.zip](https://github.com/Arelle/Arelle/files/8110030/test-20220216.zip) when validated using the UKFRC authority.

**review**:
@hermfischer-wf
cc: @derekgengenbacher-wf @sagesmith-wf