### PR TITLE
Integrate command line --internetRecheck with WebCache recheck feature

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -305,8 +305,8 @@ def parseAndRun(args):
     parser.add_option("--internetTimeout", type="int", dest="internetTimeout", 
                       help=_("Specify internet connection timeout in seconds (0 means unlimited)."))
     parser.add_option("--internettimeout", type="int", action="store", dest="internetTimeout", help=SUPPRESS_HELP)
-    parser.add_option("--internetRecheck", choices=("weekly", "daily", "never"), action="store", dest="internetRecheck", 
-                      help=_("Specify rechecking cache files (weekly is default)"))
+    parser.add_option("--internetRecheck", choices=("weekly", "daily", "never", "hourly", "quarter-hourly"), action="store", dest="internetRecheck", 
+                      help=_("Specify rechecking for newer cache files 'daily', 'weekly', 'monthly' or 'never' ('weekly' is default)"))
     parser.add_option("--internetrecheck", choices=("weekly", "daily", "never"), action="store", dest="internetRecheck", help=SUPPRESS_HELP)
     parser.add_option("--internetLogDownloads", action="store_true", dest="internetLogDownloads", 
                       help=_("Log info message for downloads to web cache."))
@@ -792,6 +792,8 @@ class CntlrCmdLine(Cntlr.Cntlr):
             self.webCache.timeout = (options.internetTimeout or None)  # use None if zero specified to disable timeout
         if options.internetLogDownloads:
             self.webCache.logDownloads = True
+        if options.internetRecheck:
+            self.webCache.recheck = options.internetRecheck
         fo = FormulaOptions()
         if options.parameters:
             parameterSeparator = (options.parameterSeparator or ',')

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -143,12 +143,17 @@ class WebCache:
             return "weekly"
         elif days >=1:
             return "daily"
+        elif self.maxAgeSeconds >= 3600.0:
+            return "hourly"
+        elif self.maxAgeSeconds >= 900.0: # 15 minutes. just intended for testing
+            return "quarter-hourly"
         else:
             return "(invalid)"
 
     @timeout.setter
     def recheck(self, recheckInterval):
-        self.maxAgeSeconds = {"daily": 1.0, "weekly": 7.0, "monthly": 30.0, "never": INF
+        self.maxAgeSeconds = {"daily": 1.0, "weekly": 7.0, "monthly": 30.0, "never": INF,
+                              "hourly": 1.0/24.0, "quarter-hourly": 1.0/96.0 # lower numbers for testing purposes
                               }.get(recheckInterval, 7.0) * (60.0 * 60.0 * 24.0) 
 
     @property


### PR DESCRIPTION
Reason for Change
The "--internetRecheck" CmdLine option wasn't integrated with the corresponding WebCache feature

Description
Configure option to use feature (specifies how often a request for a web-accessed file is to be checked to see if the web's file has a newer timestamp than the locally-cached file.).

Steps to Test
With debugger one can trace operation at WebCache#360 to verify that when prior check time plus recheck interval passes the http headers for last update time are checked in case http file is newer than cached file's timestamp.

With a web url under tester's control (such as an http-accessed instance doc file), setting to a short recheck interval (quarter-hourly) and touching the web url should cause the file-on-disk in cache to be re-fetched

review:
@derekgengenbacher-wf @sagesmith-wf
cc: @hermfischer-wf