### PR TITLE
Fix recheck and logDownloads setters Add internet recheck option to GUI

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -212,9 +212,12 @@ class CntlrWinMain (Cntlr.Cntlr):
         _internetRecheckEntries = ((_("daily"), "daily"), (_("weekly"), "weekly"), (_("monthly"), "monthly"), (_("never"), "never"))
 
         for (_opt_label, _opt_val) in _internetRecheckEntries:
-            internetCacheRecheckMenu.add_checkbutton(label=_opt_label,
-                    variable=self.internetRecheckVar, underline=0,
-                    onvalue=_opt_val)
+            internetCacheRecheckMenu.add_checkbutton(
+                    label=_opt_label,
+                    variable=self.internetRecheckVar, 
+                    underline=0,
+                    onvalue=_opt_val
+             )
 
         cacheMenu.add_command(label=_("Clear cache"), underline=0, command=self.confirmClearWebCache)
         cacheMenu.add_command(label=_("Manage cache"), underline=0, command=self.manageWebCache)

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -209,8 +209,7 @@ class CntlrWinMain (Cntlr.Cntlr):
         _recheck_initial = 'disable' if self.webCache.workOffline else 'normal'
         self.internetRecheckVar.trace("w", self.setInternetRecheck)
 
-        _internetRecheckEntries = ((_("daily"), "daily"), (_("weekly"), "weekly"
-                                ), (_("monthly"), "monthly"), (_("never"), "never"))
+        _internetRecheckEntries = ((_("daily"), "daily"), (_("weekly"), "weekly"), (_("monthly"), "monthly"), (_("never"), "never"))
 
         for (_opt_label, _opt_val) in _internetRecheckEntries:
             internetCacheRecheckMenu.add_checkbutton(label=_opt_label,
@@ -1115,10 +1114,8 @@ class CntlrWinMain (Cntlr.Cntlr):
     def setInternetRecheck(self, *args):
         self.webCache.recheck = self.internetRecheckVar.get()
         self.config["internetRecheck"] = self.webCache.recheck
-        self.addToLog('WebCache.recheck = {}'.format(self.webCache.recheck),
-                    messageCode='debug', level=logging.DEBUG)
-        self.addToLog('WebCache.maxAgeSeconds = {}'.format(self.webCache.maxAgeSeconds),
-                    messageCode='debug', level=logging.DEBUG)
+        self.addToLog('WebCache.recheck = {}'.format(self.webCache.recheck), messageCode='debug', level=logging.DEBUG)
+        self.addToLog('WebCache.maxAgeSeconds = {}'.format(self.webCache.maxAgeSeconds), messageCode='debug', level=logging.DEBUG)
         self.saveConfig()
 
     def setNoCertificateCheck(self, *args):

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -201,12 +201,30 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.downloadNotify.trace("w", self.setRetrievalNotify)
         cacheMenu.add_checkbutton(label=_("Notify file downloads"), underline=0, variable=self.workOffline, onvalue=True, offvalue=False)
         '''
+
+        internetCacheRecheckMenu = Menu(cacheMenu, tearoff=0)
+        self.webCache.recheck = self.config.setdefault("internetRecheck", "weekly")
+        self.internetRecheckVar = StringVar(value=self.webCache.recheck)
+        self._internetRecheckLabel = _("Internet recheck Interval")
+        _recheck_initial = 'disable' if self.webCache.workOffline else 'normal'
+        self.internetRecheckVar.trace("w", self.setInternetRecheck)
+
+        _internetRecheckEntries = ((_("daily"), "daily"), (_("weekly"), "weekly"
+                                ), (_("monthly"), "monthly"), (_("never"), "never"))
+
+        for (_opt_label, _opt_val) in _internetRecheckEntries:
+            internetCacheRecheckMenu.add_checkbutton(label=_opt_label,
+                    variable=self.internetRecheckVar, underline=0,
+                    onvalue=_opt_val)
+
         cacheMenu.add_command(label=_("Clear cache"), underline=0, command=self.confirmClearWebCache)
         cacheMenu.add_command(label=_("Manage cache"), underline=0, command=self.manageWebCache)
+        cacheMenu.add_cascade(label=self._internetRecheckLabel, menu=internetCacheRecheckMenu, underline=0, state=_recheck_initial)
         cacheMenu.add_command(label=_("Proxy Server"), underline=0, command=self.setupProxy)
         cacheMenu.add_command(label=_("HTTP User Agent"), underline=0, command=self.setupUserAgent)
         self.webCache.httpUserAgent = self.config.get("httpUserAgent")
-        
+        self._cacheMenu = cacheMenu
+
         logmsgMenu = Menu(self.menubar, tearoff=0)
         toolsMenu.add_cascade(label=_("Messages log"), menu=logmsgMenu, underline=0)
         logmsgMenu.add_command(label=_("Clear"), underline=0, command=self.logClear)
@@ -1088,7 +1106,21 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.webCache.workOffline = self.workOffline.get()
         self.config["workOffline"] = self.webCache.workOffline
         self.saveConfig()
-                    
+        # disable internet recheck choices when working offline
+        if self.workOffline.get():
+            self._cacheMenu.entryconfig(self._internetRecheckLabel, state='disable')
+        else:
+            self._cacheMenu.entryconfig(self._internetRecheckLabel, state='normal')
+
+    def setInternetRecheck(self, *args):
+        self.webCache.recheck = self.internetRecheckVar.get()
+        self.config["internetRecheck"] = self.webCache.recheck
+        self.addToLog('WebCache.recheck = {}'.format(self.webCache.recheck),
+                    messageCode='debug', level=logging.DEBUG)
+        self.addToLog('WebCache.maxAgeSeconds = {}'.format(self.webCache.maxAgeSeconds),
+                    messageCode='debug', level=logging.DEBUG)
+        self.saveConfig()
+
     def setNoCertificateCheck(self, *args):
         self.webCache.noCertificateCheck = self.noCertificateCheck.get() # resets proxy handlers
         self.config["noCertificateCheck"] = self.webCache.noCertificateCheck

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -150,7 +150,7 @@ class WebCache:
         else:
             return "(invalid)"
 
-    @timeout.setter
+    @recheck.setter
     def recheck(self, recheckInterval):
         self.maxAgeSeconds = {"daily": 1.0, "weekly": 7.0, "monthly": 30.0, "never": INF,
                               "hourly": 1.0/24.0, "quarter-hourly": 1.0/96.0 # lower numbers for testing purposes
@@ -160,7 +160,7 @@ class WebCache:
     def logDownloads(self):
         return self._logDownloads
 
-    @timeout.setter
+    @logDownloads.setter
     def logDownloads(self, _logDownloads):
         self._logDownloads = _logDownloads
 


### PR DESCRIPTION
## Description
1. Fix WebCache properties recheck and logDownloads setters.
2. Add option to control internet recheck intervals in GUI.

## Tests
### 1. WebCache recheck and logDownloads properties setters: 
`WebCache.recheck` and `WebCache.logDownLoads` not returning the correct value. The issue can be demonstrated and tested as follows:
```python
from arelle import Cntlr, FileSource

cntlr = Cntlr.Cntlr(logFileName="logToPring")

## before commit 
### set internet recheck and logDownload
cntlr.webCache.recheck = 'monthly'
cntlr.webCache.logDownloads = True
print(cntlr.webCache.recheck, cntlr.webCache.maxAgeSeconds) 
# >>> None 2592000.0 -> expected: monthly 2592000.0
print(cntlr.webCache.logDownloads)
# >>> None  -> expected True

# now set timeout
cntlr.webCache.timeout = 10
print(cntlr.webCache.recheck, cntlr.webCache.logDownloads, cntlr.webCache.timeout)
# >>> 10 10 10 -> expected: monthly True 10
# max age seconds still correct
print(cntlr.webCache.maxAgeSeconds)
# >>> 2592000.0

## after commit 
### set internet recheck and logDownload
cntlr.webCache.recheck = 'monthly'
cntlr.webCache.logDownloads = True
print(cntlr.webCache.recheck, cntlr.webCache.maxAgeSeconds) 
# >>> monthly 2592000.0 -> as expected
print(cntlr.webCache.logDownloads)
# >>> True  -> as expected

# set timeout
cntlr.webCache.timeout = 10
print(cntlr.webCache.recheck, cntlr.webCache.logDownloads, cntlr.webCache.timeout)
# >>> monthly True 10 -> as expected
# max age seconds still correct
print(cntlr.webCache.maxAgeSeconds)
# >>> 2592000.0
```
### 2. Add internet recheck interval to GUI:
Nice to have feature to be able to control recheck intervals from GUI since it is already available in command line. 
Added menu under `Tools>Internet>Internet recheck interval`:
![recheck_opts](https://user-images.githubusercontent.com/16232793/155748693-070f55dd-a120-472e-9fb0-7735bd8714db.png)
When working offline, selection is disabled:
![recheck_opts2](https://user-images.githubusercontent.com/16232793/155749098-24bf623c-4e18-4c7e-b5a2-3d1dfb82d1de.png)

**Added configuration key `internetRecheck` to save and restore selection.**

**Testing**: Set Show debug messages from `Tools>Messages log>Show debug messages` and change selections, the new values for `WebCache.recheck` and `WebCache.maxAgeSeconds` will be logged in the messages panel.
Also can redo same test from [here](https://github.com/Arelle/Arelle/issues/139#issuecomment-1047420213) but make sure to restart arelle after changing dates in `cachedUrlCheckTimes.json` so it will take effect. 

 