### PR TITLE
[ESEF] Replace 2.6.1 message for unconsolidated disclosure system

### DIFF
--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -292,9 +292,15 @@ def validateXbrlFinally(val, *args, **kwargs):
             if doc.type in (ModelDocument.Type.INLINEXBRL, ModelDocument.Type.UnknownXML):
                 _baseName, _baseExt = os.path.splitext(doc.basename)
                 if _baseExt not in (".xhtml",".html"):
-                    modelXbrl.error("ESEF.2.6.1.incorrectFileExtension",
-                        _("Inline XBRL document included within a ESEF report package MUST have a .html or .xhtml extension: %(fileName)s"),
-                        modelObject=doc, fileName=doc.basename)
+                    if val.consolidated:
+                        XHTMLExtensionGuidance = "2.6.1"
+                        reportType = _("Inline XBRL document included within a ESEF report package")
+                    else:
+                        XHTMLExtensionGuidance = "4.1.1"
+                        reportType = _("Stand-alone XHTML document")
+                    modelXbrl.error("ESEF.%s.incorrectFileExtension" % XHTMLExtensionGuidance,
+                                    _("%(reportType)s MUST have a .html or .xhtml extension: %(fileName)s"),
+                                    modelObject=doc, fileName=doc.basename, reportType=reportType)
                 docinfo = doc.xmlRootElement.getroottree().docinfo
                 docTypeMatch = docTypeXhtmlPattern.match(docinfo.doctype)
                 if val.consolidated:


### PR DESCRIPTION
#### Reason for Change

When validating stand-alone XHTML with the ESEF unconsolidated disclosure system, Arelle reports an error `2.6.1.incorrectFileExtension` if the file extension is not `.html` or `.xhtml`

![image](https://user-images.githubusercontent.com/57985290/155891879-135fdb3b-62dd-4f30-a9eb-ee0f4c7fded5.png)

Although neither the reporting manual nor the conformance suite provide a specific error message for an incorrect extension for stand-alone XHTML, ESMA "recommends" using one of the above mentioned extensions.  
However referring to the 2.6.1 section of the manual is imprecise, as is the current message mentioning a "ESEF report package".

#### Description

This small change make use of the `val.consolidated` variable to dynamically set the guidance reference as well as part of the error message according to the active disclosure system.

For the unconsolidated setting the guidance reference is `4.1.1`:

![image](https://user-images.githubusercontent.com/57985290/155891932-44c632e5-df91-426a-a53b-26687290b86e.png)

I'm not absolutely sure about the severity level here, I suppose it makes sense to use the same one as for iXBRL reports.

#### Steps to Test

1. Validate a XHTML file with an extension that is not `.html` or `.xhtml` using the `esef-unconsolidated` disclosure system, and check that the error message is `[ESEF.4.1.1.incorrectFileExtension] Stand-alone XHTML document MUST have a .html or .xhtml extension` (I used a case from the ESEF conformance suite with a modified extension `.htm`; the other error serves as a telltale sign the the validation was correctly run)

![image](https://user-images.githubusercontent.com/57985290/155892050-2f70697c-63b9-4b46-b5c1-60dbd99babf6.png)

2. Validate a XHTML file with the `.xhtml` extension using the `esef-unconsolidated` disclosure system, and check that no error about the file extension is reported (again, using an invalid test case triggering another error allows to check that the correct ESEF validation is active)
3. Run the G2-6-1_2 suite **with the `esef` disclosure system** (not unconsolidated) to verify that this suite passes and the error message and guidance reference are still correct.

![image](https://user-images.githubusercontent.com/57985290/155892499-14cb8a00-7a40-4b26-bb1e-101a81ad389c.png)

**review**:
@hermfischer-wf
cc: @austinmatherne-wk @derekgengenbacher-wf @sagesmith-wf