### PR TITLE
Support zipped testcase suites with test cases of report packages

### DIFF
--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -24,7 +24,7 @@ XMLdeclaration = re.compile(r"<\?xml[^><\?]*\?>", re.DOTALL)
 
 TAXONOMY_PACKAGE_FILE_NAMES = ('.taxonomyPackage.xml', 'catalog.xml') # pre-PWD packages
 
-def openFileSource(filename, cntlr=None, sourceZipStream=None, checkIfXmlIsEis=False, reloadCache=False, base=None):
+def openFileSource(filename, cntlr=None, sourceZipStream=None, checkIfXmlIsEis=False, reloadCache=False, base=None, sourceFileSource=None):
     if sourceZipStream:
         filesource = FileSource(POST_UPLOADED_ZIP, cntlr)
         filesource.openZipStream(sourceZipStream)
@@ -38,7 +38,11 @@ def openFileSource(filename, cntlr=None, sourceZipStream=None, checkIfXmlIsEis=F
         if archivepathSelection is not None:
             archivepath = archivepathSelection[0]
             selection = archivepathSelection[1]
-            filesource = FileSource(archivepath, cntlr, checkIfXmlIsEis)
+            if sourceFileSource and sourceFileSource.isArchive and selection in sourceFileSource.dir and selection.endswith(".zip"):
+                filesource = FileSource(filename, cntlr)
+                selection = None
+            else:
+                filesource = FileSource(archivepath, cntlr, checkIfXmlIsEis)
             filesource.open(reloadCache)
             if selection:
                 filesource.select(selection)

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -522,9 +522,21 @@ class Type:
             for _event, elt in etree.iterparse(file, events=("start",), recover=True, huge_tree=True):
                 if _rootElt:
                     _rootElt = False
+                    _type = {"testcases": Type.TESTCASESINDEX, 
+                             "documentation": Type.TESTCASESINDEX, 
+                             "testSuite": Type.TESTCASESINDEX, 
+                             "registries": Type.TESTCASESINDEX,
+                             "testcase": Type.TESTCASE, 
+                             "testSet": Type.TESTCASE,
+                             "rss": Type.RSSFEED
+                        }.get(etree.QName(elt).localname)
+                    if _type:
+                        break
                     _type = {"{http://www.xbrl.org/2003/instance}xbrl": Type.INSTANCE,
                              "{http://www.xbrl.org/2003/linkbase}linkbase": Type.LINKBASE,
-                             "{http://www.w3.org/2001/XMLSchema}schema": Type.SCHEMA}.get(elt.tag, Type.UnknownXML)
+                             "{http://www.w3.org/2001/XMLSchema}schema": Type.SCHEMA,
+                             "{http://xbrl.org/2008/registry}registry": Type.REGISTRY
+                             }.get(elt.tag, Type.UnknownXML)
                     if _type == Type.UnknownXML and elt.tag.endswith("html"):
                         pass # following is not a valid test: 
                         # if XbrlConst.ixbrl in elt.nsmap.values():

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -224,7 +224,7 @@ class Validate:
                         modelXbrl = PrototypeInstanceObject.XbrlPrototype(self.modelXbrl.modelManager, readMeFirstUri)
                         PackageManager.packageInfo(self.modelXbrl.modelManager.cntlr, readMeFirstUri, reload=True, errors=modelXbrl.errors)
                     else: # not a multi-schemaRef versioning report
-                        if self.useFileSource.isArchive:
+                        if self.useFileSource.isArchive and (os.path.isabs(readMeFirstUri) or not readMeFirstUri.endswith(".zip")):
                             modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager, 
                                                        readMeFirstUri,
                                                        _("validating"), 
@@ -233,7 +233,8 @@ class Validate:
                                                        errorCaptureLevel=errorCaptureLevel,
                                                        ixdsTarget=modelTestcaseVariation.ixdsTarget)
                         else: # need own file source, may need instance discovery
-                            filesource = FileSource.openFileSource(readMeFirstUri, self.modelXbrl.modelManager.cntlr, base=baseForElement)
+                            filesource = FileSource.openFileSource(readMeFirstUri, self.modelXbrl.modelManager.cntlr, base=baseForElement,
+                                                                   sourceFileSource=self.useFileSource if self.useFileSource.isArchive and not os.path.isabs(readMeFirstUri) and readMeFirstUri.endswith(".zip") else None)
                             _errors = [] # accumulate pre-loading errors, such as during taxonomy package loading
                             if filesource and not filesource.selection and filesource.isArchive:
                                 try:

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -102,15 +102,21 @@ def disclosureSystemConfigURL(disclosureSystem, *args, **kwargs):
 def modelXbrlBeforeLoading(modelXbrl, normalizedUri, filepath, isEntry=False, **kwargs):
     if getattr(modelXbrl.modelManager.disclosureSystem, "ESEFplugin", False):
         if isEntry and not any("unconsolidated" in n for n in modelXbrl.modelManager.disclosureSystem.names):
-            if modelXbrl.fileSource.isArchive and not validateTaxonomyPackage(modelXbrl.modelManager.cntlr, modelXbrl.fileSource):
-                modelXbrl.error("ESEF.RTS.Annex.III.3.missingOrInvalidTaxonomyPackage",
-                    _("Single reporting package with issuer's XBRL extension taxonomy files and Inline XBRL instance document must be compliant with the latest recommended version of the Taxonomy Packages specification (1.0)"),
-                    modelObject=modelXbrl) 
-                return ModelDocument.LoadingException("Invalid taxonomy package") 
+            if modelXbrl.fileSource.isArchive:
+                if (modelXbrl.fileSource.selection.endswith(".xml") and 
+                    ModelDocument.Type.identify(modelXbrl.fileSource, modelXbrl.fileSource.url) in (
+                        ModelDocument.Type.TESTCASESINDEX, ModelDocument.Type.TESTCASE)):
+                    return None # allow zipped test case to load normally
+                if not validateTaxonomyPackage(modelXbrl.modelManager.cntlr, modelXbrl.fileSource):
+                    modelXbrl.error("ESEF.RTS.Annex.III.3.missingOrInvalidTaxonomyPackage",
+                        _("Single reporting package with issuer's XBRL extension taxonomy files and Inline XBRL instance document must be compliant with the latest recommended version of the Taxonomy Packages specification (1.0)"),
+                        modelObject=modelXbrl) 
+                    return ModelDocument.LoadingException("Invalid taxonomy package") 
     return None                       
 
 def modelXbrlLoadComplete(modelXbrl):
-    if getattr(modelXbrl.modelManager.disclosureSystem, "ESEFplugin", False):
+    if (getattr(modelXbrl.modelManager.disclosureSystem, "ESEFplugin", False) and
+        (modelXbrl.modelDocument is None or modelXbrl.modelDocument.type not in (ModelDocument.Type.TESTCASESINDEX, ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRY, ModelDocument.Type.RSSFEED))):
         if any("unconsolidated" in n for n in modelXbrl.modelManager.disclosureSystem.names):
             htmlElement = modelXbrl.modelDocument.xmlRootElement
             if htmlElement.namespaceURI == xhtml:  
@@ -125,9 +131,8 @@ def modelXbrlLoadComplete(modelXbrl):
             modelXbrl.error("ESEF.3.1.3.missingOrInvalidTaxonomyPackage",
                             _("RTS Annex III Par 3 and ESEF 3.1.3 requires an XBRL Report Package but one could not be loaded."), 
                             modelObject=modelXbrl)
-        if (modelXbrl.modelDocument is None or 
-            (modelXbrl.modelDocument.type not in (ModelDocument.Type.TESTCASESINDEX, ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRY, ModelDocument.Type.RSSFEED)
-            and not modelXbrl.facts and "ESEF.RTS.Art.6.a.noInlineXbrlTags" not in modelXbrl.errors)):
+        if (modelXbrl.modelDocument is None or
+            not modelXbrl.facts and "ESEF.RTS.Art.6.a.noInlineXbrlTags" not in modelXbrl.errors):
             modelXbrl.error("ESEF.RTS.Art.6.a.noInlineXbrlTags",
                             _("RTS on ESEF requires inline XBRL, no facts were reported."),
                             modelObject=modelXbrl)
@@ -324,6 +329,8 @@ def validateXbrlFinally(val, *args, **kwargs):
                     reportCorrectlyPlacedInPackage = reportIsInZipFile = False
                     for i, dir in enumerate(docDirPath):
                         if dir.lower().endswith(".zip"):
+                            if reportIsInZipFile: # report package was nested in a zip file
+                                ixdsDocDirs.clear() # ignore containing zip
                             reportIsInZipFile = True
                             packageName = dir[:-4] # web service posted zips are always named POSTupload.zip instead of the source file name
                             if len(docDirPath) >= i + 2 and packageName in (docDirPath[i+1],"POSTupload") and docDirPath[i+2] == "reports":
@@ -331,7 +338,6 @@ def validateXbrlFinally(val, *args, **kwargs):
                                 reportCorrectlyPlacedInPackage = True
                             else:
                                 ixdsDocDirs.add("/".join(docDirPath[i+1:len(docDirPath)-1])) # needed for error msg on orphaned instance docs
-                            break
                     if not reportIsInZipFile:
                         modelXbrl.error("ESEF.2.6.1.reportIncorrectlyPlacedInPackage",
                             _("Inline XBRL document MUST be included within an ESEF report package as defined in"

--- a/scripts/runESEFtests.sh
+++ b/scripts/runESEFtests.sh
@@ -3,14 +3,17 @@
 # Run ESMA ESEF conformance tests
 
 ARELLECMDLINESRC=/users/hermf/Documents/mvsl/projects/arelle/arelleproject/src/arelleCmdLine.py
-PYTHON=python3.9
+PYTHON=/opt/homebrew/bin/python3.9
 PLUGINS='validate/ESEF'
 PACKAGES=/Users/hermf/Documents/mvsl/projects/ESMA/esef_taxonomy_2021.zip 
 FILTER='(?!arelle:testcaseDataUnexpected)'
 FORMULA=none
 FORMULA=run
 
-TESTCASESROOT=/Users/hermf/Documents/mvsl/projects/ESMA/conf/esef_conformance_suite_2021
+# run from directory test case root
+#TESTCASESROOT=/Users/hermf/Documents/mvsl/projects/ESMA/conf/esef_conformance_suite_2021
+# zip file test case root
+TESTCASESROOT=/Users/hermf/Documents/mvsl/projects/ESMA/conf/esef_conformance_suite_2021.zip/esef_conformance_suite_2021/esef_conformance_suite_2021
 
 rm -f /users/hermf/temp/ESEF-conf-*
 


### PR DESCRIPTION
#### Reason for change
Running zipped testcase suites (the usual form of their distribution by XII, ESMA and SEC) didn't work with readMeFirst report packages.

#### Description of change
Add check for archive-loaded testcase variations which load taxonomy packages, allow FileSource to load a taxonomy package which is a zip within a zip.

#### Steps to Test
Used this shell command:
/opt/homebrew/bin/python3.9 arelleCmdLine.py -f /Users/hermf/Documents/mvsl/projects/ESMA/conf/esef_conformance_suite_2021.zip/esef_conformance_suite_2021/esef_conformance_suite_2021/index_inline_xbrl.xml -v --plugin validate/ESEF --disclosureSystem esef --packages /Users/hermf/Documents/mvsl/projects/ESMA/esef_taxonomy_2021.zip --testcaseResultsCaptureWarnings --logFile ~/temp/test.log  --csvTestReport ~/temp/test.xlsx

#### TBD
scripts/runESEFtests.sh doesn't work (yet)

**review**:
@Arelle/arelle
