### PR TITLE
EDGAR release 22.1.h2

### DIFF
--- a/arelle/plugin/validate/EFM/resources/dei-validations.json
+++ b/arelle/plugin/validate/EFM/resources/dei-validations.json
@@ -23,6 +23,7 @@
         "Each validation object contains the following entries:",
         "  sub-types: arrayed submissionType or submissionType references or single submissionType or submissionType reference,",
         "             where specific to a form type, section-sign § separates sub and form types, e.g. 'POS EX§N-2' ",
+        "  sub-types-pattern: a regex to match submissionTypes instead of the sub-types array of submissionType values",
         "  xbrl-names, elo-names, and severities may be array (plural) or individual", 
         "  xbrl-names: arrayed dei local names or prefixed non-dei nmes of XBRL elements,",
         "  elo-names: optional corresponding arrayed ELO schema names of XML elements,",
@@ -86,7 +87,7 @@
         "N-6": ["N-6", "N-6/A", "485POS§N-6", "485APOS§N-6", "485BPOS§N-6", "485BXT§N-6", "497§N-6"],
         "N-346": ["@N-3", "@N-4", "@N-6"],
 		"POS": ["POS AM", "POS EX"],
-		"RR": ["485APOS", "485BPOS", "485BXT", "497", "N-1A"],
+		"RR": ["485APOS", "485BPOS", "485BXT", "497", "N-1A", "N-1A/A"],
 		"SP 15D2": ["SP 15D2", "SP 15D2/A"],
 		"S-n": ["S-1", "S-1/A", "S-3", "S-3/A", "S-4", "S-4/A", "S-11", "S-11/A"],
 		"S-nX": ["S-1MEF", "S-3D", "S-3DPOS", "S-3MEF", "S-4EF", "S-4MEF", "S-4 POS", "S-11MEF"],
@@ -338,7 +339,12 @@
         "dei/cover": "dei"
     },
     {
-    	"sub-types": ["@all"],
+        "sub-types": [
+            "@all-FAST",
+            "@POS", "N-CSR", "N-CSR/A", "N-CSRS", "N-CSRS/A",
+            "@6-K", "@SP 15D2", "@RR", "@N-346", "@SDR",
+            "@N", "N-3", "N-4", "N-6"
+        ],
         "xbrl-names": "DocumentPeriodEndDate",
         "store-db-name": "periodOfReport",
         "store-db-object": "eloValuesFromFacts",
@@ -802,6 +808,15 @@
         "elo-name": "invCompanyType",
         "efm": "6.5.40",
         "validation": "r",
+        "source": "both",
+        "dei/cover": "dei"
+    },
+    {
+        "sub-types-pattern": "^(N-.*|(485(A|B)(POS|BXT))|486.*|497.*|POS(ASR|462[BC]| 8C| AMI))$",
+        "xbrl-names": "EntityInvCompanyType",
+        "elo-name": "invCompanyType",
+        "efm": "6.5.40",
+        "validation": "o",
         "source": "both",
         "dei/cover": "dei"
     },

--- a/arelle/plugin/validate/EFM/resources/dqc-us-rules.json
+++ b/arelle/plugin/validate/EFM/resources/dqc-us-rules.json
@@ -19,6 +19,8 @@
         "DQC.US rule 0043 is implemented below (new for 2022)",
         "DQC.US rule 0044 is implemented below (new for 2022)",
         "DQC.US rule 0048 is implemented below",
+        "DQC.US rule 0060 is implemented below (new for 2022)",
+        "DQC.US rule 0079 is implemented below (new for 2022)",
         "",
         "Each below rule contains a description of syntax used herein, message and rules. ",
         "",

--- a/buildVersion.py
+++ b/buildVersion.py
@@ -8,7 +8,7 @@ This module emits the version.py file contents which are used in the
 build process to indicate the time that this version was built.
 
 '''
-import datetime, sys
+import datetime, sys, subprocess, os
 arelleMajorVersion = 1 # major verison = 1 (python), 2 (cython)
 
 if __name__ == "__main__":
@@ -30,6 +30,17 @@ if __name__ == "__main__":
                  "version = '{3}'  # string version of date compiled\n"
                  "copyrightLatestYear = '{0}'  # string version of year compiled\n"
                  ).format(dateYr, arelleMajorVersion, dateDotYmd, dateDashYmdHmUtc)
+
+    try:
+        arelleCommit = subprocess.check_output(["git", "show", "--format='%h'", "--no-patch"]).decode("utf-8").strip()
+        os.chdir("arelle/plugin/EdgarRenderer")
+        edgarRendererCommit = subprocess.check_output(["git", "show", "--format='%h'", "--no-patch"]).decode("utf-8").strip()
+        os.chdir("../../..")
+        versionPy += ("arelleCommit = {0} # git Arelle commit \n"
+                      "edgarRendererCommit = {1} # git EdgarRenderer commit \n"
+                      ).format(arelleCommit, edgarRendererCommit)
+    except Exception:
+        pass
 
     with open("arelle/Version.py", "w") as fh:
         fh.write(versionPy)

--- a/buildVersion.py
+++ b/buildVersion.py
@@ -30,6 +30,8 @@ if __name__ == "__main__":
                  "version = '{3}'  # string version of date compiled\n"
                  "copyrightLatestYear = '{0}'  # string version of year compiled\n"
                  ).format(dateYr, arelleMajorVersion, dateDotYmd, dateDashYmdHmUtc)
+                 
+    versionTxt = dateDashYmdHmUtc
 
     try:
         arelleCommit = subprocess.check_output(["git", "show", "--format='%h'", "--no-patch"]).decode("utf-8").strip()
@@ -39,6 +41,9 @@ if __name__ == "__main__":
         versionPy += ("arelleCommit = {0} # git Arelle commit \n"
                       "edgarRendererCommit = {1} # git EdgarRenderer commit \n"
                       ).format(arelleCommit, edgarRendererCommit)
+        versionTxt += ("\narelleCommit {0} "
+                       "\nedgarRendererCommit {1}"
+                      ).format(arelleCommit[1:-1], edgarRendererCommit[1:-1])
     except Exception:
         pass
 
@@ -46,7 +51,7 @@ if __name__ == "__main__":
         fh.write(versionPy)
         
     with open("version.txt", "w") as fh:
-        fh.write(dateDashYmdHmUtc)
+        fh.write(versionTxt)
         
 
     # add name suffix, like ER3 or TKTABLE

--- a/installWin64.nsi
+++ b/installWin64.nsi
@@ -43,7 +43,7 @@
 ;--------------------------------
 ;Pages
 
-  !insertmacro MUI_PAGE_LICENSE "License.txt"
+  !insertmacro MUI_PAGE_LICENSE "LICENSE.md"
   ; !insertmacro MUI_PAGE_COMPONENTS
   !insertmacro MUI_PAGE_DIRECTORY
   

--- a/installWin86.nsi
+++ b/installWin86.nsi
@@ -39,7 +39,7 @@
 ;--------------------------------
 ;Pages
 
-  !insertmacro MUI_PAGE_LICENSE "License.txt"
+  !insertmacro MUI_PAGE_LICENSE "LICENSE.md"
   ; !insertmacro MUI_PAGE_COMPONENTS
   !insertmacro MUI_PAGE_DIRECTORY
   

--- a/scripts/runEFMtests.sh
+++ b/scripts/runEFMtests.sh
@@ -4,7 +4,7 @@
 
 TESTCASESINDEXFILE=/Users/hermf/Documents/mvsl/projects/SEC/efm/conf/testcases.xml
 PLUGINS=EdgarRenderer
-DISCLOSURE_SYSTEM=efm-pragmatic-preview
+DISCLOSURE_SYSTEM=efm-pragmatic
 
 LOG_DIR=/users/hermf/temp
 rm -f $LOG_DIR/EFM-conf-*


### PR DESCRIPTION
#### Reason for change
EDGAR hotfix 22.1.h2

#### Description of change
fixes EntityInvCompanyType validations for N2-family forms and DQC 0060
adds git commit references to build's version.txt (e.g., of the PR being built for) (for Arelle and EdgarRenderer projects)

#### Steps to Test
1 - [EFM test suite, 2022-03-31 or newer](https://www.sec.gov/structureddata/osdinteractivedatatestsuite) for EntityInvCompanyType
2 - for DQC 0060 [this filing should have no DQC 0060](http://www.sec.gov/Archives/edgar/data/707605/000155837022004065/tmb-20211231x10ka.htm) issues (it did before) and [this filing should have 2 DQC 0060 issues](http://www.sec.gov/Archives/edgar/data/1568385/000149315221032437/bmtm-20201231.xml)

**review**:
@Arelle/arelle
