### PR TITLE
OIM load from csv in excel with imprecise general float cell content

### DIFF
--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -481,6 +481,8 @@ def xlValue(cell): # excel values may have encoded unicode, such as _0000D_
         v = xlUnicodePattern.sub(xlUnicodeChar, v).replace('\r\n','\n').replace('\r','\n')
     elif v is None:
         v = ""
+    elif isinstance(v, float): 
+        return str(round(v, 14)) # Deal with general numbers which may be imprecise
     else:
         v = str(v)
     return csvCellValue(v)


### PR DESCRIPTION
#### Reason for change
FERC form 714 has submitters providing OIM CSV with instance facts in float that have imprecise general number representation.   The issue may be any cell with a general number even if the cell is used as a string or other value (e.g., not monetary where decimals are known) or not for a fact (such as typed dimension).  (E.g. 21.009999999999998 where the value is 21.01).

#### Description of change
Experimentation shows that for any excel cell with a float, round(float, 14) seems to fix this.  (Please confirm.)

#### Steps to Test
Ensure test suite still passes to same degree as before change.
Ensure unpublished FERC samples no longer have the 9999999999998 problem, or any other wacko imprecision.

**review**:
@Arelle/arelle
