### PR TITLE
ModelRelationshipSet.label should not mutate the shared modelRelationshipsFrom dict

### DIFF
--- a/arelle/ModelRelationshipSet.py
+++ b/arelle/ModelRelationshipSet.py
@@ -342,7 +342,7 @@ class ModelRelationshipSet:
                             labelsOtherLinks.append(modelLabelRel)
                 labels = (labelsHintedLink or labelsDefaultLink or labelsOtherLinks)
         if len(labels) > 1: # order by priority (ignoring equivalence of relationships)
-            labels.sort(key=lambda rel: rel.priority, reverse=True)
+            labels = sorted(labels, key=lambda rel: rel.priority, reverse=True)
         for modelLabelRel in labels:
             label = modelLabelRel.toModelObject
             if wildRole or role == label.role:


### PR DESCRIPTION
#### Reason for change
While investigating EdgarRenderer behavior for a filing zip with duplicate labels, I noticed that the HTML section labels and MetaLinks.json were out of sync.  The HTML was generated using `.label`, and the MetaLinks.json is generated using `.relationshipSet`.  Based on the (surprisingly?) [MetaLinks.json logic](https://github.com/Arelle/EdgarRenderer/blob/ec39b3dc359c4f434823cea35cc6bcb170e779e7/Summary.py#L573-L586), I expected the label with highest `order` to be selected, but instead the label with the lowest `priority` was being selected because [this logic](https://github.com/Arelle/Arelle/blob/bbf9608c36e6f64b70ce6effd490e5cb11712be9/arelle/ModelRelationshipSet.py#L323-L344) is mutating the `modelRelationshipsFrom` list value when `linkroleHint` is `None`.

#### Description of change
Use `sorted` rather than `.sort`.

#### Steps to Test
Private filing zip.  Compare `_lab.htm`, generated HTML, and generate MetaLinks.json.

**review**:
@Arelle/arelle
