### PR TITLE
Day is out of range for month error

### DIFF
--- a/arelle/TableStructure.py
+++ b/arelle/TableStructure.py
@@ -276,7 +276,25 @@ def evaluateTableIndex(modelXbrl, lang=None):
                 if startMo <= 0:
                     startMo += 12
                     startYr -= 1
-                startDatetime = datetime(startYr, startMo, endDatetime.day, endDatetime.hour, endDatetime.minute, endDatetime.second)
+                start_datetime_day = endDatetime.day
+                # check if we are in Feb past the 28th
+                if startMo == 2 and start_datetime_day > 28:
+                    import calendar
+                    if endOfMonth:
+                        # reset day to the last day of Feb.
+                        start_datetime_day = 29 if calendar.isleap(startYr) else 28
+                    else:
+                        # probably 52-53 weeks fiscal year, 2 cases only, current qtr ends on May 29th or 30th (31st then endOfMonth is True)
+                        if start_datetime_day == 29:
+                            if not calendar.isleap(startYr):
+                                start_datetime_day = 1
+                                # step into March
+                                startMo +=1
+                        elif start_datetime_day == 30:
+                            start_datetime_day = 1 if calendar.isleap(startYr) else 2
+                            # step into March
+                            startMo +=1
+                startDatetime = datetime(startYr, startMo, start_datetime_day, endDatetime.hour, endDatetime.minute, endDatetime.second)
                 if endOfMonth:
                     startDatetime -= timedelta(1)
                     endDatetime -= timedelta(1)


### PR DESCRIPTION
#### Reason for change
This is relevant to [TableStructure.py evaluateTableIndex](https://github.com/Arelle/Arelle/blob/0821b3388ee363a3b0a0fe39bfb2cf93a9e085ba/arelle/TableStructure.py#L275).
The pr tries to resolve `day out of range for month` error that happens in the rare cases where current quarter end is on May 29th or 30th, the algorithm tries to determine the start date and looks for February 29/30 which results in an error.

#### Description of change
Identifies if start month is February and considers if it is a leap year, and sets start day and start month accordingly.

#### Steps to Test
The 2 cases I came across that produces this error are:
https://www.sec.gov/Archives/edgar/data/1050825/000105082521000159/0001050825-21-000159-xbrl.zip
https://www.sec.gov/Archives/edgar/data/1616533/000156459021035883/0001564590-21-035883-xbrl.zip

Try loading using GUI or produce fact table using command line
```shell
arelleCmdLine -f https://www.sec.gov/Archives/edgar/data/1616533/000156459021035883/0001564590-21-035883-xbrl.zip --plugins transforms/SEC --factTable ./test.xml --logFile ./test.log
```
before pr this produces the error:
[ValueError] [Exception] Failed to complete request: day is out of range for month

The error should disappear after the pr and factTable should be produced.


**review**:
@Arelle/arelle
