### PR TITLE
lxml schema validation resolve when in archive

### DIFF
--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -599,16 +599,24 @@ def validateAnyWildcard(qnElt, qnAttr, attributeWildcards):
     return False
 
 class lxmlSchemaResolver(etree.Resolver):
-    def __init__(self, cntlr):
+    def __init__(self, cntlr, modelXbrl=None):
         super(lxmlSchemaResolver, self).__init__()
         self.cntlr = cntlr
+        self.modelXbrl = modelXbrl
     def resolve(self, url, id, context): 
-        filepath = self.cntlr.webCache.getfilename(url)
-        return self.resolve_filename(filepath, context)
+        if self.modelXbrl is None or not self.modelXbrl.fileSource.isInArchive(url):
+            url = self.cntlr.webCache.getfilename(url)
+        if url: # may be None if file doesn't exist
+            if self.modelXbrl is not None: # use fileSource
+                fh = self.modelXbrl.fileSource.file(url,binary=True)[0]
+                return self.resolve_file(fh, context, close=True)
+            else: # probably no active modelXbrl yet, such as when loading packages, use url
+                return self.resolve_filename(url, context)
+        return self.resolve_empty(context)
 
-def lxmlResolvingParser(cntlr):
+def lxmlResolvingParser(cntlr, modelXbrl=None):
     parser = etree.XMLParser()
-    parser.resolvers.add(lxmlSchemaResolver(cntlr))
+    parser.resolvers.add(lxmlSchemaResolver(cntlr, modelXbrl))
     return parser
 
 def lxmlSchemaValidate(modelDocument):
@@ -630,7 +638,7 @@ def lxmlSchemaValidate(modelDocument):
                         if _sl[i] == ns and i+1 < len(_sl):
                             url = cntlr.webCache.normalizeUrl(_sl[i+1], modelDocument.baseForElement(slElt))
                             try:
-                                xsdTree = etree.parse(url,parser=lxmlResolvingParser(cntlr))
+                                xsdTree = etree.parse(url,parser=lxmlResolvingParser(cntlr, modelXbrl))
                                 break
                             except (EnvironmentError, KeyError, UnicodeDecodeError) as err:
                                 msgCode = "arelle.schemaFileError"


### PR DESCRIPTION
#### Reason for change
Conf suite in an archive may have schema files needed by test case files within the archive, add capability for lxml to resolve from achive contents.

#### Description of change
Add modelXbrl as optional parameter to lxmlResolvingParser constructor, when present resolver checks whether requested url is present within the archive (via its fileSource).

#### Steps to Test
Zipped ESEF test suite fail to load a schema file before this change and sails smoothly with the change.

**review**:
@Arelle/arelle
