### PR TITLE
FERC validation allow data: scheme in footnotes

### DIFF
--- a/arelle/DisclosureSystem.py
+++ b/arelle/DisclosureSystem.py
@@ -4,7 +4,7 @@ Created on Dec 16, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import os, re, logging
+import os, re, logging, json
 from collections import defaultdict
 from lxml import etree
 from arelle import UrlUtil
@@ -63,6 +63,7 @@ class DisclosureSystem:
         self.validateFileText = False
         self.validateEntryText = False
         self.allowedExternalHrefPattern = None
+        self.allowedImageTypes = None
         self.schemaValidateSchema = None
         self.blockDisallowedReferences = False
         self.maxSubmissionSubdirectoryEntryNesting = 0
@@ -180,6 +181,8 @@ class DisclosureSystem:
                                 self.validateEntryText = dsElt.get("validateEntryText") == "true"
                                 if dsElt.get("allowedExternalHrefPattern"):
                                     self.allowedExternalHrefPattern = re.compile(dsElt.get("allowedExternalHrefPattern"))
+                                if dsElt.get("allowedImageTypes"):
+                                    self.allowedImageTypes = json.loads(dsElt.get("allowedImageTypes"))
                                 self.blockDisallowedReferences = dsElt.get("blockDisallowedReferences") == "true"
                                 try:
                                     self.maxSubmissionSubdirectoryEntryNesting = int(dsElt.get("maxSubmissionSubdirectoryEntryNesting"))

--- a/arelle/ValidateFilingText.py
+++ b/arelle/ValidateFilingText.py
@@ -695,7 +695,7 @@ def validateFootnote(modelXbrl, footnote):
                 _("%(validatedObjectLabel)s causes the XML error %(error)s"),
                 modelObject=footnote, validatedObjectLabel=validatedObjectLabel,
                 error=', '.join(e.message for e in edbodyDTD.error_log.filter_from_errors()))
-        validateHtmlContent(modelXbrl, footnote, footnoteHtml, validatedObjectLabel, modelXbrl.modelManager.disclosureSystem.validationType + ".6.05.34.", supportedImageTypes=supportedImageTypes)
+        validateHtmlContent(modelXbrl, footnote, footnoteHtml, validatedObjectLabel, modelXbrl.modelManager.disclosureSystem.validationType + ".6.05.34.")
     except (XMLSyntaxError,
             UnicodeDecodeError) as err:
         #if not err.endswith("undefined entity"):
@@ -770,7 +770,7 @@ def validateHtmlContent(modelXbrl, referenceElt, htmlEltTree, validatedObjectLab
                             m = imgDataMediaBase64Pattern.match(attrValue)
                             if (not allowedImageTypes["data-scheme"] or
                                 not m or not m.group(1) or not m.group(2)
-                                or m.group(1)[1:] not in supportedImageTypes["mime-types"]
+                                or m.group(1)[1:] not in allowedImageTypes["mime-types"]
                                 or m.group(1)[1:] != validateGraphicHeaderType(base64.b64decode(m.group(3)))):
                                 modelXbrl.error(messageCodePrefix + "graphicDataUrl",
                                     _("%(validatedObjectLabel)s references a graphics data URL which isn't accepted '%(attribute)s' for <%(element)s>"),
@@ -781,7 +781,7 @@ def validateHtmlContent(modelXbrl, referenceElt, htmlEltTree, validatedObjectLab
                                     _("%(validatedObjectLabel)s references a graphics data URL with Base64 encoding error %(err)s in <%(element)s>"),
                                     modelObject=elt, validatedObjectLabel=validatedObjectLabel,
                                     element=eltTag, err=err)
-                    elif attrValue.lower()[-4:] not in allowedImageTypes["img-file-extensions"]:
+                    elif attrValue.lower()[-3:] not in allowedImageTypes["img-file-extensions"]:
                         modelXbrl.error(messageCodePrefix + "graphicFileType",
                             _("%(validatedObjectLabel)s references a graphics file which isn't %(allowedExtensions)s '%(attribute)s' for <%(element)s>"),
                             modelObject=elt, validatedObjectLabel=validatedObjectLabel,

--- a/arelle/config/disclosuresystems.xsd
+++ b/arelle/config/disclosuresystems.xsd
@@ -65,6 +65,7 @@
       <xs:attribute name="validateFileText" type="xs:boolean"/>
       <xs:attribute name="validateEntryText" type="xs:boolean"/>
       <xs:attribute name="allowedExternalHrefPattern" type="xs:string"/>
+      <xs:attribute name="allowedImageTypes" type="xs:string"/>
       <xs:attribute name="blockDisallowedReferences" type="xs:boolean"/>
       <xs:attribute name="maxSubmissionSubdirectoryEntryNesting" type="xs:integer"/>
       <xs:attribute name="logLevelFilter" />

--- a/arelle/plugin/validate/EFM/Consts.py
+++ b/arelle/plugin/validate/EFM/Consts.py
@@ -239,9 +239,3 @@ linkbaseValidations = {
         preSources = ()
     )
 }
-
-supportedImageTypes = {
-    "data-scheme": False,
-    "img-file-extensions": ("gif", "jpg"), # img file extensions
-    "mime-types": () # mime types: none at this time
-    }

--- a/arelle/plugin/validate/EFM/Consts.py
+++ b/arelle/plugin/validate/EFM/Consts.py
@@ -239,3 +239,9 @@ linkbaseValidations = {
         preSources = ()
     )
 }
+
+supportedImageTypes = {
+    "data-scheme": False,
+    "img-file-extensions": ("gif", "jpg"), # img file extensions
+    "mime-types": () # mime types: none at this time
+    }

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -43,7 +43,7 @@ from .Consts import submissionTypesAllowingWellKnownSeasonedIssuer, \
                     submissionTypesAllowingVoluntaryFilerFlag, docTypesNotAllowingInlineXBRL, \
                     docTypesRequiringRrSchema, docTypesNotAllowingIfrs, \
                     untransformableTypes, rrUntransformableEltsPattern, \
-                    docTypes20F, hideableNamespacesPattern, linkbaseValidations
+                    docTypes20F, hideableNamespacesPattern, linkbaseValidations, supportedImageTypes
                                         
 from .Dimensions import checkFilingDimensions
 from .PreCalAlignment import checkCalcsTreeWalk
@@ -887,10 +887,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                     
 
         #6.5.15 facts with xml in text blocks
-        ValidateFilingText.validateTextBlockFacts(modelXbrl, {
-                                    True: ("gif", "jpg"), # img file extensions
-                                    False: () # mime types: none at this time
-                                    })
+        ValidateFilingText.validateTextBlockFacts(modelXbrl, supportedImageTypes)
         
         isDei2018orLater = any(doc.targetNamespace.startswith("http://xbrl.sec.gov/dei/") and doc.targetNamespace >= "http://xbrl.sec.gov/dei/2018"
                                for doc in modelXbrl.urlDocs.values() if doc.targetNamespace)
@@ -1953,7 +1950,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                                     modelObject=child, xlinkLabel=getattr(child, "xlinkLabel", None),
                                     role=footnoterole)
                             if isEFM and not isInlineXbrl: # inline content was validated before and needs continuations assembly
-                                ValidateFilingText.validateFootnote(modelXbrl, child)
+                                ValidateFilingText.validateFootnote(modelXbrl, child, supportedImageTypes)
                             # find modelResource for this element
                             foundFact = False
                             if XmlUtil.text(child) != "" and not isInlineXbrl:

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -43,7 +43,7 @@ from .Consts import submissionTypesAllowingWellKnownSeasonedIssuer, \
                     submissionTypesAllowingVoluntaryFilerFlag, docTypesNotAllowingInlineXBRL, \
                     docTypesRequiringRrSchema, docTypesNotAllowingIfrs, \
                     untransformableTypes, rrUntransformableEltsPattern, \
-                    docTypes20F, hideableNamespacesPattern, linkbaseValidations, supportedImageTypes
+                    docTypes20F, hideableNamespacesPattern, linkbaseValidations
                                         
 from .Dimensions import checkFilingDimensions
 from .PreCalAlignment import checkCalcsTreeWalk
@@ -887,7 +887,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                     
 
         #6.5.15 facts with xml in text blocks
-        ValidateFilingText.validateTextBlockFacts(modelXbrl, supportedImageTypes)
+        ValidateFilingText.validateTextBlockFacts(modelXbrl)
         
         isDei2018orLater = any(doc.targetNamespace.startswith("http://xbrl.sec.gov/dei/") and doc.targetNamespace >= "http://xbrl.sec.gov/dei/2018"
                                for doc in modelXbrl.urlDocs.values() if doc.targetNamespace)
@@ -1950,7 +1950,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                                     modelObject=child, xlinkLabel=getattr(child, "xlinkLabel", None),
                                     role=footnoterole)
                             if isEFM and not isInlineXbrl: # inline content was validated before and needs continuations assembly
-                                ValidateFilingText.validateFootnote(modelXbrl, child, supportedImageTypes)
+                                ValidateFilingText.validateFootnote(modelXbrl, child)
                             # find modelResource for this element
                             foundFact = False
                             if XmlUtil.text(child) != "" and not isInlineXbrl:

--- a/arelle/plugin/validate/EFM/config.xml
+++ b/arelle/plugin/validate/EFM/config.xml
@@ -21,6 +21,11 @@
      validateFileText="true"
      validateEntryText="true"
      allowedExternalHrefPattern="https?://www.sec.gov/(ix[?]doc=/)?Archives/edgar/data/"
+	 allowedImageTypes = '{
+	    "data-scheme": false,
+	    "img-file-extensions": ["gif", "jpg"],
+	    "mime-types": []
+	    }'
      identifierSchemePattern="^http://www\.sec\.gov/CIK$"
      identifierValuePattern="^[0-9]{10}$" 
      identifierValueName="CIK" 
@@ -54,6 +59,11 @@
      validateFileText="true"
      validateEntryText="true"
      allowedExternalHrefPattern="https?://www.sec.gov/(ix[?]doc=/)?Archives/edgar/data/"
+	 allowedImageTypes = '{
+	    "data-scheme": false,
+	    "img-file-extensions": ["gif", "jpg"],
+	    "mime-types": []
+	    }'
      identifierSchemePattern="^http://www\.sec\.gov/CIK$"
      identifierValuePattern="^[0-9]{10}$" 
      identifierValueName="CIK" 
@@ -93,6 +103,11 @@
      validateFileText="true"
      validateEntryText="true"
      allowedExternalHrefPattern="https?://www.sec.gov/(ix[?]doc=/)?Archives/edgar/data/"
+	 allowedImageTypes = '{
+	    "data-scheme": false,
+	    "img-file-extensions": ["gif", "jpg"],
+	    "mime-types": []
+	    }'
      identifierSchemePattern="^http://www\.sec\.gov/CIK$"
      identifierValuePattern="^[0-9]{10}$" 
      identifierValueName="CIK" 
@@ -130,6 +145,11 @@
       validateFileText="true"
       validateEntryText="true"
       allowedExternalHrefPattern="https?://www.sec.gov/(ix[?]doc=/)?Archives/edgar/data/"
+	  allowedImageTypes = '{
+	    "data-scheme": false,
+	    "img-file-extensions": ["gif", "jpg"],
+	    "mime-types": []
+	    }'
       identifierSchemePattern="^http://www\.sec\.gov/CIK$"
       identifierValuePattern="^[0-9]{10}$" 
       identifierValueName="CIK" 
@@ -165,6 +185,11 @@
      validateFileText="true"
      validateEntryText="true"
      allowedExternalHrefPattern="https?://www.sec.gov/(ix[?]doc=/)?Archives/edgar/data/"
+	 allowedImageTypes = '{
+	    "data-scheme": false,
+	    "img-file-extensions": ["gif", "jpg"],
+	    "mime-types": []
+	    }'
      identifierSchemePattern="^http://www\.sec\.gov/CIK$"
      identifierValuePattern="^[0-9]{10}$" 
      identifierValueName="CIK" 
@@ -200,6 +225,11 @@
      validateFileText="true"
      validateEntryText="true"
      allowedExternalHrefPattern="https?://www.sec.gov/(ix[?]doc=/)?Archives/edgar/data/"
+	 allowedImageTypes = '{
+	    "data-scheme": false,
+	    "img-file-extensions": ["gif", "jpg"],
+	    "mime-types": []
+	    }'
      identifierSchemePattern="^http://www\.sec\.gov/CIK$"
      identifierValuePattern="^[0-9]{10}$" 
      identifierValueName="CIK" 
@@ -237,6 +267,11 @@
      validateFileText="true"
      validateEntryText="true"
      allowedExternalHrefPattern="https?://www.sec.gov/(ix[?]doc=/)?Archives/edgar/data/"
+	 allowedImageTypes = '{
+	    "data-scheme": false,
+	    "img-file-extensions": ["gif", "jpg"],
+	    "mime-types": []
+	    }'
      identifierSchemePattern="^http://www\.sec\.gov/CIK$"
      identifierValuePattern="^[0-9]{10}$" 
      identifierValueName="CIK" 
@@ -272,6 +307,11 @@
      validateFileText="true"
      validateEntryText="true"
      allowedExternalHrefPattern="https?://www.sec.gov/(ix[?]doc=/)?Archives/edgar/data/"
+	 allowedImageTypes = '{
+	    "data-scheme": false,
+	    "img-file-extensions": ["gif", "jpg"],
+	    "mime-types": []
+	    }'
      identifierSchemePattern="^http://www\.sec\.gov/CIK$"
      identifierValuePattern="^[0-9]{10}$" 
      identifierValueName="CIK" 

--- a/arelle/plugin/validate/FERC/__init__.py
+++ b/arelle/plugin/validate/FERC/__init__.py
@@ -33,12 +33,6 @@ def validateXbrlStart(val, parameters=None, *args, **kwargs):
     # use UTR validation if list of URLs was provided
     val.validateUTR = bool(val.disclosureSystem.utrUrl)
     
-supportedImageTypes = {
-        "data-scheme": True,
-        "img-file-extensions": ("gif", "jpg", "jpeg", "png"), # img file extensions
-        "mime-types": ("gif", "jpeg", "png") # mime types: jpg is not a valid mime type
-    }
-    
 def validateXbrlFinally(val, *args, **kwargs):
     if not (val.validateFERCplugin):
         return
@@ -69,7 +63,7 @@ def validateXbrlFinally(val, *args, **kwargs):
         xbrlInstRoots = [modelXbrl.modelDocument.xmlDocument.getroot()]
             
     #6.5.15 facts with xml in text blocks
-    ValidateFilingText.validateTextBlockFacts(modelXbrl, supportedImageTypes)
+    ValidateFilingText.validateTextBlockFacts(modelXbrl)
     
     # check footnotes text
     if isInlineXbrl:
@@ -88,7 +82,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                     xlinkType = child.get("{http://www.w3.org/1999/xlink}type")
                     if xlinkType == "resource" or isinstance(child,ModelInlineFootnote): # footnote
                         if not isInlineXbrl: # inline content was validated before and needs continuations assembly
-                            ValidateFilingText.validateFootnote(modelXbrl, child, supportedImageTypes)
+                            ValidateFilingText.validateFootnote(modelXbrl, child)
 
     # same identifier in all contexts (EFM 6.5.3)
     entityIdentifiers = set()

--- a/arelle/plugin/validate/FERC/__init__.py
+++ b/arelle/plugin/validate/FERC/__init__.py
@@ -33,6 +33,12 @@ def validateXbrlStart(val, parameters=None, *args, **kwargs):
     # use UTR validation if list of URLs was provided
     val.validateUTR = bool(val.disclosureSystem.utrUrl)
     
+supportedImageTypes = {
+        "data-scheme": True,
+        "img-file-extensions": ("gif", "jpg", "jpeg", "png"), # img file extensions
+        "mime-types": ("gif", "jpeg", "png") # mime types: jpg is not a valid mime type
+    }
+    
 def validateXbrlFinally(val, *args, **kwargs):
     if not (val.validateFERCplugin):
         return
@@ -63,10 +69,7 @@ def validateXbrlFinally(val, *args, **kwargs):
         xbrlInstRoots = [modelXbrl.modelDocument.xmlDocument.getroot()]
             
     #6.5.15 facts with xml in text blocks
-    ValidateFilingText.validateTextBlockFacts(modelXbrl, {
-                                    True: ("gif", "jpg", "jpeg", "png"), # img file extensions
-                                    False: ("gif", "jpeg", "png") # mime types: jpg is not a valid mime type
-                                    })
+    ValidateFilingText.validateTextBlockFacts(modelXbrl, supportedImageTypes)
     
     # check footnotes text
     if isInlineXbrl:
@@ -85,7 +88,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                     xlinkType = child.get("{http://www.w3.org/1999/xlink}type")
                     if xlinkType == "resource" or isinstance(child,ModelInlineFootnote): # footnote
                         if not isInlineXbrl: # inline content was validated before and needs continuations assembly
-                            ValidateFilingText.validateFootnote(modelXbrl, child)
+                            ValidateFilingText.validateFootnote(modelXbrl, child, supportedImageTypes)
 
     # same identifier in all contexts (EFM 6.5.3)
     entityIdentifiers = set()

--- a/arelle/plugin/validate/FERC/config.xml
+++ b/arelle/plugin/validate/FERC/config.xml
@@ -16,6 +16,11 @@
      defaultXmlLang="en" 
      defaultLanguage="English" 
      validateEntryText="true"
+     allowedImageTypes = '{
+        "data-scheme": true,
+        "img-file-extensions": ["gif", "jpg", "jpeg", "png"],
+        "mime-types": ["gif", "jpeg", "png"]
+     }'
      contextElement="segment" 
      utrUrl="http://www.xbrl.org/utr/utr.xml resources/ferc-utr.xml"
      utrStatusFilters="REC CR"
@@ -33,6 +38,11 @@
      defaultXmlLang="en" 
      defaultLanguage="English" 
      validateEntryText="true"
+     allowedImageTypes = '{
+        "data-scheme": true,
+        "img-file-extensions": ["gif", "jpg", "jpeg", "png"],
+        "mime-types": ["gif", "jpeg", "png"]
+     }'
      contextElement="segment" 
      utrUrl=""
      utrStatusFilters="REC CR"


### PR DESCRIPTION
#### Reason for change
FERC footnote validation was not supporting image data: scheme or FERC image types (as it was doing for text block fact images).

#### Description of change
Add text block fact image validation parameterization to footnote checking code. 
Improve maintainability of parameter structure.
Move to disclosureSystem @allowedImageTypes so it is available in document loading validation workflow same as @allowedExternalHrefPattern.

#### Steps to Test
##### FERC
Add data: scheme text block facts and footnotes to a test case (example footnote provided separately).
Try with allowed and disallowed image and mime types.
Try with mismatching image and mime types vs contents (e.g. gif content with jpg file suffix or mime type).
Test with inline submission.
##### ESEF
Test for regression in img and footnote behavior
##### EFM
Test for regression in img and footnote behavior
Test both traditional and inline submissions.


**review**:
@Arelle/arelle
