### PR TITLE
Deprecate ESEF 2019

### DIFF
--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -51,11 +51,11 @@
         "dimension-default-arc-ELRs": null,
         "outdatedTaxonomyURLs": [
             "http://www.esma.europa.eu/taxonomy/2017-03-31/esef_cor.xsd",
-            "https://www.esma.europa.eu/taxonomy/2017-03-31/esef_cor.xsd"
+            "https://www.esma.europa.eu/taxonomy/2017-03-31/esef_cor.xsd",
+            "http://www.esma.europa.eu/taxonomy/2019-03-27/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2019-03-27/esef_cor.xsd"
         ],
         "effectiveTaxonomyURLs": [
-            "http://www.esma.europa.eu/taxonomy/2019-03-27/esef_cor.xsd",
-            "https://www.esma.europa.eu/taxonomy/2019-03-27/esef_cor.xsd",
             "http://www.esma.europa.eu/taxonomy/2020-03-16/esef_cor.xsd",
             "https://www.esma.europa.eu/taxonomy/2020-03-16/esef_cor.xsd",
             "http://www.esma.europa.eu/taxonomy/2021-03-24/esef_cor.xsd",


### PR DESCRIPTION
#### Reason for change
The RTS released by ESMA in March 8th states that ESEF 2019 will be deprecated on March 27, 2022. That time has come and gone. The ESEF validation plugin needs to be updated in order to reflect this and appropriately flag the taxonomy as deprecated.

#### Description of change
Updated the ESEF validation config to reflect that the ESEF 2019 namespaces are now deprecated.

#### Steps to Test
- Run the ESEF conformance suite, `G3-1-2/TC3_invalid` should now pass. 


#146 

**review**:
@Arelle/arelle
