### PR TITLE
Fix regression in validate.determineTestStatus

### DIFF
--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -566,7 +566,6 @@ class Validate:
         elif isinstance(expected,(QName,_STR_BASE,dict,list)): # string or assertion id counts dict
             status = "fail"
             _passCount = 0
-            matched_expected = []
             if isinstance(expected, list):
                 _expectedList = expected.copy() # need shallow copy
             else:
@@ -604,15 +603,12 @@ class Validate:
                             _expMatched = True
                     if _expMatched:
                         _passCount += 1
-                        matched_expected.append(_exp)
                         if matchAllExpected:
                             _expectedList.remove(_exp)
                         break
             if _passCount > 0:
                 if expectedCount is not None and (expectedCount != _passCount or 
                                                   (matchAllExpected and expectedCount != numErrors)):
-                    status = "fail"
-                elif set(matched_expected) != set(expected):
                     status = "fail"
                 else:
                     status = "pass"


### PR DESCRIPTION
#### Reason for change
A bug was introduced in this [commit](https://github.com/Arelle/Arelle/commit/f3072b8ef519118c73e7b7e2a11b6c2e71657218). This code is wrong because it does not take into account all of the different structures that can potentially be run through this function. Most notably it does not handle dicts being passed in from formula. This code wrong altogether and was thought to handle a scenario that does not happen.

#### Description of change
Revert the commit mentioned above.

#### Steps to Test
- Run the ESEF conformance suite. All but one test should pass. 
- Run the formula conformance suite. All but one test should pass.

#176 

**review**:
@Arelle/arelle
