### PR TITLE
CEF taxonomy custom element labels element scheme hrefs

### DIFF
--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -796,6 +796,8 @@ def xpointerElement(modelDocument, fragmentIdentifier):
                     node = modelDocument.xmlDocument.find("//*[@id='{0}']".format(id))
                 if node is None:
                     continue    # this scheme fails
+                elif len(pathParts) > 1:
+                    iter = node
             else:
                 node = modelDocument.xmlDocument
                 iter = (node.getroot(),)


### PR DESCRIPTION
Fix element scheme pointer operation when relative to an element identified by id

#### Reason for change
CEF taxonomy allows custom (extension) labels for elements with labels in base taxonomy.  [See section 4.6](https://xbrl.sec.gov/cef/2021q4/cef-taxonomy-guide-2021-12-20.pdf).  Table on pg 13 implies these elements may have custom labels:
 * SalesLoadPercent
 * UnderwritersCompensation
 * DividendReinvestmentAndCashPurchaseFees
 * OtherTransactionExpense1Percent
 * OtherTransactionExpense2Percent
 * OtherTransactionExpensesPercent

An extension taxonomy element would report an error for EFM section 6.10.4 unless the base taxonomy label were prohibited.  The prohibit arc requires an href to the base taxonomy label element, lacking an id on labels it would use [element scheme](https://www.w3.org/TR/xptr-element/), e.g. element(/1/7/1/20/47/23) for the label SalesLoadPercent.  This is highly problematical because the number of role definitions preceding the containing linkbase element may change in the future, and the linkbase element has an id, so less problematical would be element(lnk/47/23).

#### Description of change
Allow element scheme to provide a child sequence after an id reference.

#### Steps to Test
Attached TestCaseSample.zip raises an exception before this fix.  Note the label linkbase prohibit arc after `<!-- prohibit original label -->`.

**review**:
@Arelle/arelle
