### PR TITLE
Add ModelInlineFootnote.htmlValue property

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -1589,6 +1589,10 @@ class ModelInlineFootnote(ModelResource):
     def stringValue(self):
         """(str) -- override xml-level stringValue for transformed value descendants text"""
         return self.value
+
+    @property
+    def htmlValue(self):
+        return XmlUtil.innerText(self, ixExclude=True, ixContinuation=True, strip=False)
     
     @property
     def role(self):
@@ -1626,7 +1630,7 @@ class ModelInlineFootnote(ModelResource):
         return (("file", self.modelDocument.basename),
                 ("line", self.sourceline)) + \
                super(ModelInlineFootnote,self).propertyView + \
-               (("html value", XmlUtil.innerText(self)),)
+               (("html value", self.htmlValue),)
         
     def __repr__(self):
         return ("modelInlineFootnote[{0}]{1})".format(self.objectId(),self.propertyView))


### PR DESCRIPTION
#### Reason for change

The content of the `html value` field in the "Properties" view for inline XBRL footnotes does not take into account the `ix:exclude` or `ix:continuation` elements.

It looks like the "html value" is the text content of the footnote without the inner HTML tags:

![image](https://user-images.githubusercontent.com/57985290/167119305-de5a9101-9509-4288-b309-e5a63fa74b37.png)

However it includes the content of `ix:exclude` elements and does not display the content of `ix:continuation`.

* Expected:

![image](https://user-images.githubusercontent.com/57985290/167119519-7e5f0319-61c0-4983-a1df-b5d07c121eb0.png)

![image](https://user-images.githubusercontent.com/57985290/167120340-f754f207-742e-43e1-a53c-20913fe86f82.png)

* Actual:

![image](https://user-images.githubusercontent.com/57985290/167120014-f89f93da-fdf7-4541-b9c0-e1a3d3971fd7.png)

![image](https://user-images.githubusercontent.com/57985290/167120464-da04e4d2-dec9-45ad-acbf-87efe987ce26.png)

#### Description of change

* Add a `htmlValue` property to the `ModelInlineFootnote` class which returns  
`XmlUtil.innerText(self, ixExclude=True, ixContinuation=True, strip=False)` (consider `ix:exclude`, consider `ix:continuation`, do not remove whitespace or newlines)
* Use that new property in `ModelInlineFootnote.propertyView`
* Extracting that htmlValue in a dedicated property could allow its usage in other places.

#### Steps to Test

1. Loading a sample inline XBRL report with different footnotes (for instance [this one](https://github.com/Arelle/Arelle/files/8639545/footnoteValues.zip))
2. Opening the `Fact-Footnote` view if it is not already active
3. Checking that the html value for the different footnotes are as expected

**review**:
@Arelle/arelle
