### PR TITLE
Configure unit tests to run on PR's

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,21 @@
+name: Run Python Unit Tests
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python 3
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run tests with pytest
+        run: pytest tests/unit_tests


### PR DESCRIPTION
#### Reason for change
Unit tests are not running as part of continuous integration on PRs which makes it difficult to vet changes

#### Description of change
Unit tests now run on PRs, when they are created

**review**:
@Arelle/arelle
