### PR TITLE
Publish PyPI Package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,26 @@
+name: Build, test, publish python package
+
+on:
+  pull_request:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python 3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Build python package
+        run: |
+          pip install setuptools wheel twine
+          python -m build
+      - name: Publish package on release
+        if: startsWith(github.ref, 'refs/tags')
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        run: twine upload dist/*

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,7 +6,7 @@ on:
     types: [created]
 
 jobs:
-  build:
+  build-and-publish-package:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.9'
       - name: Build python package
         run: |
-          pip install setuptools wheel twine
+          pip install setuptools wheel twine build
           python -m build
       - name: Publish package on release
         if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Python 3
-      - uses: actions/setup-python@v3
+        uses: actions/setup-python@v3
         with:
           python-version: '3.9'
       - name: Build python package

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,4 @@
-name: Build, test, publish python package
+name: Build and publish python package
 
 on:
   pull_request:
@@ -18,6 +18,11 @@ jobs:
         run: |
           pip install setuptools wheel twine build
           python -m build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: arelle.tar.gz
+          path: dist/*.tar.gz
       - name: Publish package on release
         if: startsWith(github.ref, 'refs/tags')
         env:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
-include README.md
-include CONTRIBUTING.md
-include LICENSE.md
-include INSTALLATION.md
-include arelleCmdLine.py
-include requirements.txt
-include arelleGUI.pyw
 graft arelle
+include arelleCmdLine.py
+include arelleGUI.pyw
+include CONTRIBUTING.md
+include INSTALLATION.md
+include LICENSE.md
+include README.md
+include requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
-include README.txt
-recursive-include arelle *.gif
-recursive-include arelle *.ico
-recursive-include arelle *.xbm
-recursive-include arelle *.xsd
-recursive-include arelle *.xml
-recursive-include arelle *.pot
-
+include README.md
+include CONTRIBUTING.md
+include LICENSE.md
+include INSTALLATION.md
+include arelleCmdLine.py
+include requirements.txt
+include arelleGUI.pyw
+graft arelle

--- a/setup.py
+++ b/setup.py
@@ -334,7 +334,7 @@ else:
 
 timestamp = datetime.datetime.utcnow()
 setup(
-    name='Arelle-ac',
+    name='arelle-release',
     version=get_version(),
     description='An open source XBRL platform',
     long_description=open('README.md').read(),
@@ -349,16 +349,17 @@ setup(
     platforms=['OS Independent'],
     license='Apache-2',
     keywords=['xbrl'],
-    classifiers=[ # valid classifiers here: https://pypi.org/classifiers/
-        'Development Status :: 5 - Production/Stable', # 'Development Status :: 1 - Active
+    # Valid classifiers here: https://pypi.org/classifiers/
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License', # License :: OSI Approved :: Apache-2 License
+        'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.9',
         'Operating System :: OS Independent',
-        'Topic :: Text Processing :: Markup :: XML', # Topic :: XBRL Validation and Versioning
+        'Topic :: Text Processing :: Markup :: XML',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -335,7 +335,7 @@ else:
 timestamp = datetime.datetime.utcnow()
 setup(
     name='Arelle-ac',
-    version='0.0.2',#get_version(),
+    version=get_version(),
     description='An open source XBRL platform',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
#### Reason for change
Automatically publish to PyPI via Github Actions

#### Description of change
Added Github Action that builds package and uploads it as an artifact.
If a version tag is included, the package will be published to PyPI

#### Steps to Test

- Add twine credentials as secrets (TWINE_USERNAME, TWINE_PASSWORD)
- Open a PR, with and without version tag. Confirm a .tar is included as an artifact, and that the tagged PR results in a package being published to PyPI

**review**:
@Arelle/arelle
