### PR TITLE
Move cx freeze to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+cx_Freeze==6.11.0
 mock==4.0.3
 pytest==7.1.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pycrypto
 pg8000
 pymysql
 pyodbc
-rdflib
+rdflib<6
 # other
 graphviz
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,3 @@ rdflib
 # other
 graphviz
 Pillow
-# freezing
-cx_freeze


### PR DESCRIPTION
#### Reason for change
As mentioned in #203 the XbrlSemanticRdfDB plugin doesn't work with newer versions of rdflib (and will cause cx_Freeze builds to fail). Additionally, the cx_Freeze plugin shouldn't be required for users who simply wish to run the service directly.

#### Description of change
* Makes cx_Freeze a dev dependency
* Restricts rdflib to compatible versions

#### Steps to Test
* CI/Conformance suites

**review**:
@Arelle/arelle
