### PR TITLE
Run all conformance suite tests even if one fails

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -5,6 +5,7 @@ jobs:
   run-conformance-suite:
     permissions: read-all
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         test-path:


### PR DESCRIPTION
#### Reason for change
Conformance suite tests will sometimes encounter expected errors, or errors that otherwise shouldn't prevent merging, we should make sure the rest of the conformance suite tests continue to run so we can see all results.

#### Description of change
Use [job.continue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error) to ensure all jobs in the conformance suite matrix continue running despite errors in other conformance suites.

#### Steps to Test
In a separate fork, create a PR from branch A (with an arbitrary change) to branch B (with this PR's change) and confirm that no conformance suite tests are canceled when the XBRL Dimensions test encounters failures.

**review**:
@Arelle/arelle
