### PR TITLE
Add Table Linkbase Conformance Suite to CI

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -14,6 +14,7 @@ jobs:
           - tests/integration_tests/validation/test_utr_conformance_suite.py
           - tests/integration_tests/validation/XBRL/test_xbrl_dimensions_conformance_suite.py
           - tests/integration_tests/validation/XBRL/test_xbrl_conformance_suite.py
+          - tests/integration_tests/validation/XBRL/test_xbrl_table_linkbase_conformance_suite.py
     environment: integration-tests
     steps:
       - name: Download XBRL validation config

--- a/scripts/conformance_suites/run_xbrl_table_linkbase_conformance_suite.py
+++ b/scripts/conformance_suites/run_xbrl_table_linkbase_conformance_suite.py
@@ -1,0 +1,31 @@
+import os
+
+from arelle.CntlrCmdLine import parseAndRun
+
+
+CONFORMANCE_SUITE = 'tests/resources/conformance_suites/table-linkbase-conf-2014-03-18.zip/conf'
+BASE_ARGS = [
+    '--csvTestReport', './table-linkbase-conf-report.csv',
+    '--file', os.path.abspath(os.path.join(CONFORMANCE_SUITE, 'testcases-index.xml')),
+    '--formula', 'run',
+    '--logFile', './table-linkbase-conf-log.txt',
+    '--testcaseResultsCaptureWarnings',
+    '--validate'
+]
+
+
+def run_xbrl_table_linkbase_conformance_suite(args):
+    """
+    Kicks off the validation of the XBRL Table Linkbase conformance suite.
+
+    :param args: The arguments to pass to Arelle in order to accurately validate the XBRL Table Linkbase conformance suite
+    :param args: list of str
+    :return: Returns the result of parseAndRun which in this case is the created controller object
+    :rtype: ::class:: `~arelle.CntlrCmdLine.CntlrCmdLine`
+    """
+    return parseAndRun(args)
+
+
+if __name__ == "__main__":
+    print('Running XBRL Table Linkbase tests...')
+    run_xbrl_table_linkbase_conformance_suite(BASE_ARGS)

--- a/tests/integration_tests/validation/XBRL/test_xbrl_conformance_suite.py
+++ b/tests/integration_tests/validation/XBRL/test_xbrl_conformance_suite.py
@@ -18,12 +18,35 @@ if os.getenv('CONFORMANCE_SUITES_TEST_MODE') == 'OFFLINE':
 
 TEST_DATA = get_test_data(ARGS)
 
+EXPECTED_FAILURE_IDS = [
+    # 202.02b in the absence of source/target constraints, an empty href doesn't pose a problem
+    # 202-02b-HrefResolutionCounterExample-custom.xml Expected: valid, Actual: arelle:hrefWarning
+    'Common/200-linkbase/V-02b',
+    # Tests that a decimals 0 value 0 is not treated as precision 0 (invalid) but as numeric zero.
+    # In the prior approach where decimals 0 value 0 converted to precision 0 value 0, this would have been invalid.
+    # 320-30-BindCalculationInferDecimals-instance.xbrl Expected: valid, Actual: xbrl.5.2.5.2:calcInconsistency
+    'Common/300-instance/V-300',
+    # Edge case tests that decimal rounding with is performed.
+    # 320-31-BindCalculationInferDecimals-instance.xbrl Expected: valid, Actual: xbrl.5.2.5.2:calcInconsistency
+    'Common/300-instance/V-310',
+    # Checks that .5 rounds half to nearest even sum.
+    # 320-32-BindCalculationInferDecimals-instance.xbrl Expected: invalid, Actual: valid
+    'Common/300-instance/V-320',
+    # Checks that .5 rounds half to nearest even regardless whether a processor uses float sum.
+    # 320-34-BindCalculationInferDecimals-instance.xbrl Expected: valid, Actual: xbrl.5.2.5.2:calcInconsistency
+    'Common/300-instance/V-340',
+    # 397-28-PrecisionDifferentScales.xbrl Expected: valid, Actual: xbrl.5.2.5.2:calcInconsistency
+    'Common/300-instance/V-281'
+]
+
 
 @pytest.mark.parametrize("result", TEST_DATA)
-def test_xbrl_conformance_suite(result):
+def test_xbrl_conformance_suite(result, request):
     """
     Test the XBRL 2.1 Conformance Suite
     """
+    if request.node.callspec.id in EXPECTED_FAILURE_IDS:
+        pytest.xfail(f"Test '{request.node.callspec.id}' not supported yet")
     assert result.get('status') == 'pass', \
         'Expected these validation suffixes: {}, but received these validations: {}'.format(
             result.get('expected'), result.get('actual')

--- a/tests/integration_tests/validation/XBRL/test_xbrl_dimensions_conformance_suite.py
+++ b/tests/integration_tests/validation/XBRL/test_xbrl_dimensions_conformance_suite.py
@@ -18,12 +18,29 @@ if os.getenv('CONFORMANCE_SUITES_TEST_MODE') == 'OFFLINE':
 
 TEST_DATA = get_test_data(ARGS)
 
+EXPECTED_FAILURE_IDS = [
+    # The value of the xbrldt:targetRole attribute is valid
+    # Expected: sche:XmlSchemaError, Actual: xbrldte:TargetRoleNotResolvedError
+    '000-Schema-invalid/001-Taxonomy/V-03',
+    # An all hypercube has an msdos path in the targetRole attribute to locate the domain - dimension arc network
+    # Expected: sche:XmlSchemaError, Actual: xbrldte:TargetRoleNotResolvedError
+    '000-Schema-invalid/001-Taxonomy/V-08',
+    # A dimension-domain relationship has an msdos path in targetRole attribute to locate the domain-member arc network
+    # Expected: sche:XmlSchemaError, Actual: xbrldte:TargetRoleNotResolvedError
+    '000-Schema-invalid/001-Taxonomy/V-09',
+    # A domain-member relationship has an msdos path in targetRole attribute to locate the domain-member arc network
+    # Expected: sche:XmlSchemaError, Actual: xbrldte:TargetRoleNotResolvedError
+    '000-Schema-invalid/001-Taxonomy/V-10',
+]
+
 
 @pytest.mark.parametrize("result", TEST_DATA)
-def test_xbrl_dimensions_conformance_suite(result):
+def test_xbrl_dimensions_conformance_suite(result, request):
     """
     Test the XBRL Dimensions 1.0 Conformance Suite
     """
+    if request.node.callspec.id in EXPECTED_FAILURE_IDS:
+        pytest.xfail(f"Test '{request.node.callspec.id}' not supported yet")
     assert result.get('status') == 'pass', \
         'Expected these validation suffixes: {}, but received these validations: {}'.format(
             result.get('expected'), result.get('actual')

--- a/tests/integration_tests/validation/XBRL/test_xbrl_table_linkbase_conformance_suite.py
+++ b/tests/integration_tests/validation/XBRL/test_xbrl_table_linkbase_conformance_suite.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+from tests.integration_tests.validation.validation_util import get_test_data
+
+
+CONFORMANCE_SUITE = 'tests/resources/conformance_suites/table-linkbase-conf-2014-03-18.zip/conf'
+ARGS = [
+    '--file', os.path.abspath(os.path.join(CONFORMANCE_SUITE, 'testcases-index.xml')),
+    '--formula', 'run',
+    '--keepOpen',
+    '--testcaseResultsCaptureWarnings',
+    '--validate'
+]
+
+if os.getenv('CONFORMANCE_SUITES_TEST_MODE') == 'OFFLINE':
+    ARGS.extend(['--internetConnectivity', 'offline'])
+
+TEST_DATA = get_test_data(ARGS)
+
+EXPECTED_FAILURE_IDS = []
+
+
+@pytest.mark.parametrize("result", TEST_DATA)
+def test_xbrl_table_linkbase_conformance_suite(result, request):
+    """
+    Test the XBRL Table Linkbase Conformance Suite
+    """
+    if request.node.callspec.id in EXPECTED_FAILURE_IDS:
+        pytest.xfail(f"Test '{request.node.callspec.id}' not supported yet")
+    assert result.get('status') == 'pass', \
+        'Expected these validation suffixes: {}, but received these validations: {}'.format(
+            result.get('expected'), result.get('actual')
+        )


### PR DESCRIPTION
#### Reason for change
Increase conformance suite coverage to include Table Linkbase specification

#### Description of change
Add python test and run script for suite and add to Github actions
(also excluded some expected failure IDs for 2.1 and Dimensions tests)

#### Steps to Test

Download `table-linkbase-conf-2014-03-18.zip` from S3 and place in /tests/resources
Run `run_xbrl_table_linkbase_conformance_suite.py` and ensure tests complete. (Expect ~75% to fail initially)
Run pytest on `test_xbrl_table_linkbase_conformance_suite.py` and ensure tests complete.
Due to `pull_request_target` we can't run CI actions as updated in our PRs, so we can only test that portion after merging.

**review**:
@Arelle/arelle
