### PR TITLE
Add OIM Conformance Test suite to CI

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -58,4 +58,4 @@ jobs:
       - name: Run integration tests with pytest
         env:
           CONFORMANCE_SUITES_TEST_MODE: OFFLINE
-        run: pytest --disable-warnings ${{ matrix.test.path }}
+        run: pytest -s --disable-warnings ${{ matrix.test.path }}

--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -1427,6 +1427,12 @@ def loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                                 tableUrl, _sep, sheetAndRange = tableUrl.partition("#")
                                 xlSheetName, _sep, xlNamedRange = sheetAndRange.partition('!')
                             tablePath = os.path.join(_dir, tableUrl)
+                            # Remove unnecessary relative segments within path. Effected paths are handled fine
+                            # when loading from directories, but this fails when loading from ZIP archives.
+                            # OIM conformance suites expect this to be supported:
+                            # oim-conf-2021-10-13.zip/300-csv-conformant-processor/V-11,
+                            # oim-conf-2021-10-13.zip/300-csv-conformant-processor/V-12
+                            tablePath = tablePath.replace("\\.\\", "\\").replace("/./", "/")
                             if not modelXbrl.fileSource.exists(tablePath):
                                 if not tableIsOptional:
                                     error("xbrlce:missingRequiredCSVFile", 

--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -1431,7 +1431,9 @@ def loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                             # when loading from directories, but this fails when loading from ZIP archives.
                             # OIM conformance suites expect this to be supported:
                             # oim-conf-2021-10-13.zip/300-csv-conformant-processor/V-11,
+                            #  "/300-csv-conformant-processor/./helloWorld-value-date-table2-facts.csv"
                             # oim-conf-2021-10-13.zip/300-csv-conformant-processor/V-12
+                            #  "/300-csv-conformant-processor/./helloWorld-SQNameSpecial-facts.csv"
                             tablePath = os.path.normpath(tablePath)
                             if not modelXbrl.fileSource.exists(tablePath):
                                 if not tableIsOptional:

--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -1432,7 +1432,7 @@ def loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                             # OIM conformance suites expect this to be supported:
                             # oim-conf-2021-10-13.zip/300-csv-conformant-processor/V-11,
                             # oim-conf-2021-10-13.zip/300-csv-conformant-processor/V-12
-                            tablePath = tablePath.replace("\\.\\", "\\").replace("/./", "/")
+                            tablePath = os.path.normpath(tablePath)
                             if not modelXbrl.fileSource.exists(tablePath):
                                 if not tableIsOptional:
                                     error("xbrlce:missingRequiredCSVFile", 

--- a/scripts/conformance_suites/run_xbrl_oim_conformance_suite.py
+++ b/scripts/conformance_suites/run_xbrl_oim_conformance_suite.py
@@ -1,0 +1,32 @@
+import os
+
+from arelle.CntlrCmdLine import parseAndRun
+
+
+CONFORMANCE_SUITE = 'tests/resources/conformance_suites/oim-conf-2021-10-13.zip'
+BASE_ARGS = [
+    '--csvTestReport', './oim-conf-report.csv',
+    '--file', os.path.abspath(os.path.join(CONFORMANCE_SUITE, 'oim-index.xml')),
+    '--formula', 'run',
+    '--logFile', './oim-conf-log.txt',
+    '--plugins', 'loadFromOIM',
+    '--testcaseResultsCaptureWarnings',
+    '--validate'
+]
+
+
+def run_xbrl_oim_conformance_suite(args):
+    """
+    Kicks off the validation of the XBRL Open Information Model 1.0 conformance suite.
+
+    :param args: The arguments to pass to Arelle in order to accurately validate the XBRL Open Information Model 1.0 conformance suite
+    :param args: list of str
+    :return: Returns the result of parseAndRun which in this case is the created controller object
+    :rtype: ::class:: `~arelle.CntlrCmdLine.CntlrCmdLine`
+    """
+    return parseAndRun(args)
+
+
+if __name__ == "__main__":
+    print('Running XBRL Open Information Model 1.0 tests...')
+    run_xbrl_oim_conformance_suite(BASE_ARGS)

--- a/tests/integration_tests/validation/XBRL/test_xbrl_oim_conformance_suite.py
+++ b/tests/integration_tests/validation/XBRL/test_xbrl_oim_conformance_suite.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+from tests.integration_tests.validation.validation_util import get_test_data
+
+
+CONFORMANCE_SUITE = 'tests/resources/conformance_suites/oim-conf-2021-10-13.zip'
+ARGS = [
+    '--file', os.path.abspath(os.path.join(CONFORMANCE_SUITE, 'oim-index.xml')),
+    '--formula', 'run',
+    '--keepOpen',
+    '--plugins', 'loadFromOIM',
+    '--testcaseResultsCaptureWarnings',
+    '--validate'
+]
+
+if os.getenv('CONFORMANCE_SUITES_TEST_MODE') == 'OFFLINE':
+    ARGS.extend(['--internetConnectivity', 'offline'])
+
+TEST_DATA = get_test_data(ARGS)
+
+
+@pytest.mark.parametrize("result", TEST_DATA)
+def test_xbrl_oim_conformance_suite(result):
+    """
+    Test the XBRL Open Information Model 1.0 Conformance Suite
+    """
+    assert result.get('status') == 'pass', \
+        'Expected these validation suffixes: {}, but received these validations: {}'.format(
+            result.get('expected'), result.get('actual')
+        )

--- a/tests/integration_tests/validation/XBRL/test_xbrl_oim_conformance_suite.py
+++ b/tests/integration_tests/validation/XBRL/test_xbrl_oim_conformance_suite.py
@@ -7,6 +7,7 @@ CONFORMANCE_SUITE = 'tests/resources/conformance_suites/oim-conf-2021-10-13.zip'
 ARGS = [
     '--file', os.path.abspath(os.path.join(CONFORMANCE_SUITE, 'oim-index.xml')),
     '--formula', 'run',
+    '--httpsRedirectCache',
     '--keepOpen',
     '--plugins', 'loadFromOIM',
     '--testcaseResultsCaptureWarnings',


### PR DESCRIPTION
#### Reason for change
Increase conformance suite coverage to include OIM (Open Information Model) 1.0 specification

#### Description of change
Add python test and run script for suite and add to Github actions
I ran this against the `oim-master-update` branch and confirmed the 4 tests that currently fail are fixed with those updates, so no expected failure IDs are necessary.

#### Steps to Test
CI

**review**:
@Arelle/arelle
