### PR TITLE
Add XBRL Taxonomy Packages 1.0 conformance suite

### DIFF
--- a/scripts/conformance_suites/run_xbrl_taxonomy_packages_conformance_suite.py
+++ b/scripts/conformance_suites/run_xbrl_taxonomy_packages_conformance_suite.py
@@ -1,0 +1,31 @@
+import os
+
+from arelle.CntlrCmdLine import parseAndRun
+
+
+CONFORMANCE_SUITE = 'tests/resources/conformance_suites/taxonomy-package-conformance.zip'
+BASE_ARGS = [
+    '--csvTestReport', './taxonomy-package-conf-report.csv',
+    '--file', os.path.abspath(os.path.join(CONFORMANCE_SUITE, 'index.xml')),
+    '--formula', 'run',
+    '--logFile', './taxonomy-package-conf-log.txt',
+    '--testcaseResultsCaptureWarnings',
+    '--validate'
+]
+
+
+def run_xbrl_taxonomy_package_conformance_suite(args):
+    """
+    Kicks off the validation of the XBRL Taxonomy Packages 1.0 conformance suite.
+
+    :param args: The arguments to pass to Arelle in order to accurately validate the conformance suite
+    :param args: list of str
+    :return: Returns the result of parseAndRun which in this case is the created controller object
+    :rtype: ::class:: `~arelle.CntlrCmdLine.CntlrCmdLine`
+    """
+    return parseAndRun(args)
+
+
+if __name__ == "__main__":
+    print('Running XBRL Taxonomy Packages 1.0 tests...')
+    run_xbrl_taxonomy_package_conformance_suite(BASE_ARGS)

--- a/tests/integration_tests/validation/XBRL/test_xbrl_taxonomy_packages_conformance_suite.py
+++ b/tests/integration_tests/validation/XBRL/test_xbrl_taxonomy_packages_conformance_suite.py
@@ -1,0 +1,29 @@
+import os
+import pytest
+from tests.integration_tests.validation.validation_util import get_test_data
+
+
+CONFORMANCE_SUITE = 'tests/resources/conformance_suites/taxonomy-package-conformance.zip'
+ARGS = [
+    '--file', os.path.abspath(os.path.join(CONFORMANCE_SUITE, 'index.xml')),
+    '--formula', 'run',
+    '--keepOpen',
+    '--testcaseResultsCaptureWarnings',
+    '--validate'
+]
+
+if os.getenv('CONFORMANCE_SUITES_TEST_MODE') == 'OFFLINE':
+    ARGS.extend(['--internetConnectivity', 'offline'])
+
+TEST_DATA = get_test_data(ARGS)
+
+
+@pytest.mark.parametrize("result", TEST_DATA)
+def test_xbrl_taxonomy_packages_conformance_suite(result):
+    """
+    Test the XBRL Taxonomy Packages 1.0 Conformance Suite
+    """
+    assert result.get('status') == 'pass', \
+        'Expected these validation suffixes: {}, but received these validations: {}'.format(
+            result.get('expected'), result.get('actual')
+        )

--- a/tests/integration_tests/validation/validation_util.py
+++ b/tests/integration_tests/validation/validation_util.py
@@ -18,21 +18,25 @@ def get_test_data(args):
     results = []
     model_document = cntlr.modelManager.modelXbrl.modelDocument
     if model_document is not None:
-        if model_document.type == ModelDocument.Type.TESTCASESINDEX:
-            for tc in sorted(model_document.referencesDocument.keys(), key=lambda doc: doc.uri):
-                uri_dir_parts = os.path.dirname(tc.uri).split('/')
-                test_case_dir = '/'.join(uri_dir_parts[-2:])
-                if hasattr(tc, "testcaseVariations"):
-                    for mv in tc.testcaseVariations:
-                        param = pytest.param(
-                            {
-                                'status': mv.status,
-                                'expected': mv.expected,
-                                'actual': mv.actual
-                            },
-                            id='{}/{}'.format(test_case_dir, str(mv.id or mv.name))
-                        )
-                        results.append(param)
+        test_cases = []
+        if model_document.type == ModelDocument.Type.TESTCASE:
+            test_cases.append(model_document)
+        elif model_document.type == ModelDocument.Type.TESTCASESINDEX:
+            test_cases = sorted(model_document.referencesDocument.keys(), key=lambda doc: doc.uri)
+        for test_case in test_cases:
+            uri_dir_parts = os.path.dirname(test_case.uri).split('/')
+            test_case_dir = '/'.join(uri_dir_parts[-2:])
+            if hasattr(test_case, "testcaseVariations"):
+                for mv in test_case.testcaseVariations:
+                    param = pytest.param(
+                        {
+                            'status': mv.status,
+                            'expected': mv.expected,
+                            'actual': mv.actual
+                        },
+                        id='{}/{}'.format(test_case_dir, str(mv.id or mv.name))
+                    )
+                    results.append(param)
     cntlr.modelManager.close()
     PackageManager.close()
     PluginManager.close()


### PR DESCRIPTION
#### Reason for change
Increase conformance suite coverage to include XBRL Taxonomy Packages 1.0 specification

#### Description of change
Added support for validating conformance suites that run as a single test case with variations
Add python test and run script for suite (automatically included in Github actions due to recent changes)

#### Steps to Test
CI

**review**:
@Arelle/arelle
