### PR TITLE
Add basic support for Visual Studio Code containerised dev environment

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,0 +1,25 @@
+ARG VARIANT=3.9-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+ENV VIRTUAL_ENV=/opt/.venv
+ENV FILE_LOCATION "/usr/src/app"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV LOCAL_USER="vscode"
+
+USER $LOCAL_USER
+
+COPY . $FILE_LOCATION
+
+WORKDIR $FILE_LOCATION
+
+# Install base system requirements
+RUN sudo apt-get update \
+    && xargs sudo  apt-get install -y  < .devcontainer/requirements_system_dev.txt \
+    && sudo apt-get clean \
+    && sudo apt-get autoremove
+
+RUN sudo python3 -m venv $VIRTUAL_ENV && \
+    sudo chown -R $LOCAL_USER:$LOCAL_USER ${VIRTUAL_ENV} && \
+    . $VIRTUAL_ENV/bin/activate && \
+    python3 -m pip install --upgrade setuptools wheel && \
+    python3 -m pip install -r $FILE_LOCATION/requirements-dev.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+	"name": "Arelle dev container",
+	"context": "..",
+	"dockerFile": "Dockerfile.dev",
+	"containerEnv": {
+		"DEVCONTAINER": "1"
+	},
+	"settings": {
+		"python.pythonPath": "/opt/.venv/bin/python",
+		"python.defaultInterpreterPath": "/opt/.venv/bin/python",
+		"python.terminal.activateEnvInCurrentTerminal": true,
+		"python.linting.enabled": true,
+		"files.trimTrailingWhitespace": true,
+		"python.languageServer": "Pylance",
+		"python.testing.unittestEnabled": false,
+		"python.testing.pytestEnabled": true
+	},
+	"extensions": [
+		"ms-python.vscode-pylance",
+		"visualstudioexptteam.vscodeintellicode",
+	],
+}

--- a/.devcontainer/requirements_system_dev.txt
+++ b/.devcontainer/requirements_system_dev.txt
@@ -1,0 +1,1 @@
+unixodbc-dev


### PR DESCRIPTION
#### Reason for change
Adding support for a Visual Studio Code ("VS Code") containerised dev environment makes it easier for new developers to get up and running.

#### Description of change
This pull request adds a folder to the root folder of this project. The existence of this folder prompts the VS Code user to open the project in a Docker container. This container is then set up using a Python virtual environment based on the requirements of the project as defined in `requirements-dev.txt`.

The container is built using an official Microsoft Docker image using Python 3.9. I have chosen Bullseye as I've found it to work well for both Mac's (including the Silicon processor) and PC's.

Caveat: although I haven't tried this extensively as it's not my main use case, I don't seem to be able to run the GUI in the container. The CLI seems to run though.

#### Steps to Test
- Download and install VS code
- Install the `Remote - Containers` extension (`ms-vscode-remote.remote-containers`).
- Run the command `Remote-containers: Open Folder in Container ...`

**review**:
@Arelle/arelle
