### PR TITLE
Deprecate imp module, part 1

### DIFF
--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -8,11 +8,8 @@ based on pull request 4
 
 '''
 from __future__ import annotations
-from importlib.machinery import ModuleSpec
 import os, sys, types, time, ast, imp, io, json, gettext, traceback
-from importlib.util import find_spec
-
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from arelle.Locale import getLanguageCodes
 from arelle.FileSource import openFileStream
 from arelle.UrlUtil import isAbsolute
@@ -21,6 +18,9 @@ try:
 except ImportError:
     OrderedDict = dict # python 3.0 lacks OrderedDict, json file will be in weird order
 
+if TYPE_CHECKING:
+    # Prevent circular import error
+    from .Cntlr import Cntlr
 
 PLUGIN_TRACE_FILE = None
 # PLUGIN_TRACE_FILE = "c:/temp/pluginerr.txt"
@@ -318,117 +318,117 @@ def moduleInfo(pluginInfo):
         elif isinstance(value, types.FunctionType):
             moduleInfo.getdefault('classes',[]).append(name)
 
+def get_name_dir_prefix(
+    controller: Cntlr,
+    pluginBase: str,
+    moduleInfo: dict[str, Any],
+    packagePrefix: str = "",
+) -> tuple[str, str, str] | tuple[None, None, None]:
+    """Get the name, directory and prefix of a module."""
+    moduleFilename: str
+    moduleDir: str
+    packageImportPrefix: str
+
+    moduleURL = moduleInfo["moduleURL"]
+    moduleFilename = controller.webCache.getfilename(
+        url=moduleURL, normalize=True, base=pluginBase
+    )
+
+    if moduleFilename is not None and moduleFilename:
+        if os.path.basename(moduleFilename) == "__init__.py" and os.path.isfile(
+            moduleFilename
+        ):
+            #missing
+            moduleFilename = os.path.dirname(
+                moduleFilename
+            )  # want just the dirpart of package
+
+        if os.path.isdir(moduleFilename) and os.path.isfile(
+            os.path.join(moduleFilename, "__init__.py")
+        ):
+            moduleDir = os.path.dirname(moduleFilename)
+            moduleName = os.path.basename(moduleFilename)
+            packageImportPrefix = moduleName + "."
+        else:
+            moduleName = os.path.basename(moduleFilename).partition(".")[0]
+            moduleDir = os.path.dirname(moduleFilename)
+            packageImportPrefix = packagePrefix
+
+        return (moduleName, moduleDir, packageImportPrefix)
+
+    return (None, None, None)
+
+
 def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
-    print(f"a: {moduleInfo}")
-    print(f"b: {packagePrefix}")
-    print(f"c: {_pluginBase}")
     name = moduleInfo['name']
     moduleURL = moduleInfo['moduleURL']
-    moduleFilename = _cntlr.webCache.getfilename(moduleURL, normalize=True, base=_pluginBase)
-    if moduleFilename:
-        try:
-            if os.path.basename(moduleFilename) == "__init__.py" and os.path.isfile(moduleFilename):
-                moduleFilename = os.path.dirname(moduleFilename) # want just the dirpart of package
-            if os.path.isdir(moduleFilename) and os.path.isfile(os.path.join(moduleFilename, "__init__.py")):
-                moduleDir = os.path.dirname(moduleFilename)
-                moduleName = os.path.basename(moduleFilename)
-                packageImportPrefix = moduleName + "."
-            else:
-                moduleName = os.path.basename(moduleFilename).partition('.')[0]
-                moduleDir = os.path.dirname(moduleFilename)
-                packageImportPrefix = packagePrefix
-            print(f"d: {moduleName}")
-            print(f"e: {moduleDir}")
 
-            from importlib.machinery import PathFinder, ModuleSpec, FileFinder, all_suffixes
-            from importlib.util import module_from_spec
-            import importlib
+    moduleName, moduleDir, packageImportPrefix = get_name_dir_prefix(
+        controller=_cntlr,
+        pluginBase=_pluginBase,
+        moduleInfo=moduleInfo,
+        packagePrefix=packagePrefix,
+    )
 
-            def _get_description(moduleDir):
-                for suffix, mode, type_ in all_suffixes():
-                    file_name = name + suffix
-                    file_path = os.path.join(moduleDir, file_name)
-                    if os.path.isfile(file_path):
-                        return suffix, mode, type_
-
-            loader: ModuleSpec = PathFinder().find_spec(moduleName, [moduleDir])
-            path = loader.origin
-            #description = (".py", "r", 1,)
-            description = _get_description(moduleDir)
-            file = open(path, 'r')
-
-            #from pprint import pprint
-            #pprint(vars(loader))
-            #file, path, description = find_spec(moduleName, moduleDir)
-            #from importlib.abc import MetaPathFinder
-            file, path, description = imp.find_module(moduleName, [moduleDir])
-            print(f"f: {file}")
-            print(f"g: {path}")
-            print(f"h: {description}")
-            if file or path: # file returned if non-package module, otherwise just path for package
-                try:
-                    module = imp.load_module(packagePrefix + moduleName, file, path, description)
-                    pluginInfo = module.__pluginInfo__.copy()
-                    elementSubstitutionClasses = None
-                    if name == pluginInfo.get('name'):
-                        pluginInfo["moduleURL"] = moduleURL
-                        modulePluginInfos[name] = pluginInfo
-                        if 'localeURL' in pluginInfo:
-                            # set L10N internationalization in loaded module
-                            localeDir = os.path.dirname(module.__file__) + os.sep + pluginInfo['localeURL']
-                            try:
-                                _gettext = gettext.translation(pluginInfo['localeDomain'], localeDir, getLanguageCodes())
-                            except IOError:
-                                _gettext = lambda x: x # no translation
-                        else:
-                            _gettext = lambda x: x
-                        for key, value in pluginInfo.items():
-                            if key == 'name':
-                                if name:
-                                    pluginConfig['modules'][name] = moduleInfo
-                            elif isinstance(value, types.FunctionType):
-                                classModuleNames = pluginConfig['classes'].setdefault(key, [])
-                                if name and name not in classModuleNames:
-                                    classModuleNames.append(name)
-                            if key == 'ModelObjectFactory.ElementSubstitutionClasses':
-                                elementSubstitutionClasses = value
-                        module._ = _gettext
-                        global pluginConfigChanged
-                        pluginConfigChanged = True
-                    if elementSubstitutionClasses:
+    if moduleName is not None and moduleName is not None and packageImportPrefix is not None:
+        file, path, description = imp.find_module(moduleName, [moduleDir])
+        if file or path: # file returned if non-package module, otherwise just path for package
+            try:
+                module = imp.load_module(packagePrefix + moduleName, file, path, description)
+                pluginInfo = module.__pluginInfo__.copy()
+                elementSubstitutionClasses = None
+                if name == pluginInfo.get('name'):
+                    pluginInfo["moduleURL"] = moduleURL
+                    modulePluginInfos[name] = pluginInfo
+                    if 'localeURL' in pluginInfo:
+                        # set L10N internationalization in loaded module
+                        localeDir = os.path.dirname(module.__file__) + os.sep + pluginInfo['localeURL']
                         try:
-                            from arelle.ModelObjectFactory import elementSubstitutionModelClass
-                            elementSubstitutionModelClass.update(elementSubstitutionClasses)
-                        except Exception as err:
-                            _msg = _("Exception loading plug-in {name}: processing ModelObjectFactory.ElementSubstitutionClasses").format(
-                                    name=name, error=err)
-                            if PLUGIN_TRACE_FILE:
-                                with open(PLUGIN_TRACE_FILE, "at", encoding='utf-8') as fh:
-                                    fh.write(_msg + '\n')
-                            else:
-                                print(_msg, file=sys.stderr)
-                    for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
-                        loadModule(importModuleInfo, packageImportPrefix)
-                except (ImportError, AttributeError, TypeError, SystemError) as err:
-                    _msg = _("Exception loading plug-in {name}: {error}\n{traceback}").format(
-                            name=name, error=err, traceback=traceback.format_tb(sys.exc_info()[2]))
-                    if PLUGIN_TRACE_FILE:
-                        with open(PLUGIN_TRACE_FILE, "at", encoding='utf-8') as fh:
-                            fh.write(_msg + '\n')
+                            _gettext = gettext.translation(pluginInfo['localeDomain'], localeDir, getLanguageCodes())
+                        except IOError:
+                            _gettext = lambda x: x # no translation
                     else:
-                        print(_msg, file=sys.stderr)
+                        _gettext = lambda x: x
+                    for key, value in pluginInfo.items():
+                        if key == 'name':
+                            if name:
+                                pluginConfig['modules'][name] = moduleInfo
+                        elif isinstance(value, types.FunctionType):
+                            classModuleNames = pluginConfig['classes'].setdefault(key, [])
+                            if name and name not in classModuleNames:
+                                classModuleNames.append(name)
+                        if key == 'ModelObjectFactory.ElementSubstitutionClasses':
+                            elementSubstitutionClasses = value
+                    module._ = _gettext
+                    global pluginConfigChanged
+                    pluginConfigChanged = True
+                if elementSubstitutionClasses:
+                    try:
+                        from arelle.ModelObjectFactory import elementSubstitutionModelClass
+                        elementSubstitutionModelClass.update(elementSubstitutionClasses)
+                    except Exception as err:
+                        _msg = _("Exception loading plug-in {name}: processing ModelObjectFactory.ElementSubstitutionClasses").format(
+                                name=name, error=err)
+                        if PLUGIN_TRACE_FILE:
+                            with open(PLUGIN_TRACE_FILE, "at", encoding='utf-8') as fh:
+                                fh.write(_msg + '\n')
+                        else:
+                            print(_msg, file=sys.stderr)
+                for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
+                    loadModule(importModuleInfo, packageImportPrefix)
+            except (ImportError, AttributeError, TypeError, SystemError) as err:
+                _msg = _("Exception loading plug-in {name}: {error}\n{traceback}").format(
+                        name=name, error=err, traceback=traceback.format_tb(sys.exc_info()[2]))
+                if PLUGIN_TRACE_FILE:
+                    with open(PLUGIN_TRACE_FILE, "at", encoding='utf-8') as fh:
+                        fh.write(_msg + '\n')
+                else:
+                    print(_msg, file=sys.stderr)
 
-                finally:
-                    if file:
-                        file.close() # non-package module
-        except (EnvironmentError, ImportError, NameError, SyntaxError) as err: #find_module failed, no file to close
-            _msg = _("Exception obtaining plug-in module info: {moduleFilename}\n{error}\n{traceback}").format(
-                    error=err, moduleFilename=moduleFilename, traceback=traceback.format_tb(sys.exc_info()[2]))
-            if PLUGIN_TRACE_FILE:
-                with open(PLUGIN_TRACE_FILE, "at", encoding='utf-8') as fh:
-                    fh.write(_msg + '\n')
-            else:
-                print(_msg, file=sys.stderr)
+            finally:
+                if file:
+                    file.close() # non-package module
+
 
 def pluginClassMethods(className):
     if pluginConfig:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -318,7 +318,7 @@ def moduleInfo(pluginInfo):
         elif isinstance(value, types.FunctionType):
             moduleInfo.getdefault('classes',[]).append(name)
 
-def get_name_dir_prefix(
+def _get_name_dir_prefix(
     controller: Cntlr,
     pluginBase: str,
     moduleInfo: dict[str, Any],
@@ -362,7 +362,7 @@ def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
     name = moduleInfo['name']
     moduleURL = moduleInfo['moduleURL']
 
-    moduleName, moduleDir, packageImportPrefix = get_name_dir_prefix(
+    moduleName, moduleDir, packageImportPrefix = _get_name_dir_prefix(
         controller=_cntlr,
         pluginBase=_pluginBase,
         moduleInfo=moduleInfo,

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -19,7 +19,7 @@ except ImportError:
     OrderedDict = dict # python 3.0 lacks OrderedDict, json file will be in weird order
 
 if TYPE_CHECKING:
-    # Prevent circular import error
+    # Prevent potential circular import error
     from .Cntlr import Cntlr
 
 PLUGIN_TRACE_FILE = None
@@ -338,7 +338,6 @@ def get_name_dir_prefix(
         if os.path.basename(moduleFilename) == "__init__.py" and os.path.isfile(
             moduleFilename
         ):
-            #missing
             moduleFilename = os.path.dirname(
                 moduleFilename
             )  # want just the dirpart of package

--- a/tests/unit_tests/arelle/test_pluginmanager.py
+++ b/tests/unit_tests/arelle/test_pluginmanager.py
@@ -1,7 +1,7 @@
 from mock import Mock
-
+import sys
 from arelle import PluginManager
-
+from arelle.Cntlr import Cntlr
 
 def test_plugin_manager_init_first_pass():
     """
@@ -73,3 +73,30 @@ def test_plugin_manager_reset():
     assert len(PluginManager.modulePluginInfos) == 0
     assert len(PluginManager.pluginMethodsForClasses) == 0
     assert PluginManager._cntlr == cntlr
+
+def test_function_loadModule():
+    """Test helper function loadModule."""
+
+    class Controller(Cntlr):  # type: ignore
+        """Controller."""
+
+        pluginDir = "tests/unit_tests/arelle"
+
+        def __init__(self) -> None:
+            """Init controller with logging."""
+            super().__init__(logFileName="logToPrint")
+
+    cntlr = Controller()
+    PluginManager.init(cntlr, loadPluginConfig=False)
+
+    PluginManager.loadModule(
+        moduleInfo={
+            "name": "Mock name",
+            "moduleURL": "functionsMath",
+        }
+    )
+
+    all_modules_list = [m.__name__ for m in sys.modules.values() if m]
+    assert "functionsMath" in all_modules_list
+
+    assert True

--- a/tests/unit_tests/arelle/test_pluginmanager.py
+++ b/tests/unit_tests/arelle/test_pluginmanager.py
@@ -1,7 +1,14 @@
-from mock import Mock
+"""Tests for the PluginManager module."""
+from __future__ import annotations
+
 import sys
+
+import pytest
+from mock import Mock
+
 from arelle import PluginManager
 from arelle.Cntlr import Cntlr
+
 
 def test_plugin_manager_init_first_pass():
     """
@@ -74,10 +81,71 @@ def test_plugin_manager_reset():
     assert len(PluginManager.pluginMethodsForClasses) == 0
     assert PluginManager._cntlr == cntlr
 
-def test_function_loadModule():
-    """Test helper function loadModule."""
+@pytest.mark.parametrize(
+    "test_data, expected_result",
+    [
+        # Test case 1
+        (
+            # Test data
+            ("tests/unit_tests/arelle", "functionsMaths", "xyz"),
+            # Expected result
+            ("functionsMaths", "tests/unit_tests", "xyz")
+        ),
+        # Test case 2
+        (
+            # Test data
+            ("arelle/plugin/", "sphinx/__init__.py", "xyz"),
+            # Expected result
+            ("sphinx", "arelle/plugin", "sphinx.")
+        ),
+        # Test case 3
+        (
+            # Test data
+            ("plugin/sphinx", None, "xyz"),
+            # Expected result
+            (None, None, None)
+        ),
+    ]
+)
+def test_function_get_name_dir_prefix(
+    test_data: tuple[str, str, str],
+    expected_result: tuple[str, str, str],
+    ):
+    """Test util function get_name_dir_prefix."""
+    class Controller(Cntlr):
+        """Controller."""
 
-    class Controller(Cntlr):  # type: ignore
+        pluginDir = test_data[0]
+
+        def __init__(self) -> None:
+            """Init controller with logging."""
+            super().__init__(logFileName="logToPrint")
+
+    cntlr = Controller()
+    PluginManager.init(cntlr, loadPluginConfig=False)
+
+    moduleName, moduleDir, packageImportPrefix = PluginManager.get_name_dir_prefix(
+        controller=cntlr,
+        pluginBase=Controller.pluginDir,
+        moduleInfo={
+            "moduleURL": test_data[1],
+        },
+        packagePrefix=test_data[2],
+    )
+
+    assert moduleName == expected_result[0]
+    assert moduleDir == expected_result[1]
+    assert packageImportPrefix == expected_result[2]
+
+def test_function_loadModule():
+    """
+    Test helper function loadModule.
+
+    This test asserts that a plugin module is loaded when running
+    the function.
+    """
+
+    class Controller(Cntlr):
         """Controller."""
 
         pluginDir = "tests/unit_tests/arelle"
@@ -91,12 +159,17 @@ def test_function_loadModule():
 
     PluginManager.loadModule(
         moduleInfo={
-            "name": "Mock name",
+            "name": "mock",
             "moduleURL": "functionsMath",
         }
     )
 
-    all_modules_list = [m.__name__ for m in sys.modules.values() if m]
-    assert "functionsMath" in all_modules_list
+    # all_modules_list contains a list of all currently loaded modules, eg:
+    # arelle.XPathContext
+    # arelle.FunctionUtil
+    # arelle.FunctionXs
+    # isodate.isoduration
+    # functionsMath
+    all_modules_list: list[str] = [m.__name__ for m in sys.modules.values() if m]
 
-    assert True
+    assert "functionsMath" in all_modules_list

--- a/tests/unit_tests/arelle/test_pluginmanager.py
+++ b/tests/unit_tests/arelle/test_pluginmanager.py
@@ -124,7 +124,7 @@ def test_function_get_name_dir_prefix(
     cntlr = Controller()
     PluginManager.init(cntlr, loadPluginConfig=False)
 
-    moduleName, moduleDir, packageImportPrefix = PluginManager.get_name_dir_prefix(
+    moduleName, moduleDir, packageImportPrefix = PluginManager._get_name_dir_prefix(
         controller=cntlr,
         pluginBase=Controller.pluginDir,
         moduleInfo={


### PR DESCRIPTION
#### Reason for change
When importing and running Arelle as a third-party module, the following error is raised due to Python's `imp` module being deprecated:
```
arelle/PluginManager.py:11
  /workspaces/Arelle/arelle/PluginManager.py:11: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import os, sys, types, time, ast, imp, io, json, gettext, traceback
```

The error is raised in two lines of the `loadModule` function and I'm trying to migrate that function to using `importlib` instead of `imp`. I'm breaking the change down in multiple steps, in which this is the first step, to try to avoid introducing bugs.

#### Description of change
In this PR, I have refactored `loadModule` by moving some of its functionality into a helper function `_get_name_dir_prefix`. I have also added unit tests for this new helper function, as well as a unit test for the `loadModule` function. The idea if having a unit test for `loadModule` is that we would be able to catch any errors that breaks the functionality of this function.

There also appears to have been spaces in the code. These spaces were automatically removed by my IDE and is thus also a part of this PR.

#### Steps to Test

**review**:
@Arelle/arelle
