### PR TITLE
Fix bug in PackageManager.save() 

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -389,7 +389,7 @@ class Cntlr:
            :type saveConfig: bool
         """
         PluginManager.save(self)
-        PluginManager.save(self)
+
         if self.hasGui:
             PackageManager.save(self)
         if saveConfig:

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -45,9 +45,9 @@ def resourcesDir():
     return _resourcesDir
 
 class Cntlr:
-    """    
+    """
     Initialization sets up for platform
-    
+
     - Platform directories for application, configuration, locale, and cache
     - Context menu click event (TKinter)
     - Clipboard presence
@@ -55,52 +55,52 @@ class Cntlr:
     - Reloads prior config user preferences (saved in json file)
     - Sets up proxy and web cache
     - Sets up logging
-    
-    A controller subclass object is instantiated, CntlrWinMain for the GUI and CntlrCmdLine for command 
+
+    A controller subclass object is instantiated, CntlrWinMain for the GUI and CntlrCmdLine for command
     line batch operation.  (Other controller modules and/or objects may be subordinate to a CntlrCmdLine,
     such as CntlrWebMain, and CntlrQuickBooks).
-    
-    This controller base class initialization sets up specifics such as directory paths, 
-    for its environment (Mac, Windows, or Unix), sets up a web file cache, and retrieves a 
-    configuration dictionary of prior user choices (such as window arrangement, validation choices, 
+
+    This controller base class initialization sets up specifics such as directory paths,
+    for its environment (Mac, Windows, or Unix), sets up a web file cache, and retrieves a
+    configuration dictionary of prior user choices (such as window arrangement, validation choices,
     and proxy settings).
-    
-    The controller sub-classes (such as CntlrWinMain, CntlrCmdLine, and CntlrWebMain) most likely will 
-    load an XBRL related object, such as an XBRL instance, taxonomy, 
-    testcase file, versioning report, or RSS feed, by requesting the model manager to load and 
-    return a reference to its modelXbrl object.  The modelXbrl object loads the entry modelDocument 
-    object(s), which in turn load documents they discover (for the case of instance, taxonomies, and 
-    versioning reports), but defer loading instances for test case and RSS feeds.  The model manager 
-    may be requested to validate the modelXbrl object, or views may be requested as below.  
+
+    The controller sub-classes (such as CntlrWinMain, CntlrCmdLine, and CntlrWebMain) most likely will
+    load an XBRL related object, such as an XBRL instance, taxonomy,
+    testcase file, versioning report, or RSS feed, by requesting the model manager to load and
+    return a reference to its modelXbrl object.  The modelXbrl object loads the entry modelDocument
+    object(s), which in turn load documents they discover (for the case of instance, taxonomies, and
+    versioning reports), but defer loading instances for test case and RSS feeds.  The model manager
+    may be requested to validate the modelXbrl object, or views may be requested as below.
     (Validating a testcase or RSS feed will validate the test case variations or RSS feed items, one by one.)
-    
+
         .. attribute:: isMac
         True if system is MacOS
-        
+
         .. attribute:: isMSW
         True if system is Microsoft Windows
-        
+
         .. attribute:: userAppDir
         Full pathname to application directory (for persistent json files, cache, etc).
-        
+
         .. attribute:: configDir
         Full pathname to config directory as installed (validation options, redirection URLs, common xsds).
-        
+
         .. attribute:: imagesDir
         Full pathname to images directory as installed (images for GUI and web server).
-        
+
         .. attribute:: localeDir
         Full pathname to locale directory as installed (for support of gettext localization feature).
-        
+
         .. attribute:: hasClipboard
         True if a system platform clipboard is implemented on current platform
-        
+
         .. attribute:: updateURL
         URL string of application download file (on arelle.org server).  Usually redirected to latest released application installable module.
-        
+
     """
     __version__ = "1.6.0"
-    
+
     def __init__(self, hasGui=False, logFileName=None, logFileMode=None, logFileEncoding=None, logFormat=None):
         self.hasWin32gui = False
         self.hasGui = hasGui
@@ -109,7 +109,7 @@ class Cntlr:
         self.isCGI = False
         self.systemWordSize = int(round(math.log(sys.maxsize, 2)) + 1) # e.g., 32 or 64
         self.uiLangDir = "ltr"
-        
+
         # sys.setrecursionlimit(10000) # 1000 default exceeded in some inline documents
 
         _resourcesDir = resourcesDir()
@@ -128,9 +128,9 @@ class Cntlr:
             gatewayInterface = os.getenv("GATEWAY_INTERFACE", "")
             if gatewayInterface.startswith("CGI/"):
                 self.isCGI = True
-            
+
         configHomeDir = None  # look for path configDir/CONFIG_HOME in argv and environment parameters
-        for i, arg in enumerate(sys.argv):  # check if config specified in a argv 
+        for i, arg in enumerate(sys.argv):  # check if config specified in a argv
             if arg.startswith("--xdgConfigHome="):
                 configHomeDir = arg[16:]
                 break
@@ -230,36 +230,36 @@ class Cntlr:
         if not self.config:
             self.config = {
                 'fileHistory': [],
-                'windowGeometry': "{0}x{1}+{2}+{3}".format(800, 500, 200, 100),                
+                'windowGeometry': "{0}x{1}+{2}+{3}".format(800, 500, 200, 100),
             }
-            
+
         # start language translation for domain
         self.setUiLanguage(self.config.get("userInterfaceLangOverride",None), fallbackToDefault=True)
         setDisableRTL(self.config.get('disableRtl', False))
-           
+
         from arelle.WebCache import WebCache
         self.webCache = WebCache(self, self.config.get("proxySettings"))
-        
+
         # start plug in server (requres web cache initialized, but not logger)
         PluginManager.init(self, loadPluginConfig=hasGui)
 
         # requires plug ins initialized
         self.modelManager = ModelManager.initialize(self)
- 
+
         # start taxonomy package server (requres web cache initialized, but not logger)
         PackageManager.init(self, loadPackagesConfig=hasGui)
- 
+
         self.startLogging(logFileName, logFileMode, logFileEncoding, logFormat)
-        
+
         # Cntlr.Init after logging started
         for pluginMethod in PluginManager.pluginClassMethods("Cntlr.Init"):
             pluginMethod(self)
-            
+
     def setUiLanguage(self, lang, fallbackToDefault=False):
         try:
             langCodes = getLanguageCodes(lang)
-            gettext.translation("arelle", 
-                                self.localeDir, 
+            gettext.translation("arelle",
+                                self.localeDir,
                                 langCodes).install()
             self.uiLang = langCodes[0].lower()
             self.uiLangDir = 'rtl' if self.uiLang[0:2] in {"ar","he"} else 'ltr'
@@ -275,10 +275,10 @@ class Cntlr:
             if fallbackToDefault or (lang and lang.lower().startswith("en")):
                 self.uiLang = "en"
                 self.uiLangDir = "ltr"
-                gettext.install("arelle", 
+                gettext.install("arelle",
                                 self.localeDir)
-        
-    def startLogging(self, logFileName=None, logFileMode=None, logFileEncoding=None, logFormat=None, 
+
+    def startLogging(self, logFileName=None, logFileMode=None, logFileEncoding=None, logFormat=None,
                      logLevel=None, logHandler=None, logToBuffer=False, logTextMaxLength=None, logRefObjectProperties=True):
         # add additional logging levels (for python 2.7, all of these are ints)
         logging.addLevelName(logging.INFO - 1, "INFO-RESULT") # result data, has @name, @value, optional href to source and readable message
@@ -306,7 +306,7 @@ class Cntlr:
                 if not logFormat:
                     logFormat = "%(message)s"
             else:
-                self.logHandler = logging.FileHandler(filename=logFileName, 
+                self.logHandler = logging.FileHandler(filename=logFileName,
                                                       mode=logFileMode or "a",  # should this be "w" mode??
                                                       encoding=logFileEncoding or "utf-8")
             self.logHandler.setFormatter(LogFormatter(logFormat or "%(asctime)s [%(messageCode)s] %(message)s - %(file)s\n"))
@@ -326,18 +326,18 @@ class Cntlr:
             self.logger.messageCodeFilter = None
             self.logger.messageLevelFilter = None
             self.logHandler.logTextMaxLength = (logTextMaxLength or LOG_TEXT_MAX_LENGTH)
-                
+
     def setLogLevelFilter(self, logLevelFilter):
         if self.logger:
             self.logger.messageLevelFilter = re.compile(logLevelFilter) if logLevelFilter else None
-            
+
     def setLogCodeFilter(self, logCodeFilter):
         if self.logger:
             self.logger.messageCodeFilter = re.compile(logCodeFilter) if logCodeFilter else None
 
     def addToLog(self, message, messageCode="", messageArgs=None, file="", refs=None, level=logging.INFO):
         """Add a simple info message to the default logger
-           
+
         :param message: Text of message to add to log.
         :type message: str
         : param messageArgs: optional dict of message format-string key-value pairs
@@ -355,7 +355,7 @@ class Cntlr:
             if refs is None:
                 refs = []
             if isinstance(file, (tuple,list,set)):
-                for _file in file: 
+                for _file in file:
                     refs.append( {"href": _file} )
             elif isinstance(file, _STR_BASE):
                 refs.append( {"href": file} )
@@ -370,21 +370,21 @@ class Cntlr:
                 print((message
                        .encode(sys.stdout.encoding, 'backslashreplace')
                        .decode(sys.stdout.encoding, 'strict')))
-            
+
     def showStatus(self, message, clearAfter=None):
-        """Dummy method for specialized controller classes to specialize, 
+        """Dummy method for specialized controller classes to specialize,
         provides user feedback on status line of GUI or web page
-        
+
         :param message: Message to display on status widget.
         :type message: str
         :param clearAfter: Time, in ms., after which to clear the message (e.g., 5000 for 5 sec.)
         :type clearAfter: int
         """
         pass
-    
+
     def close(self, saveConfig=False):
         """Closes the controller and its logger, optionally saving the user preferences configuration
-           
+
            :param saveConfig: save the user preferences configuration
            :type saveConfig: bool
         """
@@ -397,51 +397,51 @@ class Cntlr:
                 self.logHandler.close()
             except Exception: # fails on some earlier pythons (3.1)
                 pass
-        
+
     def saveConfig(self):
         """Save user preferences configuration (in json configuration file)."""
         if self.hasFileSystem:
             with io.open(self.configJsonFile, 'wt', encoding='utf-8') as f:
                 jsonStr = _STR_UNICODE(json.dumps(self.config, ensure_ascii=False, indent=2)) # might not be unicode in 2.7
                 f.write(jsonStr)  # 2.7 getss unicode this way
-            
-    # default non-threaded viewModelObject                 
+
+    # default non-threaded viewModelObject
     def viewModelObject(self, modelXbrl, objectId):
         """Notify any watching views to show and highlight selected object.  Generally used
         to scroll list control to object and highlight it, or if tree control, to find the object
         and open tree branches as needed for visibility, scroll to and highlight the object.
-           
+
         :param modelXbrl: ModelXbrl (DTS) whose views are to be notified
         :type modelXbrl: ModelXbrl
         :param objectId: Selected object id (string format corresponding to ModelObject.objectId() )
         :type objectId: str
         """
         modelXbrl.viewModelObject(objectId)
-            
+
     def reloadViews(self, modelXbrl):
         """Notification to reload views (probably due to change within modelXbrl).  Dummy
         for subclasses to specialize when they have a GUI or web page.
-           
+
         :param modelXbrl: ModelXbrl (DTS) whose views are to be notified
         :type modelXbrl: ModelXbrl
         """
         pass
-    
+
     def rssWatchUpdateOption(self, **args):
         """Notification to change rssWatch options, as passed in, usually from a modal dialog."""
         pass
-    
+
     def onPackageEnablementChanged(self):
         """Notification that package enablement changed, usually from a modal dialog."""
         pass
-        
+
     # default web authentication password
     def internet_user_password(self, host, realm):
-        """Request (for an interactive UI or web page) to obtain user ID and password (usually for a proxy 
+        """Request (for an interactive UI or web page) to obtain user ID and password (usually for a proxy
         or when getting a web page that requires entry of a password).  This function must be overridden
         in a subclass that provides interactive user interface, as the superclass provides only a dummy
-        method. 
-           
+        method.
+
         :param host: The host that is requesting the password
         :type host: str
         :param realm: The domain on the host that is requesting the password
@@ -449,28 +449,28 @@ class Cntlr:
         :returns: tuple -- ('myusername','mypassword')
         """
         return ('myusername','mypassword')
-    
+
     # default web authentication password
     def internet_logon(self, url, quotedUrl, dialogCaption, dialogText):
         """Web file retrieval results in html that appears to require user logon,
-        if interactive allow the user to log on. 
-           
+        if interactive allow the user to log on.
+
         :url: The URL as requested (by an import, include, href, schemaLocation, ...)
         :quotedUrl: The processed and retrievable URL
         :dialogCaption: The dialog caption for the situation
         :dialogText:  The dialog text for the situation at hand
-        :returns: string -- 'retry' if user logged on and file can be retried, 
+        :returns: string -- 'retry' if user logged on and file can be retried,
                             'cancel' to abandon retrieval
                             'no' if the file is expected and valid contents (not a logon request)
         """
         return 'cancel'
-    
+
     # if no text, then return what is on the clipboard, otherwise place text onto clipboard
     def clipboardData(self, text=None):
         """Places text onto the clipboard (if text is not None), otherwise retrieves and returns text from the clipboard.
         Only supported for those platforms that have clipboard support in the current python implementation (macOS
         or ActiveState Windows Python).
-           
+
         :param text: Text to place onto clipboard if not None, otherwise retrieval of text from clipboard.
         :type text: str
         :returns: str -- text from clipboard if parameter text is None, otherwise returns None if text is provided
@@ -509,7 +509,7 @@ class Cntlr:
             except Exception:
                 pass
         return None
-    
+
     @property
     def memoryUsed(self):
         try:
@@ -528,14 +528,14 @@ class Cntlr:
         except Exception:
             pass
         return 0
-    
+
 def logRefsFileLines(refs):
     fileLines = defaultdict(set)
     for ref in refs:
         href = ref.get("href")
         if href:
             fileLines[href.partition("#")[0]].add(ref.get("sourceLine", 0))
-    return ", ".join(file + " " + ', '.join(str(line) 
+    return ", ".join(file + " " + ', '.join(str(line)
                                             for line in sorted(lines, key=lambda l: l)
                                             if line)
                     for file, lines in sorted(fileLines.items()))
@@ -543,11 +543,11 @@ def logRefsFileLines(refs):
 class LogFormatter(logging.Formatter):
     def __init__(self, fmt=None, datefmt=None):
         super(LogFormatter, self).__init__(fmt, datefmt)
-        
+
     def fileLines(self, record):
         # provide a file parameter made up from refs entries
         return logRefsFileLines(record.refs)
-        
+
     def format(self, record):
         record.file = self.fileLines(record)
         try:
@@ -567,9 +567,9 @@ class LogFormatter(logging.Formatter):
 class LogToPrintHandler(logging.Handler):
     """
     .. class:: LogToPrintHandler()
-    
+
     A log handler that emits log entries to standard out as they are logged.
-    
+
     CAUTION: Output is utf-8 encoded, which is fine for saving to files, but may not display correctly in terminal windows.
 
     :param logOutput: 'logToStdErr' to cause log printint to stderr instead of stdout
@@ -581,7 +581,7 @@ class LogToPrintHandler(logging.Handler):
             self.logFile = sys.stderr
         else:
             self.logFile = None
-        
+
     def emit(self, logRecord):
         file = sys.stderr if self.logFile else None
         logEntry = self.format(logRecord)
@@ -593,19 +593,19 @@ class LogToPrintHandler(logging.Handler):
             # extra parentheses in print to allow for 3-to-2 conversion
             print((logEntry
                    .encode(sys.stdout.encoding, 'backslashreplace')
-                   .decode(sys.stdout.encoding, 'strict')), 
+                   .decode(sys.stdout.encoding, 'strict')),
                   file=file)
 
-class LogHandlerWithXml(logging.Handler):        
+class LogHandlerWithXml(logging.Handler):
     def __init__(self):
         super(LogHandlerWithXml, self).__init__()
-        
+
     def recordToXml(self, logRec):
         def entityEncode(arg, truncateAt=self.logTextMaxLength):  # be sure it's a string, vs int, etc, and encode &, <, ".
             s = str(arg)
             s = s if len(s) <= truncateAt else s[:truncateAt] + '...'
             return s.replace("&","&amp;").replace("<","&lt;").replace('"','&quot;')
-        
+
         def ncNameEncode(arg):
             s = []
             for c in arg:
@@ -614,39 +614,39 @@ class LogHandlerWithXml(logging.Handler):
                 else: # covers : and any other non-allowed character
                     s.append('_') # change : into _ for xml correctness
             return "".join(s)
-        
+
         def propElts(properties, indent, truncateAt=128):
             nestedIndent = indent + ' '
             return indent.join('<property name="{0}" value="{1}"{2}>'.format(
                                     entityEncode(p[0]),
                                     entityEncode(p[1], truncateAt=truncateAt),
-                                    '/' if len(p) == 2 
+                                    '/' if len(p) == 2
                                     else '>' + nestedIndent + propElts(p[2],nestedIndent) + indent + '</property')
-                                for p in properties 
+                                for p in properties
                                 if 2 <= len(p) <= 3)
-        
+
         msg = self.format(logRec)
         if logRec.args:
-            args = "".join([' {0}="{1}"'.format(ncNameEncode(n), entityEncode(v, 
-                                                truncateAt=(65535 if n in ("json",) else 128))) 
+            args = "".join([' {0}="{1}"'.format(ncNameEncode(n), entityEncode(v,
+                                                truncateAt=(65535 if n in ("json",) else 128)))
                             for n, v in logRec.args.items()])
         else:
             args = ""
         refs = "\n ".join('\n <ref href="{0}"{1}{2}{3}>'.format(
-                        entityEncode(ref["href"]), 
+                        entityEncode(ref["href"]),
                         ' sourceLine="{0}"'.format(ref["sourceLine"]) if "sourceLine" in ref else '',
-                        ''.join(' {}="{}"'.format(ncNameEncode(k),entityEncode(v)) 
+                        ''.join(' {}="{}"'.format(ncNameEncode(k),entityEncode(v))
                                                   for k,v in ref["customAttributes"].items())
                              if 'customAttributes' in ref else '',
-                        (">\n  " + propElts(ref["properties"],"\n  ", truncateAt=self.logTextMaxLength) + "\n </ref" ) 
+                        (">\n  " + propElts(ref["properties"],"\n  ", truncateAt=self.logTextMaxLength) + "\n </ref" )
                                    if ("properties" in ref) else '/')
                        for ref in logRec.refs)
         return ('<entry code="{0}" level="{1}">'
                 '\n <message{2}>{3}</message>{4}'
-                '</entry>\n'.format(logRec.messageCode, 
-                                    logRec.levelname.lower(), 
-                                    args, 
-                                    entityEncode(msg), 
+                '</entry>\n'.format(logRec.messageCode,
+                                    logRec.levelname.lower(),
+                                    args,
+                                    entityEncode(msg),
                                     refs))
     def recordToJson(self, logRec):
         message = { "text": self.format(logRec) }
@@ -657,11 +657,11 @@ class LogHandlerWithXml(logging.Handler):
                 "level": logRec.levelname.lower(),
                 "refs": logRec.refs,
                 "message": message}
-    
+
 class LogToXmlHandler(LogHandlerWithXml):
     """
     .. class:: LogToXmlHandler(filename)
-    
+
     A log handler that writes log entries to named XML file (utf-8 encoded) upon closing the application.
     """
     def __init__(self, filename=None, mode='w'):
@@ -669,7 +669,7 @@ class LogToXmlHandler(LogHandlerWithXml):
         self.filename = filename # may be none if buffer is retrieved by get methods below and not written anywhere
         self.logRecordBuffer = []
         self.filemode = mode
-        
+
     def flush(self):
         if self.filename == "logToStdOut.xml":
             print('<?xml version="1.0" encoding="utf-8"?>')
@@ -708,34 +708,34 @@ class LogToXmlHandler(LogHandlerWithXml):
                         # extra parentheses in print to allow for 3-to-2 conversion
                         print((logEntry
                                .encode(sys.stdout.encoding, 'backslashreplace')
-                               .decode(sys.stdout.encoding, 'strict')), 
+                               .decode(sys.stdout.encoding, 'strict')),
                               file=_file)
             else:
                 with open(self.filename, self.filemode, encoding='utf-8') as fh:
                     for logRec in self.logRecordBuffer:
                         fh.write(self.format(logRec) + "\n")
         self.clearLogBuffer()
-                
+
     def clearLogBuffer(self):
         del self.logRecordBuffer[:]
-        
+
     def getXml(self, clearLogBuffer=True):
         """Returns an XML document (as a string) representing the messages in the log buffer, and clears the buffer.
-        
+
         :reeturns: str -- XML document string of messages in the log buffer.
         """
         xml = ['<?xml version="1.0" encoding="utf-8"?>\n',
                '<log>']
         for logRec in self.logRecordBuffer:
             xml.append(self.recordToXml(logRec))
-        xml.append('</log>')  
+        xml.append('</log>')
         if clearLogBuffer:
             self.clearLogBuffer()
         return '\n'.join(xml)
-    
+
     def getJson(self, clearLogBuffer=True):
         """Returns an JSON string representing the messages in the log buffer, and clears the buffer.
-        
+
         :returns: str -- json representation of messages in the log buffer
         """
         entries = []
@@ -744,40 +744,40 @@ class LogToXmlHandler(LogHandlerWithXml):
         if clearLogBuffer:
             self.clearLogBuffer()
         return json.dumps( {"log": entries}, ensure_ascii=False, indent=1, default=str )
-    
+
     def getLines(self, clearLogBuffer=True):
         """Returns a list of the message strings in the log buffer, and clears the buffer.
-        
+
         :returns: [str] -- list of strings representing messages corresponding to log buffer entries
         """
         lines = [self.format(logRec) for logRec in self.logRecordBuffer]
         if clearLogBuffer:
             self.clearLogBuffer()
         return lines
-    
+
     def getText(self, separator='\n', clearLogBuffer=True):
         """Returns a string of the lines in the log buffer, separated by newline or provided separator.
-        
+
         :param separator: Line separator (default is platform os newline character)
         :type separator: str
         :returns: str -- joined lines of the log buffer.
         """
         return separator.join(self.getLines(clearLogBuffer=clearLogBuffer))
-    
+
     def emit(self, logRecord):
         self.logRecordBuffer.append(logRecord)
 
 class LogToBufferHandler(LogToXmlHandler):
     """
     .. class:: LogToBufferHandler()
-    
+
     A log handler that writes log entries to a memory buffer for later retrieval (to a string) in XML, JSON, or text lines,
     usually for return to a web service or web page call.
     """
     def __init__(self):
         super(LogToBufferHandler, self).__init__()
-        
+
     def flush(self):
         pass # do nothing -- overrides LogToXmlHandler's flush
-    
+
 

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -389,7 +389,9 @@ class Cntlr:
            :type saveConfig: bool
         """
         PluginManager.save(self)
-        PackageManager.save(self)
+        PluginManager.save(self)
+        if self.hasGui:
+            PackageManager.save(self)
         if saveConfig:
             self.saveConfig()
         if self.logger is not None:


### PR DESCRIPTION
#### Reason for change
I was running through a couple of hundred reports in the ESEF-format when I encountered this error:
```
    cntlr.close()
  File "/opt/.venv/lib/python3.10/site-packages/arelle/Cntlr.py", line 496, in close
    PackageManager.save(self)
  File "/opt/.venv/lib/python3.10/site-packages/arelle/PackageManager.py", line 443, in save
    with io.open(packagesJsonFile, 'wt', encoding='utf-8') as f:
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

#### Description of change
Following a discussion in #228, this PR introduces a check for the existence of a gui in the close-function of the Cntlr-file. This PR is made to keep the commit history clean.

My IDE has also removed random spaces throughout the code.

Closes #228.

#### Steps to Test

**review**:
@Arelle/arelle
