### PR TITLE
Deprecate imp module, part 2/2

### DIFF
--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -364,8 +364,9 @@ def _get_name_dir_prefix(
 
 def _get_location(moduleDir: str, moduleName: str) -> str:
     """Get the file name of a plugin."""
-    if os.path.isfile(Path(f"{moduleDir}/{moduleName}.py")):
-        return Path(f"{moduleDir}/{moduleName}.py")
+    module_name_path = os.path.isfile(Path(f"{moduleDir}/{moduleName}.py"))
+    if os.path.isfile(module_name_path):
+        return module_name_path
 
     return Path(f"{moduleDir}/{moduleName}/__init__.py")
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -364,7 +364,7 @@ def _get_name_dir_prefix(
 
 def _get_location(moduleDir: str, moduleName: str) -> str:
     """Get the file name of a plugin."""
-    module_name_path = os.path.isfile(Path(f"{moduleDir}/{moduleName}.py"))
+    module_name_path = Path(f"{moduleDir}/{moduleName}.py")
     if os.path.isfile(module_name_path):
         return module_name_path
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -396,16 +396,8 @@ def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
     if moduleName is None and moduleDir is None and packageImportPrefix is None:
         _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
     else:
-        module = _find_and_load_module(moduleName=moduleName, moduleDir=moduleDir)
-
-        if module is None:
-            _cntlr.addToLog(
-                message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(moduleName),
-                level=logging.ERROR,
-            )
-            return
-
         try:
+            module = _find_and_load_module(moduleName=moduleName, moduleDir=moduleDir)
             pluginInfo = module.__pluginInfo__.copy()
             elementSubstitutionClasses = None
             if name == pluginInfo.get('name'):

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -393,7 +393,9 @@ def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
         packagePrefix=packagePrefix,
     )
 
-    if moduleName is not None and moduleDir is not None and packageImportPrefix is not None:
+    if moduleName is None and moduleDir is None and packageImportPrefix is None:
+        _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
+    else:
         module = _find_and_load_module(moduleName=moduleName, moduleDir=moduleDir)
 
         if module is None:
@@ -453,8 +455,6 @@ def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
                     fh.write(_msg + '\n')
             else:
                 print(_msg, file=sys.stderr)
-    else:
-        _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
 
 def pluginClassMethods(className):
     if pluginConfig:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -393,7 +393,7 @@ def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
         packagePrefix=packagePrefix,
     )
 
-    if moduleName is None and moduleDir is None and packageImportPrefix is None:
+    if all(p is None for p in [moduleName, moduleDir, packageImportPrefix]):
         _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
     else:
         try:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -362,7 +362,7 @@ def _get_name_dir_prefix(
 
     return (None, None, None)
 
-def _find_and_load_module(moduleName: str, moduleDir: str) -> ModuleType | None:
+def _find_and_load_module(moduleDir: str, moduleName: str) -> ModuleType | None:
     """Load a module based on name and directory."""
     location = Path(f"{moduleDir}/{moduleName}.py")
     spec = importlib.util.spec_from_file_location(name=moduleName, location=location)
@@ -394,7 +394,7 @@ def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
         _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
     else:
         try:
-            module = _find_and_load_module(moduleName=moduleName, moduleDir=moduleDir)
+            module = _find_and_load_module(moduleDir=moduleDir, moduleName=moduleName)
             pluginInfo = module.__pluginInfo__.copy()
             elementSubstitutionClasses = None
             if name == pluginInfo.get('name'):

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -362,7 +362,7 @@ def _get_name_dir_prefix(
 
     return (None, None, None)
 
-def _get_location(moduleDir: str, moduleName: str) ->str:
+def _get_location(moduleDir: str, moduleName: str) -> str:
     """Get the file name of a plugin."""
     if os.path.isfile(Path(f"{moduleDir}/{moduleName}.py")):
         return Path(f"{moduleDir}/{moduleName}.py")

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -378,7 +378,7 @@ def _find_and_load_module(moduleName: str, moduleDir: str) -> ModuleType | None:
         sys.modules[moduleName] = module # This line is required before exec_module
         spec.loader.exec_module(sys.modules[moduleName])
     except ImportError as err:
-        raise ModuleNotFoundError(f"Unable to load module due to {err}") from err
+        raise ImportError(f"Unable to load module due to {err}") from err
 
     return sys.modules[moduleName]
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -362,9 +362,16 @@ def _get_name_dir_prefix(
 
     return (None, None, None)
 
+def _get_location(moduleDir: str, moduleName: str) ->str:
+    """Get the file name of a plugin."""
+    if os.path.isfile(Path(f"{moduleDir}/{moduleName}.py")):
+        return Path(f"{moduleDir}/{moduleName}.py")
+
+    return Path(f"{moduleDir}/__init__.py")
+
 def _find_and_load_module(moduleDir: str, moduleName: str) -> ModuleType | None:
     """Load a module based on name and directory."""
-    location = Path(f"{moduleDir}/{moduleName}.py")
+    location = _get_location(moduleDir=moduleDir, moduleName=moduleName)
     spec = importlib.util.spec_from_file_location(name=moduleName, location=location)
 
     # spec_from_file_location returns ModuleSpec or None.

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -447,7 +447,7 @@ def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
                         print(_msg, file=sys.stderr)
             for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
                 loadModule(importModuleInfo, packageImportPrefix)
-        except (AttributeError, TypeError, SystemError) as err:
+        except (AttributeError, ImportError, ModuleNotFoundError, TypeError, SystemError) as err:
             _msg = _("Exception loading plug-in {name}: {error}\n{traceback}").format(
                     name=name, error=err, traceback=traceback.format_tb(sys.exc_info()[2]))
             if PLUGIN_TRACE_FILE:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -448,6 +448,9 @@ def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
             for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
                 loadModule(importModuleInfo, packageImportPrefix)
         except (AttributeError, ImportError, ModuleNotFoundError, TypeError, SystemError) as err:
+            # Send a summary of the error to the logger and retain the stacktrace for stderr
+            _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
+
             _msg = _("Exception loading plug-in {name}: {error}\n{traceback}").format(
                     name=name, error=err, traceback=traceback.format_tb(sys.exc_info()[2]))
             if PLUGIN_TRACE_FILE:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -371,14 +371,14 @@ def _find_and_load_module(moduleName: str, moduleDir: str) -> ModuleType | None:
     # spec.loader returns Loader or None.
     # We want to make sure neither of them are None before proceeding
     if spec is None or spec.loader is None:
-        return None
+        raise ModuleNotFoundError("Unable to load module")
 
     try:
         module = importlib.util.module_from_spec(spec)
         sys.modules[moduleName] = module # This line is required before exec_module
         spec.loader.exec_module(sys.modules[moduleName])
-    except ImportError:
-        return None
+    except ImportError as err:
+        raise ModuleNotFoundError(f"Unable to load module due to {err}") from err
 
     return sys.modules[moduleName]
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -373,12 +373,9 @@ def _find_and_load_module(moduleName: str, moduleDir: str) -> ModuleType | None:
     if spec is None or spec.loader is None:
         raise ModuleNotFoundError("Unable to load module")
 
-    try:
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[moduleName] = module # This line is required before exec_module
-        spec.loader.exec_module(sys.modules[moduleName])
-    except ImportError as err:
-        raise ImportError(f"Unable to load module due to {err}") from err
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[moduleName] = module # This line is required before exec_module
+    spec.loader.exec_module(sys.modules[moduleName])
 
     return sys.modules[moduleName]
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -369,7 +369,7 @@ def _find_and_load_module(moduleName: str, moduleDir: str) -> ModuleType | None:
 
     # spec_from_file_location returns ModuleSpec or None.
     # spec.loader returns Loader or None.
-    # We want to make sure neither of them are are None before proceeding
+    # We want to make sure neither of them are None before proceeding
     if spec is None or spec.loader is None:
         return None
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -367,7 +367,7 @@ def _get_location(moduleDir: str, moduleName: str) -> str:
     if os.path.isfile(Path(f"{moduleDir}/{moduleName}.py")):
         return Path(f"{moduleDir}/{moduleName}.py")
 
-    return Path(f"{moduleDir}/__init__.py")
+    return Path(f"{moduleDir}/{moduleName}/__init__.py")
 
 def _find_and_load_module(moduleDir: str, moduleName: str) -> ModuleType | None:
     """Load a module based on name and directory."""


### PR DESCRIPTION
#### Reason for change
As stated in the [first part of this change](https://github.com/Arelle/Arelle/pull/226), when importing and running Arelle as a third-party module, the following error is raised due to Python's `imp` module being deprecated:
```
arelle/PluginManager.py:11
  /workspaces/Arelle/arelle/PluginManager.py:11: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import os, sys, types, time, ast, imp, io, json, gettext, traceback
```

This PR removes the use of `imp` in favor of the currently supported `importlib` building on the method explained [here](https://docs.python.org/3/library/importlib.html#checking-if-a-module-can-be-imported).

#### Description of change
In this PR, I have replaced `imp.find_module` and `imp.find_module` with a helper function using importlib methods.

#### Steps to Test
We previously added a test to assert that `loadModule` properly loads a module.

**review**:
@Arelle/arelle
