### PR TITLE
OIM: check DTS for context element

### DIFF
--- a/tests/unit_tests/arelle/plugin/test_loadfromoim.py
+++ b/tests/unit_tests/arelle/plugin/test_loadfromoim.py
@@ -1,0 +1,39 @@
+from unittest.mock import Mock
+
+import pytest
+
+from arelle import ModelRelationshipSet, ModelXbrl
+from arelle.ModelDtsObject import ModelRelationship
+from arelle.plugin.loadFromOIM import getTaxonomyContextElement
+
+
+def _mock_model_xbrl(dts_context_elements: list[str]):
+    return Mock(
+        spec=ModelXbrl,
+        relationshipSet=lambda x: Mock(
+            spec=ModelRelationshipSet,
+            modelRelationships=[
+                Mock(spec_set=ModelRelationship, contextElement=context_element)
+                for context_element in dts_context_elements
+            ]
+        )
+    )
+
+
+class TestLoadFromOIM:
+
+    @pytest.mark.parametrize(
+        "dts_context_elements, expected_context_element",
+        [
+            ([], "scenario"),
+            (["scenario"], "scenario"),
+            (["segment"], "segment"),
+            (["segment", "scenario"], "scenario"),
+        ]
+    )
+    def test_get_taxonomy_context_element(self, dts_context_elements: list[str], expected_context_element: str):
+        model_xbrl = _mock_model_xbrl(dts_context_elements)
+
+        result = getTaxonomyContextElement(model_xbrl)
+
+        assert result == expected_context_element


### PR DESCRIPTION
#### Reason for change
`segment` is hard coded in the loadFromOIM plugin. The [OIM xbrl-xml spec](https://www.xbrl.org/Specification/xbrl-xml/REC-2021-10-13/xbrl-xml-REC-2021-10-13.html#sec-dimensions) describes how the proper context element from the DTS should be determined. This PR does not address taxonomies which use both.

> When serialising to xBRL-XML, all taxonomy-defined dimensions for all facts in a report are serialised to the same container element (either <xbrli:segment> or <xbrli:scenario> ). If the report's DTS contains hypercubes for a single container, then that container is used for all taxonomy-defined dimensions. If the DTS contains hypercubes for both containers, the container should be chosen so as to achieve dimensional validity for all facts, if possible. If this is not possible, the container should be chosen arbitrarily, and appropriate XBRL Dimensions [[DIMENSIONS]](https://www.xbrl.org/Specification/xbrl-xml/REC-2021-10-13/xbrl-xml-REC-2021-10-13.html#DIMENSIONS) errors raised. If the report's DTS does not contain any hypercubes, or if dimensional validity can be achieved using either container, <xbrli:scenario> should be used for all dimensions.

#### Description of change
fixes #221 

#### Steps to Test
Load [an OIM report](https://github.com/Arelle/Arelle/files/9135370/oim-scenario.zip) with a taxonomy that has scenario has-hypercube relationships.

`python -m arelleCmdLine --plugins loadFromOIM|saveLoadableOIM -f oim-example-metadata.json --saveOIMinstance oim-example-metadata.xml`

**review**:
@Arelle/arelle


