### PR TITLE
Add VS code config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ tests/resources/conformance_suites/
 
 # PyCharm
 .idea
+
+# VS Code
+.devcontainer
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ arelle/plugin/xule
 Arelle.egg-info
 .eggs
 *.iml
-.idea
+
 /venv/
 tests/resources/conformance_suites/
+
+### IDE-specific ignores
+
+# PyCharm
+.idea


### PR DESCRIPTION
#### Reason for change
In https://github.com/Arelle/Arelle/pull/223#discussion_r919513692 it was suggested to not support all IDE-flavors. I still use the containerised environment propoed in that PR. Everytime I start up the Arelle-environment , I have to checkout my VS-code branch and start from there. Adding these lines to the .gitignore-file would allow me to have the VS code config present at all times without having to stash it or switch branches.

#### Description of change
I have added two lines to ignore the two folders created by VS code.

#### Steps to Test

**review**:
@Arelle/arelle
