### PR TITLE
Warnings for LRR roles not REC or ACK status

### DIFF
--- a/arelle/ValidateXbrlDTS.py
+++ b/arelle/ValidateXbrlDTS.py
@@ -1310,6 +1310,10 @@ def checkLinkRole(val, elt, linkEltQname, xlinkRole, xlinkType, roleRefURIs):
                 val.modelXbrl.error("xbrlgene:missingResourceRoleUsedOnValue",
                     _("Generic resource role %(xlinkRole)s missing usedOn for %(element)s"),
                     modelObject=elt, xlinkRole=xlinkRole, element=linkEltQname)
+    if xlinkRole in XbrlConst.lrrUnapprovedRoles:
+        val.modelXbrl.warning("lrr:unApprovedRole",
+            _("LRR resource role %(xlinkRole)s on %(element)s has status %(status)s"),
+            modelObject=elt, xlinkRole=xlinkRole, element=linkEltQname, status=XbrlConst.lrrUnapprovedRoles[xlinkRole])
                 
 def checkArcrole(val, elt, arcEltQname, arcrole, arcroleRefURIs):
     if arcrole == "" and \
@@ -1351,6 +1355,10 @@ def checkArcrole(val, elt, arcEltQname, arcrole, arcroleRefURIs):
             val.modelXbrl.error("xbrl.5.1.4.5:custArcroleUsedOn",
                 _("Standard arcrole %(arcrole)s used on wrong arc %(element)s"),
                 modelObject=elt, element=arcEltQname, arcrole=arcrole)
+    if arcrole in XbrlConst.lrrUnapprovedArcroles:
+        val.modelXbrl.warning("lrr:unApprovedArcrole",
+            _("LRR arcrole %(arcrole)s on %(element)s has status %(status)s"),
+            modelObject=elt, arcrole=arcrole, element=arcEltQname, status=XbrlConst.lrrUnapprovedArcroles[arcrole])
 
 
 def checkIxContinuationChain(elt, chain=None):

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -873,4 +873,18 @@ lrrArcroleHrefs = {
     "http://www.xbrl.org/2009/arcrole/dep-mutuallyExclusiveConcept-deprecatedConcept": "http://www.xbrl.org/lrr/arcrole/deprecated-2009-12-16.xsd#dep-mutuallyExclusiveConcept-deprecatedConcept",
     "http://www.xbrl.org/2009/arcrole/dep-partConcept-deprecatedAggregateConcept": "http://www.xbrl.org/lrr/arcrole/deprecated-2009-12-16.xsd#dep-partConcept-deprecatedAggregateConcept",
     "http://www.xbrl.org/2013/arcrole/parent-child": "http://www.xbrl.org/lrr/arcrole/parent-child-2013-09-19.xsd#parent-child",
+    "http://www.esma.europa.eu/xbrl/esef/arcrole/wider-narrower": "http://www.xbrl.org/lrr/arcrole/esma-arcrole-2018-11-21.xsd#wider-narrower",
+    }
+lrrUnapprovedRoles = { # lrr entries which are not REC or ACK status
+    "http://info.edinet-fsa.go.jp/jp/fr/gaap/role/NotesNumber":"IWD",
+    "http://info.edinet-fsa.go.jp/jp/fr/gaap/role/NotesNumberPeriodStart": "IWD",
+    "http://info.edinet-fsa.go.jp/jp/fr/gaap/role/NotesNumberPeriodEnd": "IWD",
+    # proposed but commented out in lrr
+    "http://www.xbrl.org/2013/arcrole/item-enumeration": "PROPOSED",
+    # only for test case use
+    "http://www.xbrl.org/2005/role/nieRole": "NIE",
+    }
+lrrUnapprovedArcroles = { # lrr entries which are not REC or ACK status
+    # only for test case use
+    "http://www.xbrl.org/2005/arcrole/nieRole": "NIE",
     }


### PR DESCRIPTION
#### Reason for change
Arelle was not complaining about usage of non-REC/ACK LRR entries.

#### Description of change
Add checking for usage of non-REC (or ACK) LRR entries

#### Steps to Test
LRR test suite.

#### Additional cascaded possible change
Consider checking whether role is in XbrlConf.lrrRoleHrefs  in plugin/validate/ESEF/DTS.py#57 (commented out check)

**review**:
@Arelle/arelle
