### PR TITLE
Formula test suite changes

### DIFF
--- a/arelle/ModelFormulaObject.py
+++ b/arelle/ModelFormulaObject.py
@@ -584,6 +584,7 @@ class ModelValueAssertion(ModelVariableSetAssertion):
 class ModelConsistencyAssertion(ModelFormulaResource):
     def init(self, modelDocument):
         super(ModelConsistencyAssertion, self).init(modelDocument)
+        self.modelXbrl.modelConsistencyAssertions.add(self)
         self.modelXbrl.hasFormulae = True
                 
     def clear(self):

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -205,6 +205,10 @@ class ModelXbrl:
 
         Set of variableSets in formula linkbases
 
+        .. attribute:: modelConsistencyAssertions
+
+        Set of modelConsistencyAssertions in formula linkbases
+
         .. attribute:: modelCustomFunctionSignatures
 
         Dict of custom function signatures by qname and by qname,arity
@@ -287,6 +291,7 @@ class ModelXbrl:
         self.modelObjects = []
         self.qnameParameters = {}
         self.modelVariableSets = set()
+        self.modelConsistencyAssertions = set()
         self.modelCustomFunctionSignatures = {}
         self.modelCustomFunctionImplementations = set()
         self.modelRenderingTables = set()

--- a/arelle/ValidateFormula.py
+++ b/arelle/ValidateFormula.py
@@ -708,6 +708,12 @@ def validate(val, xpathContext=None, parametersOnly=False, statusMsg='', compile
         variableDependencies.clear()
         varSetInstanceDependencies.clear()
 
+    # check unlinked Consistency Assertions
+    for consisAsser in val.modelXbrl.modelConsistencyAssertions:
+        if not val.modelXbrl.relationshipSet(XbrlConst.consistencyAssertionFormula).fromModelObject(consisAsser):
+            checkValidationMessages(val, consisAsser)
+            checkValidationMessageVariables(val, consisAsser, {}, xpathContext.parameterQnames)
+
     val.modelXbrl.profileActivity("... assertion and formula checks and compilation", minTimeToShow=1.0)
             
     for modelTable in val.modelXbrl.modelRenderingTables:
@@ -771,30 +777,32 @@ def validate(val, xpathContext=None, parametersOnly=False, statusMsg='', compile
                _("Variable instances processing order: %(dependencies)s"),
                 modelObject=val.modelXbrl, dependencies=orderedInstancesList)
 
+    # consistency assertions whether linked or not
+    for consisAsser in val.modelXbrl.modelConsistencyAssertions:
+        consisAsser.countSatisfied = 0
+        consisAsser.countNotSatisfied = 0
+        consisAsser.countOkMessages = 0
+        consisAsser.countWarningMessages = 0
+        consisAsser.countErrorMessages = 0
+        if consisAsser.hasProportionalAcceptanceRadius and consisAsser.hasAbsoluteAcceptanceRadius:
+            val.modelXbrl.error("xbrlcae:acceptanceRadiusConflict",
+                _("Consistency assertion %(xlinkLabel)s has both absolute and proportional acceptance radii"), 
+                modelObject=consisAsser, xlinkLabel=consisAsser.xlinkLabel)
+        consisAsser.orderedVariableRelationships = []
+        for consisParamRel in val.modelXbrl.relationshipSet(XbrlConst.consistencyAssertionParameter).fromModelObject(consisAsser):
+            if isinstance(consisParamRel.toModelObject, ModelVariable):
+                val.modelXbrl.error("xbrlcae:variablesNotAllowed",
+                    _("Consistency assertion %(xlinkLabel)s has relationship to a %(elementTo)s %(xlinkLabelTo)s"),
+                    modelObject=consisAsser, xlinkLabel=consisAsser.xlinkLabel, 
+                    elementTo=consisParamRel.toModelObject.localName, xlinkLabelTo=consisParamRel.toModelObject.xlinkLabel)
+            elif isinstance(consisParamRel.toModelObject, ModelParameter):
+                consisAsser.orderedVariableRelationships.append(consisParamRel)
+        consisAsser.compile()
+        
     # linked consistency assertions
     for modelRel in val.modelXbrl.relationshipSet(XbrlConst.consistencyAssertionFormula).modelRelationships:
         if (isinstance(modelRel.fromModelObject, ModelConsistencyAssertion) and 
             isinstance(modelRel.toModelObject,ModelFormula)):
-            consisAsser = modelRel.fromModelObject
-            consisAsser.countSatisfied = 0
-            consisAsser.countNotSatisfied = 0
-            consisAsser.countOkMessages = 0
-            consisAsser.countWarningMessages = 0
-            consisAsser.countErrorMessages = 0
-            if consisAsser.hasProportionalAcceptanceRadius and consisAsser.hasAbsoluteAcceptanceRadius:
-                val.modelXbrl.error("xbrlcae:acceptanceRadiusConflict",
-                    _("Consistency assertion %(xlinkLabel)s has both absolute and proportional acceptance radii"), 
-                    modelObject=consisAsser, xlinkLabel=consisAsser.xlinkLabel)
-            consisAsser.orderedVariableRelationships = []
-            for consisParamRel in val.modelXbrl.relationshipSet(XbrlConst.consistencyAssertionParameter).fromModelObject(consisAsser):
-                if isinstance(consisParamRel.toModelObject, ModelVariable):
-                    val.modelXbrl.error("xbrlcae:variablesNotAllowed",
-                        _("Consistency assertion %(xlinkLabel)s has relationship to a %(elementTo)s %(xlinkLabelTo)s"),
-                        modelObject=consisAsser, xlinkLabel=consisAsser.xlinkLabel, 
-                        elementTo=consisParamRel.toModelObject.localName, xlinkLabelTo=consisParamRel.toModelObject.xlinkLabel)
-                elif isinstance(consisParamRel.toModelObject, ModelParameter):
-                    consisAsser.orderedVariableRelationships.append(consisParamRel)
-            consisAsser.compile()
             modelRel.toModelObject.hasConsistencyAssertion = True
     val.modelXbrl.profileActivity("... consistency assertion setup", minTimeToShow=1.0)
 
@@ -958,11 +966,8 @@ def validate(val, xpathContext=None, parametersOnly=False, statusMsg='', compile
                     assertionType="Existence" if isinstance(exisValAsser, ModelExistenceAssertion) else "Value", 
                     id=exisValAsser.id, satisfiedCount=exisValAsser.countSatisfied, notSatisfiedCount=exisValAsser.countNotSatisfied)
 
-    for modelRel in val.modelXbrl.relationshipSet(XbrlConst.consistencyAssertionFormula).modelRelationships:
-        if isinstance(modelRel.fromModelObject, ModelConsistencyAssertion) and \
-           isinstance(modelRel.toModelObject, ModelFormula) and \
-           (not runIDs or runIDs.match(modelRel.fromModelObject.id)):
-            consisAsser = modelRel.fromModelObject
+    for consisAsser in val.modelXbrl.modelConsistencyAssertions:
+        if (not runIDs or runIDs.match(consisAsser.id)):
             asserTests[consisAsser.id] = (consisAsser.countSatisfied, consisAsser.countNotSatisfied, consisAsser.countOkMessages, consisAsser.countWarningMessages, consisAsser.countErrorMessages)
             if formulaOptions.traceAssertionResultCounts:
                 val.modelXbrl.info("formula:trace",

--- a/scripts/runFormulaTests.sh
+++ b/scripts/runFormulaTests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Run XBRL Formula Conformance Suite tests
+
+LOGDIR=~/temp
+
+TESTCASESROOT=~/Documents/mvsl/projects/XBRL.org/conformance-formula/trunk/tests
+TESTCASESINDEXFILE=$TESTCASESROOT/index.xml
+OUTPUTLOGFILE=$LOGDIR/Formula-test-log.txt
+OUTPUTCSVFILE=$LOGDIR/Formula-test-report.xlsx
+PYTHONPATH=$ARELLEDIR
+
+rm -fr "$OUTPUTCSVFILE" "$OUTPUTLOGFILE"
+
+python3.9 arelleCmdLine.py --file "$TESTCASESINDEXFILE" --validate --csvTestReport "$OUTPUTCSVFILE" --logFile "$OUTPUTLOGFILE" --plugin formulaXPathChecker --check-formula-restricted-XPath
+
+TESTCASESROOT="~/Documents/mvsl/projects/XBRL.org/conformance-formula/trunk/function-registry"
+TESTCASESINDEXFILE=$TESTCASESROOT/registry-index.xml
+OUTPUTLOGFILE=$LOGDIR/Function-test-log.txt
+OUTPUTCSVFILE=$LOGDIR/Function-test-report.xlsx
+
+rm -fr "$OUTPUTCSVFILE" "$OUTPUTLOGFILE"
+
+python3.9 arelleCmdLine.py --file "$TESTCASESINDEXFILE" --validate --csvTestReport "$OUTPUTCSVFILE" --logFile "$OUTPUTLOGFILE" --plugin formulaXPathChecker --check-formula-restricted-XPath


### PR DESCRIPTION


Consistency Asertions - validate when no linked formula and t…race zero assertion counts

#### Reason for change
Test case 31140 Consistency Assertion Missing Formulae V-01 was not tracing zero assertions.

#### Description of change
For consistency assertions with no linked formulas, checkValidationMessages, checkValidationMessageVariables and trace assertion counts of zero. 


#### Steps to Test
Test case 31140 Consistency Assertion Missing Formulae V-01 was not tracing zero assertions.  Consider more test cases of validation message and message variables errors which weren't being detected before for unlinked consistency assertions.

**review**:
@Arelle/arelle
