### PR TITLE
Add the requests_negotiate_sspi package for the Windows build.

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Install requirements
       run: |
         pip install wheel
-        pip install -r requirements-dev.txt
+        pip install -r requirements-windows-build.txt
     - name: Make directories
       run: mkdir build,dist
     - name: Rebuild messages.pot internationalization file

--- a/requirements-windows-build.txt
+++ b/requirements-windows-build.txt
@@ -1,0 +1,3 @@
+requests_negotiate_sspi==0.5.2
+
+-r requirements-dev.txt


### PR DESCRIPTION
The `requests_negotiate_sspi` package was missed in the original Windows build change, causing builds to fail.

#### Steps to Test
Verify that the Windows build works.

**review**:
@Arelle/arelle
