### PR TITLE
Add type hints for Util.py i ESEF plugin

### DIFF
--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -99,12 +99,12 @@ def checkImageContents(modelXbrl, imgElt, imgType, isFile, data):
 def resourcesFilePath(modelManager, fileName):
     # resourcesDir can be in cache dir (production) or in validate/EFM/resources (for development)
     _resourcesDir = os.path.join( os.path.dirname(__file__), "resources") # dev/testing location
-    _target = "validate/ESEF/resources"
+
     if not os.path.isabs(_resourcesDir):
         _resourcesDir = os.path.abspath(_resourcesDir)
     if not os.path.exists(_resourcesDir): # production location
         _resourcesDir = os.path.join(modelManager.cntlr.webCache.cacheDir, "resources", "validation", "ESEF")
-        _target = "web-cache/resources"
+
     return os.path.join(_resourcesDir, fileName)
 
 def loadAuthorityValidations(modelXbrl):

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -6,15 +6,26 @@ Filer Guidelines: ESMA_ESEF Manula 2019.pdf
 @author: Workiva
 (c) Copyright 2022 Workiva, All rights reserved.
 '''
+from __future__ import annotations
 import os, json
+import threading
+
+from arelle.ModelObject import ModelObject
 from .Const import esefTaxonomyNamespaceURIs
 from lxml.etree import XML, XMLSyntaxError
 from arelle.FileSource import openFileStream
 from arelle.UrlUtil import scheme
+from arelle.ModelManager import ModelManager
+from arelle.ModelXbrl import ModelXbrl
+from arelle.ValidateXbrl import ValidateXbrl
+from typing import Any, Union, cast
+from collections.abc import Callable
+
+_: Callable  # Handle gettext
 
 # check if a modelDocument URI is an extension URI (document URI)
 # also works on a uri passed in as well as modelObject
-def isExtension(val, modelObject):
+def isExtension(val: ValidateXbrl, modelObject: ModelObject | None) -> bool:
     if modelObject is None:
         return False
     if isinstance(modelObject, str):
@@ -22,28 +33,28 @@ def isExtension(val, modelObject):
     else:
         uri = modelObject.modelDocument.uri
     return (uri.startswith(val.modelXbrl.uriDir) or
-            not any(uri.startswith(standardTaxonomyURI) for standardTaxonomyURI in val.authParam["standardTaxonomyURIs"]))
+            not any(uri.startswith(standardTaxonomyURI) for standardTaxonomyURI in val.authParam["standardTaxonomyURIs"]))  # type: ignore[attr-defined]
 
 # check if in core esef taxonomy (based on namespace URI)
-def isInEsefTaxonomy(val, modelObject):
+def isInEsefTaxonomy(val: Any, modelObject: ModelObject | None) -> bool:
     if modelObject is None:
         return False
     ns = modelObject.qname.namespaceURI
     return (any(ns.startswith(esefNsPrefix) for esefNsPrefix in esefTaxonomyNamespaceURIs))
 
-supportedImgTypes = {
+supportedImgTypes: dict[bool, tuple[str, ...]] = {
     True: ("gif", "jpg", "jpeg", "png"), # file extensions
     False: ("gif", "jpeg", "png") # mime types: jpg is not a valid mime type
     }
 # check image contents against mime/file ext and for Steganography
-def checkImageContents(modelXbrl, imgElt, imgType, isFile, data):
+def checkImageContents(modelXbrl: ModelXbrl, imgElt: ModelObject, imgType: str, isFile: bool, data: bytes) -> None:
     if "svg" in imgType:
         try:
             rootElement = True
             for elt in XML(data).iter():
                 if rootElement:
                     if elt.tag != "{http://www.w3.org/2000/svg}svg":
-                        modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",
+                        modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",  # type: ignore[no-untyped-call]
                             _("Image SVG has root element which is not svg"),
                             modelObject=imgElt)
                     rootElement = False
@@ -52,19 +63,19 @@ def checkImageContents(modelXbrl, imgElt, imgType, isFile, data):
                     (eltTag in ("audio", "foreignObject", "iframe", "image", "use", "video"))):
                     href = elt.get("href","")
                     if eltTag in ("object", "script") or "javascript:" in href:
-                        modelXbrl.error("ESEF.2.5.1.executableCodePresent",
+                        modelXbrl.error("ESEF.2.5.1.executableCodePresent",  # type: ignore[no-untyped-call]
                             _("Inline XBRL images MUST NOT contain executable code: %(element)s"),
                             modelObject=imgElt, element=eltTag)
-                    elif scheme(href) in ("http", "https", "ftp"):
-                        modelXbrl.error("ESEF.2.5.1.referencesPointingOutsideOfTheReportingPackagePresent",
+                    elif scheme(href) in ("http", "https", "ftp"):  # type: ignore[no-untyped-call]
+                        modelXbrl.error("ESEF.2.5.1.referencesPointingOutsideOfTheReportingPackagePresent",  # type: ignore[no-untyped-call]
                             _("Inline XBRL instance document [image] MUST NOT contain any reference pointing to resources outside the reporting package: %(element)s"),
                             modelObject=imgElt, element=eltTag)
         except (XMLSyntaxError, UnicodeDecodeError) as err:
-            modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",
+            modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",  # type: ignore[no-untyped-call]
                 _("Image SVG has XML error %(error)s"),
                 modelObject=imgElt, error=err)
     elif not any(it in imgType for it in supportedImgTypes[isFile]):
-        modelXbrl.error("ESEF.2.5.1.imageFormatNotSupported",
+        modelXbrl.error("ESEF.2.5.1.imageFormatNotSupported",  # type: ignore[no-untyped-call]
             _("Images included in the XHTML document MUST be saved in PNG, GIF, SVG or JPEG formats: %(imgType)s is not supported"),
             modelObject=imgElt, imgType=imgType)
     else:
@@ -90,13 +101,13 @@ def checkImageContents(modelXbrl, imgElt, imgType, isFile, data):
         if (("gif" in imgType and headerType != "gif") or
             (("jpg" in imgType or "jpeg" in imgType) and headerType != "jpg") or
             ("png" in imgType and headerType != "png")):
-            modelXbrl.error("ESEF.2.5.1.imageDoesNotMatchItsFileExtension" if isFile
+            modelXbrl.error("ESEF.2.5.1.imageDoesNotMatchItsFileExtension" if isFile  # type: ignore[no-untyped-call]
                             else "ESEF.2.5.1.incorrectMIMETypeSpecified",
                 _("Image type %(imgType)s has wrong header type: %(headerType)s"),
                 modelObject=imgElt, imgType=imgType, headerType=headerType,
                 messageCodes=("ESEF.2.5.1.imageDoesNotMatchItsFileExtension", "ESEF.2.5.1.incorrectMIMETypeSpecified"))
 
-def resourcesFilePath(modelManager, fileName):
+def resourcesFilePath(modelManager: ModelManager, fileName: str) -> str:
     # resourcesDir can be in cache dir (production) or in validate/EFM/resources (for development)
     _resourcesDir = os.path.join( os.path.dirname(__file__), "resources") # dev/testing location
 
@@ -107,8 +118,8 @@ def resourcesFilePath(modelManager, fileName):
 
     return os.path.join(_resourcesDir, fileName)
 
-def loadAuthorityValidations(modelXbrl):
-    _file = openFileStream(modelXbrl.modelManager.cntlr, resourcesFilePath(modelXbrl.modelManager, "authority-validations.json"), 'rt', encoding='utf-8')
+def loadAuthorityValidations(modelXbrl: ModelXbrl) -> list[Any] | dict[Any, Any]:
+    _file = openFileStream(modelXbrl.modelManager.cntlr, resourcesFilePath(modelXbrl.modelManager, "authority-validations.json"), 'rt', encoding='utf-8')  # type: ignore[no-untyped-call]
     validations = json.load(_file) # {localName: date, ...}
     _file.close()
-    return validations
+    return cast(Union[dict[Any, Any], list[Any]], validations)

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -30,7 +30,7 @@ def isInEsefTaxonomy(val, modelObject):
         return False
     ns = modelObject.qname.namespaceURI
     return (any(ns.startswith(esefNsPrefix) for esefNsPrefix in esefTaxonomyNamespaceURIs))
-    
+
 supportedImgTypes = {
     True: ("gif", "jpg", "jpeg", "png"), # file extensions
     False: ("gif", "jpeg", "png") # mime types: jpg is not a valid mime type
@@ -70,7 +70,7 @@ def checkImageContents(modelXbrl, imgElt, imgType, isFile, data):
     else:
         if data[:3] == b"GIF" and data[3:6] in (b'89a', b'89b', b'87a'):
             headerType = "gif"
-        elif ((data[:4] == b'\xff\xd8\xff\xe0' and data[6:11] == b'JFIF\x00') or 
+        elif ((data[:4] == b'\xff\xd8\xff\xe0' and data[6:11] == b'JFIF\x00') or
               (data[:4] == b'\xff\xd8\xff\xe1' and data[6:11] == b'Exif\x00')):
             headerType = "jpg"
         elif data[:8] == b"\x89PNG\r\n\x1a\n":
@@ -95,7 +95,7 @@ def checkImageContents(modelXbrl, imgElt, imgType, isFile, data):
                 _("Image type %(imgType)s has wrong header type: %(headerType)s"),
                 modelObject=imgElt, imgType=imgType, headerType=headerType,
                 messageCodes=("ESEF.2.5.1.imageDoesNotMatchItsFileExtension", "ESEF.2.5.1.incorrectMIMETypeSpecified"))
-            
+
 def resourcesFilePath(modelManager, fileName):
     # resourcesDir can be in cache dir (production) or in validate/EFM/resources (for development)
     _resourcesDir = os.path.join( os.path.dirname(__file__), "resources") # dev/testing location
@@ -112,4 +112,3 @@ def loadAuthorityValidations(modelXbrl):
     validations = json.load(_file) # {localName: date, ...}
     _file.close()
     return validations
-        

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -8,7 +8,6 @@ Filer Guidelines: ESMA_ESEF Manula 2019.pdf
 '''
 from __future__ import annotations
 import os, json
-import threading
 
 from arelle.ModelObject import ModelObject
 from .Const import esefTaxonomyNamespaceURIs

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,48 @@
+[mypy]
+python_version = 3.9
+show_error_codes = true
+follow_imports = silent
+ignore_missing_imports = true
+strict_equality = true
+warn_incomplete_stub = true
+warn_redundant_casts = true
+warn_unused_configs = true
+warn_unused_ignores = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
+[mypy-arelle.*]
+check_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_subclassing_any = false
+disallow_untyped_calls = false
+disallow_untyped_decorators = false
+disallow_untyped_defs = false
+no_implicit_optional = false
+warn_return_any = false
+warn_unreachable = false
+
+[mypy-tests.*]
+ignore_errors = true
+
+# --- strict typing ---
+# one entry pr file.
+# when a directory is converted, file entries are replaced by directory entry
+# when the library is converted, the above entry will be replaced (strict is demanded)
+[mypy-arelle.plugin.validate.ESEF.__init__]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -33,10 +33,10 @@ warn_unreachable = false
 ignore_errors = true
 
 # --- strict typing ---
-# one entry pr file.
+# one entry per file.
 # when a directory is converted, file entries are replaced by directory entry
 # when the library is converted, the above entry will be replaced (strict is demanded)
-[mypy-arelle.plugin.validate.ESEF.__init__]
+[mypy-arelle.plugin.validate.ESEF.util]
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_subclassing_any = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ cx_Oracle==8.3.0
 Sphinx==5.0.2
 
 mock==4.0.3
+mypy==0.971
 pytest==7.1.1
 
 -r requirements.txt


### PR DESCRIPTION
#### Reason for change
Static type checking makes it easier to understand a code base and, along with the test suite, helps developers avoid making silly errors when making changes.

#### Description of change
 This PR suggests:
- Adding `mypy` to the development requirements
- Adding a config file for `mypy`
- Adding type hints for `Util.py` in the ESEF-plugin

#### Steps to Test

**review**:
@Arelle/arelle
