### PR TITLE
Add mypy to test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,14 +8,14 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
       - name: Install Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
-      - name: Run tests with pytest
-        run: pytest tests/unit_tests --durations=0
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py39, lint, typing, coverage
+envlist = py39, typing
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.9: py39, lint, typing, coverage
+  3.9: py39, typing
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py39, lint, typing, coverage
+skip_missing_interpreters = True
+
+[gh-actions]
+python =
+  3.9: py39, lint, typing, coverage
+
+[testenv]
+commands =
+  pytest tests/unit_tests --durations=0 {posargs}
+deps =
+  -rrequirements.txt
+  -rrequirements_test.txt
+
+[testenv:typing]
+deps =
+  -rrequirements.txt
+  -rrequirements_test.txt
+commands =
+    mypy arelle


### PR DESCRIPTION
#### Reason for change
This is a follow-up to https://github.com/Arelle/Arelle/pull/244#pullrequestreview-1055974293.

#### Description of change
This change:
- Introduces tox as a container to run tests.
- Adds a config file for tox. The proposed configuration runs the current pytest unit-test suite and mypy.
- Renames the `unit-test`-file to `tests`. It seemed appropriate as we're not only running unit tests anymore.
- Pins the github action verions.

#### Steps to Test

**review**:
@Arelle/arelle
