### PR TITLE
Add dependabot for Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
#### Reason for change
When working on adding `tox` I noted some Github actions were not up to date. This configuration helps keeping Github actions up to date, but will not suggest updating other dependencies (like those managed through pypi).

#### Description of change
Adding a `dependabot.yml` configuration file.

#### Steps to Test
When a Github dependency is updated, a pull request will automatically be created in this repo.

**review**:
@Arelle/arelle
