### PR TITLE
handle iXBRL with unprocessble syntax

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -327,7 +327,19 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
         elif _type == Type.INSTANCE:
             modelDocument.instanceDiscover(rootNode)
         elif _type == Type.INLINEXBRL:
-            modelDocument.inlineXbrlDiscover(rootNode)
+            try:
+                modelDocument.inlineXbrlDiscover(rootNode)
+            except RecursionError as err:
+                schemaErrorCount = sum(e == "xmlSchema:syntax" for e in modelXbrl.errors)
+                if schemaErrorCount > 100: # arbitrary count, in case of tons of unclosed or mismatched xhtml start-end elements
+                    modelXbrl.error("html:unprocessable",
+                        _("%(element)s error, unable to process html syntax due to %(schemaErrorCount)s schema syntax errors"),
+                        modelObject=rootNode, element=rootNode.localName.title(), schemaErrorCount=schemaErrorCount)
+                else:
+                    self.modelXbrl.error("html:validationException",
+                        _("%(element)s error %(error)s, unable to process html."),
+                        modelObject=rootNode, element=rootNode.localName.title(), error=type(err).__name__)
+                return None # rootNode is not processed further to find any facts because there could be many recursion errors                
         elif _type == Type.VERSIONINGREPORT:
             modelDocument.versioningReportDiscover(rootNode)
         elif _type == Type.TESTCASESINDEX:


### PR DESCRIPTION
#### Reason for change
iXBRL with badly munged syntax (deeply mismatched element close tags) caused recursion exception

#### Description of change
detect regression exception with > n xml syntax errors (n=100 for now) and don't process document further.  Could cause recursion errors in xhtmlValidation and in many ixbrl operations, such as text block value extraction.

#### Steps to Test
use an SEC submission with redline removal tag errors

**review**:
@Arelle/arelle
