### PR TITLE
Bump Github action versions and use semantic versioning tags

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -54,15 +54,15 @@ jobs:
       - name: Cleanup ixbrl-viewer
         run: rm -rf ixbrl-viewer
       - name: Docker registry login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v2.0.0
         with:
           registry: registry.redhat.io
           username: ${{ secrets.REDHAT_USERNAME }}
           password: ${{ secrets.REDHAT_PASSWORD }}
       - name: Docker setup buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.0.0
       - name: Docker build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v3.1.0
         with:
           build-args: |
             "PYTHON_VERSION=3.9.13"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -15,16 +15,16 @@ jobs:
 
     steps:
       - name: Checkout arelle
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
       - name: Checkout EdgarRenderer
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           repository: Arelle/EdgarRenderer
           path: arelle/plugin/EdgarRenderer
       - name: Cleanup EdgarRenderer
         run: rm -rf arelle/plugin/EdgarRenderer/.git
       - name: Checkout XULE
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           repository: xbrlus/xule
           path: xule
@@ -36,12 +36,12 @@ jobs:
       - name: Cleanup XULE
         run: rm -rf xule
       - name: Checkout ixbrl-viewer
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           repository: Workiva/ixbrl-viewer
           path: ixbrl-viewer
       - name: Set up Node JS
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v3.0.2
         with:
           node-version: lts/*
       - name: Build ixbrl-viewer
@@ -80,7 +80,7 @@ jobs:
           docker cp arelle:/build/dist/ dist/
           docker rm -v arelle
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: ${{ matrix.distro }} distribution
           path: dist/*.tgz

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -41,7 +41,7 @@ jobs:
           repository: Workiva/ixbrl-viewer
           path: ixbrl-viewer
       - name: Set up Node JS
-        uses: actions/checkout@v3.0.2
+        uses: actions/setup-node@v3.4.1
         with:
           node-version: lts/*
       - name: Build ixbrl-viewer

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,16 +15,16 @@ jobs:
 
     steps:
     - name: Checkout arelle
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
     - name: Checkout EdgarRenderer
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
       with:
         repository: Arelle/EdgarRenderer
         path: arelle/plugin/EdgarRenderer
     - shell: cmd
       run: rmdir /s /q arelle\plugin\EdgarRenderer\.git
     - name: Checkout xule
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
       with:
         repository: xbrlus/xule
         path: xule
@@ -36,12 +36,12 @@ jobs:
     - shell: cmd
       run: rmdir /s /q xule
     - name: Checkout ixbrl-viewer
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.2
       with:
         repository: Workiva/ixbrl-viewer
         path: ixbrl-viewer
     - name: Set up Node JS
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v3.4.1
     - name: Build ixbrl-viewer
       working-directory: ixbrl-viewer
       run: |
@@ -50,7 +50,7 @@ jobs:
     - shell: cmd
       run: move ixbrl-viewer\iXBRLViewerPlugin arelle\plugin\iXBRLViewerPlugin && rmdir /s /q ixbrl-viewer
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4.1.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install NSIS
@@ -79,7 +79,7 @@ jobs:
     - name: Zip distribution
       run: 7z a -tzip ..\..\dist\arelle-win-x64.zip *
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.0
       with:
         name: dist
         path: dist

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -7,7 +7,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build-test-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
@@ -34,13 +34,13 @@ jobs:
           curl -L "${{ secrets.XBRL_VALIDATION_CONFIG_URL }}" -o config.zip
           unzip -d "$XDG_CONFIG_HOME/arelle/cache" config.zip 'http/*' 'https/*'
           rm config.zip
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Install Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1.6.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,9 +9,9 @@ jobs:
   build-and-publish-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
       - name: Install Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4.1.0
         with:
           python-version: '3.9'
       - name: Build python package
@@ -19,7 +19,7 @@ jobs:
           pip install setuptools wheel twine build
           python -m build
       - name: Upload build artifact
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: arelle.tar.gz
           path: dist/*.tar.gz


### PR DESCRIPTION
#### Reason for change
Pinning against major version in Github actions may introduce unexpected errors to the workflows if dependencies are updated.

#### Description of change
This PR suggests pinning against the semantic version of all Github actions in use. Updates will be implemented in a controlled manner through the dependabot workflow suggested in #246.

#### Steps to Test

**review**:
@Arelle/arelle
