### PR TITLE
Add dependabot for pip packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "RDFLib"
+        versions: [">=6"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,5 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "RDFLib"
-        versions: [">=6"]
+        versions:
+          - ">=6"


### PR DESCRIPTION
#### Reason for change
Issue #254 states that "Dependabot should be configured to manage python dependency updates. With RDFLib >= 6 included in the ignore list." This PR implements that request.

Closes #254.

#### Description of change
The dependabot workflow has been amended with configuration for the pip package system.  All versions of `RDFLib=>6` will be ignored.

The dependabot actions will be run on Mondays (this is the default for the `weekly` setting).

#### Steps to Test

**review**:
@Arelle/arelle
