### PR TITLE
Add type hints for ESEF.Const

### DIFF
--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -8,11 +8,11 @@ Filer Guidelines: esma32-60-254_esef_reporting_manual.pdf
 @author: Workiva
 (c) Copyright 2022 Workiva, All rights reserved.
 '''
-
 try:
     import regex as re
 except ImportError:
-    import re
+    import re #  type: ignore[no-redef]
+from typing import Any, Callable, Set
 from arelle.ModelValue import qname
 from arelle.XbrlConst import all, notAll, hypercubeDimension, dimensionDomain, domainMember, dimensionDefault, widerNarrower
 
@@ -32,8 +32,8 @@ disallowedURIsPattern = re.compile(
 DefaultDimensionLinkroles = ("http://www.esma.europa.eu/xbrl/role/cor/ifrs-dim_role-990000",)
 LineItemsNotQualifiedLinkrole = "http://www.esma.europa.eu/xbrl/role/cor/esef_role-999999"
 
-qnDomainItemTypes = {qname("{http://www.xbrl.org/dtr/type/non-numeric}nonnum:domainItemType"),
-                     qname("{http://www.xbrl.org/dtr/type/2020-01-21}nonnum:domainItemType")}
+qnDomainItemTypes = {qname("{http://www.xbrl.org/dtr/type/non-numeric}nonnum:domainItemType"), #  type: ignore[no-untyped-call]
+                     qname("{http://www.xbrl.org/dtr/type/2020-01-21}nonnum:domainItemType")} #  type: ignore[no-untyped-call]
 
 
 linkbaseRefTypes = {
@@ -60,7 +60,7 @@ filenameRegexes = {
     "ref": r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}_ref[.]xml$"
     }
 
-mandatory = set() # mandatory element qnames
+mandatory: Set[Callable[..., Any]] = set() # mandatory element qnames
 
 # hidden references
 untransformableTypes = {"anyURI", "base64Binary", "hexBinary", "NOTATION", "QName", "time",

--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -8,11 +8,12 @@ Filer Guidelines: esma32-60-254_esef_reporting_manual.pdf
 @author: Workiva
 (c) Copyright 2022 Workiva, All rights reserved.
 '''
+from __future__ import annotations
 try:
     import regex as re
 except ImportError:
     import re #  type: ignore[no-redef]
-from typing import Any, Callable, Set
+from typing import Any, Callable
 from arelle.ModelValue import qname
 from arelle.XbrlConst import all, notAll, hypercubeDimension, dimensionDomain, domainMember, dimensionDefault, widerNarrower
 
@@ -60,7 +61,7 @@ filenameRegexes = {
     "ref": r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}_ref[.]xml$"
     }
 
-mandatory: Set[Callable[..., Any]] = set() # mandatory element qnames
+mandatory: set[Callable[..., Any]] = set() # mandatory element qnames
 
 # hidden references
 untransformableTypes = {"anyURI", "base64Binary", "hexBinary", "NOTATION", "QName", "time",

--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -101,7 +101,7 @@ esefMandatoryElementNames2020 = (
     "DescriptionOfNatureOfEntitysOperationsAndPrincipalActivities",
     "NameOfParentEntity",
     "NameOfUltimateParentOfGroup"
-    )     
+    )
 
 esefMandatoryElementNames2022 = (
     "AddressOfRegisteredOfficeOfEntity",
@@ -347,4 +347,4 @@ esefMandatoryElementNames2022 = (
     "NameOfUltimateParentOfGroup",
     "PrincipalPlaceOfBusiness",
     "StatementOfIFRSCompliance",
-)            
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ ignore_errors = true
 # when the library is converted, the above entry will be replaced (strict is demanded)
 [[tool.mypy.overrides]]
 module = [
+    'arelle.plugin.validate.ESEF.Const',
     'arelle.plugin.validate.ESEF.Util'
 ]
 strict = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ types-PyMySQL==1.0.19
 types-pytz==2022.1.2
 types-simplejson==3.17.7
 types-ujson==5.4.0
+types-regex==2022.7.25.0
 types-waitress==2.1.4
 
 -r requirements.txt


### PR DESCRIPTION
#### Reason for change
This continues the work of adding type hints to the library.

#### Description of change
- `arelle/plugin/validate/ESEF/Const.py` as been added to the list of strictly typed files.
- Type hints have been added to the file.
- Stubs for the `regex` library have been added.

#### Steps to Test

**review**:
@Arelle/arelle
