### PR TITLE
Add protocols for ValidateXbrl and ModelXbrl

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -18,7 +18,6 @@ from arelle.PythonUtil import flattenSequence
 from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlDimensions import isFactDimensionallyValid
 
-from typing_extensions import Protocol
 
 ModelRelationshipSet = None # dynamic import
 ModelFact = None
@@ -116,12 +115,6 @@ def loadSchemalocatedSchemas(modelXbrl):
             modelDocument = modelDocuments.pop()
             modelDocumentsSchemaLocated.add(modelDocument)
             modelDocument.loadSchemalocatedSchemas()
-
-class ModelXbrlProtocol(Protocol):
-    """Implements a protocol that helps typing of the ValidateXbrl class."""
-
-    @property
-    def uriDir(self) -> str: ...
 
 
 class ModelXbrl:
@@ -268,6 +261,8 @@ class ModelXbrl:
         Logger for modelXbrl
 
     """
+
+    uriDir: str
 
     def __init__(self, modelManager, errorCaptureLevel=None):
         self.modelManager = modelManager
@@ -1225,7 +1220,7 @@ class ModelXbrl:
             """@messageCatalog=[]"""
             logger.log(numericLevel, *logArgs, exc_info=args.get("exc_info"), extra=extras)
 
-    def error(self, codes, msg, **args):
+    def error(self, codes, msg, **args) -> None:
         """Logs a message as info, by code, logging-system message text (using %(name)s named arguments
         to compose string by locale language), resolving model object references (such as qname),
         to prevent non-dereferencable memory usage.  Supports logging system parameters, and

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -17,6 +17,9 @@ from arelle.PrototypeInstanceObject import FactPrototype, DimValuePrototype
 from arelle.PythonUtil import flattenSequence
 from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlDimensions import isFactDimensionallyValid
+
+from typing_extensions import Protocol
+
 ModelRelationshipSet = None # dynamic import
 ModelFact = None
 
@@ -113,6 +116,13 @@ def loadSchemalocatedSchemas(modelXbrl):
             modelDocument = modelDocuments.pop()
             modelDocumentsSchemaLocated.add(modelDocument)
             modelDocument.loadSchemalocatedSchemas()
+
+class ModelXbrlProtocol(Protocol):
+    """Implements a protocol that helps typing of the ValidateXbrl class."""
+
+    @property
+    def uriDir(self) -> str: ...
+
 
 class ModelXbrl:
     """

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -27,14 +27,14 @@ DEFAULT = sys.intern(_STR_8BIT("default"))
 NONDEFAULT = sys.intern(_STR_8BIT("non-default"))
 DEFAULTorNONDEFAULT = sys.intern(_STR_8BIT("default-or-non-default"))
 EMPTY_TUPLE = ()
-    
+
 
 def load(modelManager, url, nextaction=None, base=None, useFileSource=None, errorCaptureLevel=None, **kwargs):
-    """Each loaded instance, DTS, testcase, testsuite, versioning report, or RSS feed, is represented by an 
-    instance of a ModelXbrl object. The ModelXbrl object has a collection of ModelDocument objects, each 
-    representing an XML document (for now, with SQL whenever its time comes). One of the modelDocuments of 
+    """Each loaded instance, DTS, testcase, testsuite, versioning report, or RSS feed, is represented by an
+    instance of a ModelXbrl object. The ModelXbrl object has a collection of ModelDocument objects, each
+    representing an XML document (for now, with SQL whenever its time comes). One of the modelDocuments of
     the ModelXbrl is the entry point (of discovery or of the test suite).
-    
+
     :param url: may be a filename or FileSource object
     :type url: str or FileSource
     :param nextaction: text to use as status line prompt on conclusion of loading and discovery
@@ -77,7 +77,7 @@ def load(modelManager, url, nextaction=None, base=None, useFileSource=None, erro
         loadSchemalocatedSchemas(modelXbrl)
     else:
         modelXbrl.modelDocument = None
-    
+
     #from arelle import XmlValidate
     #uncomment for trial use of lxml xml schema validation of entry document
     #XmlValidate.xmlValidate(modelXbrl.modelDocument)
@@ -100,7 +100,7 @@ def create(modelManager, newDocumentType=None, url=None, schemaRefs=None, create
                 del modelXbrl.entryLoadingUrl
                 loadSchemalocatedSchemas(modelXbrl)
     return modelXbrl
-    
+
 def loadSchemalocatedSchemas(modelXbrl):
     from arelle import ModelDocument
     if modelXbrl.modelDocument and modelXbrl.modelDocument.type < ModelDocument.Type.DTSENTRIES:
@@ -113,38 +113,38 @@ def loadSchemalocatedSchemas(modelXbrl):
             modelDocument = modelDocuments.pop()
             modelDocumentsSchemaLocated.add(modelDocument)
             modelDocument.loadSchemalocatedSchemas()
-        
+
 class ModelXbrl:
     """
     .. class:: ModelXbrl(modelManager)
-    
-    ModelXbrl objects represent loaded instances and inline XBRL instances and their DTSes, DTSes 
-    (without instances), versioning reports, testcase indexes, testcase variation documents, and 
+
+    ModelXbrl objects represent loaded instances and inline XBRL instances and their DTSes, DTSes
+    (without instances), versioning reports, testcase indexes, testcase variation documents, and
     other document-centric loadable objects.
-    
+
     :param modelManager: The controller's modelManager object for the current session or command line process.
     :type modelManager: ModelManager
 
         .. attribute:: urlDocs
-        
+
         Dict, by URL, of loaded modelDocuments
-        
+
         .. attribute:: errorCaptureLevel
-        
+
         Minimum logging level to capture in errors list (default is INCONSISTENCY)
-        
+
         .. attribute:: errors
-        
+
         Captured error codes (at or over minimum error capture logging level) and assertion results, which were sent to logger, via log() methods, used for validation and post-processing
-        
+
         .. attribute:: logErrorCount, logWarningCoutn, logInfoCount
-        
+
         Counts of respective error levels processed by modelXbrl logger
 
         .. attribute:: arcroleTypes
 
         Dict by arcrole of defining modelObjects
-        
+
         .. attribute:: roleTypes
 
         Dict by role of defining modelObjects
@@ -152,9 +152,9 @@ class ModelXbrl:
         .. attribute:: qnameConcepts
 
         Dict by qname (QName) of all top level schema elements, regardless of whether discovered or not discoverable (not in DTS)
-        
+
         .. attribute:: qnameAttributes
-        
+
         Dict by qname of all top level schema attributes
 
         .. attribute:: qnameAttributeGroups
@@ -166,7 +166,7 @@ class ModelXbrl:
         Dict by qname of all top level and anonymous types
 
         .. attribute:: baseSets
-        
+
         Dict of base sets by (arcrole, linkrole, arc qname, link qname), (arcrole, linkrole, *, *), (arcrole, *, *, *), and in addition, collectively for dimensions, formula,  and rendering, as arcroles 'XBRL-dimensions', 'XBRL-formula', and 'Table-rendering'.
 
         .. attribute:: relationshipSets
@@ -247,23 +247,23 @@ class ModelXbrl:
 
         .. attribute:: formulaOutputInstance
 
-        Standard output instance if formulae produce one. 
+        Standard output instance if formulae produce one.
 
         .. attribute:: hasRendering
 
         True if rendering tables are discovered
 
         .. attribute:: Log
-        
+
         Logger for modelXbrl
 
     """
-    
+
     def __init__(self, modelManager, errorCaptureLevel=None):
         self.modelManager = modelManager
         self.skipDTS = modelManager.skipDTS
         self.init(errorCaptureLevel=errorCaptureLevel)
-        
+
     def init(self, keepViews=False, errorCaptureLevel=None):
         self.uuid = uuid.uuid1().urn
         self.namespaceDocs = defaultdict(list)
@@ -275,7 +275,7 @@ class ModelXbrl:
         self.arcroleTypes = defaultdict(list)
         self.roleTypes = defaultdict(list)
         self.qnameConcepts = {} # indexed by qname of element
-        self.nameConcepts = defaultdict(list) # contains ModelConcepts by name 
+        self.nameConcepts = defaultdict(list) # contains ModelConcepts by name
         self.qnameAttributes = {}
         self.qnameAttributeGroups = {}
         self.qnameGroupDefinitions = {}
@@ -319,7 +319,7 @@ class ModelXbrl:
 
 
     def close(self):
-        """Closes any views, formula output instances, modelDocument(s), and dereferences all memory used 
+        """Closes any views, formula output instances, modelDocument(s), and dereferences all memory used
         """
         if not self.isClosed:
             self.closeViews()
@@ -334,17 +334,17 @@ class ModelXbrl:
             self.__dict__.clear() # dereference everything before closing document
             if modelDocument:
                 modelDocument.close(urlDocs=urlDocs)
-            
+
     @property
     def isClosed(self):
         """
         :returns:  bool -- True if closed (python object has deferenced and deleted all attributes after closing)
         """
         return not bool(self.__dict__)  # closed when dict is empty
-            
+
     def reload(self,nextaction,reloadCache=False):
         """Reloads all model objects from their original entry point URL, preserving any open views (which are reloaded).
-        
+
         :param nextAction: status line text string, if any, to show upon completion
         :type nextAction: str
         :param reloadCache: True to force clearing and reloading of web cache, if working online.
@@ -355,7 +355,7 @@ class ModelXbrl:
         self.modelDocument = ModelDocument.load(self, self.fileSource.url, isEntry=True, reloadCache=reloadCache)
         self.modelManager.showStatus(_("xbrl loading finished, {0}...").format(nextaction),5000)
         self.modelManager.reloadViews(self)
-            
+
     def closeViews(self):
         """Close views associated with this modelXbrl
         """
@@ -363,7 +363,7 @@ class ModelXbrl:
             for view in range(len(self.views)):
                 if len(self.views) > 0:
                     self.views[0].close()
-    
+
     @property
     def displayUri(self):
         if hasattr(self, "ixdsDocUrls"):
@@ -372,12 +372,12 @@ class ModelXbrl:
             return self.uri
         else:
             return self.fileSource.url
-        
+
     def relationshipSet(self, arcrole, linkrole=None, linkqname=None, arcqname=None, includeProhibits=False):
         """Returns a relationship set matching specified parameters (only arcrole is required).
-        
+
         Resolve and determine relationship set.  If a relationship set of the same parameters was previously resolved, it is returned from a cache.
-        
+
         :param arcrole: Required arcrole, or special collective arcroles 'XBRL-dimensions', 'XBRL-formula', and 'Table-rendering'
         :type arcrole: str
         :param linkrole: Linkrole (wild if None)
@@ -395,23 +395,23 @@ class ModelXbrl:
         if key not in self.relationshipSets:
             ModelRelationshipSet.create(self, arcrole, linkrole, linkqname, arcqname, includeProhibits)
         return self.relationshipSets[key]
-    
+
     def baseSetModelLink(self, linkElement):
         for modelLink in self.baseSets[("XBRL-footnotes",None,None,None)]:
             if modelLink == linkElement:
                 return modelLink
         return None
-    
+
     def roleUriTitle(self, roleURI):
         return re.sub(r"([A-Z])",r" \1", os.path.basename(roleURI)).title()
-    
+
     def roleTypeDefinition(self, roleURI, lang=None):
         modelRoles = self.roleTypes.get(roleURI, ())
         if modelRoles:
             _roleType = modelRoles[0]
             return _roleType.genLabel(lang=lang, strip=True)  or _roleType.definition or self.roleUriTitle(roleURI)
         return self.roleUriTitle(roleURI)
-    
+
     def roleTypeName(self, roleURI, lang=None):
         # authority-specific role type name
         for pluginXbrlMethod in pluginClassMethods("ModelXbrl.RoleTypeName"):
@@ -419,12 +419,12 @@ class ModelXbrl:
             if _roleTypeName:
                 return _roleTypeName
         return self.roleTypeDefinition(roleURI, lang)
-    
+
     def matchSubstitutionGroup(self, elementQname, subsGrpMatchTable):
         """Resolve a subsitutionGroup for the elementQname from the match table
-        
+
         Used by ModelObjectFactory to return Class type for new ModelObject subclass creation, and isInSubstitutionGroup
-        
+
         :param elementQname: Element/Concept QName to find substitution group
         :type elementQname: QName
         :param subsGrpMatchTable: Table of substitutions used to determine xml proxy object class for xml elements and substitution group membership
@@ -442,12 +442,12 @@ class ModelXbrl:
                     return subsGrpMatchTable[subsGrpQname]
                 subsGrpMdlObj = subsGrpMdlObj.substitutionGroup
         return subsGrpMatchTable.get(None)
-    
+
     def isInSubstitutionGroup(self, elementQname, subsGrpQnames):
         """Determine if element is in substitution group(s)
-        
+
         Used by ModelObjectFactory to return Class type for new ModelObject subclass creation, and isInSubstitutionGroup
-        
+
         :param elementQname: Element/Concept QName to determine if in substitution group(s)
         :type elementQname: QName
         :param subsGrpQnames: QName or list of QNames
@@ -456,16 +456,16 @@ class ModelXbrl:
         """
         return self.matchSubstitutionGroup(elementQname, {
                   qn:(qn is not None) for qn in (subsGrpQnames if hasattr(subsGrpQnames, '__iter__') else (subsGrpQnames,)) + (None,)})
-    
+
     def createInstance(self, url=None):
         """Creates an instance document for a DTS which didn't have an instance document, such as
         to create a new instance for a DTS which was loaded from a taxonomy or linkbase entry point.
-        
+
         :param url: File name to save the new instance document
         :type url: str
         """
         from arelle import (ModelDocument, FileSource)
-        if self.modelDocument and self.modelDocument.type == ModelDocument.Type.INSTANCE: 
+        if self.modelDocument and self.modelDocument.type == ModelDocument.Type.INSTANCE:
             # entry already is an instance, delete facts etc.
             del self.facts[:]
             self.factsInInstance.clear()
@@ -477,7 +477,7 @@ class ModelXbrl:
             self.modelDocument.schemaLocationElements.clear()
             self.modelDocument.referencedNamespaces.clear()
             for child in list(self.modelDocument.xmlRootElement):
-                if not (isinstance(child, ModelObject) and child.namespaceURI == XbrlConst.link and 
+                if not (isinstance(child, ModelObject) and child.namespaceURI == XbrlConst.link and
                         child.localName.endswith("Ref")): # remove contexts, facts, footnotes
                     self.modelDocument.xmlRootElement.remove(child)
         else:
@@ -498,15 +498,15 @@ class ModelXbrl:
             for view in self.views:
                 if isinstance(view, ViewWinDTS.ViewDTS):
                     self.modelManager.cntlr.uiThreadQueue.put((view.view, []))
-                
+
     def saveInstance(self, **kwargs):
         """Saves current instance document file.
-        
+
         :param overrideFilepath: specify to override saving in instance's modelDocument.filepath
         """
         self.modelDocument.save(**kwargs)
-            
-    @property    
+
+    @property
     def prefixedNamespaces(self):
         """Dict of prefixes for namespaces defined in DTS
         """
@@ -518,11 +518,11 @@ class ModelXbrl:
                     prefix = XmlUtil.xmlnsprefix(nsDoc.xmlRootElement, ns)
                     if prefix and prefix not in prefixedNamespaces:
                         prefixedNamespaces[prefix] = ns
-        return prefixedNamespaces 
-    
+        return prefixedNamespaces
+
     def matchContext(self, entityIdentScheme, entityIdentValue, periodType, periodStart, periodEndInstant, dims, segOCCs, scenOCCs):
         """Finds matching context, by aspects, as in formula usage, if any
-        
+
         :param entityIdentScheme: Scheme to match
         :type entityIdentScheme: str
         :param entityIdentValue: Entity identifier value to match
@@ -564,11 +564,11 @@ class ModelXbrl:
                 ):
                     return c
         return None
-                 
+
     def createContext(self, entityIdentScheme, entityIdentValue, periodType, periodStart, periodEndInstant, priItem, dims, segOCCs, scenOCCs,
                       afterSibling=None, beforeSibling=None, id=None):
         """Creates a new ModelContext and validates (integrates into modelDocument object model).
-        
+
         :param entityIdentScheme: Scheme to match
         :type entityIdentScheme: str
         :param entityIdentValue: Entity identifier value to match
@@ -607,12 +607,12 @@ class ModelXbrl:
         if periodType == "forever":
             XmlUtil.addChild(periodElt, XbrlConst.xbrli, "forever")
         elif periodType == "instant":
-            XmlUtil.addChild(periodElt, XbrlConst.xbrli, "instant", 
+            XmlUtil.addChild(periodElt, XbrlConst.xbrli, "instant",
                              text=XmlUtil.dateunionValue(periodEndInstant, subtractOneDay=True))
         elif periodType == "duration":
-            XmlUtil.addChild(periodElt, XbrlConst.xbrli, "startDate", 
+            XmlUtil.addChild(periodElt, XbrlConst.xbrli, "startDate",
                              text=XmlUtil.dateunionValue(periodStart))
-            XmlUtil.addChild(periodElt, XbrlConst.xbrli, "endDate", 
+            XmlUtil.addChild(periodElt, XbrlConst.xbrli, "endDate",
                              text=XmlUtil.dateunionValue(periodEndInstant, subtractOneDay=True))
         segmentElt = None
         scenarioElt = None
@@ -629,11 +629,11 @@ class ModelXbrl:
                 # force trying a valid prototype's context Elements
                 if not isFactDimensionallyValid(self, fp, setPrototypeContextElements=True):
                     self.info("arelle:info",
-                        _("Create context for %(priItem)s, cannot determine valid context elements, no suitable hypercubes"), 
+                        _("Create context for %(priItem)s, cannot determine valid context elements, no suitable hypercubes"),
                         modelObject=self, priItem=priItem)
                 fpDims = fp.context.qnameDims
             else:
-                fpDims = dims # dims known to be valid (such as for inline extraction) 
+                fpDims = dims # dims known to be valid (such as for inline extraction)
             for dimQname in sorted(fpDims.keys()):
                 dimValue = fpDims[dimQname]
                 if isinstance(dimValue, (DimValuePrototype,ModelDimensionValue)):
@@ -643,45 +643,45 @@ class ModelXbrl:
                     dimMemberQname = None
                     contextEltName = None
                 if contextEltName == "segment":
-                    if segmentElt is None: 
+                    if segmentElt is None:
                         segmentElt = XmlUtil.addChild(entityElt, XbrlConst.xbrli, "segment")
                     contextElt = segmentElt
                 elif contextEltName == "scenario":
-                    if scenarioElt is None: 
+                    if scenarioElt is None:
                         scenarioElt = XmlUtil.addChild(newCntxElt, XbrlConst.xbrli, "scenario")
                     contextElt = scenarioElt
                 else:
                     self.info("arelleLinfo",
-                        _("Create context, %(dimension)s, cannot determine context element, either no all relationship or validation issue"), 
+                        _("Create context, %(dimension)s, cannot determine context element, either no all relationship or validation issue"),
                         modelObject=self, dimension=dimQname),
                     continue
                 dimAttr = ("dimension", XmlUtil.addQnameValue(xbrlElt, dimQname))
                 if dimValue.isTyped:
-                    dimElt = XmlUtil.addChild(contextElt, XbrlConst.xbrldi, "xbrldi:typedMember", 
+                    dimElt = XmlUtil.addChild(contextElt, XbrlConst.xbrldi, "xbrldi:typedMember",
                                               attributes=dimAttr)
                     if isinstance(dimValue, (ModelDimensionValue, DimValuePrototype)) and dimValue.isTyped:
-                        XmlUtil.copyNodes(dimElt, dimValue.typedMember) 
+                        XmlUtil.copyNodes(dimElt, dimValue.typedMember)
                 elif dimMemberQname:
                     dimElt = XmlUtil.addChild(contextElt, XbrlConst.xbrldi, "xbrldi:explicitMember",
                                               attributes=dimAttr,
                                               text=XmlUtil.addQnameValue(xbrlElt, dimMemberQname))
         if segOCCs:
-            if segmentElt is None: 
+            if segmentElt is None:
                 segmentElt = XmlUtil.addChild(entityElt, XbrlConst.xbrli, "segment")
             XmlUtil.copyNodes(segmentElt, segOCCs)
         if scenOCCs:
-            if scenarioElt is None: 
+            if scenarioElt is None:
                 scenarioElt = XmlUtil.addChild(newCntxElt, XbrlConst.xbrli, "scenario")
             XmlUtil.copyNodes(scenarioElt, scenOCCs)
-                
+
         XmlValidate.validate(self, newCntxElt)
         self.modelDocument.contextDiscover(newCntxElt)
         return newCntxElt
-        
-        
+
+
     def matchUnit(self, multiplyBy, divideBy):
         """Finds matching unit, by measures, as in formula usage, if any
-        
+
         :param multiplyBy: List of multiply-by measure QNames (or top level measures if no divideBy)
         :type multiplyBy: [QName]
         :param divideBy: List of multiply-by measure QNames (or empty list if no divideBy)
@@ -697,7 +697,7 @@ class ModelXbrl:
 
     def createUnit(self, multiplyBy, divideBy, afterSibling=None, beforeSibling=None, id=None):
         """Creates new unit, by measures, as in formula usage, if any
-        
+
         :param multiplyBy: List of multiply-by measure QNames (or top level measures if no divideBy)
         :type multiplyBy: [QName]
         :param divideBy: List of multiply-by measure QNames (or empty list if no divideBy)
@@ -730,11 +730,11 @@ class ModelXbrl:
         XmlValidate.validate(self, newUnitElt)
         self.modelDocument.unitDiscover(newUnitElt)
         return newUnitElt
-    
+
     @property
     def nonNilFactsInInstance(self): # indexed by fact (concept) qname
         """Facts in the instance which are not nil, cached
-        
+
         :returns: set -- non-nil facts in instance
         """
         try:
@@ -742,37 +742,37 @@ class ModelXbrl:
         except AttributeError:
             self._nonNilFactsInInstance = set(f for f in self.factsInInstance if not f.isNil)
             return self._nonNilFactsInInstance
-        
+
     @property
     def factsByQname(self): # indexed by fact (concept) qname
         """Facts in the instance indexed by their QName, cached
-        
+
         :returns: dict -- indexes are QNames, values are ModelFacts
         """
         try:
             return self._factsByQname
         except AttributeError:
             self._factsByQname = fbqn = defaultdict(set)
-            for f in self.factsInInstance: 
+            for f in self.factsInInstance:
                 if f.qname is not None:
                     fbqn[f.qname].add(f)
             return fbqn
-        
+
     @property
     def factsByLocalName(self): # indexed by fact (concept) localName
         """Facts in the instance indexed by their LocalName, cached
-        
+
         :returns: dict -- indexes are LocalNames, values are ModelFacts
         """
         try:
             return self._factsByLocalName
         except AttributeError:
             self._factsByLocalName = fbln = defaultdict(set)
-            for f in self.factsInInstance: 
+            for f in self.factsInInstance:
                 if f.qname is not None:
                     fbln[f.qname.localName].add(f)
             return fbln
-        
+
     def factsByDatatype(self, notStrict, typeQname): # indexed by fact (concept) qname
         """Facts in the instance indexed by data type QName, cached as types are requested
 
@@ -792,7 +792,7 @@ class ModelXbrl:
                 if c.typeQname == typeQname or (notStrict and c.type.isDerivedFrom(typeQname)):
                     fbdt.add(f)
             return fbdt
-        
+
     def factsByPeriodType(self, periodType): # indexed by fact (concept) qname
         """Facts in the instance indexed by periodType, cached
 
@@ -811,10 +811,10 @@ class ModelXbrl:
             return self.factsByPeriodType(periodType)
         except KeyError:
             return set()  # no facts for this period type
-        
+
     def factsByDimMemQname(self, dimQname, memQname=None): # indexed by fact (concept) qname
         """Facts in the instance indexed by their Dimension  and Member QName, cached
-        
+
         :returns: dict -- indexes are (Dimension, Member) and (Dimension) QNames, values are ModelFacts
         If Member is None, returns facts that have the dimension (explicit or typed)
         If Member is NONDEFAULT, returns facts that have the dimension (explicit non-default or typed)
@@ -828,7 +828,7 @@ class ModelXbrl:
             return self.factsByDimMemQname(dimQname, memQname)
         except KeyError:
             self._factsByDimQname[dimQname] = fbdq = defaultdict(set)
-            for fact in self.factsInInstance: 
+            for fact in self.factsInInstance:
                 if fact.isItem and fact.context is not None:
                     dimValue = fact.context.dimValue(dimQname)
                     if isinstance(dimValue, ModelValue.QName):  # explicit dimension default value
@@ -844,8 +844,8 @@ class ModelXbrl:
                     else: # default typed dimension
                         fbdq[DEFAULT].add(fact)
             return fbdq[memQname]
-    
-    @property    
+
+    @property
     def contextsInUse(self):
         try:
             if self._contextsInUseMarked:
@@ -857,8 +857,8 @@ class ModelXbrl:
                     cntx._inUse = True
             self._contextsInUseMarked = True
             return self.contextsInUse
-    
-    @property    
+
+    @property
     def dimensionsInUse(self):
         try:
             return self._dimensionsInUse
@@ -867,11 +867,11 @@ class ModelXbrl:
                                         for cntx in self.contexts.values()  # use contextsInUse?  slower?
                                         for dim in cntx.qnameDims.values())
             return self._dimensionsInUse
-                
+
     def matchFact(self, otherFact, unmatchedFactsStack=None, deemP0inf=False, matchId=False, matchLang=True):
         """Finds matching fact, by XBRL 2.1 duplicate definition (if tuple), or by
         QName and VEquality (if an item), lang and accuracy equality, as in formula and test case usage
-        
+
         :param otherFact: Fact to match
         :type otherFact: ModelFact
         :deemP0inf: boolean for formula validation to deem P0 facts to be VEqual as if they were P=INF
@@ -894,10 +894,10 @@ class ModelXbrl:
                             fact.precision == otherFact.precision):
                             return fact
         return None
-            
+
     def createFact(self, conceptQname, attributes=None, text=None, parent=None, afterSibling=None, beforeSibling=None, validate=True):
         """Creates new fact, as in formula output instance creation, and validates into object model
-        
+
         :param conceptQname: QNames of concept
         :type conceptQname: QName
         :param attributes: Tuple of name, value, or tuples of name, value tuples (name,value) or ((name,value)[,(name,value...)]), where name is either QName or clark-notation name string
@@ -939,8 +939,8 @@ class ModelXbrl:
             if hasattr(self, "_factsByDimQname"):
                 del self._factsByDimQname
         self.setIsModified()
-        return newFact    
-        
+        return newFact
+
     def setIsModified(self):
         """Records that the underlying document has been modified.
         """
@@ -957,7 +957,7 @@ class ModelXbrl:
 
     def modelObject(self, objectId):
         """Finds a model object by an ordinal ID which may be buried in a tkinter view id string (e.g., 'somedesignation_ordinalnumber').
-        
+
         :param objectId: string which includes _ordinalNumber, produced by ModelObject.objectId(), or integer object index
         :type objectId: str or int
         :returns: ModelObject
@@ -969,7 +969,7 @@ class ModelXbrl:
             return self.modelObjects[_INT(objectId.rpartition("_")[2])]
         except (IndexError, ValueError):
             return None
-    
+
     # UI thread viewModelObject
     def viewModelObject(self, objectId):
         """Finds model object, if any, and synchronizes any views displaying it to bring the model object into scrollable view region and highlight it
@@ -990,7 +990,7 @@ class ModelXbrl:
                             modelObject,
                             err, traceback.format_tb(sys.exc_info()[2])))
 
-    def effectiveMessageCode(self, messageCodes):     
+    def effectiveMessageCode(self, messageCodes):
         """
         If codes includes EFM, GFM, HMRC, or SBR-coded error then the code chosen (if a sequence)
         corresponds to whether EFM, GFM, HMRC, or SBR validation is in effect.
@@ -998,7 +998,7 @@ class ModelXbrl:
         effectiveMessageCode = None
         _validationType = self.modelManager.disclosureSystem.validationType
         _exclusiveTypesPattern = self.modelManager.disclosureSystem.exclusiveTypesPattern
-        
+
         for argCode in messageCodes if isinstance(messageCodes,tuple) else (messageCodes,):
             if (isinstance(argCode, ModelValue.QName) or
                 (_validationType and argCode.startswith(_validationType)) or
@@ -1017,7 +1017,7 @@ class ModelXbrl:
                 messageCodes = kwargs["messageCode"]
             messageCode = self.effectiveMessageCode(messageCodes)
             codeEffective = (messageCode and
-                             (not logger.messageCodeFilter or logger.messageCodeFilter.match(messageCode))) 
+                             (not logger.messageCodeFilter or logger.messageCodeFilter.match(messageCode)))
         else:
             codeEffective = True
         if "level" in kwargs and logger.messageLevelFilter:
@@ -1149,13 +1149,13 @@ class ModelXbrl:
         for pluginXbrlMethod in pluginClassMethods("Logging.Message.Parameters"):
             # plug in can rewrite msg string or return msg if not altering msg
             msg = pluginXbrlMethod(messageCode, msg, modelObjectArgs, fmtArgs) or msg
-        return (messageCode, 
-                (msg, fmtArgs) if fmtArgs else (msg,), 
+        return (messageCode,
+                (msg, fmtArgs) if fmtArgs else (msg,),
                 extras)
-        
+
     def loggableValue(self, argValue): # must be dereferenced and not related to object lifetimes
         if isinstance(argValue, (ModelValue.QName, ModelObject, FileNamedStringIO,
-                                 # might be a set of lxml objects not dereferencable at shutdown 
+                                 # might be a set of lxml objects not dereferencable at shutdown
                                  tuple, list, set)):
             return str(argValue)
         elif argValue is None:
@@ -1178,19 +1178,19 @@ class ModelXbrl:
         """
         """@messageCatalog=[]"""
         self.log('DEBUG', codes, msg, **args)
-                    
+
     def info(self, codes, msg, **args):
         """Same as error(), but as info
         """
         """@messageCatalog=[]"""
         self.log('INFO', codes, msg, **args)
-                    
+
     def warning(self, codes, msg, **args):
         """Same as error(), but as warning, and no error code saved for Validate
         """
         """@messageCatalog=[]"""
         self.log('WARNING', codes, msg, **args)
-                    
+
     def log(self, level, codes, msg, **args):
         """Same as error(), but level passed in as argument
         """
@@ -1214,21 +1214,21 @@ class ModelXbrl:
                     self.errors.append(messageCode) # assume one error occurence
             """@messageCatalog=[]"""
             logger.log(numericLevel, *logArgs, exc_info=args.get("exc_info"), extra=extras)
-                    
+
     def error(self, codes, msg, **args):
-        """Logs a message as info, by code, logging-system message text (using %(name)s named arguments 
-        to compose string by locale language), resolving model object references (such as qname), 
-        to prevent non-dereferencable memory usage.  Supports logging system parameters, and 
-        special parameters modelObject, modelXbrl, or modelDocument, to provide trace 
-        information to the file, source line, and href (XPath element scheme pointer).  
+        """Logs a message as info, by code, logging-system message text (using %(name)s named arguments
+        to compose string by locale language), resolving model object references (such as qname),
+        to prevent non-dereferencable memory usage.  Supports logging system parameters, and
+        special parameters modelObject, modelXbrl, or modelDocument, to provide trace
+        information to the file, source line, and href (XPath element scheme pointer).
         Supports the logging exc_info argument.
-        
+
         Args may include a specification of one or more ModelObjects that identify the source of the
         message, as modelObject={single-modelObject, (sequence-of-modelObjects)} or modelXbrl=modelXbrl or
         modelDocument=modelDocument.
-        
+
         Args must include a named argument for each msg %(namedArg)s replacement.
-        
+
         :param codes: Message code or tuple/list of message codes
         :type codes: str or [str]
         :param msg: Message text string to be formatted and replaced with named parameters in **args
@@ -1243,7 +1243,7 @@ class ModelXbrl:
         """
         """@messageCatalog=[]"""
         self.log('CRITICAL', codes, msg, **args)
-        
+
     def logProfileStats(self):
         """Logs profile stats that were collected
         """
@@ -1256,7 +1256,7 @@ class ModelXbrl:
                 " \n", # put instance reference on fresh line in traces
                 modelObject=self.modelXbrl.modelDocument, profileStats=self.profileStats,
                 timeTotal=timeTotal, timeEFM=timeEFM)
-    
+
     def profileStat(self, name=None, stat=None):
         '''
         order 1xx - load, import, setup, etc
@@ -1279,14 +1279,14 @@ class ModelXbrl:
                 pass
             if stat is None:
                 self._startedTimeStat = time.time()
-        
+
     def profileActivity(self, activityCompleted=None, minTimeToShow=0):
         """Used to provide interactive GUI messages of long-running processes.
-        
+
         When the time between last profileActivity and this profileActivity exceeds minTimeToShow, then
         the time is logged (if it is shorter than it is not logged), thus providing feedback of long
         running (and possibly troublesome) processing steps.
-        
+
         :param activityCompleted: Description of activity completed, or None if call is just to demark starting of a profiled activity.
         :type activityCompleted: str
         :param minTimeToShow: Seconds of elapsed time for activity, if longer then the profile message appears in the log.
@@ -1307,21 +1307,21 @@ class ModelXbrl:
 
     def saveDTSpackage(self):
         """Contributed program to save DTS package as a zip file.  Refactored into a plug-in (and may be removed from main code).
-        """ 
+        """
         if self.fileSource.isArchive:
             return
-        from zipfile import ZipFile 
-        import os 
-        entryFilename = self.fileSource.url 
-        pkgFilename = entryFilename + ".zip" 
+        from zipfile import ZipFile
+        import os
+        entryFilename = self.fileSource.url
+        pkgFilename = entryFilename + ".zip"
         with ZipFile(pkgFilename, 'w') as zip:
             numFiles = 0
-            for fileUri in sorted(self.urlDocs.keys()): 
-                if not isHttpUrl(fileUri): 
+            for fileUri in sorted(self.urlDocs.keys()):
+                if not isHttpUrl(fileUri):
                     numFiles += 1
                     # this has to be a relative path because the hrefs will break
-                    zip.write(fileUri, os.path.basename(fileUri)) 
+                    zip.write(fileUri, os.path.basename(fileUri))
         self.info("info",
-                  _("DTS of %(entryFile)s has %(numberOfFiles)s files packaged into %(packageOutputFile)s"), 
+                  _("DTS of %(entryFile)s has %(numberOfFiles)s files packaged into %(packageOutputFile)s"),
                 modelObject=self,
                 entryFile=os.path.basename(entryFilename), packageOutputFile=pkgFilename, numberOfFiles=numFiles)

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -16,7 +16,7 @@ from arelle.ModelObject import ModelObject
 from arelle.ModelDtsObject import ModelConcept
 from arelle.ModelInstanceObject import ModelInlineFact
 from arelle.ModelValue import qname
-from arelle.ModelXbrl import ModelXbrlProtocol
+from arelle.ModelXbrl import ModelXbrl
 from arelle.PluginManager import pluginClassMethods
 from arelle.ValidateXbrlCalcs import inferredDecimals
 from arelle.XbrlConst import (ixbrlAll, dtrNoDecimalsItemTypes, dtrPrefixedContentItemTypes, dtrPrefixedContentTypes,
@@ -25,7 +25,6 @@ from arelle.XhtmlValidate import ixMsgCode
 from arelle.XmlValidate import VALID
 from collections import defaultdict
 
-from typing_extensions import Protocol
 
 validateUniqueParticleAttribution = None # dynamic import
 
@@ -49,17 +48,11 @@ baseXbrliTypes = {
         "normalizedStringItemType", "tokenItemType", "languageItemType", "NameItemType", "NCNameItemType"
       }
 
-class ValidateXbrlProtocol(Protocol):
-    """Implements a protocol that helps typing of the ValidateXbrl class."""
-
-    @property
-    def authParam(self) -> dict[str, Any]: ...
-
-    @property
-    def modelXbrl(self) -> ModelXbrlProtocol: ...
-
 
 class ValidateXbrl:
+
+    authParam: dict[str, Any]
+
     def __init__(self, testModelXbrl):
         self.testModelXbrl = testModelXbrl
 
@@ -75,7 +68,7 @@ class ValidateXbrl:
         self.precisionPattern = re.compile("^([0-9]+|INF)$")
         self.decimalsPattern = re.compile("^(-?[0-9]+|INF)$")
         self.isoCurrencyPattern = re.compile(r"^[A-Z]{3}$")
-        self.modelXbrl = modelXbrl
+        self.modelXbrl: ModelXbrl = modelXbrl
         self.validateDisclosureSystem = modelXbrl.modelManager.validateDisclosureSystem
         self.disclosureSystem = modelXbrl.modelManager.disclosureSystem
         self.validateEFM = self.validateDisclosureSystem and self.disclosureSystem.EFM  # deprecated non-plugin validators

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -8,7 +8,7 @@ try:
     import regex as re
 except ImportError:
     import re
-from arelle import (ModelDocument, XmlUtil, XbrlUtil, XbrlConst, 
+from arelle import (ModelDocument, XmlUtil, XbrlUtil, XbrlConst,
                 ValidateXbrlCalcs, ValidateXbrlDimensions, ValidateXbrlDTS, ValidateFormula, ValidateUtr)
 from arelle import FunctionIxt
 from arelle.ModelObject import ModelObject
@@ -47,14 +47,14 @@ baseXbrliTypes = {
 class ValidateXbrl:
     def __init__(self, testModelXbrl):
         self.testModelXbrl = testModelXbrl
-        
+
     def close(self, reusable=True):
         if reusable:
             testModelXbrl = self.testModelXbrl
         self.__dict__.clear()   # dereference everything
         if reusable:
             self.testModelXbrl = testModelXbrl
-        
+
     def validate(self, modelXbrl, parameters=None):
         self.parameters = parameters
         self.precisionPattern = re.compile("^([0-9]+|INF)$")
@@ -75,12 +75,12 @@ class ValidateXbrl:
         self.validateDedupCalcs = modelXbrl.modelManager.validateDedupCalcs
         self.validateUTR = (modelXbrl.modelManager.validateUtr or
                             (self.parameters and self.parameters.get(qname("forceUtrValidation",noPrefixIsNoNamespace=True),(None,"false"))[1] == "true") or
-                            (self.validateEFM and 
-                             any((concept.qname.namespaceURI in self.disclosureSystem.standardTaxonomiesDict and concept.modelDocument.inDTS) 
+                            (self.validateEFM and
+                             any((concept.qname.namespaceURI in self.disclosureSystem.standardTaxonomiesDict and concept.modelDocument.inDTS)
                                  for concept in self.modelXbrl.nameConcepts.get("UTR",()))))
         self.validateIXDS = False # set when any inline document found
         self.validateEnum = bool(XbrlConst.enums & _DICT_SET(modelXbrl.namespaceDocs.keys()))
-        
+
         for pluginXbrlMethod in pluginClassMethods("Validate.XBRL.Start"):
             pluginXbrlMethod(self, parameters)
 
@@ -146,9 +146,9 @@ class ValidateXbrl:
                             arcrole=arcrole, linkrole=ELR, linkname=linkqname, arcname=arcqname,
                             messageCodes=("xbrlgene:violatedCyclesConstraint", "xbrl.5.1.4.3:cycles",
                                           # from XbrlCoinst.standardArcroleCyclesAllowed
-                                          "xbrl.5.2.4.2", "xbrl.5.2.5.2", "xbrl.5.2.6.2.1", "xbrl.5.2.6.2.1", "xbrl.5.2.6.2.3", "xbrl.5.2.6.2.4")) 
+                                          "xbrl.5.2.4.2", "xbrl.5.2.5.2", "xbrl.5.2.6.2.1", "xbrl.5.2.6.2.1", "xbrl.5.2.6.2.3", "xbrl.5.2.6.2.4"))
                         break
-                
+
             # check calculation arcs for weight issues (note calc arc is an "any" cycles)
             if arcrole == XbrlConst.summationItem:
                 for modelRel in relsSet.modelRelationships:
@@ -160,7 +160,7 @@ class ValidateXbrl:
                             modelXbrl.error("xbrl.5.2.5.2.1:zeroWeight",
                                 _("Calculation relationship has zero weight from %(source)s to %(target)s in link role %(linkrole)s"),
                                 modelObject=modelRel,
-                                source=fromConcept.qname, target=toConcept.qname, linkrole=ELR), 
+                                source=fromConcept.qname, target=toConcept.qname, linkrole=ELR),
                         fromBalance = fromConcept.balance
                         toBalance = toConcept.balance
                         if fromBalance and toBalance:
@@ -170,15 +170,15 @@ class ValidateXbrl:
                                                 ("Negative" if weight < 0 else "Positive"),
                                     _("Calculation relationship has illegal weight %(weight)s from %(source)s, %(sourceBalance)s, to %(target)s, %(targetBalance)s, in link role %(linkrole)s (per 5.1.1.2 Table 6)"),
                                     modelObject=modelRel, weight=weight,
-                                    source=fromConcept.qname, target=toConcept.qname, linkrole=ELR, 
+                                    source=fromConcept.qname, target=toConcept.qname, linkrole=ELR,
                                     sourceBalance=fromBalance, targetBalance=toBalance,
                                     messageCodes=("xbrl.5.1.1.2:balanceCalcWeightIllegalNegative", "xbrl.5.1.1.2:balanceCalcWeightIllegalPositive"))
                         if not fromConcept.isNumeric or not toConcept.isNumeric:
                             modelXbrl.error("xbrl.5.2.5.2:nonNumericCalc",
                                 _("Calculation relationship has illegal concept from %(source)s%(sourceNumericDecorator)s to %(target)s%(targetNumericDecorator)s in link role %(linkrole)s"),
                                 modelObject=modelRel,
-                                source=fromConcept.qname, target=toConcept.qname, linkrole=ELR, 
-                                sourceNumericDecorator="" if fromConcept.isNumeric else _(" (non-numeric)"), 
+                                source=fromConcept.qname, target=toConcept.qname, linkrole=ELR,
+                                sourceNumericDecorator="" if fromConcept.isNumeric else _(" (non-numeric)"),
                                 targetNumericDecorator="" if toConcept.isNumeric else _(" (non-numeric)"))
             # check presentation relationships for preferredLabel issues
             elif arcrole == XbrlConst.parentChild:
@@ -192,13 +192,13 @@ class ValidateXbrl:
                             modelXbrl.error("xbrl.5.2.4.2.1:preferredLabelMissing",
                                 _("Presentation relationship from %(source)s to %(target)s in link role %(linkrole)s missing preferredLabel %(preferredLabel)s"),
                                 modelObject=modelRel,
-                                source=fromConcept.qname, target=toConcept.qname, linkrole=ELR, 
+                                source=fromConcept.qname, target=toConcept.qname, linkrole=ELR,
                                 preferredLabel=preferredLabel)
                         elif not label: # empty string
                             modelXbrl.info("arelle:info.preferredLabelEmpty",
                                 _("(Info xbrl.5.2.4.2.1) Presentation relationship from %(source)s to %(target)s in link role %(linkrole)s has empty preferredLabel %(preferredLabel)s"),
                                 modelObject=modelRel,
-                                source=fromConcept.qname, target=toConcept.qname, linkrole=ELR, 
+                                source=fromConcept.qname, target=toConcept.qname, linkrole=ELR,
                                 preferredLabel=preferredLabel)
             # check essence-alias relationships
             elif arcrole == XbrlConst.essenceAlias:
@@ -220,12 +220,12 @@ class ValidateXbrl:
                                     modelObject=modelRel,
                                     source=fromConcept.qname, target=toConcept.qname, linkrole=ELR)
             elif modelXbrl.hasXDT and arcrole.startswith(XbrlConst.dimStartsWith):
-                ValidateXbrlDimensions.checkBaseSet(self, arcrole, ELR, relsSet)             
+                ValidateXbrlDimensions.checkBaseSet(self, arcrole, ELR, relsSet)
             elif arcrole in ValidateFormula.arcroleChecks:
                 ValidateFormula.checkBaseSet(self, arcrole, ELR, relsSet)
         modelXbrl.isDimensionsValidated = True
         modelXbrl.profileStat(_("validateRelationships"))
-                            
+
         # instance checks
         modelXbrl.modelManager.showStatus(_("validating instance"))
         if modelXbrl.modelDocument.type in (ModelDocument.Type.INSTANCE, ModelDocument.Type.INLINEXBRL, ModelDocument.Type.INLINEXBRLDOCUMENTSET):
@@ -235,10 +235,10 @@ class ValidateXbrl:
 
             modelXbrl.profileStat(_("validateInstance"))
 
-            if modelXbrl.hasXDT:            
+            if modelXbrl.hasXDT:
                 modelXbrl.modelManager.showStatus(_("validating dimensions"))
                 ''' uncomment if using otherFacts in checkFact
-                dimCheckableFacts = set(f 
+                dimCheckableFacts = set(f
                                         for f in modelXbrl.factsInInstance
                                         if f.concept.isItem and f.context is not None)
                 while (dimCheckableFacts): # check one and all of its compatible family members
@@ -249,17 +249,17 @@ class ValidateXbrl:
                 self.checkFactsDimensions(modelXbrl.facts) # check fact dimensions in document order
                 self.checkContextsDimensions(modelXbrl.contexts.values())
                 modelXbrl.profileStat(_("validateDimensions"))
-                    
+
         # dimensional validity
         #concepts checks
         modelXbrl.modelManager.showStatus(_("validating concepts"))
         for concept in modelXbrl.qnameConcepts.values():
             conceptType = concept.type
             if (concept.qname is None or
-                XbrlConst.isStandardNamespace(concept.qname.namespaceURI) or 
+                XbrlConst.isStandardNamespace(concept.qname.namespaceURI) or
                 not concept.modelDocument.inDTS):
                 continue
-            
+
             if concept.isTuple:
                 # must be global
                 if not concept.getparent().localName == "schema":
@@ -353,12 +353,12 @@ class ValidateXbrl:
             if modelXbrl.hasXDT:
                 ValidateXbrlDimensions.checkConcept(self, concept)
         modelXbrl.profileStat(_("validateConcepts"))
-        
+
         for pluginXbrlMethod in pluginClassMethods("Validate.XBRL.Finally"):
             pluginXbrlMethod(self)
 
         modelXbrl.profileStat() # reset after plugins
-            
+
         modelXbrl.modelManager.showStatus(_("validating DTS"))
         self.DTSreferenceResourceIDs = {}
         checkedModelDocuments = set()
@@ -367,25 +367,25 @@ class ValidateXbrl:
         for importedModelDocument in (set(modelXbrl.urlDocs.values()) - checkedModelDocuments):
             ValidateXbrlDTS.checkDTS(self, importedModelDocument, checkedModelDocuments)
         del checkedModelDocuments, self.DTSreferenceResourceIDs
-        
+
         global validateUniqueParticleAttribution
         if validateUniqueParticleAttribution is None:
             from arelle.XmlValidateParticles import validateUniqueParticleAttribution
         for modelType in modelXbrl.qnameTypes.values():
             validateUniqueParticleAttribution(modelXbrl, modelType.particlesList, modelType)
         modelXbrl.profileStat(_("validateDTS"))
-        
+
         if self.validateCalcLB:
             modelXbrl.modelManager.showStatus(_("Validating instance calculations"))
-            ValidateXbrlCalcs.validate(modelXbrl, 
+            ValidateXbrlCalcs.validate(modelXbrl,
                                        inferDecimals=self.validateInferDecimals,
                                        deDuplicate=self.validateDedupCalcs)
             modelXbrl.profileStat(_("validateCalculations"))
-            
+
         if self.validateUTR:
             ValidateUtr.validateFacts(modelXbrl)
             modelXbrl.profileStat(_("validateUTR"))
-            
+
         if self.validateIXDS:
             modelXbrl.modelManager.showStatus(_("Validating inline document set"))
             _ixNS = modelXbrl.modelDocument.ixNS
@@ -452,7 +452,7 @@ class ValidateXbrl:
                 self.modelXbrl.info("arelle:info",
                     _("%(count)s facts have deprecated transformation namespace %(namespace)s"),
                         modelObject=self.factsWithDeprecatedIxNamespace,
-                        count=len(self.factsWithDeprecatedIxNamespace), 
+                        count=len(self.factsWithDeprecatedIxNamespace),
                         namespace=FunctionIxt.deprecatedNamespaceURI)
 
             del self.factsWithDeprecatedIxNamespace
@@ -462,7 +462,7 @@ class ValidateXbrl:
                 for i, ixReference in enumerate(ixReferences):
                     defaultNamepace = XmlUtil.xmlns(ixReference, None)
                     if i == 0:
-                        targetDefaultNamespace = defaultNamepace 
+                        targetDefaultNamespace = defaultNamepace
                     elif targetDefaultNamespace != defaultNamepace:
                         modelXbrl.error(ixMsgCode("referenceInconsistentDefaultNamespaces", ns=_ixNS, sect="validation"),
                             _("Inline XBRL document set must have consistent default namespaces for target %(target)s"),
@@ -504,25 +504,25 @@ class ValidateXbrl:
                         ValidateXbrlDTS.checkLinkRole(self, ixRel, XbrlConst.qnLinkFootnoteLink, ixRel.get("linkRole"), "extended", self.ixdsRoleRefURIs)
                     if ixRel.get("arcrole") is not None:
                         ValidateXbrlDTS.checkArcrole(self, ixRel, XbrlConst.qnLinkFootnoteArc, ixRel.get("arcrole"), self.ixdsArcroleRefURIs)
-            
+
 
             del ixdsIdObjects
             # tupleRefs already checked during loading
             modelXbrl.profileStat(_("validateInline"))
-        
+
         if modelXbrl.hasFormulae or modelXbrl.modelRenderingTables:
-            ValidateFormula.validate(self, 
+            ValidateFormula.validate(self,
                                      statusMsg=_("compiling formulae and rendering tables") if (modelXbrl.hasFormulae and modelXbrl.modelRenderingTables)
                                      else (_("compiling formulae") if modelXbrl.hasFormulae
                                            else _("compiling rendering tables")),
                                      # block executing formulas when validating if hasFormula is False (e.g., --formula=none)
                                      compileOnly=modelXbrl.modelRenderingTables and not modelXbrl.hasFormulae)
-            
+
         for pluginXbrlMethod in pluginClassMethods("Validate.Finally"):
             pluginXbrlMethod(self)
 
         modelXbrl.modelManager.showStatus(_("ready"), 2000)
-        
+
     def checkLinks(self, modelLinks):
         for modelLink in modelLinks:
             fromToArcs = {}
@@ -538,8 +538,8 @@ class ValidateXbrl:
                             self.modelXbrl.error("xlink:locatorHref",
                                 _("Xlink locator %(xlinkLabel)s missing href in extended link %(linkrole)s"),
                                 modelObject=arcElt,
-                                linkrole=modelLink.role, 
-                                xlinkLabel=arcElt.get("{http://www.w3.org/1999/xlink}label")) 
+                                linkrole=modelLink.role,
+                                xlinkLabel=arcElt.get("{http://www.w3.org/1999/xlink}label"))
                         locLabels[arcElt.get("{http://www.w3.org/1999/xlink}label")] = arcElt
                     elif xlinkType == "resource":
                         resourceLabels[arcElt.get("{http://www.w3.org/1999/xlink}label")] = arcElt
@@ -552,7 +552,7 @@ class ValidateXbrl:
                             self.modelXbrl.error("xlink:dupArcs",
                                 _("Duplicate xlink arcs  in extended link %(linkrole)s from %(xlinkLabelFrom)s to %(xlinkLabelTo)s"),
                                 modelObject=arcElt,
-                                linkrole=modelLink.role, 
+                                linkrole=modelLink.role,
                                 xlinkLabelFrom=fromLabel, xlinkLabelTo=toLabel)
                         else:
                             fromToArcs[fromTo] = arcElt
@@ -588,8 +588,8 @@ class ValidateXbrl:
                     if value not in locLabels and value not in resourceLabels:
                         self.modelXbrl.error("xbrl.{0}:arcResource".format(sect),
                             _("Arc in extended link %(linkrole)s from %(xlinkLabelFrom)s to %(xlinkLabelTo)s attribute '%(attribute)s' has no matching loc or resource label"),
-                            modelObject=arcElt, 
-                            linkrole=modelLink.role, xlinkLabelFrom=fromLabel, xlinkLabelTo=toLabel, 
+                            modelObject=arcElt,
+                            linkrole=modelLink.role, xlinkLabelFrom=fromLabel, xlinkLabelTo=toLabel,
                             attribute=name,
                             messageCodes=("xbrl.3.5.3.9.2:arcResource", "xbrl.3.5.3.9.3:arcResource"))
                 if arcElt.localName == "footnoteArc" and arcElt.namespaceURI == XbrlConst.link and \
@@ -597,15 +597,15 @@ class ValidateXbrl:
                     if fromLabel not in locLabels:
                         self.modelXbrl.error("xbrl.4.11.1.3.1:factFootnoteArcFrom",
                             _("Footnote arc in extended link %(linkrole)s from %(xlinkLabelFrom)s to %(xlinkLabelTo)s \"from\" is not a loc"),
-                            modelObject=arcElt, 
+                            modelObject=arcElt,
                             linkrole=modelLink.role, xlinkLabelFrom=fromLabel, xlinkLabelTo=toLabel)
-                    if not((toLabel in resourceLabels and resourceLabels[toLabel] is not None 
+                    if not((toLabel in resourceLabels and resourceLabels[toLabel] is not None
                               and resourceLabels[toLabel].qname == XbrlConst.qnLinkFootnote) or
                            (toLabel in locLabels and locLabels[toLabel].dereference() is not None
                               and locLabels[toLabel].dereference().qname == XbrlConst.qnLinkFootnote)):
                         self.modelXbrl.error("xbrl.4.11.1.3.1:factFootnoteArcTo",
                             _("Footnote arc in extended link %(linkrole)s from %(xlinkLabelFrom)s to %(xlinkLabelTo)s \"to\" is not a footnote resource"),
-                            modelObject=arcElt, 
+                            modelObject=arcElt,
                             linkrole=modelLink.role, xlinkLabelFrom=fromLabel, xlinkLabelTo=toLabel)
             # check unprohibited label arcs to remote locs
             for resourceArcTo in resourceArcTos:
@@ -617,8 +617,8 @@ class ValidateXbrl:
                     else:
                         self.modelXbrl.error("xbrl.5.2.2.3:labelArcRemoteResource",
                             _("Unprohibited labelArc in extended link %(linkrole)s has illegal remote resource loc labeled %(xlinkLabel)s href %(xlinkHref)s"),
-                            modelObject=arcElt, 
-                            linkrole=modelLink.role, 
+                            modelObject=arcElt,
+                            linkrole=modelLink.role,
                             xlinkLabel=resourceArcToLabel,
                             xlinkHref=toLabel.get("{http://www.w3.org/1999/xlink}href"))
                 elif resourceArcToLabel in resourceLabels:
@@ -627,18 +627,18 @@ class ValidateXbrl:
                         if not self.isGenericLabel(toResource):
                             self.modelXbrl.error("xbrlle.2.1.1:genericLabelTarget",
                                 _("Generic label arc in extended link %(linkrole)s to %(xlinkLabel)s must target a generic label"),
-                                modelObject=arcElt, 
-                                linkrole=modelLink.role, 
+                                modelObject=arcElt,
+                                linkrole=modelLink.role,
                                 xlinkLabel=resourceArcToLabel)
                     elif resourceArcUse == XbrlConst.elementReference:
                         if not self.isGenericReference(toResource):
                             self.modelXbrl.error("xbrlre.2.1.1:genericReferenceTarget",
                                 _("Generic reference arc in extended link %(linkrole)s to %(xlinkLabel)s must target a generic reference"),
-                                modelObject=arcElt, 
-                                linkrole=modelLink.role, 
+                                modelObject=arcElt,
+                                linkrole=modelLink.role,
                                 xlinkLabel=resourceArcToLabel)
             resourceArcTos = None # dereference arcs
-        
+
     def checkFacts(self, facts, inTuple=None):  # do in document order
         for f in facts:
             concept = f.concept
@@ -704,7 +704,7 @@ class ValidateXbrl:
                             self.modelXbrl.error("xbrl.4.7.2:contextPeriodType",
                                 _("Fact %(fact)s context %(contextID)s has period type %(periodType)s conflict with context"),
                                 modelObject=f, fact=f.qname, contextID=f.contextID, periodType=periodType)
-                            
+
                     # check precision and decimals
                     if f.isNil:
                         if hasPrecision or hasDecimals:
@@ -778,14 +778,14 @@ class ValidateXbrl:
                             self.modelXbrl.error(
                                 ("enum2ie:InvalidEnumerationSetValue" if concept.instanceOfType(XbrlConst.qnEnumerationSetItemTypes)
                                  else "enum2ie:InvalidEnumerationValue") if concept.instanceOfType(XbrlConst.qnEnumeration2ItemTypes)
-                                else ("InvalidListFactValue" if concept.instanceOfType(XbrlConst.qnEnumerationListItemTypes) 
+                                else ("InvalidListFactValue" if concept.instanceOfType(XbrlConst.qnEnumerationListItemTypes)
                                       else "InvalidFactValue"),
                                 _("Fact %(fact)s context %(contextID)s enumeration %(value)s is not in the domain of %(concept)s"),
                                 modelObject=f, fact=f.qname, contextID=f.contextID, value=f.xValue, concept=f.qname,
                                 messageCodes=("enumie:InvalidFactValue", "enumie:InvalidListFactValue",
                                               "enum2ie:InvalidEnumerationValue", "enum2ie:InvalidEnumerationSetValue"))
                         if concept.instanceOfType(XbrlConst.qnEnumerationSetItemTypes) and len(qnEnums) > len(set(qnEnums)):
-                            self.modelXbrl.error(("enum2ie:" if concept.instanceOfType(XbrlConst.qnEnumeration2ItemTypes) 
+                            self.modelXbrl.error(("enum2ie:" if concept.instanceOfType(XbrlConst.qnEnumeration2ItemTypes)
                                                   else "enumie:") +
                                                  "RepeatedEnumerationSetValue",
                                 _("Fact %(fact)s context %(contextID)s enumeration has non-unique values %(value)s"),
@@ -796,7 +796,7 @@ class ValidateXbrl:
                             self.modelXbrl.error("enum2ie:InvalidEnumerationSetOrder",
                                 _("Fact %(fact)s context %(contextID)s enumeration is not in lexicographical order %(value)s"),
                                 modelObject=f, fact=f.qname, contextID=f.contextID, value=f.xValue, concept=f.qname)
-                            
+
                 elif concept.isTuple:
                     if f.contextID:
                         self.modelXbrl.error("xbrl.4.6.1:tupleContextRef",
@@ -811,14 +811,14 @@ class ValidateXbrl:
                         if attrQname.namespaceURI in (XbrlConst.xbrli, XbrlConst.link, XbrlConst.xlink, XbrlConst.xl):
                             self.modelXbrl.error("xbrl.4.9:tupleAttribute",
                                 _("Fact %(fact)s is a tuple and must not have attribute in this namespace %(attribute)s"),
-                                modelObject=f, fact=f.qname, attribute=attrQname), 
+                                modelObject=f, fact=f.qname, attribute=attrQname),
                 else:
                     self.modelXbrl.error("xbrl.4.6:notItemOrTuple",
                         _("Fact %(fact)s must be an item or tuple"),
                         modelObject=f, fact=f.qname)
-                    
+
             if isinstance(f, ModelInlineFact):
-                if not inTuple and f.order is not None: 
+                if not inTuple and f.order is not None:
                     self.modelXbrl.error(ixMsgCode("tupleOrder", f, sect="validation"),
                         _("Fact %(fact)s must not have an order (%(order)s) unless in a tuple"),
                         modelObject=f, fact=f.qname, order=f.order)
@@ -831,18 +831,18 @@ class ValidateXbrl:
                 self.checkFacts(f.modelTupleFacts, inTuple=inTuple)
             if isinstance(f, ModelInlineFact) and (f.isTuple or f.tupleID):
                 del inTuple[f.qname]
-             
-            # uncomment if anybody uses this   
+
+            # uncomment if anybody uses this
             #for pluginXbrlMethod in pluginClassMethods("Validate.XBRL.Fact"):
             #    pluginXbrlMethod(self, f)
-                
+
     def checkFactsDimensions(self, facts): # check fact dimensions in document order
         for f in facts:
             if f.concept is not None and (f.concept.isItem and f.context is not None):
                 ValidateXbrlDimensions.checkFact(self, f)
             elif f.modelTupleFacts:
                 self.checkFactsDimensions(f.modelTupleFacts)
-                
+
     def checkIxTupleContent(self, tf, parentTuples):
         if tf.isNil:
             if tf.modelTupleFacts:
@@ -854,14 +854,14 @@ class ValidateXbrl:
                 self.modelXbrl.error("ix:tupleContent",
                     _("Inline XBRL non-nil tuple requires content: ix:fraction, ix:nonFraction, ix:nonNumeric or ix:tuple"),
                     modelObject=tf)
-        tfTarget = tf.get("target") 
+        tfTarget = tf.get("target")
         prevTupleFact = None
         for f in tf.modelTupleFacts:
             if f.qname in parentTuples:
                 self.modelXbrl.error("ix:tupleRecursion",
                     _("Fact %(fact)s is recursively nested in tuple %(tuple)s"),
                     modelObject=(f, parentTuples[f.qname]), fact=f.qname, tuple=tf.qname)
-            if f.order is None: 
+            if f.order is None:
                 self.modelXbrl.error("ix:tupleOrder",
                     _("Fact %(fact)s missing an order in tuple %(tuple)s"),
                     modelObject=f, fact=f.qname, tuple=tf.qname)
@@ -871,12 +871,12 @@ class ValidateXbrl:
                     modelObject=(tf, f), fact=f.qname, tuple=tf.qname, factTarget=f.get("target"), tupleTarget=tfTarget)
             if prevTupleFact is None:
                 prevTupleFact = f
-            elif (prevTupleFact.order == f.order and 
+            elif (prevTupleFact.order == f.order and
                   XmlUtil.collapseWhitespace(prevTupleFact.textValue) == XmlUtil.collapseWhitespace(f.textValue)):
                 self.modelXbrl.error("ix:tupleContentDuplicate",
                     _("Inline XBRL at order %(order)s has non-matching content %(value)s"),
                     modelObject=(prevTupleFact, f), order=f.order, value=prevTupleFact.textValue.strip())
-                
+
     def checkContexts(self, contexts):
         for cntx in contexts:
             if cntx.isStartEndPeriod:
@@ -899,7 +899,7 @@ class ValidateXbrl:
                         modelObject=cntx, contextID=cntx.id, error=err)
             self.segmentScenario(cntx.segment, cntx.id, "segment", "4.7.3.2")
             self.segmentScenario(cntx.scenario, cntx.id, "scenario", "4.7.4")
-            
+
             for dim in cntx.qnameDims.values():
                 if dim.isTyped:
                     typedMember = dim.typedMember
@@ -920,12 +920,12 @@ class ValidateXbrl:
                                 self.modelXbrl.error("dtre:prefixedContentType",
                                     _("Context %(contextID)s dimension %(dim)s must not have an unrecognized subtype of dtr:prefixedContentType."),
                                     modelObject=typedMember, dim=typedMember.qname, contextID=cntx.id, value=typedMember.xValue[:200])
-                         
-                
+
+
     def checkContextsDimensions(self, contexts):
         for cntx in contexts:
             ValidateXbrlDimensions.checkContext(self,cntx)
-        
+
     def checkUnits(self, units):
         for unit in units:
             mulDivMeasures = unit.measures
@@ -941,9 +941,9 @@ class ValidateXbrl:
                     if numeratorMeasure in mulDivMeasures[1]:
                         self.modelXbrl.error("xbrl.4.8.4:measureBothNumDenom",
                             _("Unit %(unitID)s numerator measure: %(measure)s also appears as denominator measure"),
-                            modelObject=unit, unitID=unit.id, measure=numeratorMeasure)        
-    
-        
+                            modelObject=unit, unitID=unit.id, measure=numeratorMeasure)
+
+
     def fwdCycle(self, relsSet, rels, noUndirected, fromConcepts, cycleType="directed", revCycleRel=None):
         for rel in rels:
             if revCycleRel is not None and rel.isIdenticalTo(revCycleRel):
@@ -965,7 +965,7 @@ class ValidateXbrl:
                     foundCycle.append(rel)
                     return foundCycle
         return None
-    
+
     def revCycle(self, relsSet, toConcept, turnbackRel, fromConcepts):
         for rel in relsSet.toModelObject(toConcept):
             if not rel.isIdenticalTo(turnbackRel):
@@ -984,7 +984,7 @@ class ValidateXbrl:
                     return foundCycle
                 fromConcepts.discard(relFrom)
         return None
-    
+
     def segmentScenario(self, element, contextId, name, sect, topLevel=True):
         if topLevel:
             if element is None:
@@ -1012,16 +1012,16 @@ class ValidateXbrl:
                 _("Context %(contextID)s %(contextElement)s cannot be empty"),
                 modelObject=element, contextID=contextId, contextElement=name,
                 messageCodes=("xbrl.4.7.3.2:segmentEmpty", "xbrl.4.7.4:scenarioEmpty"))
-        
+
     def isGenericObject(self, elt, genQname):
         return self.modelXbrl.isInSubstitutionGroup(elt.qname,genQname)
-    
+
     def isGenericLink(self, elt):
         return self.isGenericObject(elt, XbrlConst.qnGenLink)
-    
+
     def isGenericArc(self, elt):
         return self.isGenericObject(elt, XbrlConst.qnGenArc)
-    
+
     def isGenericResource(self, elt):
         return self.isGenericObject(elt.getparent(), XbrlConst.qnGenLink)
 
@@ -1034,4 +1034,4 @@ class ValidateXbrl:
     def executeCallTest(self, modelXbrl, name, callTuple, testTuple):
         self.modelXbrl = modelXbrl
         ValidateFormula.executeCallTest(self, name, callTuple, testTuple)
-                
+

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -8,6 +8,7 @@ try:
     import regex as re
 except ImportError:
     import re
+from typing import Any
 from arelle import (ModelDocument, XmlUtil, XbrlUtil, XbrlConst,
                 ValidateXbrlCalcs, ValidateXbrlDimensions, ValidateXbrlDTS, ValidateFormula, ValidateUtr)
 from arelle import FunctionIxt
@@ -15,6 +16,7 @@ from arelle.ModelObject import ModelObject
 from arelle.ModelDtsObject import ModelConcept
 from arelle.ModelInstanceObject import ModelInlineFact
 from arelle.ModelValue import qname
+from arelle.ModelXbrl import ModelXbrlProtocol
 from arelle.PluginManager import pluginClassMethods
 from arelle.ValidateXbrlCalcs import inferredDecimals
 from arelle.XbrlConst import (ixbrlAll, dtrNoDecimalsItemTypes, dtrPrefixedContentItemTypes, dtrPrefixedContentTypes,
@@ -22,6 +24,9 @@ from arelle.XbrlConst import (ixbrlAll, dtrNoDecimalsItemTypes, dtrPrefixedConte
 from arelle.XhtmlValidate import ixMsgCode
 from arelle.XmlValidate import VALID
 from collections import defaultdict
+
+from typing_extensions import Protocol
+
 validateUniqueParticleAttribution = None # dynamic import
 
 arcNamesTo21Resource = {"labelArc","referenceArc"}
@@ -43,6 +48,16 @@ baseXbrliTypes = {
         "gYearItemType", "gMonthDayItemType", "gDayItemType", "gMonthItemType",
         "normalizedStringItemType", "tokenItemType", "languageItemType", "NameItemType", "NCNameItemType"
       }
+
+class ValidateXbrlProtocol(Protocol):
+    """Implements a protocol that helps typing of the ValidateXbrl class."""
+
+    @property
+    def authParam(self) -> dict[str, Any]: ...
+
+    @property
+    def modelXbrl(self) -> ModelXbrlProtocol: ...
+
 
 class ValidateXbrl:
     def __init__(self, testModelXbrl):

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -16,7 +16,7 @@ from arelle.FileSource import openFileStream
 from arelle.UrlUtil import scheme
 from arelle.ModelManager import ModelManager
 from arelle.ModelXbrl import ModelXbrl
-from arelle.ValidateXbrl import ValidateXbrlProtocol
+from arelle.ValidateXbrl import ValidateXbrl
 from typing import Any, Union, cast
 from collections.abc import Callable
 
@@ -24,7 +24,7 @@ _: Callable[[str], str]  # Handle gettext
 
 # check if a modelDocument URI is an extension URI (document URI)
 # also works on a uri passed in as well as modelObject
-def isExtension(val: ValidateXbrlProtocol, modelObject: ModelObject | str | None) -> bool:
+def isExtension(val: ValidateXbrl, modelObject: ModelObject | str | None) -> bool:
     if modelObject is None:
         return False
     if isinstance(modelObject, str):
@@ -35,7 +35,7 @@ def isExtension(val: ValidateXbrlProtocol, modelObject: ModelObject | str | None
             not any(uri.startswith(standardTaxonomyURI) for standardTaxonomyURI in val.authParam["standardTaxonomyURIs"]))
 
 # check if in core esef taxonomy (based on namespace URI)
-def isInEsefTaxonomy(val: ValidateXbrlProtocol, modelObject: ModelObject | None) -> bool:
+def isInEsefTaxonomy(val: ValidateXbrl, modelObject: ModelObject | None) -> bool:
     if modelObject is None:
         return False
     ns = modelObject.qname.namespaceURI
@@ -53,7 +53,7 @@ def checkImageContents(modelXbrl: ModelXbrl, imgElt: ModelObject, imgType: str, 
             for elt in XML(data).iter():
                 if rootElement:
                     if elt.tag != "{http://www.w3.org/2000/svg}svg":
-                        modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",  # type: ignore[no-untyped-call]
+                        modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",
                             _("Image SVG has root element which is not svg"),
                             modelObject=imgElt)
                     rootElement = False
@@ -62,19 +62,19 @@ def checkImageContents(modelXbrl: ModelXbrl, imgElt: ModelObject, imgType: str, 
                     (eltTag in ("audio", "foreignObject", "iframe", "image", "use", "video"))):
                     href = elt.get("href","")
                     if eltTag in ("object", "script") or "javascript:" in href:
-                        modelXbrl.error("ESEF.2.5.1.executableCodePresent",  # type: ignore[no-untyped-call]
+                        modelXbrl.error("ESEF.2.5.1.executableCodePresent",
                             _("Inline XBRL images MUST NOT contain executable code: %(element)s"),
                             modelObject=imgElt, element=eltTag)
                     elif scheme(href) in ("http", "https", "ftp"):  # type: ignore[no-untyped-call]
-                        modelXbrl.error("ESEF.2.5.1.referencesPointingOutsideOfTheReportingPackagePresent",  # type: ignore[no-untyped-call]
+                        modelXbrl.error("ESEF.2.5.1.referencesPointingOutsideOfTheReportingPackagePresent",
                             _("Inline XBRL instance document [image] MUST NOT contain any reference pointing to resources outside the reporting package: %(element)s"),
                             modelObject=imgElt, element=eltTag)
         except (XMLSyntaxError, UnicodeDecodeError) as err:
-            modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",  # type: ignore[no-untyped-call]
+            modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",
                 _("Image SVG has XML error %(error)s"),
                 modelObject=imgElt, error=err)
     elif not any(it in imgType for it in supportedImgTypes[isFile]):
-        modelXbrl.error("ESEF.2.5.1.imageFormatNotSupported",  # type: ignore[no-untyped-call]
+        modelXbrl.error("ESEF.2.5.1.imageFormatNotSupported",
             _("Images included in the XHTML document MUST be saved in PNG, GIF, SVG or JPEG formats: %(imgType)s is not supported"),
             modelObject=imgElt, imgType=imgType)
     else:
@@ -100,7 +100,7 @@ def checkImageContents(modelXbrl: ModelXbrl, imgElt: ModelObject, imgType: str, 
         if (("gif" in imgType and headerType != "gif") or
             (("jpg" in imgType or "jpeg" in imgType) and headerType != "jpg") or
             ("png" in imgType and headerType != "png")):
-            modelXbrl.error("ESEF.2.5.1.imageDoesNotMatchItsFileExtension" if isFile  # type: ignore[no-untyped-call]
+            modelXbrl.error("ESEF.2.5.1.imageDoesNotMatchItsFileExtension" if isFile
                             else "ESEF.2.5.1.incorrectMIMETypeSpecified",
                 _("Image type %(imgType)s has wrong header type: %(headerType)s"),
                 modelObject=imgElt, imgType=imgType, headerType=headerType,

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -16,7 +16,7 @@ from arelle.FileSource import openFileStream
 from arelle.UrlUtil import scheme
 from arelle.ModelManager import ModelManager
 from arelle.ModelXbrl import ModelXbrl
-from arelle.ValidateXbrl import ValidateXbrl
+from arelle.ValidateXbrl import ValidateXbrlProtocol
 from typing import Any, Union, cast
 from collections.abc import Callable
 
@@ -24,7 +24,7 @@ _: Callable[[str], str]  # Handle gettext
 
 # check if a modelDocument URI is an extension URI (document URI)
 # also works on a uri passed in as well as modelObject
-def isExtension(val: ValidateXbrl, modelObject: ModelObject | str | None) -> bool:
+def isExtension(val: ValidateXbrlProtocol, modelObject: ModelObject | str | None) -> bool:
     if modelObject is None:
         return False
     if isinstance(modelObject, str):
@@ -32,10 +32,10 @@ def isExtension(val: ValidateXbrl, modelObject: ModelObject | str | None) -> boo
     else:
         uri = modelObject.modelDocument.uri
     return (uri.startswith(val.modelXbrl.uriDir) or
-            not any(uri.startswith(standardTaxonomyURI) for standardTaxonomyURI in val.authParam["standardTaxonomyURIs"]))  # type: ignore[attr-defined]
+            not any(uri.startswith(standardTaxonomyURI) for standardTaxonomyURI in val.authParam["standardTaxonomyURIs"]))
 
 # check if in core esef taxonomy (based on namespace URI)
-def isInEsefTaxonomy(val: Any, modelObject: ModelObject | None) -> bool:
+def isInEsefTaxonomy(val: ValidateXbrlProtocol, modelObject: ModelObject | None) -> bool:
     if modelObject is None:
         return False
     ns = modelObject.qname.namespaceURI


### PR DESCRIPTION
#### Reason for change
This continues work on adding type hints by adding protocols implementing some properties that are being used but not defined in the `ValidateXbrl` and `ModelXbrl` classes.

#### Description of change
This PR:
- Cleans up whitespace.
- Adds missing properties on two classes.
- Implements the protocols in ESEF.Util
- Removes reduntant `type: ignore`-comments.

#### Steps to Test
Run mypy:
```
(.venv) vscode ➜ /workspaces/Arelle (add-protocol) $ mypy arelle --namespace-packages
Success: no issues found in 263 source files
```

**review**:
@Arelle/arelle
