### PR TITLE
Add basic pre-commit hook setup

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -1,0 +1,30 @@
+name: Pre-commit auto-update
+on:
+  schedule:
+    # Run on mondays
+    - cron: "0 0 * * 1"
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - name: Set up Python
+        uses: actions/setup-python@v4.2.0
+        with:
+          python-version: "3.9"
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4.0.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-autoupdate
+          title: Auto-update pre-commit hooks
+          commit-message: Auto-update pre-commit hooks
+          body: |
+            Update versions of tools in pre-commit
+            configs to latest version
+          labels: dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      # Prevent committing directly to master
+      - id: no-commit-to-branch
+        args:
+          - --branch=master
+      # Sorts entries in requirements*.txt
+      - id: requirements-txt-fixer
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: ./scripts/run-pre-commit.sh mypy --namespace-packages
+        language: script
+        types: [python]
+        require_serial: true
+        files: ^(arelle)/.+\.py$

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,18 @@
+
+-r requirements.txt
 cx_Oracle==8.3.0
-Sphinx==5.1.1
+
+lxml-stubs==0.4.0
 
 mock==4.0.3
 mypy==0.971
-pytest==7.1.2
 
-lxml-stubs==0.4.0
+pre-commit==2.20.0
+pytest==7.1.2
+Sphinx==5.1.1
 types-PyMySQL==1.0.19
 types-pytz==2022.1.2
+types-regex==2022.7.25.0
 types-simplejson==3.17.7
 types-ujson==5.4.0
-types-regex==2022.7.25.0
 types-waitress==2.1.4
-
--r requirements.txt

--- a/scripts/run-pre-commit.sh
+++ b/scripts/run-pre-commit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+exec "$@"


### PR DESCRIPTION
#### Reason for change
We discussed adding a pre-commit hook here: #268

#### Description of change
This PR:
- Adds `pre-commit` as a dev-dependency (the hook re-ordered the sort-order of the file).
- Adds a simple pre-commit config including `mypy`.
- Adds a script to run `mypy` locally.
- Adds a workflow to keep the pre-commit config up-to-date.

Closes #268.

#### Steps to Test
1: Run `pip install pre-commit`
2: Run `pre-commit install`
3: Change the order of any of the requirements file and add it using `git add requirements.txt`. Run `pre-commit run` and you will see that the pre-commit hook run fails.

If you are commiting from the master-branch, the commit should fail due to that as well.

**review**:
@Arelle/arelle
