### PR TITLE
Exclude extension concept namespaces from `supported-taxonomy` validations

### DIFF
--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -85,6 +85,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
     styleIxHiddenPattern = re.compile(r"(.*[^\w]|^)-sec-ix-hidden\s*:\s*([\w.-]+).*")
     efmRoleDefinitionPattern = re.compile(r"([0-9]+) - (Statement|Disclosure|Schedule|Document) - (.+)")
     messageKeySectionPattern = re.compile(r"(.*[{]efmSection[}]|[a-z]{2}-[0-9]{4})(.*)")
+    secDomainPattern = re.compile(r"((fasb)|(xbrl\.sec))\.((org)|(gov))")
     
     val._isStandardUri = {}
     modelXbrl.modelManager.disclosureSystem.loadStandardTaxonomiesDict()
@@ -1149,7 +1150,10 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                             if name.endswith(":*") and validation == "(supported-taxonomy)": # taxonomy-prefix filter
                                 txPrefix = name[:-2]
                                 ns = deiDefaultPrefixedNamespaces.get(txPrefix)
-                                if ns:
+                                # Its possible that extension concepts could have prefixes that match `cef` of `vip`
+                                # and trip this validation so we exclude all extension namespaces by making sure the
+                                # qname namespace matches known SEC domains.
+                                if ns and secDomainPattern.match(ns):
                                     unexpectedFacts = set()
                                     for qn, facts in modelXbrl.factsByQname.items():
                                         if qn.namespaceURI == ns:


### PR DESCRIPTION
#### Reason for change
If an extension concept has a prefix of `vip` or `cef` then EFM.6.5.55 or EFM.6.5.56 can be thrown inappropriately.

#### Description of change
Exclude extension qname namespaces if they do not match known SEC domains during the validation of EFM.6.5.55 and EFM.6.5.56.

#### Steps to Test
- Run [gaap-with-no-vip.zip](https://github.com/Arelle/Arelle/files/9311209/gaap-with-no-vip.zip) with the EFM validation plugin and verify that EFM.6.5.56 does not fire.
- Run the EFM conformance suite and verify 100% success.


**review**:
@Arelle/arelle
