### PR TITLE
Don't check hasHypercubeRelationships for None

### DIFF
--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -46,10 +46,6 @@ def checkFilingDimensions(val: ValidateXbrl) -> None:
     for hasHypercubeArcrole in (XbrlConst.all, XbrlConst.notAll):
         hasHypercubeRelationships = val.modelXbrl.relationshipSet(hasHypercubeArcrole).fromModelObjects()
 
-        # fromModelObjects() has an optional return type, we need to handle that here
-        if hasHypercubeRelationships is None:
-            continue
-
         for hasHcRels in hasHypercubeRelationships.values():
             for hasHcRel in hasHcRels:
                 sourceConcept: ModelConcept = hasHcRel.fromModelObject


### PR DESCRIPTION
#### Reason for change
This is a follow-up of https://github.com/Arelle/Arelle/pull/269#discussion_r943809386

#### Description of change
A not needed check for `None` of the `hasHypercubeRelationships` variable is removed.

#### Steps to Test

**review**:
@Arelle/arelle
