### PR TITLE
EdgarRenderer Archive Filesource

### DIFF
--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -320,6 +320,7 @@ class FileSource:
         if self.isEis and self.isOpen:
             self.eisDocument.getroot().clear() # unlink nodes
             self.eisDocument = None
+            self.isOpen = False
             self.isEis = False
         if self.isXfd and self.isOpen:
             self.xfdDocument.getroot().clear() # unlink nodes


### PR DESCRIPTION
#### Reason for change
When running EdgarRenderer from an archive filesource (here, an SEC EIS submission archive), with a referenced jpg file included, filesource was prematurely closed resulting in an exception. 

#### Description of change
In Filesource.py close(), set isOpen=false for isEis filesource
In EdgarRenderer __init__.py, notify modelXbrl to leave filesource open (for EdgarRenderer plugin finalization), and move file source.close out of loop to end of method. 

NOTE: requires [EdgarRenderer PR#41](https://github.com/Arelle/EdgarRenderer/pull/41) to also be merged.

#### Steps to Test
Try with an EIS submission archive filesource on a submission with a jpg referenced.

**review**:
@Arelle/arelle
