### PR TITLE
Add type hints to ModelValue.qname

### DIFF
--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -4,11 +4,12 @@ Created on Jan 4, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
+from __future__ import annotations
 from arelle import PythonUtil # define 2.x or 3.x string types
 import copy, datetime, isodate
 from decimal import Decimal
 from functools import total_ordering
-from typing import Optional
+from typing import Any, Optional
 
 try:
     import regex as re
@@ -16,7 +17,8 @@ except ImportError:
     import re
 XmlUtil = None
 
-def qname(value, name=None, noPrefixIsNoNamespace=False, castException=None, prefixException=None):
+def qname(value: ModelObject | str | QName | Any | None, name: str | ModelObject | None = None, noPrefixIsNoNamespace: bool = False, castException: Exception | None = None, prefixException: Exception | None = None) -> QName | None:
+    # Note: while using Any for value catches all of the other types, it adds value to know what types are expected here
     # either value can be an etree ModelObject element: if no name then qname is element tag quanem
     #     if name provided qname uses element as xmlns reference and name as prefixed name
     # value can be namespaceURI and name is localname or prefix:localname
@@ -719,5 +721,4 @@ class InvalidValue(str):
         return str.__new__(cls, value)
 
 INVALIDixVALUE = InvalidValue("(ixTransformValueError)")
-
 

--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -33,8 +33,8 @@ disallowedURIsPattern = re.compile(
 DefaultDimensionLinkroles = ("http://www.esma.europa.eu/xbrl/role/cor/ifrs-dim_role-990000",)
 LineItemsNotQualifiedLinkrole = "http://www.esma.europa.eu/xbrl/role/cor/esef_role-999999"
 
-qnDomainItemTypes = {qname("{http://www.xbrl.org/dtr/type/non-numeric}nonnum:domainItemType"), #  type: ignore[no-untyped-call]
-                     qname("{http://www.xbrl.org/dtr/type/2020-01-21}nonnum:domainItemType")} #  type: ignore[no-untyped-call]
+qnDomainItemTypes = {qname("{http://www.xbrl.org/dtr/type/non-numeric}nonnum:domainItemType"),
+                     qname("{http://www.xbrl.org/dtr/type/2020-01-21}nonnum:domainItemType")}
 
 
 linkbaseRefTypes = {

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -66,7 +66,7 @@ def checkImageContents(modelXbrl: ModelXbrl, imgElt: ModelObject, imgType: str, 
                         modelXbrl.error("ESEF.2.5.1.executableCodePresent",
                             _("Inline XBRL images MUST NOT contain executable code: %(element)s"),
                             modelObject=imgElt, element=eltTag)
-                    elif scheme(href) in ("http", "https", "ftp"):  # type: ignore[no-untyped-call]
+                    elif scheme(href) in ("http", "https", "ftp"):
                         modelXbrl.error("ESEF.2.5.1.referencesPointingOutsideOfTheReportingPackagePresent",
                             _("Inline XBRL instance document [image] MUST NOT contain any reference pointing to resources outside the reporting package: %(element)s"),
                             modelObject=imgElt, element=eltTag)

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -97,7 +97,7 @@ ixErrorPattern = re.compile(r"ix11[.]|xmlSchema[:]|(?!xbrl.5.2.5.2|xbrl.5.2.6.2)
 docTypeXhtmlPattern = re.compile(r"^<!(?:DOCTYPE\s+)\s*html(?:PUBLIC\s+)?(?:.*-//W3C//DTD\s+(X?HTML)\s)?.*>$", re.IGNORECASE)
 
 FOOTNOTE_LINK_CHILDREN = {qnLinkLoc, qnLinkFootnoteArc, qnLinkFootnote, qnIXbrl11Footnote}
-PERCENT_TYPE = qname("{http://www.xbrl.org/dtr/type/numeric}num:percentItemType") #  type: ignore[no-untyped-call]
+PERCENT_TYPE = qname("{http://www.xbrl.org/dtr/type/numeric}num:percentItemType")
 IXT_NAMESPACES = {ixtNamespaces["ixt v4"], # only tr4 or newer REC is currently recommended
                   ixtNamespaces["ixt v5"]}
 
@@ -169,7 +169,7 @@ def validateXbrlStart(val: ValidateXbrl, parameters: dict[Any, Any] | None=None,
     val.consolidated = not val.unconsolidated
     val.authority = None
     if parameters:
-        p = parameters.get(qname("authority",noPrefixIsNoNamespace=True)) #  type: ignore[no-untyped-call]
+        p = parameters.get(qname("authority",noPrefixIsNoNamespace=True))
         if p and len(p) == 2 and p[1] not in ("null", "None", None):
             v = p[1] # formula dialog and cmd line formula parameters may need type conversion
             val.authority = v
@@ -264,9 +264,9 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
         if _ifrsNses:
             _ifrsNs = _ifrsNses[0]
 
-    esefPrimaryStatementPlaceholders = set(qname(_ifrsNs, n) for n in esefPrimaryStatementPlaceholderNames) #  type: ignore[no-untyped-call]
-    esefStatementsOfMonetaryDeclaration = set(qname(_ifrsNs, n) for n in esefStatementsOfMonetaryDeclarationNames) #  type: ignore[no-untyped-call]
-    esefMandatoryElements2020 = set(qname(_ifrsNs, n) for n in esefMandatoryElementNames2020) #  type: ignore[no-untyped-call]
+    esefPrimaryStatementPlaceholders = set(qname(_ifrsNs, n) for n in esefPrimaryStatementPlaceholderNames)
+    esefStatementsOfMonetaryDeclaration = set(qname(_ifrsNs, n) for n in esefStatementsOfMonetaryDeclarationNames)
+    esefMandatoryElements2020 = set(qname(_ifrsNs, n) for n in esefMandatoryElementNames2020)
 
     if modelDocument.type == ModelDocument.Type.INSTANCE and not val.unconsolidated:
         modelXbrl.error("ESEF.I.1.instanceShallBeInlineXBRL",
@@ -1083,9 +1083,9 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                 modelObject=missingMandatoryElements, qnames=", ".join(sorted(str(qn) for qn in missingMandatoryElements)))
 
         # supplemental authority required tags
-        additionalTagQnames = set(qname(n, prefixedNamespaces) #  type: ignore[no-untyped-call]
+        additionalTagQnames = set(qname(n, prefixedNamespaces)
                                   for n in val.authParam.get("additionalMandatoryTags", ())
-                                  if qname(n, prefixedNamespaces)) #  type: ignore[no-untyped-call]
+                                  if qname(n, prefixedNamespaces))
         missingAuthorityElements = additionalTagQnames - modelXbrl.factsByQname.keys()
         if missingAuthorityElements:
             modelXbrl.warning("arelle.ESEF.missingAuthorityMandatoryMarkups",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ ignore_errors = true
 # when the library is converted, the above entry will be replaced (strict is demanded)
 [[tool.mypy.overrides]]
 module = [
-    'arelle.plugin.validate.ESEF',
+    'arelle.plugin.validate.ESEF.*',
 ]
 ignore_errors = false
 strict = true


### PR DESCRIPTION
**Reason for change**
More type hints are added.

**Description of change**
This PR:
- Adds type hints to ModelValue.qname
- Removes type: ignore referencing ModelValue.qname
- Fixes an error I made in the mypy-setting. It needs to be a .* to include all files. I believe the current file only includes the __init__.py file.

**Steps to Test**
review:
@Arelle/arelle