### PR TITLE
Move common.py to ./<repo-root>/arelle from arelle/plugin/validate/ESEF, and rename to typing.py

### DIFF
--- a/arelle/plugin/validate/ESEF/DTS.py
+++ b/arelle/plugin/validate/ESEF/DTS.py
@@ -26,7 +26,7 @@ from .Const import (qnDomainItemTypes, esefDefinitionArcroles, DefaultDimensionL
                     linkbaseRefTypes, filenamePatterns, filenameRegexes)
 from .Util import isExtension
 from arelle.ValidateXbrl import ValidateXbrl
-from .common import TypeGetText
+from arelle.typing import TypeGetText
 
 _: TypeGetText  # Handle gettext
 

--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -22,7 +22,7 @@ except ImportError:
     import re  # type: ignore[no-redef]
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.ModelDtsObject import ModelConcept
-from .common import TypeGetText
+from arelle.typing import TypeGetText
 
 _: TypeGetText  # Handle gettext
 

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -19,7 +19,7 @@ from arelle.ModelXbrl import ModelXbrl
 from arelle.ValidateXbrl import ValidateXbrl
 from typing import Any, Union, cast
 from arelle.ModelDocument import ModelDocument
-from .common import TypeGetText
+from arelle.typing import TypeGetText
 
 _: TypeGetText  # Handle gettext
 

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -73,7 +73,7 @@ from .Const import (mandatory, untransformableTypes,
 from .Dimensions import checkFilingDimensions
 from .DTS import checkFilingDTS
 from .Util import isExtension, checkImageContents, loadAuthorityValidations
-from .common import TypeGetText
+from arelle.typing import TypeGetText
 from arelle.ModelObject import ModelObject
 from arelle.DisclosureSystem import DisclosureSystem
 from arelle.ModelDtsObject import ModelConcept

--- a/arelle/typing.py
+++ b/arelle/typing.py
@@ -1,4 +1,4 @@
-"""Shared functions and type hints."""
+"""Type hints for Arelle."""
 from __future__ import annotations
 from collections.abc import Callable
 


### PR DESCRIPTION
#### Reason for change
We are going to need the contents of this file when continuing the work of adding type hints to the other validation plugins. It looks like [this](https://github.com/Arelle/Arelle/blob/8e8277fc20526ff722ad8b6f3efce60a6bcd2846/arelle/plugin/validate/ESEF/__init__.py#L114) and possibly other functions are being reused so they could be moved to `typing.py` as well.

#### Description of change
`common.py` has been moved from `arelle/plugin/validate/ESEF` to `arelle/` and renamed to `typing.py`.

#### Steps to Test

**review**:
@Arelle/arelle
