### PR TITLE
Deprecate pytest.ini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools~=62.3", "wheel~=0.37.1"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+xfail_strict = true
+
 [tool.mypy]
 # Warn when a # type: ignore comment does not specify any error codes
 enable_error_code = "ignore-without-code"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-xfail_strict=true


### PR DESCRIPTION
#### Reason for change
Removing some of the clutter in the root directory.

#### Description of change
The `pytest.ini` has been deleted and the config has been moved to `pyproject.toml`.

#### Steps to Test

**review**:
@Arelle/arelle
