### PR TITLE
Cleanup unused imports

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -179,12 +179,10 @@ class Cntlr:
                 self.userAppDir = os.path.join( impliedAppDir, "Arelle")
             if hasGui:
                 try:
-                    import win32clipboard
                     self.hasClipboard = True
                 except ImportError:
                     self.hasClipboard = False
                 try:
-                    import win32gui
                     self.hasWin32gui = True # active state for open file dialogs
                 except ImportError:
                     pass
@@ -202,7 +200,6 @@ class Cntlr:
                     self.userAppDir = os.path.join( os.path.expanduser("~/.config"), "arelle")
             if hasGui:
                 try:
-                    import gtk
                     self.hasClipboard = True
                 except ImportError:
                     self.hasClipboard = False
@@ -210,7 +207,6 @@ class Cntlr:
                 self.hasClipboard = False
             self.contextMenuClick = "<Button-3>"
         try:
-            from arelle import webserver
             self.hasWebServer = True
         except ImportError:
             self.hasWebServer = False
@@ -380,7 +376,6 @@ class Cntlr:
         :param clearAfter: Time, in ms., after which to clear the message (e.g., 5000 for 5 sec.)
         :type clearAfter: int
         """
-        pass
 
     def close(self, saveConfig=False):
         """Closes the controller and its logger, optionally saving the user preferences configuration
@@ -427,15 +422,12 @@ class Cntlr:
         :param modelXbrl: ModelXbrl (DTS) whose views are to be notified
         :type modelXbrl: ModelXbrl
         """
-        pass
 
     def rssWatchUpdateOption(self, **args):
         """Notification to change rssWatch options, as passed in, usually from a modal dialog."""
-        pass
 
     def onPackageEnablementChanged(self):
         """Notification that package enablement changed, usually from a modal dialog."""
-        pass
 
     # default web authentication password
     def internet_user_password(self, host, realm):

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -15,8 +15,7 @@ import re
 from arelle import (Cntlr, FileSource, ModelDocument, RenderingEvaluator, XmlUtil, XbrlConst, Version,
                     ViewFileDTS, ViewFileFactList, ViewFileFactTable, ViewFileConcepts,
                     ViewFileFormulae, ViewFileRelationshipSet, ViewFileTests, ViewFileRssFeed,
-                    ViewFileRoleTypes,
-                    ModelManager)
+                    ViewFileRoleTypes)
 from arelle.ModelValue import qname
 from arelle.Locale import format_string, setDisableRTL
 from arelle.ModelFormulaObject import FormulaOptions
@@ -53,7 +52,6 @@ def parseAndRun(args):
     """interface used by Main program and py.test (arelle_test.py)
     """
     try:
-        from arelle import webserver
         hasWebServer = True
     except ImportError:
         hasWebServer = False

--- a/arelle/CntlrComServer.py
+++ b/arelle/CntlrComServer.py
@@ -12,10 +12,10 @@ Future source-code plugins may possibly use this mechanism.)
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
 from arelle import PythonUtil # define 2.1 or 3.2 string types
-import gettext, time, datetime, os, shlex, sys, traceback
-from optparse import OptionParser
+import datetime
+import gettext
+import sys
 from arelle import Cntlr
-import logging
 import datetime
 
 debugging = 0
@@ -46,7 +46,6 @@ class CntlrComServer(Cntlr.Cntlr):
         print (sys.path)
         self.startedAt = datetime.datetime.now().microsecond
         self.last = "({0})".format(self.startedAt)
-        pass
 
 
     def Load(self, url):

--- a/arelle/CntlrProfiler.py
+++ b/arelle/CntlrProfiler.py
@@ -1,9 +1,7 @@
 
-import Cntlr, ModelManager, FileSource, time
-from optparse import OptionParser
+import Cntlr
+import FileSource
 import cProfile
-import gettext
-import locale
 
 def main():
     CntlrProfiler().run()

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -7,14 +7,21 @@ This module is Arelle's controller in windowing interactive UI mode
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
 from arelle import PythonUtil # define 2.x or 3.x string types
-import os, sys, subprocess, pickle, time, locale, re, fnmatch, platform
+import fnmatch
+import os
+import pickle
+import platform
+import re
+import subprocess
+import sys
+import time
 
 if sys.platform == 'win32' and getattr(sys, 'frozen', False):
     # need the .dll directory in path to be able to access Tk and Tcl DLLs efore importinng Tk, etc.
     os.environ['PATH'] = os.path.dirname(sys.executable) + ";" + os.environ['PATH']
 
-from tkinter import (Tk, Tcl, TclError, Toplevel, Menu, PhotoImage, StringVar, BooleanVar, N, S, E, W, EW,
-                     HORIZONTAL, VERTICAL, END, font as tkFont)
+from tkinter import (Tk, Tcl, TclError, Menu, PhotoImage, StringVar, BooleanVar, N, S, E, W, EW, HORIZONTAL,
+                     VERTICAL, END, font as tkFont)
 try:
     from tkinter.ttk import Frame, Button, Label, Combobox, Separator, PanedWindow, Notebook
 except ImportError:  # 3.0 versions of tkinter
@@ -27,7 +34,6 @@ import tkinter.tix
 import tkinter.filedialog
 import tkinter.messagebox, traceback
 import tkinter.simpledialog
-from arelle.FileSource import saveFile as writeToFile
 from arelle.Locale import format_string
 from arelle.CntlrWinTooltip import ToolTip
 from arelle import XbrlConst
@@ -41,16 +47,15 @@ from arelle import Cntlr
 from arelle import (DialogURL, DialogLanguage,
                     DialogPluginManager, DialogPackageManager,
                     ModelDocument,
-                    ModelManager,
                     PackageManager,
                     RenderingEvaluator,
                     TableStructure,
                     ViewWinDTS,
-                    ViewWinProperties, ViewWinConcepts, ViewWinRelationshipSet, ViewWinFormulae,
-                    ViewWinFactList, ViewFileFactList, ViewWinFactTable, ViewWinRenderedGrid, ViewWinXml,
-                    ViewWinRoleTypes, ViewFileRoleTypes, ViewFileConcepts,
-                    ViewWinTests, ViewWinTree, ViewWinVersReport, ViewWinRssFeed,
-                    ViewFileTests,
+                    ViewWinProperties,
+                    ViewWinConcepts, ViewWinRelationshipSet, ViewWinFormulae, ViewWinFactList,
+                    ViewFileFactList, ViewWinFactTable, ViewWinRenderedGrid, ViewWinXml, ViewWinRoleTypes,
+                    ViewFileRoleTypes, ViewFileConcepts, ViewWinTests,
+                    ViewWinTree, ViewWinVersReport, ViewWinRssFeed, ViewFileTests,
                     ViewFileRenderedGrid,
                     ViewFileRelationshipSet,
                     Updater

--- a/arelle/DialogArcroleGroup.py
+++ b/arelle/DialogArcroleGroup.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from ttk import Frame, Button
 import os, re
-from arelle.UiUtil import gridHdr, gridCell, gridCombobox, label, checkbox
+from arelle.UiUtil import checkbox, gridCombobox, label
 from arelle.CntlrWinTooltip import ToolTip
 from arelle import XbrlConst
 

--- a/arelle/DialogLanguage.py
+++ b/arelle/DialogLanguage.py
@@ -4,21 +4,19 @@ Created on Apr 7, 2012
 @author: Mark V Systems Limited
 (c) Copyright 2012 Mark V Systems Limited, All rights reserved.
 '''
-import os
-from tkinter import Toplevel, StringVar, N, S, E, W, EW, messagebox
+from tkinter import E, EW, N, S, Toplevel, W, messagebox
 try:
-    from tkinter.ttk import Frame, Button, Label, Entry
+    from tkinter.ttk import Button, Frame
 except ImportError:
-    from ttk import Frame, Button, Label, Entry
+    from ttk import Button, Frame
 from arelle.CntlrWinTooltip import ToolTip
 from arelle.Locale import setDisableRTL
-from arelle.UiUtil import gridHdr, gridCell, gridCombobox, label, checkbox
-import gettext
+from arelle.UiUtil import checkbox, gridCombobox, gridHdr, label
 try:
     import regex as re
 except ImportError:
     import re
-from arelle.Locale import getLanguageCodes, languageCodes, getUserLocale, availableLocales
+from arelle.Locale import availableLocales, getUserLocale, languageCodes
 
 '''
 allow user to override system language codes for user interface and labels

--- a/arelle/DialogNewFactItem.py
+++ b/arelle/DialogNewFactItem.py
@@ -15,7 +15,6 @@ except ImportError:
     import re
 from arelle.ModelInstanceObject import NewFactItemOptions
 from arelle.ModelValue import dateTime
-from arelle import XmlUtil
 from arelle.UiUtil import gridCell, gridCombobox, label
 from arelle.CntlrWinTooltip import ToolTip
 

--- a/arelle/DialogOpenArchive.py
+++ b/arelle/DialogOpenArchive.py
@@ -9,7 +9,7 @@ try:
     from tkinter.ttk import Frame, Button, Treeview, Scrollbar
 except ImportError:
     from ttk import Frame, Button, Treeview, Scrollbar
-import os, sys
+import os
 from collections import defaultdict
 try:
     import regex as re
@@ -20,7 +20,6 @@ from arelle.CntlrWinTooltip import ToolTip
 from arelle.UrlUtil import isHttpUrl
 from arelle.PackageManager import parsePackage
 from arelle.PythonUtil import attrdict
-from arelle import PluginManager
 
 '''
 caller checks accepted, if True, caller retrieves url

--- a/arelle/DialogPackageManager.py
+++ b/arelle/DialogPackageManager.py
@@ -12,7 +12,9 @@ except ImportError:
     from ttk import Treeview, Scrollbar, Frame, Label, Button
 from arelle import PackageManager, DialogURL, DialogOpenArchive
 from arelle.CntlrWinTooltip import ToolTip
-import os, time, json, sys, traceback
+import json
+import os
+import time
 try:
     import regex as re
 except ImportError:

--- a/arelle/DisclosureSystem.py
+++ b/arelle/DisclosureSystem.py
@@ -270,7 +270,6 @@ class DisclosureSystem:
             basename = os.path.basename(self.standardTaxonomiesUrl)
             self.modelManager.cntlr.showStatus(_("parsing {0}").format(basename))
             try:
-                from arelle.FileSource import openXmlFileStream
                 for filepath in (self.standardTaxonomiesUrl,
                                  os.path.join(self.modelManager.cntlr.configDir,"xbrlschemafiles.xml")):
                     xmldoc = etree.parse(filepath) # must open with file path for xinclude to know base of file

--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -4,12 +4,21 @@ Created on Oct 20, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import zipfile, tarfile, os, io, errno, base64, gzip, zlib, re, struct, random, time
+import base64
+import errno
+import gzip
+import io
+import os
+import random
+import re
+import struct
+import tarfile
+import zipfile
+import zlib
 from lxml import etree
 from arelle import XmlUtil
 from arelle import PackageManager
 from arelle.UrlUtil import isHttpUrl
-from operator import indexOf
 pluginClassMethods = None # dynamic import
 
 archivePathSeparators = (".zip" + os.sep, ".tar.gz" + os.sep, ".eis" + os.sep, ".xml" + os.sep, ".xfd" + os.sep, ".frm" + os.sep, '.taxonomyPackage.xml' + os.sep) + \
@@ -144,7 +153,6 @@ class FileSource:
                 except EnvironmentError as err:
                     if self.cntlr:
                         self.cntlr.addToLog(_("[{0}] {1}").format(type(err).__name__, err))
-                    pass
 
     def logError(self, err):
         if self.cntlr:
@@ -165,14 +173,12 @@ class FileSource:
                     self.isOpen = True
                 except EnvironmentError as err:
                     self.logError(err)
-                    pass
             elif self.isTarGz:
                 try:
                     self.fs = tarfile.open(self.basefile, "r:gz")
                     self.isOpen = True
                 except EnvironmentError as err:
                     self.logError(err)
-                    pass
             elif self.isEis:
                 # check first line of file
                 buf = b''
@@ -193,7 +199,6 @@ class FileSource:
                     file.close()
                 except EnvironmentError as err:
                     self.logError(err)
-                    pass
                 #uncomment to save for debugging
                 #with open("c:/temp/test.xml", "wb") as f:
                 #    f.write(buf)

--- a/arelle/FormulaEvaluator.py
+++ b/arelle/FormulaEvaluator.py
@@ -4,7 +4,7 @@ Created on Jan 9, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-from arelle import (XPathContext, XbrlConst, XmlUtil, XbrlUtil, XmlValidate)
+from arelle import (XPathContext, XbrlConst, XmlUtil, XbrlUtil)
 from arelle.FunctionXs import xsString
 from arelle.ModelObject import ModelObject
 from arelle.ModelFormulaObject import (aspectModels, Aspect, aspectModelAspect,
@@ -13,7 +13,6 @@ from arelle.ModelFormulaObject import (aspectModels, Aspect, aspectModelAspect,
                                  ModelFactVariable, ModelGeneralVariable, ModelVariable,
                                  ModelParameter, ModelFilter, ModelAspectCover, ModelBooleanFilter, ModelTypedDimension)
 from arelle.PrototypeInstanceObject import DimValuePrototype
-from arelle.PythonUtil import OrderedSet
 from arelle.ModelValue import (QName)
 import datetime, time, logging, re
 from decimal import Decimal
@@ -129,7 +128,6 @@ def evaluate(xpCtx, varSet, variablesInScope=False, uncoveredAspectFacts=None):
             vb.close()  # dereference
         xpCtx.varBindings.clear() # dereference
         uncoveredAspectFacts.clear()    # dereference
-        pass
 
 def evaluateVar(xpCtx, varSet, varIndex, cachedFilteredFacts, uncoveredAspectFacts):
     if varIndex == len(varSet.orderedVariableRelationships):
@@ -1285,7 +1283,6 @@ class VariableBinding:
 
     def close(self):
         self.__dict__.clear() # dereference
-        pass
 
     @property
     def resourceElementName(self):

--- a/arelle/FunctionCustom.py
+++ b/arelle/FunctionCustom.py
@@ -4,7 +4,6 @@ Created on Apr 21, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-import xml.dom, math, re
 from arelle.ModelValue import qname
 from arelle import XPathContext, XbrlUtil
 from arelle.ModelInstanceObject import ModelDimensionValue

--- a/arelle/FunctionFn.py
+++ b/arelle/FunctionFn.py
@@ -8,7 +8,7 @@ import math, re, sre_constants
 from arelle.ModelObject import ModelObject, ModelAttribute
 from arelle.ModelValue import (qname, dateTime, DateTime, DATE, DATETIME, dayTimeDuration,
                          YearMonthDuration, DayTimeDuration, time, Time)
-from arelle.FunctionUtil import anytypeArg, atomicArg, stringArg, numericArg, integerArg, qnameArg, nodeArg
+from arelle.FunctionUtil import anytypeArg, integerArg, nodeArg, numericArg, qnameArg, stringArg
 from arelle import FunctionXs, XPathContext, XbrlUtil, XmlUtil, UrlUtil, ModelDocument, XmlValidate
 from arelle.Locale import format_picture
 from arelle.XmlValidate import VALID_NO_CONTENT

--- a/arelle/FunctionIxt.py
+++ b/arelle/FunctionIxt.py
@@ -10,7 +10,6 @@ try:
     import regex as re
 except ImportError:
     import re
-from arelle.PluginManager import pluginClassMethods
 from arelle.XmlValidate import decimalPattern
 from arelle import XPathContext
 from datetime import datetime

--- a/arelle/FunctionUtil.py
+++ b/arelle/FunctionUtil.py
@@ -4,8 +4,8 @@ Created on Dec 31, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import xml.dom, datetime
-from arelle import (ModelValue, XmlUtil)
+import datetime
+from arelle import ModelValue
 from arelle.ModelObject import ModelObject, ModelAttribute
 from arelle.XPathContext import (XPathException, FunctionArgType)
 from arelle.PythonUtil import pyTypeName

--- a/arelle/FunctionXfi.py
+++ b/arelle/FunctionXfi.py
@@ -4,17 +4,18 @@ Created on Dec 20, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import xml.dom, datetime, re
+import datetime
+import re
 from arelle import XPathContext, XbrlConst, XbrlUtil, XmlUtil
 from arelle.ModelObject import ModelObject, ModelAttribute
-from arelle.ModelValue import qname, QName, dateTime, DATE, DATETIME, DATEUNION, DateTime, dateUnionEqual, anyURI
+from arelle.ModelValue import DATETIME, DateTime, QName, anyURI, dateTime, dateUnionEqual, qname
 from arelle.FunctionUtil import anytypeArg, stringArg, numericArg, qnameArg, nodeArg, atomicArg
 from arelle.ModelXbrl import ModelXbrl
 from arelle.ModelDtsObject import anonymousTypeSuffix, ModelConcept
 from arelle.ModelInstanceObject import ModelDimensionValue, ModelFact, ModelInlineFact
 from arelle.ModelFormulaObject import ModelFormulaResource
 from arelle.PythonUtil import flattenSequence
-from arelle.XmlValidate import UNKNOWN, VALID, VALID_NO_CONTENT, validate as xmlValidate, NCNamePattern
+from arelle.XmlValidate import NCNamePattern, VALID, VALID_NO_CONTENT, validate as xmlValidate
 from arelle.ValidateXbrlCalcs import inferredDecimals, inferredPrecision
 from arelle.ValidateXbrlDimensions import priItemElrHcRels
 from arelle.Locale import format_picture

--- a/arelle/FunctionXs.py
+++ b/arelle/FunctionXs.py
@@ -6,10 +6,10 @@ Created on Dec 20, 2010
 '''
 import datetime, re
 from arelle import (XPathContext, ModelValue)
-from arelle.FunctionUtil import (anytypeArg, atomicArg, stringArg, numericArg, qnameArg, nodeArg)
+from arelle.FunctionUtil import atomicArg
 from arelle.XmlValidate import lexicalPatterns
 from arelle.XPathParser import ProgHeader
-from math import isnan, fabs, isinf
+from math import isinf, isnan
 from decimal import Decimal, InvalidOperation
 
 class FORG0001(Exception):

--- a/arelle/HashUtil.py
+++ b/arelle/HashUtil.py
@@ -6,7 +6,7 @@ Created on Nov 8, 2014
 '''
 from hashlib import md5
 from arelle.ModelObject import ModelObject
-from arelle.ModelValue import QName, DateTime
+from arelle.ModelValue import QName
 from datetime import date, datetime
 from arelle import XmlUtil
 

--- a/arelle/HtmlUtil.py
+++ b/arelle/HtmlUtil.py
@@ -5,9 +5,9 @@ Created on April 14, 2011
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
 try:
-    import regex as re
+    pass
 except ImportError:
-    import re
+    pass
 
 def attrValue(str, name):
     # retrieves attribute in a string, such as xyz="abc" or xyz='abc' or xyz=abc;

--- a/arelle/InstanceAspectsEvaluator.py
+++ b/arelle/InstanceAspectsEvaluator.py
@@ -5,8 +5,7 @@ Created on May 12, 2011
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
 from collections import defaultdict
-import os, datetime
-from arelle import (ModelObject)
+import datetime
 
 def setup(view):
     relsSet = view.modelXbrl.relationshipSet(view.arcrole, view.linkrole, view.linkqname, view.arcqname)

--- a/arelle/LocalViewer.py
+++ b/arelle/LocalViewer.py
@@ -7,7 +7,7 @@ Created on Jan 14, 2020
 Provides infrastructure for local viewers of GUI applications such as inline XBRL viewers
 
 '''
-from arelle.webserver.bottle import Bottle, request, static_file, HTTPResponse
+from arelle.webserver.bottle import Bottle, HTTPResponse, request
 import threading, time, logging, sys, traceback
 
 class LocalViewer:

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -504,7 +504,7 @@ def atoi(conv, str):
     return atof(conv, str, _INT)
 
 # decimal formatting
-from decimal import getcontext, Decimal
+from decimal import Decimal
 
 def format_picture(conv, value, picture):
     monetary = False

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -60,10 +60,8 @@ validation.
 from __future__ import annotations
 from collections import defaultdict
 import os, sys
-from lxml import etree
 import decimal
-from arelle import (XmlUtil, XbrlConst, XbrlUtil, UrlUtil, Locale, ModelValue, XmlValidate)
-from arelle.XmlValidate import UNVALIDATED, VALID
+from arelle import (XmlUtil, XbrlConst, XbrlUtil, Locale, ModelValue, XmlValidate)
 from arelle.ModelObject import ModelObject
 
 ModelFact = None

--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -32,8 +32,7 @@
     measure sets.
 """
 from collections import defaultdict
-from lxml import etree
-from arelle import XmlUtil, XbrlConst, XbrlUtil, UrlUtil, Locale, ModelValue
+from arelle import Locale, ModelValue, XbrlConst, XbrlUtil, XmlUtil
 from arelle.ValidateXbrlCalcs import inferredPrecision, inferredDecimals, roundValue, rangeValue
 from arelle.XmlValidate import UNVALIDATED, INVALID, VALID, validate as xmlValidate
 from arelle.PrototypeInstanceObject import DimValuePrototype
@@ -41,7 +40,7 @@ from math import isnan, isinf
 from arelle.ModelObject import ModelObject
 from decimal import Decimal, InvalidOperation
 from hashlib import md5
-from arelle.HashUtil import md5hash, Md5Sum
+from arelle.HashUtil import md5hash
 
 Aspect = None
 Type = None

--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -6,7 +6,6 @@ Refactored on Jun 11, 2011 to ModelDtsObject, ModelInstanceObject, ModelTestcase
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
 from lxml import etree
-from collections import namedtuple
 from arelle import Locale
 XmlUtil = None
 VALID_NO_CONTENT = None

--- a/arelle/ModelObjectFactory.py
+++ b/arelle/ModelObjectFactory.py
@@ -19,10 +19,6 @@ from arelle.ModelDtsObject import (ModelConcept, ModelAttribute, ModelAttributeG
 ModelDocument = ModelFact = None # would be circular imports, resolve at first use after static loading
 from arelle.ModelRssItem import ModelRssItem
 from arelle.ModelTestcaseObject import ModelTestcaseVariation
-from arelle.ModelVersObject import (ModelAssignment, ModelAction, ModelNamespaceRename,
-                                    ModelRoleChange, ModelVersObject, ModelConceptUseChange,
-                                    ModelConceptDetailsChange, ModelRelationshipSetChange,
-                                    ModelRelationshipSet, ModelRelationships)
 
 def parser(modelXbrl, baseUrl, target=None):
     moduleObject_init() # init ModelObject globals

--- a/arelle/ModelRenderingObject.py
+++ b/arelle/ModelRenderingObject.py
@@ -5,7 +5,7 @@ Created on Mar 7, 2011
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
 import inspect, os
-from arelle import XmlUtil, XbrlConst, XPathParser, Locale, XPathContext
+from arelle import XPathContext, XPathParser, XbrlConst, XmlUtil
 from arelle.ModelDtsObject import ModelResource
 from arelle.ModelInstanceObject import ModelDimensionValue
 from arelle.ModelValue import qname, QName

--- a/arelle/ModelRssObject.py
+++ b/arelle/ModelRssObject.py
@@ -4,7 +4,6 @@ Created on Nov 11, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import os
 from arelle import XmlUtil
 from arelle.ModelDocument import ModelDocument, Type
 

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -6,7 +6,8 @@ Created on Jan 4, 2011
 '''
 from __future__ import annotations
 from arelle import PythonUtil # define 2.x or 3.x string types
-import copy, datetime, isodate
+import datetime
+import isodate
 from decimal import Decimal
 from functools import total_ordering
 from typing import Any, Optional

--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -18,7 +18,7 @@ if sys.version[0] >= '3':
 else:
     from urlparse import urljoin
 openFileSource = None
-from arelle import Locale
+from arelle import Locale, XmlUtil # Node 2022-08-23: XmlUtil import required for tests to work
 from arelle.UrlUtil import isAbsolute
 from arelle.XmlValidate import lxmlResolvingParser
 ArchiveFileIOError = None

--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -4,7 +4,12 @@ Separated on Jul 28, 2013 from DialogOpenArchive.py
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import sys, os, io, re, time, json, logging
+import io
+import json
+import logging
+import os
+import sys
+import time
 from collections import defaultdict
 from fnmatch import fnmatch
 from lxml import etree
@@ -13,7 +18,7 @@ if sys.version[0] >= '3':
 else:
     from urlparse import urljoin
 openFileSource = None
-from arelle import Locale, XmlUtil
+from arelle import Locale
 from arelle.UrlUtil import isAbsolute
 from arelle.XmlValidate import lxmlResolvingParser
 ArchiveFileIOError = None

--- a/arelle/PrototypeDtsObject.py
+++ b/arelle/PrototypeDtsObject.py
@@ -1,5 +1,4 @@
-from arelle import XmlUtil, XbrlConst
-from arelle.ModelValue import QName
+from arelle import XbrlConst
 from arelle.XmlValidate import VALID
 from collections import defaultdict
 import decimal, os

--- a/arelle/RenderingEvaluator.py
+++ b/arelle/RenderingEvaluator.py
@@ -6,10 +6,8 @@ Created on Jun 6, 2012
 '''
 from arelle import XPathContext, XbrlConst, XmlUtil
 from arelle.ModelFormulaObject import (aspectModels, aspectStr, Aspect)
-from arelle.ModelRenderingObject import (CHILD_ROLLUP_FIRST, CHILD_ROLLUP_LAST,
-                                         ModelDefinitionNode, ModelEuAxisCoord,
-                                         ModelBreakdown,
-                                         ModelClosedDefinitionNode,
+from arelle.ModelRenderingObject import (ModelDefinitionNode, ModelEuAxisCoord,
+                                         ModelBreakdown, ModelClosedDefinitionNode,
                                          ModelRuleDefinitionNode,
                                          ModelFilterDefinitionNode,
                                          ModelDimensionRelationshipDefinitionNode)

--- a/arelle/RenderingResolver.py
+++ b/arelle/RenderingResolver.py
@@ -4,7 +4,8 @@ Created on Sep 13, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-import os, io, sys, json
+import os
+import sys
 from collections import defaultdict
 from arelle import XbrlConst
 from arelle.ModelObject import ModelObject
@@ -16,8 +17,7 @@ from arelle.ModelRenderingObject import (ModelEuTable, ModelTable, ModelBreakdow
                                          ModelRelationshipDefinitionNode, ModelSelectionDefinitionNode, ModelFilterDefinitionNode,
                                          ModelConceptRelationshipDefinitionNode, ModelDimensionRelationshipDefinitionNode,
                                          ModelCompositionDefinitionNode, ModelTupleDefinitionNode, StructuralNode,
-                                         ROLLUP_NOT_ANALYZED, CHILDREN_BUT_NO_ROLLUP, CHILD_ROLLUP_FIRST, CHILD_ROLLUP_LAST,
-                                         OPEN_ASPECT_ENTRY_SURROGATE)
+                                         ROLLUP_NOT_ANALYZED, CHILD_ROLLUP_FIRST, CHILD_ROLLUP_LAST, OPEN_ASPECT_ENTRY_SURROGATE)
 from arelle.PrototypeInstanceObject import FactPrototype
 from arelle.XPathContext import XPathException
 

--- a/arelle/TableStructure.py
+++ b/arelle/TableStructure.py
@@ -8,8 +8,8 @@ try:
     import regex as re
 except ImportError:
     import re
-from collections import defaultdict
-import os, io, json
+import json
+import os
 from datetime import datetime, timedelta
 from arelle import XbrlConst
 from arelle.ModelDtsObject import ModelConcept

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -4,7 +4,9 @@ Created on May 30, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-import tkinter.messagebox, webbrowser, os, threading
+import os
+import threading
+import tkinter.messagebox
 
 def checkForUpdates(cntlr):
     if not cntlr.webCache.workOffline:
@@ -29,7 +31,7 @@ def backgroundCheckForUpdates(cntlr):
 def checkUpdateUrl(cntlr, attachmentFileName):
     # get latest header file
     try:
-        from arelle import WebCache, Version
+        from arelle import Version
         filename = os.path.basename(attachmentFileName)
         if filename and "-20" in filename:
             i = filename.index("-20") + 1

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -4,11 +4,13 @@ Created on Oct 17, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import os, sys, traceback, re, logging
+import logging
+import os
+import re
 from collections import defaultdict, OrderedDict
-from arelle import (FileSource, ModelXbrl, ModelDocument, ModelVersReport, XbrlConst,
-               ValidateXbrl, ValidateVersReport, ValidateFormula,
-               ValidateInfoset, RenderingEvaluator, ViewFileRenderedGrid, UrlUtil)
+from arelle import (FileSource, ModelXbrl, ModelVersReport, XbrlConst, ValidateXbrl,
+               ValidateVersReport, ValidateFormula, ValidateInfoset,
+               RenderingEvaluator, ViewFileRenderedGrid, UrlUtil)
 from arelle.ModelDocument import Type, ModelDocumentReference, load as modelDocumentLoad
 from arelle.ModelDtsObject import ModelResource
 from arelle.ModelInstanceObject import ModelFact
@@ -17,7 +19,7 @@ from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelTestcaseObject import testcaseVariationsByTarget
 from arelle.ModelValue import (qname, QName)
 from arelle.PluginManager import pluginClassMethods
-from arelle.XmlUtil import collapseWhitespace, xmlstring
+from arelle.XmlUtil import collapseWhitespace
 
 def validate(modelXbrl):
     validate = Validate(modelXbrl)

--- a/arelle/ValidateFilingText.py
+++ b/arelle/ValidateFilingText.py
@@ -8,7 +8,6 @@ Created on Oct 17, 2010
 from lxml.etree import XML, DTD, SubElement, _ElementTree, _Comment, _ProcessingInstruction, XMLSyntaxError, XMLParser
 import os, re, io, base64
 from arelle.XbrlConst import ixbrlAll, xhtml
-from arelle.XmlUtil import setXmlns, xmlstring
 from arelle.ModelObject import ModelObject
 from arelle.UrlUtil import isHttpUrl, scheme
 

--- a/arelle/ValidateFormula.py
+++ b/arelle/ValidateFormula.py
@@ -4,7 +4,9 @@ Created on Dec 9, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import os, sys, time, logging, re
+import logging
+import re
+import time
 from collections import defaultdict
 from threading import Timer
 
@@ -16,7 +18,6 @@ from arelle.ModelFormulaObject import (ModelParameter, ModelInstance, ModelVaria
                                        Aspect, aspectModels, ModelAspectCover,
                                        ModelMessage)
 from arelle.ModelRenderingObject import (ModelRuleDefinitionNode, ModelRelationshipDefinitionNode, ModelFilterDefinitionNode)
-from arelle.ModelObject import (ModelObject)
 from arelle.ModelValue import (qname,QName)
 from arelle.PluginManager import pluginClassMethods
 from arelle.PythonUtil import normalizeSpace

--- a/arelle/ValidateVersReport.py
+++ b/arelle/ValidateVersReport.py
@@ -4,7 +4,7 @@ Created on Nov 9, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-from arelle import ModelVersObject, XbrlConst, ValidateXbrl, ModelDocument
+from arelle import ModelVersObject, ValidateXbrl, XbrlConst
 from arelle.ModelValue import qname
 
 conceptAttributeEventAttributes = {

--- a/arelle/ViewFileDTS.py
+++ b/arelle/ViewFileDTS.py
@@ -4,7 +4,6 @@ Created on Oct 5, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import os
 from arelle import ViewFile
 
 def viewDTS(modelXbrl, outfile):

--- a/arelle/ViewFileFactList.py
+++ b/arelle/ViewFileFactList.py
@@ -5,7 +5,6 @@ Created on Jan 10, 2011
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
 from arelle import ViewFile, XbrlConst, XmlUtil
-from collections import defaultdict
 
 def viewFacts(modelXbrl, outfile, lang=None, labelrole=None, cols=None):
     modelXbrl.modelManager.showStatus(_("viewing facts"))

--- a/arelle/ViewFileFactTable.py
+++ b/arelle/ViewFileFactTable.py
@@ -6,7 +6,7 @@ Created on Jan 24, 2011
 '''
 from arelle import ViewFile, ModelDtsObject, XbrlConst, XmlUtil
 from arelle.XbrlConst import conceptNameLabelRole, standardLabel, terseLabel, documentationLabel
-from arelle.ViewFile import CSV, XLSX, HTML, XML, JSON
+from arelle.ViewFile import CSV, HTML, XLSX
 import datetime, re
 from collections import defaultdict
 

--- a/arelle/ViewFileFormulae.py
+++ b/arelle/ViewFileFormulae.py
@@ -4,11 +4,9 @@ Created on Nov 27, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-from arelle import ModelObject, XbrlConst, ViewFile
-from arelle.ModelDtsObject import ModelRelationship
+from arelle import ViewFile, XbrlConst
 from arelle.ModelFormulaObject import ModelParameter, ModelVariable, ModelVariableSetAssertion, ModelConsistencyAssertion
 from arelle.ViewUtilFormulae import rootFormulaObjects, formulaObjSortKey
-import os
 
 def viewFormulae(modelXbrl, outfile, header, lang=None):
     modelXbrl.modelManager.showStatus(_("viewing formulae"))

--- a/arelle/ViewFileRelationshipSet.py
+++ b/arelle/ViewFileRelationshipSet.py
@@ -4,9 +4,9 @@ Created on Oct 6, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-from arelle import ModelObject, ModelDtsObject, XbrlConst, XmlUtil, ViewFile
+from arelle import ModelDtsObject, ViewFile, XbrlConst, XmlUtil
 from arelle.ModelDtsObject import ModelRelationship
-from arelle.ViewFile import NOOUT, CSV, XLSX, HTML, XML, JSON
+from arelle.ViewFile import CSV, JSON, XML
 from arelle.ViewUtil import viewReferences
 from arelle.XbrlConst import conceptNameLabelRole, documentationLabel, widerNarrower
 from arelle.ModelRenderingObject import ModelEuAxisCoord, ModelRuleDefinitionNode

--- a/arelle/ViewFileRenderedGrid.py
+++ b/arelle/ViewFileRenderedGrid.py
@@ -10,7 +10,7 @@ from lxml import etree
 from arelle.RenderingResolver import resolveAxesStructure, RENDER_UNITS_PER_CHAR
 from arelle.ViewFile import HTML, XML
 from arelle.ModelObject import ModelObject
-from arelle.ModelFormulaObject import Aspect, aspectModels, aspectRuleAspects, aspectModelAspect, aspectStr
+from arelle.ModelFormulaObject import Aspect, aspectModelAspect, aspectModels, aspectStr
 from arelle.FormulaEvaluator import aspectMatches
 from arelle.FunctionXs import xsString
 from arelle.ModelInstanceObject import ModelDimensionValue
@@ -25,7 +25,7 @@ from arelle.XbrlConst import (tableModelMMDD as tableModelNamespace,
                               tableModelMMDDQName as tableModelQName)
 '''
 from arelle import XbrlConst
-from arelle.XmlUtil import innerTextList, child, elementFragmentIdentifier, addQnameValue
+from arelle.XmlUtil import addQnameValue, elementFragmentIdentifier, innerTextList
 from collections import defaultdict
 
 emptySet = set()

--- a/arelle/ViewFileRoleTypes.py
+++ b/arelle/ViewFileRoleTypes.py
@@ -4,10 +4,7 @@ Created on Aug 8, 2013
 @author: Mark V Systems Limited
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
-from arelle import ModelObject, ModelDtsObject, XbrlConst, XmlUtil, ViewFile
-from arelle.ModelDtsObject import ModelRelationship
-from arelle.ViewUtil import viewReferences
-import os
+from arelle import ViewFile
 
 def viewRoleTypes(modelXbrl, outfile, header, isArcrole=False, lang=None):
     modelXbrl.modelManager.showStatus(_("viewing arcrole types") if isArcrole else _("viewing role types"))

--- a/arelle/ViewFileRssFeed.py
+++ b/arelle/ViewFileRssFeed.py
@@ -5,7 +5,6 @@ Created on Apr 5, 2013
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
 from arelle import ModelDocument, ViewFile
-import os
 
 def viewRssFeed(modelXbrl, outfile, cols):
     modelXbrl.modelManager.showStatus(_("viewing RSS feed"))

--- a/arelle/ViewWinDiffs.py
+++ b/arelle/ViewWinDiffs.py
@@ -4,8 +4,6 @@ Created on Mar 21, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-from collections import defaultdict
-import os
 from tkinter import *
 try:
     from tkinter.ttk import *

--- a/arelle/ViewWinFactGrid.py
+++ b/arelle/ViewWinFactGrid.py
@@ -5,11 +5,11 @@ Created on May 12, 2011
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
 import datetime
-from tkinter import Menu, constants, BooleanVar
-from arelle import ViewWinGrid, ModelObject, XbrlConst
+from tkinter import BooleanVar, Menu
+from arelle import ViewWinGrid, XbrlConst
 from arelle.UiUtil import (gridBorder, gridSpacer, gridHdr, gridCell, gridCombobox,
-                     label, checkbox,
-                     TOPBORDER, LEFTBORDER, RIGHTBORDER, BOTTOMBORDER, CENTERCELL)
+                     TOPBORDER, LEFTBORDER,
+                     RIGHTBORDER, BOTTOMBORDER, CENTERCELL)
 from collections import defaultdict
 
 def viewFactsGrid(modelXbrl, tabWin, header="Fact Grid", arcrole=XbrlConst.parentChild, linkrole=None, linkqname=None, arcqname=None, lang=None):

--- a/arelle/ViewWinFactTable.py
+++ b/arelle/ViewWinFactTable.py
@@ -6,7 +6,7 @@ Created on Nov 15, 2010
 '''
 from collections import defaultdict
 import os, datetime, re
-from tkinter import Menu, constants, BooleanVar
+from tkinter import BooleanVar, Menu
 from arelle import ViewWinTree, ModelDtsObject, ModelInstanceObject, XbrlConst, XmlUtil
 from arelle.XbrlConst import conceptNameLabelRole
 

--- a/arelle/ViewWinFormulae.py
+++ b/arelle/ViewWinFormulae.py
@@ -5,10 +5,9 @@ Created on Dec 6, 2010
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
 from collections import defaultdict
-import os
-from arelle import ViewWinTree, ModelObject, XbrlConst
-from arelle.ModelFormulaObject import (ModelParameter, ModelVariable, ModelVariableSet,
-                                       ModelVariableSetAssertion, ModelConsistencyAssertion)
+from arelle import ViewWinTree, XbrlConst
+from arelle.ModelFormulaObject import (ModelParameter, ModelVariable, ModelVariableSetAssertion,
+                                       ModelConsistencyAssertion)
 from arelle.ModelDtsObject import ModelRelationship
 from arelle.ViewUtilFormulae import rootFormulaObjects, formulaObjSortKey
 

--- a/arelle/ViewWinList.py
+++ b/arelle/ViewWinList.py
@@ -4,14 +4,12 @@ Created on Feb 6, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-import io
 from tkinter import *
 try:
     from tkinter.ttk import *
 except ImportError:
     from ttk import *
 from arelle.CntlrWinTooltip import ToolTip
-from arelle import XmlUtil
 
 class ViewList():
     def __init__(self, modelXbrl, tabWin, tabTitle, hasToolTip=False):

--- a/arelle/ViewWinProperties.py
+++ b/arelle/ViewWinProperties.py
@@ -4,8 +4,7 @@ Created on Oct 5, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-from arelle import (ViewWinTree, ModelObject)
-from tkinter import TRUE
+from arelle import ViewWinTree
 
 def viewProperties(modelXbrl, tabWin):
     modelXbrl.modelManager.showStatus(_("viewing properties"))

--- a/arelle/ViewWinRelationshipSet.py
+++ b/arelle/ViewWinRelationshipSet.py
@@ -6,10 +6,8 @@ Created on Oct 6, 2010
 '''
 from collections import defaultdict
 import os
-from arelle import ViewWinTree, ModelDtsObject, ModelInstanceObject, ModelRenderingObject, XbrlConst, XmlUtil, Locale
-from arelle.ModelRelationshipSet import ModelRelationshipSet
+from arelle import Locale, ModelDtsObject, ModelInstanceObject, ModelRenderingObject, ViewWinTree, XbrlConst
 from arelle.ModelDtsObject import ModelRelationship
-from arelle.ModelFormulaObject import ModelFilter
 from arelle.ViewUtil import viewReferences, groupRelationshipSet, groupRelationshipLabel
 from arelle.XbrlConst import conceptNameLabelRole, documentationLabel, widerNarrower
 

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -5,7 +5,9 @@ Created on Oct 5, 2010
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 
 '''
-import os, threading, time, logging
+import os
+import threading
+import time
 from tkinter import Menu, BooleanVar, font as tkFont
 from arelle import (ViewWinTkTable, ModelDocument, ModelDtsObject, ModelInstanceObject, XbrlConst,
                     ModelXbrl, Locale, FunctionXfi,

--- a/arelle/ViewWinRoleTypes.py
+++ b/arelle/ViewWinRoleTypes.py
@@ -5,7 +5,7 @@ Created on Aug 8, 2013
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
 from collections import defaultdict
-from arelle import ViewWinTree, ModelDtsObject, XbrlConst, XmlUtil, Locale
+from arelle import ModelDtsObject, ViewWinTree
 
 def viewRoleTypes(modelXbrl, tabWin, isArcrole=False, lang=None):
     modelXbrl.modelManager.showStatus(_("viewing arcrole types") if isArcrole else _("viewing role types"))

--- a/arelle/ViewWinRssFeed.py
+++ b/arelle/ViewWinRssFeed.py
@@ -9,8 +9,7 @@ try:
     from tkinter.ttk import *
 except ImportError:
     from ttk import *
-import os
-from arelle import (ViewWinTree, ModelDocument)
+from arelle import ViewWinTree
 
 def viewRssFeed(modelXbrl, tabWin):
     view = ViewRssFeed(modelXbrl, tabWin)

--- a/arelle/ViewWinTree.py
+++ b/arelle/ViewWinTree.py
@@ -235,7 +235,6 @@ class ViewTree:
                 if menulabel is None: menulabel = _("Name Style")
                 nameStyleMenu = Menu(self.viewFrame, tearoff=0)
                 self.menu.add_cascade(label=menulabel, menu=nameStyleMenu, underline=0)
-                from arelle.ModelRelationshipSet import labelroles
                 nameStyleMenu.add_command(label=_("Prefixed"), underline=0, command=lambda a=True: self.setNamestyle(a))
                 nameStyleMenu.add_command(label=_("No prefix"), underline=0, command=lambda a=False: self.setNamestyle(a))
             except Exception as ex: # tkinter menu problem maybe

--- a/arelle/ViewWinTupleGrid.py
+++ b/arelle/ViewWinTupleGrid.py
@@ -6,8 +6,8 @@ Created on May 12, 2011
 '''
 from arelle import (ViewWinGrid, )
 from arelle.UiUtil import (gridBorder, gridSpacer, gridHdr, gridCell,
-                     label,
-                     TOPBORDER, LEFTBORDER, RIGHTBORDER, BOTTOMBORDER, CENTERCELL)
+                     TOPBORDER,
+                     LEFTBORDER, RIGHTBORDER, BOTTOMBORDER, CENTERCELL)
 
 def viewTuplesGrid(modelXbrl, tabWin, tupleObjectId, lang=None):
     modelTuple = modelXbrl.modelObject(tupleObjectId)

--- a/arelle/ViewWinXml.py
+++ b/arelle/ViewWinXml.py
@@ -9,7 +9,6 @@ try:
     from tkinter.ttk import *
 except ImportError:
     from ttk import *
-from arelle.CntlrWinTooltip import ToolTip
 import io
 from arelle import (XmlUtil, ViewWinList)
 
@@ -35,7 +34,6 @@ class ViewXml(ViewWinList.ViewList):
     def validate(self):
         try:
             from arelle import Validate
-            import traceback
             Validate.validate(self.modelXbrl)
         except Exception as err:
             self.modelXbrl.exception("exception", _("Validation exception: \s%(error)s"), error=err, exc_info=True)

--- a/arelle/WatchRss.py
+++ b/arelle/WatchRss.py
@@ -4,14 +4,11 @@ Created on Oct 17, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import os, sys, traceback, re
-from arelle import (ModelXbrl, XmlUtil, ModelVersReport, XbrlConst, ModelDocument,
-               ValidateXbrl, ValidateFormula)
+import re
+from arelle import (ModelXbrl, XmlUtil, ModelDocument, ValidateXbrl, ValidateFormula)
 from arelle.FileSource import openFileSource
-from arelle.ModelValue import (qname, QName)
 from arelle.PluginManager import pluginClassMethods
 from arelle.UrlUtil import parseRfcDatetime
-import datetime
 
 def initializeWatcher(modelXbrl):
     return WatchRss(modelXbrl)

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -13,7 +13,6 @@ if sys.version[0] >= '3':
     from urllib.parse import quote, unquote
     from urllib.error import URLError, HTTPError, ContentTooShortError
     from http.client import IncompleteRead
-    from urllib import request
     from urllib import request as proxyhandlers
 else: # python 2.7.2
     from urllib import quote, unquote

--- a/arelle/XPathContext.py
+++ b/arelle/XPathContext.py
@@ -16,7 +16,6 @@ from arelle.PluginManager import pluginClassMethods
 from arelle.PrototypeDtsObject import PrototypeObject, PrototypeElementTree
 from decimal import Decimal, InvalidOperation
 from lxml import etree
-from types import LambdaType
 
 # deferred types initialization
 boolean = None

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -13,14 +13,14 @@ if sys.version[0] >= '3':
     # python 3 requires modified parser to allow release of global objects when closing DTS
     from arelle.pyparsing.pyparsing_py3 import (Word, Keyword, alphas, ParseException, ParseSyntaxException,
                  Literal, CaselessLiteral,
-                 Combine, Optional, nums, Or, Forward, Group, ZeroOrMore, StringEnd, alphanums,
-                 ParserElement, quotedString, delimitedList, Suppress, Regex)
+                 Combine, Optional, nums, Forward, Group, ZeroOrMore, StringEnd, alphanums, ParserElement,
+                 quotedString, delimitedList, Suppress, Regex)
 else:
     # installed for python 2.7 and clean packages, otherwise use tweaked version
     from arelle.pyparsing.pyparsing_py2 import (Word, Keyword, alphas, ParseException, ParseSyntaxException,
                  Literal, CaselessLiteral,
-                 Combine, Optional, nums, Or, Forward, Group, ZeroOrMore, StringEnd, alphanums,
-                 ParserElement, quotedString, delimitedList, Suppress, Regex)
+                 Combine, Optional, nums, Forward, Group, ZeroOrMore, StringEnd, alphanums, ParserElement,
+                 quotedString, delimitedList, Suppress, Regex)
 from arelle.Locale import format_string
 import time, xml.dom, traceback
 from decimal import Decimal

--- a/arelle/XbrlUtil.py
+++ b/arelle/XbrlUtil.py
@@ -4,9 +4,8 @@ Created on Nov 26, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import xml.dom.minidom, math
-from arelle import XbrlConst, XmlUtil
-from arelle.ModelValue import qname, QName, DateTime
+import math
+from arelle.ModelValue import DateTime, QName
 from arelle.ModelObject import ModelObject, ModelAttribute
 from arelle.XmlValidate import UNKNOWN, VALID, VALID_ID, validate as xmlValidate
 

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -11,7 +11,7 @@ except ImportError:
     import re
 from lxml import etree
 from arelle.XbrlConst import ixbrlAll, qnLinkFootnote, xhtml, xml, xsd, xhtml
-from arelle.ModelObject import ModelObject, ModelComment
+from arelle.ModelObject import ModelObject
 from arelle.ModelValue import qname, QName, tzinfoStr
 from arelle.PrototypeDtsObject import PrototypeElementTree, PrototypeObject
 htmlEltUriAttrs = resolveHtmlUri = None

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -4,7 +4,7 @@ Created on Feb 20, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-import os, logging
+import logging
 from lxml import etree
 try:
     from regex import compile as re_compile

--- a/arelle/XmlValidateParticles.py
+++ b/arelle/XmlValidateParticles.py
@@ -4,11 +4,8 @@ Created on Jan 20, 2012
 @author: Mark V Systems Limited
 (c) Copyright 2012 Mark V Systems Limited, All rights reserved.
 '''
-from lxml import etree
-from arelle.ModelDtsObject import (ModelConcept, ModelType, ModelGroupDefinition,
-                                   ModelAll, ModelChoice, ModelSequence,
-                                   ModelAny, anonymousTypeSuffix)
-from arelle.ModelObject import ModelObject, ModelAttribute
+from arelle.ModelDtsObject import (ModelConcept, ModelType, ModelAll,
+                                   ModelChoice, ModelAny, anonymousTypeSuffix)
 from arelle.XbrlConst import xsd
 from arelle.XmlValidate import validate
 

--- a/arelle/XmlValidateSchema.py
+++ b/arelle/XmlValidateSchema.py
@@ -4,13 +4,9 @@ Created on Apr 10, 2013
 @author: Mark V Systems Limited
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
-import time
-from arelle import ModelXbrl, XbrlConst, XmlValidate
+from arelle import XbrlConst
 from arelle.ModelObject import ModelObject
 from arelle.ModelDtsObject import ModelAttribute, ModelConcept, ModelType
-from arelle.ModelValue import qname
-from arelle.Locale import format_string
-from lxml import etree
 
 XMLSchemaURI = "http://www.w3.org/2001/XMLSchema.xsd"
 

--- a/arelle/examples/SaveTableToExelle.py
+++ b/arelle/examples/SaveTableToExelle.py
@@ -5,10 +5,10 @@ Preconfigured here to use SEC Edgar Rendering R files as input
 @author: Mark V Systems Limited
 (c) Copyright 2014 Mark V Systems Limited, All rights reserved.
 '''
-import os, sys, re
+import os
+import re
 from lxml import etree, html
 from openpyxl.workbook import Workbook
-from openpyxl.worksheet import ColumnDimension
 from openpyxl.cell import get_column_letter
 from openpyxl.style import Alignment
 

--- a/arelle/examples/plugin/bigInstance.py
+++ b/arelle/examples/plugin/bigInstance.py
@@ -7,7 +7,8 @@ for efficiency and to avoid dependency on an underlying DOM.
 (c) Copyright 2012 Mark V Systems Limited, All rights reserved.
 '''
 
-import xml.sax, io, sys
+import io
+import xml.sax
 from collections import defaultdict
 from arelle import XbrlConst, XmlUtil, XmlValidate
 from arelle.ModelDocument import ModelDocument, Type
@@ -311,7 +312,6 @@ class saxHandler(xml.sax.ContentHandler):
             self.currentNamespaceURI = None
             self.currentLocalName = None
             XmlValidate.validate(self.modelXbrl, elt, recurse=False)
-            pass
 
     def characters(self, content):
         if self.currentNamespaceURI:

--- a/arelle/examples/plugin/cmdWebServerExtension.py
+++ b/arelle/examples/plugin/cmdWebServerExtension.py
@@ -8,7 +8,7 @@ To run test:
 
 '''
 
-from arelle.CntlrWebMain import GET, Options, runOptionsAndGetResult
+from arelle.CntlrWebMain import Options, runOptionsAndGetResult
 
 def my_test():
     return _("<html><body><h1>Test</h1><p>It works!</p></body></html>")

--- a/arelle/examples/plugin/importTestImported1.py
+++ b/arelle/examples/plugin/importTestImported1.py
@@ -4,7 +4,6 @@ pluginPackages test case
 (c) Copyright 2012 Mark V Systems Limited, All rights reserved.
 '''
 # this module would raise system error due to PEP 366 after python 3.4.3
-from . import importTestImported11
 
 def foo():
 	print ("imported unpackaged plug-in relative imported 1")

--- a/arelle/examples/plugin/packagedImportTest/__init__.py
+++ b/arelle/examples/plugin/packagedImportTest/__init__.py
@@ -3,9 +3,7 @@ pluginPackages test case
 
 (c) Copyright 2012 Mark V Systems Limited, All rights reserved.
 '''
-from os import path
 from arelle.PluginManager import pluginClassMethods
-from . import importTestImported1
 from .importTestImported1 import foo
 
 def parentMenuEntender(cntlr, menu):

--- a/arelle/examples/plugin/packagedImportTest/importTestImported1.py
+++ b/arelle/examples/plugin/packagedImportTest/importTestImported1.py
@@ -3,9 +3,6 @@ pluginPackages test case
 
 (c) Copyright 2012 Mark V Systems Limited, All rights reserved.
 '''
-from . import importTestImported11
-from .subdir import importTestImported111
-from .subdir.subsubdir import importTestImported1111
 
 def foo():
 	print ("imported packaged plug-in relative imported 1")

--- a/arelle/examples/plugin/saveInstanceInfoset.py
+++ b/arelle/examples/plugin/saveInstanceInfoset.py
@@ -8,8 +8,7 @@ that will save facts decorated with ptv:periodType, ptv:balance, ptv:decimals an
 def generateInstanceInfoset(dts, instanceInfosetFile):
     if dts.fileSource.isArchive:
         return
-    import os, io
-    from arelle import XmlUtil, XbrlConst
+    from arelle import XmlUtil
     from arelle.ValidateXbrlCalcs import inferredPrecision, inferredDecimals
 
     XmlUtil.setXmlns(dts.modelDocument, "ptv", "http://www.xbrl.org/2003/ptv")

--- a/arelle/examples/plugin/streamingExtensions.py
+++ b/arelle/examples/plugin/streamingExtensions.py
@@ -9,16 +9,14 @@ for efficiency and to avoid dependency on an underlying DOM.
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
 
-import io, sys, os, time
+import io
+import os
+import time
 from decimal import Decimal, InvalidOperation
 from lxml import etree
-from collections import defaultdict
-from arelle import XbrlConst, XmlUtil, XmlValidate, ValidateXbrlDimensions
+from arelle import ValidateXbrlDimensions, XbrlConst, XmlValidate
 from arelle.ModelDocument import ModelDocument, Type
-from arelle.ModelObject import ModelObject
 from arelle.ModelObjectFactory import parser
-from arelle.ModelValue import QName
-from arelle.ModelInstanceObject import ModelContext, ModelFact, ModelUnit
 from arelle.Validate import Validate
 
 _streamingExtensionsValidate = False

--- a/arelle/examples/plugin/updateTableLB.py
+++ b/arelle/examples/plugin/updateTableLB.py
@@ -6,9 +6,8 @@ that updates a table linkbase from Eurofiling 2010 syntax to XII 2011 PWD syntax
 '''
 
 def generateUpdatedTableLB(dts, updatedTableLinkbaseFile):
-    import os, io
+    import io
     from arelle import XmlUtil, XbrlConst
-    from arelle.ViewUtil import viewReferences, referenceURI
     from arelle.ModelRenderingObject import ModelEuAxisCoord
 
     if dts.fileSource.isArchive:

--- a/arelle/plugin/EdgarRendererAllReports.py
+++ b/arelle/plugin/EdgarRendererAllReports.py
@@ -24,7 +24,6 @@ modified to not have an instance html header on the table body in xsl:template m
 '''
 import os
 from lxml import etree
-from lxml.etree import tostring as treeToString
 
 def edgarRendererFilingStartSupplement(cntlr, options, entrypointFiles, filing, *args, **kwargs):
     edgarRenderer = filing.edgarRenderer

--- a/arelle/plugin/SECCorrespondenceLoader.py
+++ b/arelle/plugin/SECCorrespondenceLoader.py
@@ -7,9 +7,8 @@ that loads a Correspondence tar.gz file.
 (c) Copyright 2014 Mark V Systems Limited, All rights reserved.
 '''
 import datetime, re, os, time
-from arelle import FileSource, ModelDocument
+from arelle import ModelDocument
 from arelle.ModelRssObject import ModelRssObject
-from arelle.XmlValidate import UNVALIDATED, VALID
 
 class SECCorrespondenceItem:
     def __init__(self, modelXbrl, fileName, entryUrl):

--- a/arelle/plugin/UKCompaniesHouseLoader.py
+++ b/arelle/plugin/UKCompaniesHouseLoader.py
@@ -6,9 +6,7 @@ that loads a Companies House zip XBRL instances file.
 
 (c) Copyright 2014 Mark V Systems Limited, All rights reserved.
 '''
-from lxml import html
-import datetime, re, os
-from arelle import FileSource
+import datetime
 from arelle.ModelRssObject import ModelRssObject
 from arelle.XmlValidate import UNVALIDATED, VALID
 

--- a/arelle/plugin/formulaLoader.py
+++ b/arelle/plugin/formulaLoader.py
@@ -1280,12 +1280,11 @@ def compileXfsGrammar( cntlr, debugParsing ):
         return xfsProg
 
     cntlr.showStatus(_("Compiling Formula Grammar"))
-    from pyparsing import (Word, Keyword, alphas,
-                 Literal, CaselessLiteral,
-                 Combine, Optional, nums, Or, Forward, Group, ZeroOrMore, OneOrMore, StringEnd, alphanums,
-                 ParserElement, quotedString, dblQuotedString, sglQuotedString, QuotedString,
-                 delimitedList, Suppress, Regex, FollowedBy,
-                 lineno, line, col)
+    from pyparsing import (Word, Keyword, Literal,
+                 CaselessLiteral, Combine,
+                 Optional, nums, Forward, ZeroOrMore, OneOrMore, StringEnd, ParserElement, quotedString, dblQuotedString, sglQuotedString,
+                 QuotedString, delimitedList, Suppress, Regex, lineno,
+                 line, col)
 
     ParserElement.enablePackrat()
 
@@ -2109,8 +2108,6 @@ def guiXbrlLoaded(cntlr, modelXbrl, attach, *args, **kwargs):
     #return
     #### disabled for future less annoying option
     if cntlr.hasGui and getattr(modelXbrl, "loadedFromXbrlFormula", False):
-        from arelle import ModelDocument
-        from tkinter.filedialog import askdirectory
         for doc in modelXbrl.urlDocs.values():
             if getattr(doc,"loadedFromXbrlFormula", False):
                 linkbaseFile = cntlr.uiFileDialog("save",

--- a/arelle/plugin/formulaSaver.py
+++ b/arelle/plugin/formulaSaver.py
@@ -19,18 +19,18 @@ from arelle.ModelFormulaObject import (ModelValueAssertion, ModelExistenceAssert
                                        ModelAssertionSet,
                                        ModelFactVariable, ModelGeneralVariable, ModelFormula, ModelParameter,
                                        ModelFilter, ModelConceptName, ModelConceptPeriodType, ModelConceptBalance,
-                                       ModelConceptCustomAttribute, ModelConceptDataType, ModelConceptSubstitutionGroup,
-                                       ModelTestFilter, ModelGeneral, ModelGeneralMeasures, ModelInstantDuration,
-                                       ModelDateTimeFilter, ModelSingleMeasure, ModelExplicitDimension, ModelTypedDimension,
-                                       ModelEntitySpecificIdentifier, ModelEntityScheme, ModelEntityRegexpScheme,
-                                       ModelEntityRegexpIdentifier, ModelMatchFilter, ModelRelativeFilter,
-                                       ModelAncestorFilter, ModelParentFilter, ModelSiblingFilter, ModelNilFilter,
-                                       ModelAspectCover, ModelConceptRelation,
-                                       ModelCustomFunctionSignature, ModelCustomFunctionImplementation,
-                                       ModelPeriod,
-                                       ModelAndFilter, ModelOrFilter, ModelMessage, ModelAssertionSeverity)
+                                       ModelConceptDataType, ModelConceptSubstitutionGroup, ModelTestFilter,
+                                       ModelGeneral, ModelGeneralMeasures, ModelInstantDuration, ModelDateTimeFilter,
+                                       ModelSingleMeasure, ModelExplicitDimension, ModelTypedDimension, ModelEntitySpecificIdentifier,
+                                       ModelEntityScheme, ModelEntityRegexpScheme, ModelEntityRegexpIdentifier,
+                                       ModelMatchFilter, ModelRelativeFilter, ModelAncestorFilter,
+                                       ModelParentFilter, ModelSiblingFilter, ModelNilFilter, ModelAspectCover,
+                                       ModelConceptRelation, ModelCustomFunctionSignature,
+                                       ModelCustomFunctionImplementation, ModelPeriod,
+                                       ModelAndFilter,
+                                       ModelOrFilter, ModelMessage, ModelAssertionSeverity)
 from arelle import XbrlConst, XmlUtil, XPathParser
-import os, datetime
+import datetime
 
 class NotExportable(Exception):
     def __init__(self, message):

--- a/arelle/plugin/formulaXPathChecker.py
+++ b/arelle/plugin/formulaXPathChecker.py
@@ -24,24 +24,15 @@ from arelle.ViewUtilFormulae import rootFormulaObjects, formulaObjSortKey
 from arelle.ModelFormulaObject import (aspectStr, ModelValueAssertion, ModelExistenceAssertion, ModelConsistencyAssertion,
                                        ModelAssertionSet,
                                        ModelFactVariable, ModelGeneralVariable, ModelFormula, ModelParameter,
-                                       ModelFilter, ModelConceptName, ModelConceptPeriodType, ModelConceptBalance,
-                                       ModelConceptCustomAttribute, ModelConceptDataType, ModelConceptSubstitutionGroup,
-                                       ModelTestFilter, ModelGeneral, ModelGeneralMeasures, ModelInstantDuration,
-                                       ModelDateTimeFilter, ModelSingleMeasure, ModelExplicitDimension, ModelTypedDimension,
-                                       ModelEntitySpecificIdentifier, ModelEntityScheme, ModelEntityRegexpScheme,
-                                       ModelEntityRegexpIdentifier, ModelMatchFilter, ModelRelativeFilter,
-                                       ModelAncestorFilter, ModelParentFilter, ModelSiblingFilter, ModelNilFilter,
-                                       ModelAspectCover, ModelConceptRelation,
-                                       ModelCustomFunctionSignature, ModelCustomFunctionImplementation,
-                                       ModelPeriod,
-                                       ModelAndFilter, ModelOrFilter, ModelMessage, ModelAssertionSeverity)
-from arelle.XPathParser import (VariableRef, QNameDef, OperationDef, RangeDecl, Expr, ProgHeader,
-                                exceptionErrorIndication)
+                                       ModelFilter, ModelConceptName, ModelTestFilter, ModelSingleMeasure,
+                                       ModelExplicitDimension, ModelTypedDimension, ModelEntitySpecificIdentifier,
+                                       ModelEntityScheme, ModelAncestorFilter, ModelParentFilter, ModelAspectCover,
+                                       ModelConceptRelation, ModelCustomFunctionImplementation, ModelMessage)
+from arelle.XPathParser import (QNameDef, OperationDef, RangeDecl, Expr, ProgHeader)
 from arelle.XPathContext import (XPathException, VALUE_OPS, GENERALCOMPARISON_OPS, NODECOMPARISON_OPS,
-                                 COMBINING_OPS, LOGICAL_OPS, UNARY_OPS, FORSOMEEVERY_OPS, PATH_OPS,
-                                 SEQUENCE_TYPES, GREGORIAN_TYPES)
-from arelle import FileSource, PackageManager, XbrlConst, XmlUtil, XPathParser, ValidateXbrlDimensions, ValidateFormula
-import os, datetime, logging
+                                 COMBINING_OPS, LOGICAL_OPS, UNARY_OPS, FORSOMEEVERY_OPS, PATH_OPS)
+from arelle import FileSource, PackageManager, XbrlConst
+import logging
 
 FNs_BLOCKED = ("doc", "doc-available", "collection", "element-with-id")
 

--- a/arelle/plugin/functionsMath.py
+++ b/arelle/plugin/functionsMath.py
@@ -5,7 +5,7 @@ Formula math functions plugin.
 '''
 import math
 from arelle.ModelValue import qname
-from arelle import XPathContext, XbrlUtil
+from arelle import XPathContext
 from arelle.FunctionUtil import numericArg
 
 INF = float('inf')

--- a/arelle/plugin/functionsXmlCreation.py
+++ b/arelle/plugin/functionsXmlCreation.py
@@ -5,10 +5,10 @@ Sample custom functions plugin for formula XML Element, Attribute creation funct
 
 (c) Copyright 2012 Mark V Systems Limited, All rights reserved.
 '''
-from arelle import XPathContext, XbrlUtil
+from arelle import XPathContext
 from arelle.ModelValue import qname, QName
-from arelle.ModelInstanceObject import ModelDimensionValue, XmlUtil
-from arelle.FunctionUtil import qnameArg, nodeArg, atomicArg
+from arelle.ModelInstanceObject import XmlUtil
+from arelle.FunctionUtil import atomicArg, qnameArg
 from arelle import XmlValidate
 from lxml import etree
 

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -41,7 +41,7 @@ from arelle.PluginManager import pluginClassMethods
 from arelle.PythonUtil import attrdict
 from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateFilingText import CDATApattern
-from arelle.XmlUtil import addChild, copyIxFootnoteHtml, elementFragmentIdentifier, elementChildSequence, xmlnsprefix, setXmlns
+from arelle.XmlUtil import addChild, copyIxFootnoteHtml, elementFragmentIdentifier, setXmlns, xmlnsprefix
 import os, zipfile, re
 from optparse import SUPPRESS_HELP
 from lxml.etree import XML, XMLSyntaxError

--- a/arelle/plugin/instanceInfo.py
+++ b/arelle/plugin/instanceInfo.py
@@ -6,7 +6,11 @@ instanceInfo.py provides information about an XBRL instance
 Operation with arelleCmdLine: --plugin instanceInfo -f entryUrl
 
 '''
-import sys, os, time, math, re, logging
+import logging
+import math
+import os
+import re
+import time
 from math import isnan
 from collections import defaultdict
 from arelle.ValidateXbrlCalcs import inferredDecimals, rangeValue

--- a/arelle/plugin/internet/proxyNTLM/ntlm.py
+++ b/arelle/plugin/internet/proxyNTLM/ntlm.py
@@ -13,7 +13,6 @@
 
 import struct
 import base64
-import string
 try:
     from . import des
 except ValueError:
@@ -422,7 +421,7 @@ def create_sessionbasekey(password):
     return hashlib.new('md4', create_NT_hashed_password_v1(password)).digest()
 
 if __name__ == "__main__":
-    from binascii import unhexlify, hexlify
+    from binascii import unhexlify
     def ByteToHex( byteStr ):
         """
         Convert a byte string to it's hex string representation e.g. for output.

--- a/arelle/plugin/loadFromExcel.py
+++ b/arelle/plugin/loadFromExcel.py
@@ -6,10 +6,16 @@ input and optionally save an (extension) DTS.
 
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
-import os, io, sys, time, re, traceback, json, posixpath
+import json
+import os
+import posixpath
+import re
+import sys
+import time
+import traceback
 from fnmatch import fnmatch
 from collections import defaultdict, OrderedDict
-from arelle import PythonUtil, XbrlConst, ModelDocument, UrlUtil
+from arelle import PythonUtil, UrlUtil, XbrlConst
 from arelle.PythonUtil import OrderedDefaultDict, OrderedSet
 from arelle.ModelDocument import Type, create as createModelDocument
 from arelle.ModelValue import qname, QName
@@ -46,7 +52,7 @@ facetSortOrder = {
 
 def loadFromExcel(cntlr, modelXbrl, excelFile, mappedUri):
     from openpyxl import load_workbook
-    from arelle import ModelDocument, ModelXbrl, XmlUtil
+    from arelle import ModelDocument, XmlUtil
     from arelle.ModelDocument import ModelDocumentReference
     from arelle.ModelValue import qname
 

--- a/arelle/plugin/loadFromOIM-2018.py
+++ b/arelle/plugin/loadFromOIM-2018.py
@@ -19,16 +19,13 @@ Example to run from web server:
 import os, sys, io, time, re, traceback, json, csv, logging, math, zipfile
 from collections import defaultdict, OrderedDict
 from arelle.ModelDocument import Type, create as createModelDocument
-from arelle import XbrlConst, ModelDocument, ModelXbrl, ValidateXbrlDimensions
+from arelle import ValidateXbrlDimensions, XbrlConst
 from arelle.ModelDocument import Type, create as createModelDocument
 from arelle.ModelValue import qname, dateTime, DATETIME
 from arelle.PrototypeInstanceObject import DimValuePrototype
 from arelle.PythonUtil import attrdict
 from arelle.UrlUtil import isHttpUrl
-from arelle.XbrlConst import (qnLinkLabel, standardLabelRoles, qnLinkReference, standardReferenceRoles,
-                              qnLinkPart, gen, link, defaultLinkRole,
-                              conceptLabel, elementLabel, conceptReference
-                              )
+from arelle.XbrlConst import link
 from arelle.XmlUtil import addChild, addQnameValue
 from arelle.XmlValidate import NCNamePattern, validate as xmlValidate
 
@@ -137,8 +134,7 @@ def csvCellValue(cellValue):
 def loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri, oimObject=None):
     from openpyxl import load_workbook
     from openpyxl.cell import Cell
-    from arelle import ModelDocument, ModelXbrl, XmlUtil
-    from arelle.ModelDocument import ModelDocumentReference
+    from arelle import ModelXbrl
     from arelle.ModelValue import qname
 
     _return = None # modelDocument or an exception
@@ -1219,8 +1215,6 @@ def oimLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
 
 def guiXbrlLoaded(cntlr, modelXbrl, attach, *args, **kwargs):
     if cntlr.hasGui and getattr(modelXbrl, "loadedFromOIM", False):
-        from arelle import ModelDocument
-        from tkinter.filedialog import askdirectory
         instanceFile = cntlr.uiFileDialog("save",
                 title=_("arelle - Save XBRL instance document"),
                 initialdir=cntlr.config.setdefault("outputInstanceDir","."),

--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -16,7 +16,16 @@ Example to run from web server:
 
 
 '''
-import os, sys, io, time, traceback, json, csv, logging, zipfile, datetime, isodate
+import csv
+import datetime
+import io
+import isodate
+import json
+import os
+import sys
+import time
+import traceback
+import zipfile
 from math import isnan, log10
 try:
     from regex import compile as re_compile, match as re_match, sub as re_sub, DOTALL as re_DOTALL
@@ -26,18 +35,15 @@ from lxml import etree
 from collections import defaultdict, OrderedDict
 from arelle.ModelDocument import Type, create as createModelDocument
 from arelle.ModelDtsObject import ModelResource
-from arelle import XbrlConst, ModelDocument, ModelXbrl, PackageManager, ValidateXbrlDimensions
+from arelle import ModelDocument, PackageManager, ValidateXbrlDimensions, XbrlConst
 from arelle.ModelObject import ModelObject
 from arelle.ModelValue import qname, dateTime, DateTime, DATETIME, yearMonthDuration, dayTimeDuration
 from arelle.PrototypeInstanceObject import DimValuePrototype
-from arelle.PythonUtil import attrdict, flattenToSet, strTruncate
+from arelle.PythonUtil import attrdict, strTruncate
 from arelle.UrlUtil import isHttpUrl, isAbsolute as isAbsoluteUri, isValidUriReference
-from arelle.XbrlConst import (xbrli, qnLinkLabel, standardLabelRoles, qnLinkReference, standardReferenceRoles,
-                              qnLinkPart, gen, link, defaultLinkRole, footnote, factFootnote, isStandardRole,
-                              conceptLabel, elementLabel, conceptReference, all as hc_all, notAll as hc_notAll,
-                              xhtml, qnXbrliDateItemType,
-                              dtrPrefixedContentItemTypes, dtrPrefixedContentTypes, dtrSQNameNamesItemTypes, dtrSQNameNamesTypes,
-                              lrrRoleHrefs, lrrArcroleHrefs)
+from arelle.XbrlConst import (xbrli, link, footnote, factFootnote, isStandardRole,
+                              all as hc_all, qnXbrliDateItemType, dtrPrefixedContentItemTypes, dtrPrefixedContentTypes, dtrSQNameNamesItemTypes, dtrSQNameNamesTypes, lrrRoleHrefs,
+                              lrrArcroleHrefs)
 from arelle.XmlUtil import addChild, addQnameValue, copyIxFootnoteHtml, setXmlns
 from arelle.XmlValidate import integerPattern, languagePattern, NCNamePattern, QNamePattern, validate as xmlValidate, VALID
 from arelle.ValidateXbrlCalcs import inferredDecimals, rangeValue
@@ -763,8 +769,7 @@ def getTaxonomyContextElement(modelXbrl):
 def loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
     from openpyxl import load_workbook
     from openpyxl.cell import Cell
-    from arelle import ModelDocument, ModelXbrl, XmlUtil
-    from arelle.ModelDocument import ModelDocumentReference
+    from arelle import ModelXbrl
     from arelle.ModelValue import qname
 
     _return = None # modelDocument or an exception
@@ -2882,8 +2887,6 @@ def oimLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
 
 def guiXbrlLoaded(cntlr, modelXbrl, attach, *args, **kwargs):
     if cntlr.hasGui and getattr(modelXbrl, "loadedFromOIM", False):
-        from arelle import ModelDocument
-        from tkinter.filedialog import askdirectory
         instanceFile = cntlr.uiFileDialog("save",
                 title=_("arelle - Save XBRL instance document"),
                 initialdir=cntlr.config.setdefault("outputInstanceDir","."),

--- a/arelle/plugin/logging/dqcParameters.py
+++ b/arelle/plugin/logging/dqcParameters.py
@@ -8,7 +8,7 @@ from arelle.ModelDtsObject import ModelConcept
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelObject import ModelObject
 from arelle.PythonUtil import flattenSequence
-from arelle.XmlUtil import xmlstring, descendantAttr
+from arelle.XmlUtil import descendantAttr
 from arelle import XbrlConst, XmlUtil
 import re
 from collections import defaultdict

--- a/arelle/plugin/logging/saveMessages.py
+++ b/arelle/plugin/logging/saveMessages.py
@@ -9,8 +9,8 @@ and does not apply to the XBRL US Database schema and description.
 
 '''
 
-import time, os, io, sys, logging
-from arelle.Locale import format_string
+import logging
+import os
 from arelle.ModelDtsObject import ModelConcept, ModelRelationship, ModelLocator
 from arelle.ModelInstanceObject import ModelFact
 

--- a/arelle/plugin/objectmaker.py
+++ b/arelle/plugin/objectmaker.py
@@ -8,9 +8,9 @@ This product uses graphviz, which must be installed separately on the platform.
 
 (c) Copyright 2017 Mark V Systems Limited, All rights reserved.
 '''
-import os, io, time, re
+import os
 from tkinter import Menu
-from arelle import ModelDocument, XmlUtil, XbrlConst
+from arelle import ModelDocument, XbrlConst
 from arelle.ModelDtsObject import ModelConcept
 
 diagramNetworks = {

--- a/arelle/plugin/saveCHComponentFile.py
+++ b/arelle/plugin/saveCHComponentFile.py
@@ -5,14 +5,13 @@ that will save the presentation tree of concepts in Charlie Hoffman's Component 
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
 
-from arelle.ModelDtsObject import ModelConcept, ModelRelationship
 from arelle import XbrlConst
 from lxml import etree
 
 def generateCHComponent(dts, componentFile):
     if dts.fileSource.isArchive:
         return
-    import os, io
+    import io
     from arelle import XmlUtil, XbrlConst
     file = io.StringIO('''
 <nsmap>

--- a/arelle/plugin/saveDTS.py
+++ b/arelle/plugin/saveDTS.py
@@ -12,7 +12,6 @@ def package(dts):
     from zipfile import ZipFile, ZIP_STORED, ZIP_DEFLATED
     from arelle.UrlUtil import isHttpUrl
     try:
-        import zlib
         compression = ZIP_DEFLATED
     except ImportError:
         compression = ZIP_STORED

--- a/arelle/plugin/saveHtmlEBAtables.py
+++ b/arelle/plugin/saveHtmlEBAtables.py
@@ -206,7 +206,6 @@ def saveHtmlEbaTablesMenuEntender(cntlr, menu, *args, **kwargs):
 
 def saveHtmlEbaTablesMenuCommand(cntlr):
     # save Infoset menu item has been invoked
-    from arelle.ModelDocument import Type
     if cntlr.modelManager is None or cntlr.modelManager.modelXbrl is None:
         cntlr.addToLog("No DTS loaded.")
         return

--- a/arelle/plugin/saveLoadableExcel.py
+++ b/arelle/plugin/saveLoadableExcel.py
@@ -5,7 +5,8 @@ input and optionally save an (extension) DTS.
 
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
-import os, io, time, re
+import os
+import re
 from collections import defaultdict
 from arelle import XbrlConst
 
@@ -94,7 +95,7 @@ dtsWsHeaders = (
 
 def saveLoadableExcel(dts, excelFile):
     from arelle import ModelDocument, XmlUtil
-    from openpyxl import Workbook, cell
+    from openpyxl import Workbook
     from openpyxl.styles import Font, PatternFill, Border, Alignment, Color, fills, Side
     from openpyxl.worksheet.dimensions import ColumnDimension
     from openpyxl.utils import get_column_letter

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -23,20 +23,24 @@ Extensions can be added to the results in the following manner:
 
 (c) Copyright 2015 Mark V Systems Limited, All rights reserved.
 '''
-import sys, os, io, time, regex as re, json, csv, zipfile
+import csv
+import io
+import json
+import os
+import regex as re
+import sys
+import zipfile
 from decimal import Decimal
 from math import isinf, isnan
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict
 from arelle import ModelDocument, XbrlConst
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelValue import (qname, QName, DateTime, YearMonthDuration, tzinfoStr,
-                               dayTimeDuration, DayTimeDuration, yearMonthDayTimeDuration, Time,
-                               gYearMonth, gMonthDay, gYear, gMonth, gDay, IsoDuration)
+                               DayTimeDuration, Time, gYearMonth, gMonthDay,
+                               gYear, gMonth, gDay, IsoDuration)
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.UrlUtil import relativeUri
 from arelle.ValidateXbrlCalcs import inferredDecimals
-from arelle.XmlUtil import dateunionValue, elementIndex, xmlstring
-from collections import defaultdict
 
 nsOim = "https://xbrl.org/2021"
 qnOimConceptAspect = qname("concept", noPrefixIsNoNamespace=True)
@@ -527,7 +531,7 @@ def saveLoadableOIM(modelXbrl, oimFile, outputZip=None,
                             "entity": 20, "period": 20, "unit": 20, "metadata": 100}
             from openpyxl import Workbook
             from openpyxl.cell.cell import WriteOnlyCell
-            from openpyxl.styles import Font, PatternFill, Border, Alignment, Color, fills, Side
+            from openpyxl.styles import Alignment, Color, PatternFill, fills
             from openpyxl.worksheet.dimensions import ColumnDimension
             hdrCellFill = PatternFill(patternType=fills.FILL_SOLID, fgColor=Color("00FFBF5F")) # Excel's light orange fill color = 00FF990
             workbook = Workbook()

--- a/arelle/plugin/saveSKOS.py
+++ b/arelle/plugin/saveSKOS.py
@@ -7,7 +7,7 @@ that will save the concepts a DTS into an RDF file.
 
 def generateSkos(dts, skosFile):
     try:
-        import os, io
+        import io
         from arelle import XmlUtil, XbrlConst
         from arelle.ViewUtil import viewReferences, referenceURI
         skosNs = "http://www.w3.org/2004/02/skos/core#"

--- a/arelle/plugin/saveSampleInstance.py
+++ b/arelle/plugin/saveSampleInstance.py
@@ -28,14 +28,13 @@ To specify entity identifier scheme:
   --sample-entity-scheme http://foo.com/scheme
 '''
 
-import os, io, re
-from arelle.ModelDtsObject import ModelConcept, ModelRelationship
-from arelle import Locale, XbrlConst, ModelXbrl, XmlUtil
+import os
+import re
+from arelle import Locale, XbrlConst, XmlUtil
 from arelle.ModelValue import qname
 from arelle.PrototypeInstanceObject import DimValuePrototype
 from arelle.ValidateXbrlDimensions import loadDimensionDefaults
-from arelle.XbrlConst import conceptLabel, conceptReference, qnXsiNil
-from lxml import etree
+from arelle.XbrlConst import qnXsiNil
 try:
     import exrex
 except ImportError:

--- a/arelle/plugin/sphinx/FormulaGenerator.py
+++ b/arelle/plugin/sphinx/FormulaGenerator.py
@@ -10,21 +10,23 @@ Sphinx copyright applies to the Sphinx language, not to this software.
 Mark V Systems conveys neither rights nor license for the Sphinx language.
 '''
 
-import time, sys, io, os.path, re
+import io
+import os.path
+import re
+import sys
 from lxml import etree
 from arelle.ModelValue import QName
 from .SphinxParser import (parse, astNode, astNamespaceDeclaration,
-                           astFormulaRule, astReportRule, astValidationRule,
-                           astQnameLiteral)
+                           astFormulaRule, astReportRule, astValidationRule)
 from .SphinxMethods import aggreateFunctionImplementation
 
 
 def generateFormulaLB(cntlr, sphinxFiles, generatedSphinxFormulasDirectory):
 
     if sys.version[0] >= '3':
-        from arelle.pyparsing.pyparsing_py3 import lineno
+        pass
     else:
-        from pyparsing import lineno
+        pass
 
     from .SphinxContext import SphinxContext
     from .SphinxValidator import validate

--- a/arelle/plugin/sphinx/SphinxContext.py
+++ b/arelle/plugin/sphinx/SphinxContext.py
@@ -10,14 +10,12 @@ Sphinx copyright applies to the Sphinx language, not to this software.
 Mark V Systems conveys neither rights nor license for the Sphinx language.
 '''
 
-from collections import OrderedDict
-from .SphinxParser import astNode, astWith
+from .SphinxParser import astNode
 from arelle.ModelFormulaObject import aspectModels, Aspect, aspectStr
-from arelle.ModelInstanceObject import ModelFact, ModelDimensionValue
+from arelle.ModelInstanceObject import ModelDimensionValue
 from arelle.FormulaEvaluator import implicitFilter, aspectsMatch
 from arelle.ModelValue import QName
 from arelle.ModelXbrl import DEFAULT, NONDEFAULT
-from arelle import XmlUtil
 
 class SphinxContext:
     def __init__(self, sphinxProgs, modelXbrl=None):

--- a/arelle/plugin/sphinx/SphinxEvaluator.py
+++ b/arelle/plugin/sphinx/SphinxEvaluator.py
@@ -12,9 +12,8 @@ Mark V Systems conveys neither rights nor license for the Sphinx language.
 
 import operator
 from .SphinxContext import HyperspaceBindings, HyperspaceBinding
-from .SphinxParser import (astFunctionReference, astHyperspaceExpression, astNode,
-                           astFormulaRule, astReportRule,
-                           astVariableReference)
+from .SphinxParser import (astFunctionReference, astNode, astFormulaRule,
+                           astReportRule, astVariableReference)
 from .SphinxMethods import (methodImplementation, functionImplementation,
                             aggreateFunctionImplementation, aggreateFunctionAcceptsFactArgs,
                             moduleInit as SphinxMethodsModuleInit)

--- a/arelle/plugin/sphinx/SphinxParser.py
+++ b/arelle/plugin/sphinx/SphinxParser.py
@@ -12,7 +12,7 @@ Mark V Systems conveys neither rights nor license for the Sphinx language.
 
 import time, sys, os, os.path, re, zipfile
 from arelle.ModelValue import qname
-from arelle.ModelFormulaObject import Aspect, aspectStr
+from arelle.ModelFormulaObject import Aspect
 from arelle.ModelXbrl import DEFAULT, NONDEFAULT, DEFAULTorNONDEFAULT
 
 # Debugging flag can be set to either "debug_flag=True" or "debug_flag=False"
@@ -773,17 +773,15 @@ def compileSphinxGrammar( cntlr ):
     cntlr.showStatus(_("Compiling Sphinx Grammar"))
     if sys.version[0] >= '3':
         # python 3 requires modified parser to allow release of global objects when closing DTS
-        from arelle.pyparsing.pyparsing_py3 import (Word, Keyword, alphas,
-                     Literal, CaselessLiteral,
-                     Combine, Optional, nums, Or, Forward, Group, ZeroOrMore, StringEnd, alphanums,
-                     ParserElement, quotedString, delimitedList, Suppress, Regex, FollowedBy,
-                     lineno)
+        from arelle.pyparsing.pyparsing_py3 import (Word, Keyword, Literal,
+                     CaselessLiteral, Combine,
+                     Optional, nums, Forward, ZeroOrMore, StringEnd, ParserElement, quotedString, delimitedList, Suppress,
+                     Regex, lineno)
     else:
-        from pyparsing import (Word, Keyword, alphas,
-                     Literal, CaselessLiteral,
-                     Combine, Optional, nums, Or, Forward, Group, ZeroOrMore, StringEnd, alphanums,
-                     ParserElement, quotedString, delimitedList, Suppress, Regex, FollowedBy,
-                     lineno)
+        from pyparsing import (Word, Keyword, Literal,
+                     CaselessLiteral, Combine,
+                     Optional, nums, Forward, ZeroOrMore, StringEnd, ParserElement, quotedString, delimitedList, Suppress,
+                     Regex, lineno)
 
     ParserElement.enablePackrat()
 
@@ -1102,4 +1100,4 @@ def parse(cntlr, _logMessage, sphinxFiles):
 
     return sphinxProgs
 
-from .SphinxMethods import methodImplementation, aggreateFunctionImplementation
+from .SphinxMethods import methodImplementation

--- a/arelle/plugin/sphinx/SphinxValidator.py
+++ b/arelle/plugin/sphinx/SphinxValidator.py
@@ -11,13 +11,11 @@ Mark V Systems conveys neither rights nor license for the Sphinx language.
 '''
 
 from arelle.ModelValue import QName
-from .SphinxParser import (astBinaryOperation, astSourceFile, astNamespaceDeclaration, astRuleBasePrecondition,
-                           astConstant, astNamespaceDeclaration, astStringLiteral,
-                           astHyperspaceExpression, astHyperspaceAxis,
+from .SphinxParser import (astBinaryOperation, astRuleBasePrecondition, astConstant, astHyperspaceExpression,
                            astFunctionDeclaration, astFunctionReference, astNode,
                            astPreconditionDeclaration, astPreconditionReference,
-                           astFormulaRule, astReportRule, astValidationRule, astWith,
-                           namedAxes
+                           astFormulaRule, astReportRule, astValidationRule,
+                           astWith
                            )
 
 def validate(logMessage, sphinxContext):

--- a/arelle/plugin/sphinx/__init__.py
+++ b/arelle/plugin/sphinx/__init__.py
@@ -16,7 +16,7 @@ Sphinx copyright applies to the Sphinx language, not to this software.
 Mark V Systems conveys neither rights nor license for the Sphinx language.
 '''
 
-import time, os, io, sys
+import os
 from arelle.ModelValue import qname
 from arelle import XmlUtil
 
@@ -49,7 +49,8 @@ def sphinxFilesOpenMenuEntender(cntlr, menu, *args, **kwargs):
 
     def sphinxFileMenuCommand():
         from arelle import ModelDocument
-        import os, sys, traceback
+        import sys
+        import traceback
         if not cntlr.modelManager.modelXbrl or cntlr.modelManager.modelXbrl.modelDocument.type not in (
              ModelDocument.Type.SCHEMA, ModelDocument.Type.LINKBASE, ModelDocument.Type.INSTANCE, ModelDocument.Type.INLINEXBRL):
             import tkinter.messagebox
@@ -88,7 +89,8 @@ def sphinxFilesOpenMenuEntender(cntlr, menu, *args, **kwargs):
 def sphinxToLBMenuEntender(cntlr, menu, *args, **kwargs):
 
     def sphinxToLBMenuCommand():
-        import os, sys, traceback
+        import sys
+        import traceback
         from .FormulaGenerator import generateFormulaLB
 
         sphinxFiles = sphinxFilesDialog(cntlr)
@@ -201,7 +203,7 @@ def sphinxTestcaseVariationExpectedSeverity(modelTestcaseVariation, *args, **kwa
     return None # no issue or not a sphinx test case variation
 
 def sphinxDialogRssWatchFileChoices(dialog, frame, row, options, cntlr, openFileImage, openDatabaseImage, *args, **kwargs):
-    from tkinter import PhotoImage, N, S, E, W
+    from tkinter import W
     try:
         from tkinter.ttk import Button
     except ImportError:

--- a/arelle/plugin/streamingExtensions.py
+++ b/arelle/plugin/streamingExtensions.py
@@ -15,17 +15,18 @@ Calls these plug-in classes:
    Streaming.Finish(modelXbrl): notifies that streaming is finished
 '''
 
-import io, os, time, sys, re, gc
+import io
+import os
+import re
+import time
 from decimal import Decimal, InvalidOperation
 from lxml import etree
 from arelle import XbrlConst, XmlUtil, XmlValidate, ValidateXbrlDimensions
 from arelle.ModelDocument import ModelDocument, Type
-from arelle.ModelObjectFactory import parser
-from arelle.ModelObject import ModelObject
 from arelle.ModelInstanceObject import ModelFact
 from arelle.PluginManager import pluginClassMethods
 from arelle.Validate import Validate
-from arelle.HashUtil import md5hash, Md5Sum
+from arelle.HashUtil import Md5Sum
 
 _streamingExtensionsCheck = True  # check streaming if enabled except for CmdLine, then only when requested
 _streamingExtensionsValidate = False

--- a/arelle/plugin/transforms/tester.py
+++ b/arelle/plugin/transforms/tester.py
@@ -42,12 +42,12 @@ For REST API operation:
     cmd line: curl 'http://localhost:8080/rest/xbrl/validation?plugins=transforms/tester&testTransform=ixt%20v3%20datedaymonthen%2029th%20February'
 
 '''
-import os, re, logging
-from optparse import SUPPRESS_HELP
+import logging
+import re
 from arelle.FunctionIxt import ixtNamespaces, ixtNamespaceFunctions
 from arelle.ModelFormulaObject import Trace
 from arelle.XmlUtil import setXmlns
-from arelle import ModelDocument, ModelXbrl, ValidateXbrl, XbrlConst, XPathParser, XPathContext
+from arelle import ModelDocument, ModelXbrl, ValidateXbrl, XPathContext, XPathParser
 
 class TransformTester:
     def __init__(self, cntlr, isCmdLine=False):
@@ -144,7 +144,7 @@ def transformationTesterMenuExtender(cntlr, menu, *args, **kwargs):
         from tkinter.ttk import Frame, Button, Entry
     except ImportError:
         from ttk import Frame, Button
-    from arelle.UiUtil import gridHdr, gridCell, gridCombobox, label, checkbox
+    from arelle.UiUtil import gridCombobox, label
     from arelle.CntlrWinTooltip import ToolTip
     class DialogTransformTester(Toplevel):
         def __init__(self, tester):

--- a/arelle/plugin/unpackSecEisFile.py
+++ b/arelle/plugin/unpackSecEisFile.py
@@ -11,7 +11,7 @@ def unpackEIS(cntlr, eisFile, unpackToDir):
     if not filesource.isArchive:
         cntlr.addToLog("[info:unpackEIS] Not recognized as an EIS file: " + eisFile)
         return
-    import os, io
+    import os
 
     unpackedFiles = []
 

--- a/arelle/plugin/validate/CIPC/__init__.py
+++ b/arelle/plugin/validate/CIPC/__init__.py
@@ -16,8 +16,7 @@ from arelle import ModelDocument, XbrlConst
 from arelle.ModelDtsObject import ModelResource
 from arelle.ModelInstanceObject import ModelFact, ModelInlineFact, ModelInlineFootnote
 from arelle.ModelObject import ModelObject
-from arelle.ModelValue import qname
-from arelle.XbrlConst import ixbrlAll, xhtml
+from arelle.XbrlConst import xhtml
 from .Const import cpicModules # , mandatoryElements
 
 cipcBlockedInlineHtmlElements = {

--- a/arelle/plugin/validate/EBA/__init__.py
+++ b/arelle/plugin/validate/EBA/__init__.py
@@ -5,11 +5,9 @@ Created on Dec 12, 2013
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
 import os, sys, re
-from arelle import PluginManager
 from arelle import ModelDocument, XbrlConst, XmlUtil, UrlUtil, LeiUtil
-from arelle.HashUtil import md5hash, Md5Sum
-from arelle.ModelDtsObject import ModelConcept, ModelType, ModelLocator, ModelResource
-from arelle.ModelFormulaObject import Aspect
+from arelle.HashUtil import Md5Sum
+from arelle.ModelDtsObject import ModelConcept
 from arelle.ModelObject import ModelObject
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelValue import qname, qnameEltPfxName

--- a/arelle/plugin/validate/EFM-htm/Const.py
+++ b/arelle/plugin/validate/EFM-htm/Const.py
@@ -7,9 +7,9 @@ Created on Dec 12, 2013
 
 '''
 try:
-    from regex import compile as re_compile, match as re_match, DOTALL as re_DOTALL
+    pass
 except ImportError:
-    from re import compile as re_compile, match as re_match, DOTALL as re_DOTALL
+    pass
 
 edgarAdditionalTags = {
     "listing",

--- a/arelle/plugin/validate/EFM-htm/__init__.py
+++ b/arelle/plugin/validate/EFM-htm/__init__.py
@@ -6,15 +6,15 @@ Created on Dec 12, 2013
 
 
 '''
-import os, io
-from lxml.etree import HTMLParser, parse, DTD, _ElementTree, _Comment, _ProcessingInstruction
+import os
+from lxml.etree import HTMLParser, _Comment, _ElementTree, _ProcessingInstruction, parse
 try:
-    from regex import compile as re_compile, match as re_match, DOTALL as re_DOTALL
+    from regex import match as re_match
 except ImportError:
-    from re import compile as re_compile, match as re_match, DOTALL as re_DOTALL
+    from re import match as re_match
 from arelle import ValidateFilingText
 from arelle.ModelDocument import Type, create as createModelDocument
-from arelle.UrlUtil import isHttpUrl, scheme
+from arelle.UrlUtil import scheme
 from .Const import edgarAdditionalTags, disallowedElements, disallowedElementAttrs, recognizedElements
 
 def dislosureSystemTypes(disclosureSystem, *args, **kwargs):

--- a/arelle/plugin/validate/EFM/DTS.py
+++ b/arelle/plugin/validate/EFM/DTS.py
@@ -4,11 +4,11 @@ Created on Oct 17, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import os, datetime, re
+import datetime
+import re
 from arelle import (ModelDocument, XmlUtil, XbrlConst, UrlUtil)
 from arelle.ModelObject import ModelObject
 from arelle.ModelDtsObject import ModelConcept
-from .Consts import standardNamespacesPattern
 
 targetNamespaceDatePattern = None
 efmFilenamePattern = None

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -12,13 +12,18 @@ to domestic copyright protection. 17 U.S.C. 105.
 Implementation of DQC rules invokes https://xbrl.us/dqc-license and https://xbrl.us/dqc-patent
 
 '''
-import re, datetime, decimal, json, unicodedata, holidays, fnmatch
+import datetime
+import fnmatch
+import holidays
+import json
+import re
+import unicodedata
 from math import isnan, pow
 from collections import defaultdict, OrderedDict
 from pytz import timezone
 from arelle import (ModelDocument, ModelValue, ModelRelationshipSet,
                     XmlUtil, XbrlConst, ValidateFilingText)
-from arelle.ModelValue import qname, QName, dateUnionEqual
+from arelle.ModelValue import dateUnionEqual, qname
 from arelle.ValidateXbrlCalcs import insignificantDigits
 from arelle.ModelObject import ModelObject
 from arelle.ModelInstanceObject import ModelFact, ModelInlineFact, ModelInlineFootnote
@@ -31,19 +36,13 @@ from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlCalcs import inferredDecimals, rangeValue, roundValue, ONE
 from arelle.XmlValidate import VALID
 from .DTS import checkFilingDTS
-from .Consts import submissionTypesAllowingWellKnownSeasonedIssuer, \
-                    submissionTypesNotRequiringPeriodEndDate, \
-                    submissionTypesAllowingEntityInvCompanyType, docTypesRequiringEntityFilerCategory, \
-                    submissionTypesAllowingAcceleratedFilerStatus, submissionTypesAllowingShellCompanyFlag, \
-                    submissionTypesAllowingEdgarSmallBusinessFlag, submissionTypesAllowingEmergingGrowthCompanyFlag, \
-                    submissionTypesAllowingExTransitionPeriodFlag, submissionTypesAllowingSeriesClasses, \
-                    submissionTypesExemptFromRoleOrder, docTypesExemptFromRoleOrder, \
-                    submissionTypesAllowingPeriodOfReport, docTypesRequiringPeriodOfReport, \
-                    docTypesRequiringEntityWellKnownSeasonedIssuer, invCompanyTypesAllowingSeriesClasses, \
-                    submissionTypesAllowingVoluntaryFilerFlag, docTypesNotAllowingInlineXBRL, \
-                    docTypesRequiringRrSchema, docTypesNotAllowingIfrs, \
-                    untransformableTypes, rrUntransformableEltsPattern, \
-                    docTypes20F, hideableNamespacesPattern, linkbaseValidations
+from .Consts import submissionTypesAllowingSeriesClasses, \
+                    submissionTypesExemptFromRoleOrder, \
+                    docTypesExemptFromRoleOrder, invCompanyTypesAllowingSeriesClasses, \
+                    docTypesNotAllowingInlineXBRL, docTypesRequiringRrSchema, \
+                    docTypesNotAllowingIfrs, untransformableTypes, \
+                    rrUntransformableEltsPattern, hideableNamespacesPattern, \
+                    linkbaseValidations
 
 from .Dimensions import checkFilingDimensions
 from .PreCalAlignment import checkCalcsTreeWalk

--- a/arelle/plugin/validate/EFM/Util.py
+++ b/arelle/plugin/validate/EFM/Util.py
@@ -9,7 +9,7 @@ from collections import defaultdict, OrderedDict
 from arelle.FileSource import openFileStream, openFileSource, saveFile # only needed if building a cached file
 from arelle.ModelValue import qname
 from arelle import XbrlConst
-from arelle.PythonUtil import attrdict, flattenSequence, pyObjectSize
+from arelle.PythonUtil import attrdict, flattenSequence
 from arelle.ValidateXbrlCalcs import inferredDecimals, floatINF
 from arelle.XmlValidate import VALID
 from .Consts import standardNamespacesPattern, latestTaxonomyDocs, latestEntireUgt

--- a/arelle/plugin/validate/EFM/__init__.py
+++ b/arelle/plugin/validate/EFM/__init__.py
@@ -99,10 +99,8 @@ For GUI mode there are two ways to set rendering output, (1) by formula paramete
 import os, io, json, zipfile, logging
 jsonIndent = 1  # None for most compact, 0 for left aligned
 from decimal import Decimal
-from lxml.etree import XML, XMLSyntaxError
-from arelle import ModelDocument, ModelValue, XmlUtil, FileSource
+from arelle import ModelValue, XmlUtil
 from arelle.ModelDocument import Type
-from arelle.ModelValue import qname
 from arelle.PluginManager import pluginClassMethods  # , pluginMethodsForClasses, modulePluginInfos
 from arelle.PythonUtil import flattenSequence
 from arelle.UrlUtil import authority, relativeUri

--- a/arelle/plugin/validate/FERC/__init__.py
+++ b/arelle/plugin/validate/FERC/__init__.py
@@ -12,7 +12,7 @@ Filer Guidelines:
 '''
 import os, re
 from arelle import ModelDocument, ValidateFilingText, XmlUtil
-from arelle.ModelInstanceObject import ModelFact, ModelInlineFact, ModelInlineFootnote
+from arelle.ModelInstanceObject import ModelInlineFootnote
 from arelle.ModelObject import ModelObject
 from arelle.PrototypeDtsObject import LinkPrototype, LocPrototype, ArcPrototype
 from arelle.XbrlConst import xbrli, xhtml

--- a/arelle/plugin/validate/GFM/__init__.py
+++ b/arelle/plugin/validate/GFM/__init__.py
@@ -5,8 +5,6 @@ Created on Dec 12, 2013
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
 import os
-from arelle import ModelDocument, ModelValue, XmlUtil
-from arelle.ModelValue import qname
 from arelle.plugin.validate.EFM.Document import checkDTSdocument
 from arelle.plugin.validate.EFM.Filing import validateFiling
 

--- a/arelle/plugin/validate/SBRnl/Filing.py
+++ b/arelle/plugin/validate/SBRnl/Filing.py
@@ -6,11 +6,10 @@ Created on Oct 05, 2012
 '''
 import re
 from collections import defaultdict
-from arelle import (ModelDocument, ModelValue,
-                ModelRelationshipSet, XmlUtil, XbrlConst)
+from arelle import (ModelDocument, ModelRelationshipSet,
+                XmlUtil, XbrlConst)
 from arelle.ModelDtsObject import ModelConcept, ModelResource
 from arelle.ModelObject import ModelObject
-from arelle.PluginManager import pluginClassMethods
 from arelle.UrlUtil import isHttpUrl
 from .Dimensions import checkFilingDimensions
 from .DTS import checkFilingDTS

--- a/arelle/plugin/validate/SBRnl/__init__.py
+++ b/arelle/plugin/validate/SBRnl/__init__.py
@@ -5,13 +5,10 @@ Created on Dec 12, 2013
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
 import os
-from arelle import ModelDocument, ModelValue, XmlUtil
-from arelle.ModelValue import qname
 try:
-    import regex as re
+    pass
 except ImportError:
-    import re
-from collections import defaultdict
+    pass
 from .CustomLoader import checkForBOMs
 from .Document import checkDTSdocument
 from .Filing import validateFiling

--- a/arelle/plugin/validate/USBestPractices.py
+++ b/arelle/plugin/validate/USBestPractices.py
@@ -1,12 +1,13 @@
 # changed from reporting locs to reporting relationships: HF 2020-06-23
 
-from arelle import PluginManager
 from arelle.ModelDtsObject import ModelConcept
 from arelle.ModelValue import qname
-from arelle.XmlValidate import UNVALIDATED, VALID
 from arelle import Locale, ModelXbrl, XbrlConst
 from arelle.FileSource import openFileSource, openFileStream, saveFile
-import os, io, re, json, time
+import json
+import os
+import re
+import time
 from collections import defaultdict
 
 # ((year, ugtNamespace, ugtDocLB, ugtEntryPoint) ...)

--- a/arelle/plugin/validate/USCorpAction.py
+++ b/arelle/plugin/validate/USCorpAction.py
@@ -1,5 +1,4 @@
 from arelle.ModelValue import qname
-from arelle.XmlValidate import VALID
 import time
 from collections import defaultdict
 

--- a/arelle/plugin/validate/USSecTagging.py
+++ b/arelle/plugin/validate/USSecTagging.py
@@ -1,5 +1,3 @@
-from arelle import PluginManager
-from arelle.ModelValue import qname
 from arelle import XbrlConst
 try:
     import regex as re

--- a/arelle/plugin/validate/calc2.py
+++ b/arelle/plugin/validate/calc2.py
@@ -12,7 +12,7 @@ from decimal import Decimal
 from arelle import Locale
 from arelle.PythonUtil import OrderedDefaultDict
 from arelle.ValidateXbrlCalcs import ZERO, inferredDecimals, rangeValue
-from arelle.XbrlConst import link, xbrli, xl, xlink, domainMember
+from arelle.XbrlConst import domainMember
 
 calc2YYYY = "http://xbrl.org/WGWD/YYYY-MM-DD/calculation-2.0"
 calc2 = {calc2YYYY}

--- a/arelle/plugin/validateSBRnl.py
+++ b/arelle/plugin/validateSBRnl.py
@@ -7,18 +7,14 @@ Created on Oct 05, 2012
 Deprecated Nov 15, 2015.  Use plugin/validate/SBRnl
 '''
 
-from arelle import PluginManager
 from arelle import ModelDocument, XbrlConst, XmlUtil
 from arelle.ModelDtsObject import ModelConcept, ModelType, ModelLocator, ModelResource
-from arelle.ModelFormulaObject import Aspect
 from arelle.ModelObject import ModelObject
-from arelle.ModelValue import qname
 try:
     import regex as re
 except ImportError:
     import re
 from lxml import etree
-from collections import defaultdict
 
 def setup(val, modelXbrl, *args, **kwargs):
     cntlr = modelXbrl.modelManager.cntlr

--- a/arelle/plugin/xbrlDB/DialogRssWatchExtender.py
+++ b/arelle/plugin/xbrlDB/DialogRssWatchExtender.py
@@ -12,8 +12,7 @@ and does not apply to the XBRL US Database schema and description.
 '''
 
 def dialogRssWatchDBextender(dialog, frame, row, options, cntlr, openFileImage, openDatabaseImage):
-    from tkinter import PhotoImage, N, S, E, W
-    from tkinter.simpledialog import askstring
+    from tkinter import W
     from arelle.CntlrWinTooltip import ToolTip
     from arelle.UiUtil import gridCell, label
     try:

--- a/arelle/plugin/xbrlDB/XbrlDpmSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlDpmSqlDB.py
@@ -53,16 +53,14 @@ from collections import defaultdict
 from arelle.HashUtil import Md5Sum
 from arelle.ModelDocument import Type, create as createModelDocument
 from arelle.ModelInstanceObject import ModelFact
-from arelle import Locale, ValidateXbrlDimensions
+from arelle import ValidateXbrlDimensions
 from arelle.ModelValue import qname, QName, dateTime, DATE, dateunionDate, DateTime
 from arelle.PrototypeInstanceObject import DimValuePrototype
-from arelle.ValidateXbrlCalcs import roundValue
-from arelle.XmlUtil import xmlstring, datetimeValue, DATETIME_MAXYEAR, dateunionValue, addChild, addQnameValue, addProcessingInstruction
+from arelle.XmlUtil import DATETIME_MAXYEAR, addChild, addProcessingInstruction, addQnameValue, datetimeValue
 from arelle import XbrlConst
-from arelle.XmlValidate import UNKNOWN, NONE as xmlValidateNONE, INVALID, VALID
+from arelle.XmlValidate import NONE as xmlValidateNONE, UNKNOWN, VALID
 from .SqlDb import XPDBException, isSqlConnection, SqlDbConnection
 from decimal import Decimal, InvalidOperation
-from _ctypes import _memset_addr
 
 qnFindFilingIndicators = qname("{http://www.eurofiling.info/xbrl/ext/filing-indicators}find:fIndicators")
 qnFindFilingIndicator = qname("{http://www.eurofiling.info/xbrl/ext/filing-indicators}find:filingIndicator")
@@ -489,7 +487,6 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                     _dim, _sig, _hierTerm, _hier = _dimSigMatch.groups()
                     _dimVals[_dim] = (_sig, _hier)
             self.signaturesForFilingIndicators[_met[4:-1]].append(_dimVals)
-        pass
 
     def dFactValue(self, dFact):
         for v in dFact[4:7]:

--- a/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
@@ -46,18 +46,16 @@ from arelle.ModelDocument import Type, create as createModelDocument
 from arelle.ModelDtsObject import ModelConcept, ModelType, ModelResource, ModelRelationship
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelXbrl import ModelXbrl
-from arelle.ModelDocument import ModelDocument
 from arelle.ModelObject import ModelObject
 from arelle.ModelValue import qname, QName, dateTime, DATETIME
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.PluginManager import pluginClassMethods
 from arelle.PrototypeInstanceObject import DimValuePrototype
-from arelle.PythonUtil import flattenSequence
 from arelle.ValidateXbrlCalcs import roundValue
 from arelle.XmlValidate import collapseWhitespacePattern, UNVALIDATED, VALID
 from arelle.XmlUtil import elementChildSequence, xmlstring, addQnameValue, addChild
 from arelle import XbrlConst, ValidateXbrlDimensions
-from arelle.UrlUtil import authority, ensureUrl
+from arelle.UrlUtil import ensureUrl
 from .SqlDb import XPDBException, isSqlConnection, SqlDbConnection
 from .tableFacts import tableFacts
 from .entityInformation import loadEntityInformation

--- a/arelle/plugin/xbrlDB/XbrlSemanticGraphDB.py
+++ b/arelle/plugin/xbrlDB/XbrlSemanticGraphDB.py
@@ -23,13 +23,18 @@ to do:
 
 '''
 
-import os, io, re, time, json, socket, logging, zlib
+import io
+import json
+import logging
+import os
+import socket
+import time
+import zlib
 from math import isnan, isinf
 from arelle.ModelDtsObject import ModelConcept, ModelResource, ModelRelationship
-from arelle.ModelInstanceObject import ModelFact, ModelInlineFact
+from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelDocument import Type
-from arelle.ModelValue import qname, datetime
-from arelle.ValidateXbrlCalcs import roundValue
+from arelle.ModelValue import datetime
 from arelle import XbrlConst, XmlUtil
 import urllib.request
 from urllib.error import HTTPError, URLError

--- a/arelle/plugin/xbrlDB/XbrlSemanticJsonDB.py
+++ b/arelle/plugin/xbrlDB/XbrlSemanticJsonDB.py
@@ -35,7 +35,13 @@ to do:
 
 '''
 
-import os, io, time, json, socket, logging, zlib, datetime
+import datetime
+import io
+import json
+import logging
+import os
+import socket
+import time
 from arelle.ModelDtsObject import ModelConcept, ModelResource, ModelRelationship
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelDocument import Type
@@ -231,7 +237,6 @@ class XbrlSemanticJsonDatabaseConnection():
 
     def loadGraphRootVertices(self):
         self.showStatus("Load/Create graph root vertices")
-        pass
 
     def getDBsize(self):
         self.showStatus("Get database size")

--- a/arelle/plugin/xbrlDB/XbrlSemanticRdfDB.py
+++ b/arelle/plugin/xbrlDB/XbrlSemanticRdfDB.py
@@ -40,7 +40,13 @@ rdflib pass
 
 '''
 
-import os, io, time, json, socket, logging, zlib, datetime
+import datetime
+import io
+import json
+import logging
+import os
+import socket
+import time
 from arelle.ModelDtsObject import ModelConcept, ModelResource, ModelRelationship
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelDocument import Type
@@ -298,7 +304,6 @@ class XbrlSemanticRdfDatabaseConnection():
 
     def loadGraphRootVertices(self):
         self.showStatus("Load/Create graph root vertices")
-        pass
 
     def getDBsize(self):
         self.showStatus("Get database size")

--- a/arelle/plugin/xbrlDB/XbrlSemanticSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlSemanticSqlDB.py
@@ -41,7 +41,6 @@ from arelle.ModelDocument import Type
 from arelle.ModelDtsObject import ModelConcept, ModelType, ModelResource, ModelRelationship
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelXbrl import ModelXbrl
-from arelle.ModelDocument import ModelDocument
 from arelle.ModelObject import ModelObject
 from arelle.ModelValue import qname
 from arelle.ValidateXbrlCalcs import roundValue

--- a/arelle/plugin/xbrlDB/__init__.py
+++ b/arelle/plugin/xbrlDB/__init__.py
@@ -13,7 +13,9 @@ and does not apply to the XBRL US Database schema and description.
 
 '''
 
-import time, os, io, sys, logging
+import logging
+import sys
+import time
 from arelle.Locale import format_string
 from .XbrlPublicPostgresDB import insertIntoDB as insertIntoPostgresDB, isDBPort as isPostgresPort
 from .XbrlSemanticSqlDB import insertIntoDB as insertIntoSemanticSqlDB, isDBPort as isSemanticSqlPort
@@ -21,7 +23,7 @@ from .XbrlOpenSqlDB import insertIntoDB as insertIntoOpenSqlDB
 from .XbrlSemanticGraphDB import insertIntoDB as insertIntoRexsterDB, isDBPort as isRexsterPort
 from .XbrlSemanticRdfDB import insertIntoDB as insertIntoRdfDB, isDBPort as isRdfPort
 from .XbrlSemanticJsonDB import insertIntoDB as insertIntoJsonDB, isDBPort as isJsonPort
-from .XbrlDpmSqlDB import insertIntoDB as insertIntoDpmDB, isDBPort as isDpmPort
+from .XbrlDpmSqlDB import insertIntoDB as insertIntoDpmDB
 
 dbTypes = {
     "postgres": insertIntoPostgresDB,

--- a/arelle/plugin/xbrlDB/entityInformation.py
+++ b/arelle/plugin/xbrlDB/entityInformation.py
@@ -16,9 +16,6 @@ former-name-{1..}.{former-conformed-name,date-changed}
 filer-category, public-float, trading-symbol, fiscal-year-focus, fiscal-period-focus
 '''
 import os, re, datetime
-from lxml import html, etree
-from arelle import ModelDocument
-from arelle.ModelValue import qname
 from arelle.ValidateXbrlCalcs import roundValue
 
 

--- a/arelle/plugin/xbrlDB/ext/china.py
+++ b/arelle/plugin/xbrlDB/ext/china.py
@@ -12,7 +12,6 @@ to use from command line:
 
 '''
 import os
-from arelle.UrlUtil import ensureUrl
 
 EXT_CHINA_TABLES = {
                 "filing_china"

--- a/arelle/plugin/xbrlDB/primaryDocumentFacts.py
+++ b/arelle/plugin/xbrlDB/primaryDocumentFacts.py
@@ -6,7 +6,7 @@ Created on Feb 21, 2014
 
 Represents modelFacts in an (SEC) filing primary document
 '''
-import os, re
+import re
 from lxml import html, etree
 from arelle import ModelDocument
 from arelle.ModelValue import qname

--- a/arelle/pyparsing/pyparsing_py3.py
+++ b/arelle/pyparsing/pyparsing_py3.py
@@ -225,12 +225,10 @@ class ParseException(ParseBaseException):
         - col - returns the column number of the exception text
         - line - returns the line containing the exception text
     """
-    pass
 
 class ParseFatalException(ParseBaseException):
     """user-throwable exception thrown when inconsistent parse content
        is found; stops all parsing immediately"""
-    pass
 
 class ParseSyntaxException(ParseFatalException):
     """just like C{ParseFatalException}, but thrown internally when an
@@ -671,7 +669,6 @@ def _defaultExceptionDebugAction( instring, loc, expr, exc ):
 
 def nullDebugAction(*args):
     """'Do-nothing' debug action, to suppress debugging output during parsing."""
-    pass
 
 class ParserElement(object):
     """Abstract base level parser element class."""

--- a/arelle/webserver/bottle-no2to3.py
+++ b/arelle/webserver/bottle-no2to3.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
         import gevent.monkey; gevent.monkey.patch_all()
 
 import base64, cgi, email.utils, functools, hmac, imp, itertools, mimetypes,\
-        os, re, subprocess, sys, tempfile, threading, time, urllib, warnings
+        os, re, subprocess, sys, tempfile, threading, time, warnings
 
 from datetime import date as datedate, datetime, timedelta
 from tempfile import TemporaryFile
@@ -72,7 +72,7 @@ if py3k:
     import http.client as httplib
     import _thread as thread
     from urllib.parse import urljoin, parse_qs, SplitResult as UrlSplitResult
-    from urllib.parse import urlencode, quote as urlquote, unquote as urlunquote
+    from urllib.parse import quote as urlquote, urlencode
     from http.cookies import SimpleCookie
     from collections import MutableMapping as DictMixin
     import pickle
@@ -86,7 +86,7 @@ else: # 2.x
     import httplib
     import thread
     from urlparse import urljoin, SplitResult as UrlSplitResult
-    from urllib import urlencode, quote as urlquote, unquote as urlunquote
+    from urllib import quote as urlquote, urlencode
     from Cookie import SimpleCookie
     from itertools import imap
     import cPickle as pickle
@@ -199,7 +199,6 @@ class lazy_attribute(object):
 
 class BottleException(Exception):
     """ A base class for exceptions used by bottle. """
-    pass
 
 
 #TODO: This should subclass BaseRequest

--- a/arelle/webserver/bottle.py
+++ b/arelle/webserver/bottle.py
@@ -263,7 +263,6 @@ class lazy_attribute(object):
 
 class BottleException(Exception):
     """ A base class for exceptions used by bottle. """
-    pass
 
 ###############################################################################
 # Routing ######################################################################


### PR DESCRIPTION
#### Reason for change
When going through the files to add type hints, I've noted that there are unused imports. Instead of removing them as a part of each PR, I'd prefer doing it in one go.

If/when approved, I'll add the commit hash to the `.git-blame-ignore-revs` file.

#### Description of change
I installed `autoflake` and ran `autoflake --in-place --remove-all-unused-imports --recursive arelle/`. This has:
- Removed unused imports
- Removed unnecessary `pass` arguments (I didn't intend to do this, autopep seem to do this automatically. We could revert this.)

#### Steps to Test

**review**:
@Arelle/arelle
