### PR TITLE
Add release drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,8 @@
+categories:
+  - title: "⬆️ Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
+template: |
+  ## What's Changed
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5.20.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Reason for change
Given the discussions on today's standup of moving towards pypi-release, I would propose adding this workflow. Everytime a PR is merged, it's added to a draft release in the ["Releases"](https://github.com/Arelle/Arelle/releases) section (only maintainers see this). When you want to deploy to pypi, you simply publish the release and get a nicely formatted changelog all included.

This is an example of what it looks like from another project I'm one of the maintainers of:
![image](https://user-images.githubusercontent.com/21142447/186985489-efc409f6-4065-416d-8422-e7a7010a6958.png)

#### Description of change
Two workflow files are added. One formatting the changelog and one drafting the release.

#### Steps to Test
I think you have to merge this to be able to test it. Once merged, you can check under the "Release section" after each PR is merged.

**review**:
@Arelle/arelle
