### PR TITLE
Add flake8 to CI/CD

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -781,5 +781,3 @@ class LogToBufferHandler(LogToXmlHandler):
 
     def flush(self):
         pass # do nothing -- overrides LogToXmlHandler's flush
-
-

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1138,4 +1138,3 @@ if __name__ == "__main__":
         main()
     '''
     main()
-

--- a/arelle/DialogFormulaParameters.py
+++ b/arelle/DialogFormulaParameters.py
@@ -221,4 +221,3 @@ class DialogFormulaParameters(Toplevel):
     def close(self, event=None):
         self.parent.focus_set()
         self.destroy()
-

--- a/arelle/DialogLanguage.py
+++ b/arelle/DialogLanguage.py
@@ -155,4 +155,3 @@ class DialogLanguage(Toplevel):
     def close(self, event=None):
         self.parent.focus_set()
         self.destroy()
-

--- a/arelle/DialogNewFactItem.py
+++ b/arelle/DialogNewFactItem.py
@@ -158,4 +158,3 @@ class DialogNewFactItemOptions(Toplevel):
     def close(self, event=None):
         self.parent.focus_set()
         self.destroy()
-

--- a/arelle/DialogOpenArchive.py
+++ b/arelle/DialogOpenArchive.py
@@ -508,4 +508,3 @@ class DialogOpenArchive(Toplevel):
         else:
             self.toolTipText.set("")
             self.toolTip.configure(state="disabled")
-

--- a/arelle/DialogPackageManager.py
+++ b/arelle/DialogPackageManager.py
@@ -526,4 +526,3 @@ class DialogPackageManager(Toplevel):
         self.packagesConfigChanged = True
         PackageManager.rebuildRemappings(self.cntlr)
         self.loadTreeViews()
-

--- a/arelle/DialogPluginManager.py
+++ b/arelle/DialogPluginManager.py
@@ -588,4 +588,3 @@ class DialogPluginManager(Toplevel):
                     self.moduleEnableButton['text'] = self.ENABLE
         self.pluginConfigChanged = True
         self.loadTreeViews()
-

--- a/arelle/DialogRssWatch.py
+++ b/arelle/DialogRssWatch.py
@@ -258,4 +258,3 @@ class DialogRssWatch(Toplevel):
     def close(self, event=None):
         self.parent.focus_set()
         self.destroy()
-

--- a/arelle/DisclosureSystem.py
+++ b/arelle/DisclosureSystem.py
@@ -385,5 +385,3 @@ class DisclosureSystem:
         if self.standardTaxonomiesUrl:
             return href in self.standardTaxonomiesDict
         return True # no standard taxonomies to test
-
-

--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -790,6 +790,3 @@ def gaeSet(key, bytesValue): # stores bytes, not string valye
             return False
         chunkKeys.append(chunkKey)
     return gaeMemcache.set(key, chunkKeys, time=GAE_EXPIRE_WEEK)
-
-
-

--- a/arelle/FormulaEvaluator.py
+++ b/arelle/FormulaEvaluator.py
@@ -1460,6 +1460,3 @@ class VariableBinding:
             elif aspect in (Aspect.UNIT_MEASURES, Aspect.MULTIPLY_BY, Aspect.DIVIDE_BY):
                 return fact.unit.measures
         return None
-
-
-

--- a/arelle/FunctionFn.py
+++ b/arelle/FunctionFn.py
@@ -919,4 +919,3 @@ fnFunctions = {
     'static-base-uri': static_base_uri,
     'format-number': format_number,
     }
-

--- a/arelle/FunctionXfi.py
+++ b/arelle/FunctionXfi.py
@@ -1517,4 +1517,3 @@ xfiFunctions = {
     'negative-filing-indicators': negative_filing_indicators,
     'negative-filing-indicator': negative_filing_indicator,
      }
-

--- a/arelle/HashUtil.py
+++ b/arelle/HashUtil.py
@@ -80,4 +80,3 @@ def md5hash(argList):
     if nestedSum == MD5SUM0:
         return md5sum # no multiple terms
     return md5sum + nestedSum
-

--- a/arelle/InstanceAspectsEvaluator.py
+++ b/arelle/InstanceAspectsEvaluator.py
@@ -44,4 +44,3 @@ def setupLinkrole(view, linkrole):
 
     view.periodKeys = list(view.periodContexts.keys())
     view.periodKeys.sort()
-

--- a/arelle/LeiUtil.py
+++ b/arelle/LeiUtil.py
@@ -59,4 +59,3 @@ if __name__ == "__main__":
 5299003M8JKHEFX58Y02""", "Error 4")
                         ):
             print ("LEI {} result {} name {}".format(lei, LEI_RESULTS[checkLei(lei)], name)  )
-

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -2000,4 +2000,3 @@ class ModelDocumentReference:
         if "href" in self.referenceTypes and isinstance(self.referringModelObject, ModelObject):
             return self.referringModelObject.get("{http://www.w3.org/1999/xlink}role")
         return None
-

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -228,4 +228,3 @@ class ModelManager:
             self.customTransforms = {}
             for pluginMethod in pluginClassMethods("ModelManager.LoadCustomTransforms"):
                 pluginMethod(self.customTransforms)
-

--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -406,5 +406,3 @@ class ObjectPropertyViewWrapper:  # extraProperties = ( (p1, v1), (p2, v2), ... 
 
     def __repr__(self):
         return "objectPropertyViewWrapper({}, extraProperties={})".format(self.modelObject, self.extraProperties)
-
-

--- a/arelle/ModelRssItem.py
+++ b/arelle/ModelRssItem.py
@@ -217,4 +217,3 @@ class ModelRssItem(ModelObject):
                 )
     def __repr__(self):
         return ("rssItem[{0}]{1})".format(self.objectId(),self.propertyView))
-

--- a/arelle/ModelRssObject.py
+++ b/arelle/ModelRssObject.py
@@ -29,4 +29,3 @@ class ModelRssObject(ModelDocument):
         self.xmlRootElement = rootElement
         for itemElt in XmlUtil.descendants(rootElement, None, "item"):
             self.rssItems.append(itemElt)
-

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -721,4 +721,3 @@ class InvalidValue(str):
         return str.__new__(cls, value)
 
 INVALIDixVALUE = InvalidValue("(ixTransformValueError)")
-

--- a/arelle/PrototypeInstanceObject.py
+++ b/arelle/PrototypeInstanceObject.py
@@ -238,4 +238,3 @@ class XbrlPrototype(): # behaves like ModelXbrl
     def close(self):
         self.modelDocument.clear()
         self.__dict__.clear()  # delete local attributes
-

--- a/arelle/RenderingEvaluator.py
+++ b/arelle/RenderingEvaluator.py
@@ -234,4 +234,3 @@ def checkBreakdownLeafNodeAspects(modelXbrl, modelTable, tblAxisRel, parentAspec
                     _("%(definitionNode)s %(xlinkLabel)s does not define an aspect for %(aspect)s"),
                     modelObject=(modelTable,definitionNode), xlinkLabel=definitionNode.xlinkLabel, definitionNode=definitionNode.localName,
                     aspect=', '.join(aspectStr(aspect) for aspect in missingAspects))
-

--- a/arelle/RenderingResolver.py
+++ b/arelle/RenderingResolver.py
@@ -628,6 +628,3 @@ def addRelationships(breakdownNode, relDefinitionNode, rels, structuralNode, car
             addRelationships(breakdownNode, relDefinitionNode, rel, childStructuralNode, cartesianProductNestedArgs)
         else:
             addRelationships(breakdownNode, relDefinitionNode, rel, childStructuralNode, cartesianProductNestedArgs)
-
-
-

--- a/arelle/TableStructure.py
+++ b/arelle/TableStructure.py
@@ -526,4 +526,3 @@ def EFMdimMems(relSet, concept, memQNames):
             memQNames.add(dimConcept.qname)
             EFMdimMems(relSet, dimConcept, memQNames)
     return memQNames
-

--- a/arelle/UiUtil.py
+++ b/arelle/UiUtil.py
@@ -719,4 +719,3 @@ class scrolledHeaderedFrame(Frame):
 #self.colHdrInterior.update()
         #self.rowHdrInterior.update()
         #self.bodyInterior.update()
-

--- a/arelle/ValidateInfoset.py
+++ b/arelle/ValidateInfoset.py
@@ -252,5 +252,3 @@ def validateRenderingInfoset(modelXbrl, comparisonFile, sourceDoc):
         modelXbrl.error("arelle:tableModelFileError",
             _("Table model comparison file %(xmlfile)s error %(error)s"),
             modelObject=modelXbrl, xmlfile=comparisonFile, error=str(err))
-
-

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -1056,4 +1056,3 @@ class ValidateXbrl:
     def executeCallTest(self, modelXbrl, name, callTuple, testTuple):
         self.modelXbrl = modelXbrl
         ValidateFormula.executeCallTest(self, name, callTuple, testTuple)
-

--- a/arelle/ViewFile.py
+++ b/arelle/ViewFile.py
@@ -357,4 +357,3 @@ class View:
             self.docEltLevels = None
 
         self.__dict__.clear() # dereference everything after closing document
-

--- a/arelle/ViewFileDTS.py
+++ b/arelle/ViewFileDTS.py
@@ -39,4 +39,3 @@ class ViewDTS(ViewFile.View):
             if referencedDocument not in visited:
                 self.viewDtsElement(referencedDocument, ref.referenceTypes, indent + 1, visited)
         visited.remove(modelDocument)
-

--- a/arelle/ViewFileRoleTypes.py
+++ b/arelle/ViewFileRoleTypes.py
@@ -44,4 +44,3 @@ class ViewRoleTypes(ViewFile.View):
                                       for usedOn in modelRoleType.usedOns))
 
                 self.addRow(cols, treeIndent=0, xmlRowElementName=xmlRowElementName, xmlRowEltAttr=attr)
-

--- a/arelle/ViewWinFactGrid.py
+++ b/arelle/ViewWinFactGrid.py
@@ -312,4 +312,3 @@ class ViewFactsGrid(ViewWinGrid.ViewGrid):
                     self.treeView.selection_set(())
             '''
             self.blockViewModelObject -= 1
-

--- a/arelle/ViewWinFactList.py
+++ b/arelle/ViewWinFactList.py
@@ -175,4 +175,3 @@ class ViewFactList(ViewWinTree.ViewTree):
             except (AttributeError, KeyError):
                     self.treeView.selection_set(())
             self.blockViewModelObject -= 1
-

--- a/arelle/ViewWinFactTable.py
+++ b/arelle/ViewWinFactTable.py
@@ -298,5 +298,3 @@ class ViewFactTable(ViewWinTree.ViewTree):
                 self.treeView.selection_set(())
             if self.blockViewModelObject > 0:
                 self.blockViewModelObject -= 1
-
-

--- a/arelle/ViewWinList.py
+++ b/arelle/ViewWinList.py
@@ -113,4 +113,3 @@ class ViewList():
         self.menu.add_command(label=_("Save to file"), underline=0, command=self.modelXbrl.modelManager.cntlr.fileSave)
         if self.modelXbrl.modelManager.cntlr.hasClipboard:
             self.menu.add_command(label=_("Copy to clipboard"), underline=0, command=self.copyToClipboard)
-

--- a/arelle/ViewWinPane.py
+++ b/arelle/ViewWinPane.py
@@ -88,4 +88,3 @@ class ViewPane:
     def setLang(self, lang):
         self.lang = lang
         self.view()
-

--- a/arelle/ViewWinRoleTypes.py
+++ b/arelle/ViewWinRoleTypes.py
@@ -107,4 +107,3 @@ class ViewRoleTypes(ViewWinTree.ViewTree):
             except (AttributeError, KeyError):
                     self.treeView.selection_set(())
             self.blockViewModelObject -= 1
-

--- a/arelle/ViewWinTupleGrid.py
+++ b/arelle/ViewWinTupleGrid.py
@@ -198,4 +198,3 @@ class ViewTuplesGrid(ViewWinGrid.ViewGrid):
                     self.treeView.selection_set(())
             '''
             self.blockViewModelObject -= 1
-

--- a/arelle/WatchRss.py
+++ b/arelle/WatchRss.py
@@ -248,4 +248,3 @@ class WatchRss:
             self.cntlr.logHandler.close()
         self.thread = None  # close thread
         self.stopRequested = False
-

--- a/arelle/XPathContext.py
+++ b/arelle/XPathContext.py
@@ -799,4 +799,3 @@ class XPathContext:
         if isinstance(x, ModelObject):
             return x.modelXbrl
         return None
-

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -687,4 +687,3 @@ class XsdPattern():
 
     def __repr__(self):
         return self.xsdPattern
-

--- a/arelle/XmlValidateSchema.py
+++ b/arelle/XmlValidateSchema.py
@@ -125,4 +125,3 @@ def validate(modelDocument, schemaElement, targetNamespace):
             checkSchemaElements(elt)
 
     checkSchemaElements(schemaElement)
-

--- a/arelle/plugin/formulaLoader.py
+++ b/arelle/plugin/formulaLoader.py
@@ -2212,5 +2212,3 @@ if __name__ == "__main__":
     # load xf formula files
     if xfFiles:
         xfsProgs = parse(_cntlr(), _logMessage, xfFiles, debugParsing=debugParsing)
-
-

--- a/arelle/plugin/internet/proxyNTLM/ntlm.py
+++ b/arelle/plugin/internet/proxyNTLM/ntlm.py
@@ -466,4 +466,3 @@ if __name__ == "__main__":
     # expected failure
     # According to the spec in section '3.3.2 NTLM v2 Authentication' the NTLMv2Response should be longer than the value given on page 77 (this suggests a mistake in the spec)
     #~ assert HexToByte("68 cd 0a b8 51 e5 1c 96 aa bc 92 7b eb ef 6a 1c") == NTLMv2Response, "\nExpected: 68 cd 0a b8 51 e5 1c 96 aa bc 92 7b eb ef 6a 1c\nActual:   %s" % ByteToHex(NTLMv2Response) # [MS-NLMP] page 77
-

--- a/arelle/plugin/security/cryptAES_CBC.py
+++ b/arelle/plugin/security/cryptAES_CBC.py
@@ -124,4 +124,3 @@ __pluginInfo__ = {
     'Security.Crypt.FileSource.File': securityFileSourceFile,
     'Security.Crypt.Write': securityWrite
 }
-

--- a/arelle/plugin/security/cryptAES_EAX.py
+++ b/arelle/plugin/security/cryptAES_EAX.py
@@ -125,4 +125,3 @@ __pluginInfo__ = {
     'Security.Crypt.FileSource.File': securityFileSourceFile,
     'Security.Crypt.Write': securityWrite
 }
-

--- a/arelle/plugin/sphinx/SphinxMethods.py
+++ b/arelle/plugin/sphinx/SphinxMethods.py
@@ -1283,4 +1283,3 @@ aggreateFunctionAcceptsFactArgs = {
     "var":          False,
     "varp":         False,
     }
-

--- a/arelle/plugin/validate/EFM/Dimensions.py
+++ b/arelle/plugin/validate/EFM/Dimensions.py
@@ -265,5 +265,3 @@ def ancestorOrSelf(domainMemberRelationshipSet,sourceConcept,result=None):
         for rels in domainMemberRelationshipSet.toModelObject(sourceConcept):
             ancestorOrSelf(domainMemberRelationshipSet, rels.fromModelObject, result)
     return result
-
-

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -86,7 +86,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
     efmRoleDefinitionPattern = re.compile(r"([0-9]+) - (Statement|Disclosure|Schedule|Document) - (.+)")
     messageKeySectionPattern = re.compile(r"(.*[{]efmSection[}]|[a-z]{2}-[0-9]{4})(.*)")
     secDomainPattern = re.compile(r"(fasb\.org|xbrl\.sec\.gov)")
-    
+
     val._isStandardUri = {}
     modelXbrl.modelManager.disclosureSystem.loadStandardTaxonomiesDict()
 
@@ -3202,4 +3202,3 @@ def cleanedCompanyName(name):
                                  ):
         name = re.sub(pattern, replacement, name, flags=re.IGNORECASE)
     return unicodedata.normalize('NFKD', name.strip().lower()).encode('ASCII', 'ignore').decode()  # remove diacritics
-

--- a/arelle/plugin/validate/ESEF/DTS.py
+++ b/arelle/plugin/validate/ESEF/DTS.py
@@ -374,4 +374,3 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, visited: lis
                 val.modelXbrl.error("UKFRC.1.1.instanceDocumentEncoding",
                     _("UKFRC instance documents should be UTF-8 encoded: %(encoding)s"),
                     modelObject=modelDocument, encoding=modelDocument.documentEncoding)
-

--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -178,4 +178,3 @@ def checkFilingDimensions(val: ValidateXbrl) -> None:
                         val.modelXbrl.error("ESEF.3.4.3.dimensionDefaultLinkrole",
                             _("Each dimension in an issuer specific extension taxonomy MUST be assigned to a default member in the ELR with role URI http://www.esma.europa.eu/xbrl/role/cor/ifrs-dim_role-990000, but linkrole used is %(linkrole)s."),
                             modelObject=linkChild, linkrole=modelLink.role)
-

--- a/arelle/plugin/validate/SBRnl/Dimensions.py
+++ b/arelle/plugin/validate/SBRnl/Dimensions.py
@@ -358,4 +358,3 @@ def checkSBRNLMembers(val, hc, dim, domELR, rels, ELR, isDomMbr, members=None, a
                 checkSBRNLMembers(val, hc, dim, domELR, domMbrRels, ELR, isDomMbr, members, ancestors)
                 ancestors.discard(relTo)
     return False
-

--- a/arelle/plugin/validate/XFsyntax/xf.py
+++ b/arelle/plugin/validate/XFsyntax/xf.py
@@ -18,7 +18,7 @@ import sys
 from tatsu.buffering import Buffer
 from tatsu.parsing import Parser
 from tatsu.parsing import tatsumasu
-from tatsu.util import re, generic_main  # noqa
+from tatsu.util import re, generic_main
 
 
 KEYWORDS = {}  # type: ignore
@@ -80,7 +80,7 @@ class XFParser(Parser):
         )
 
     @tatsumasu()
-    def _module_(self):  # noqa
+    def _module_(self):
 
         def block0():
             self._namespace_declaration_()
@@ -113,11 +113,11 @@ class XFParser(Parser):
         self._check_eof()
 
     @tatsumasu()
-    def _separator_(self):  # noqa
+    def _separator_(self):
         self._token(';')
 
     @tatsumasu()
-    def _namespace_declaration_(self):  # noqa
+    def _namespace_declaration_(self):
         self._token('namespace')
         self._name_()
         self._token('=')
@@ -125,7 +125,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _default_(self):  # noqa
+    def _default_(self):
         with self._choice():
             with self._option():
                 self._severity_()
@@ -136,13 +136,13 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _severity_(self):  # noqa
+    def _severity_(self):
         self._token('unsatisfied-severity')
         self._message_severity_()
         self._separator_()
 
     @tatsumasu()
-    def _message_severity_(self):  # noqa
+    def _message_severity_(self):
         with self._choice():
             with self._option():
                 self._token('ERROR')
@@ -153,7 +153,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _parameter_(self):  # noqa
+    def _parameter_(self):
         self._token('parameter')
         self._name_()
         with self._optional():
@@ -169,7 +169,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _filter_declaration_(self):  # noqa
+    def _filter_declaration_(self):
         self._token('filter')
         self._name_()
         self._token('{')
@@ -181,7 +181,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _filter_(self):  # noqa
+    def _filter_(self):
         with self._group():
             with self._choice():
                 with self._option():
@@ -215,7 +215,7 @@ class XFParser(Parser):
                 self._error('no available options')
 
     @tatsumasu()
-    def _concept_filter_(self):  # noqa
+    def _concept_filter_(self):
         with self._optional():
             self._token('complemented')
         with self._group():
@@ -303,7 +303,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _general_filter_(self):  # noqa
+    def _general_filter_(self):
         with self._optional():
             self._token('complemented')
         self._token('general')
@@ -312,7 +312,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _period_filter_(self):  # noqa
+    def _period_filter_(self):
         with self._optional():
             self._token('complemented')
         with self._group():
@@ -387,7 +387,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _dimension_filter_(self):  # noqa
+    def _dimension_filter_(self):
         with self._optional():
             self._token('complemented')
         with self._group():
@@ -457,7 +457,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _dimension_axis_(self):  # noqa
+    def _dimension_axis_(self):
         with self._choice():
             with self._option():
                 self._token('child')
@@ -470,7 +470,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _unit_filter_(self):  # noqa
+    def _unit_filter_(self):
         with self._optional():
             self._token('complemented')
         with self._group():
@@ -493,7 +493,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _entity_filter_(self):  # noqa
+    def _entity_filter_(self):
         with self._optional():
             self._token('complemented')
         with self._group():
@@ -525,7 +525,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _match_filter_(self):  # noqa
+    def _match_filter_(self):
         with self._optional():
             self._token('complemented')
         with self._group():
@@ -562,7 +562,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _relative_filter_(self):  # noqa
+    def _relative_filter_(self):
         with self._optional():
             self._token('complemented')
         self._token('relative')
@@ -571,7 +571,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _tuple_filter_(self):  # noqa
+    def _tuple_filter_(self):
         with self._optional():
             self._token('complemented')
         with self._group():
@@ -604,14 +604,14 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _value_filter_(self):  # noqa
+    def _value_filter_(self):
         with self._optional():
             self._token('complemented')
         self._token('nilled')
         self._separator_()
 
     @tatsumasu()
-    def _boolean_filter_(self):  # noqa
+    def _boolean_filter_(self):
         with self._optional():
             self._token('complemented')
         with self._group():
@@ -631,7 +631,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _aspect_cover_filter_(self):  # noqa
+    def _aspect_cover_filter_(self):
         with self._optional():
             self._token('complemented')
         self._token('aspect-cover')
@@ -680,7 +680,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _concept_relation_filter_(self):  # noqa
+    def _concept_relation_filter_(self):
         with self._optional():
             self._token('complemented')
         self._token('concept-relation')
@@ -726,7 +726,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _relation_axis_(self):  # noqa
+    def _relation_axis_(self):
         with self._group():
             with self._choice():
                 with self._option():
@@ -755,14 +755,14 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _declared_filter_reference_(self):  # noqa
+    def _declared_filter_reference_(self):
         self._token('filter')
         self._cut()
         self._variable_ref_()
         self._separator_()
 
     @tatsumasu()
-    def _fact_variable_(self):  # noqa
+    def _fact_variable_(self):
         self._token('variable')
         self._cut()
         self._variable_ref_()
@@ -784,7 +784,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _general_variable_(self):  # noqa
+    def _general_variable_(self):
         self._token('variable')
         self._cut()
         self._variable_ref_()
@@ -797,7 +797,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _function_declaration_(self):  # noqa
+    def _function_declaration_(self):
         self._token('function')
         self._cut()
         self._qname_()
@@ -820,7 +820,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _assertion_(self):  # noqa
+    def _assertion_(self):
         self._token('assertion')
         self._name_()
         self._token('{')
@@ -871,7 +871,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _label_(self):  # noqa
+    def _label_(self):
         self._token('label')
         with self._optional():
             self._token('(')
@@ -881,7 +881,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _message_(self):  # noqa
+    def _message_(self):
         with self._group():
             with self._choice():
                 with self._option():
@@ -899,7 +899,7 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _referenced_parameter_(self):  # noqa
+    def _referenced_parameter_(self):
         self._token('parameter')
         self._cut()
         self._variable_ref_()
@@ -908,83 +908,83 @@ class XFParser(Parser):
         self._separator_()
 
     @tatsumasu()
-    def _precondition_(self):  # noqa
+    def _precondition_(self):
         self._token('precondition')
         self._enclosed_expression_()
 
     @tatsumasu()
-    def _value_expression_(self):  # noqa
+    def _value_expression_(self):
         self._token('test')
         self._enclosed_expression_()
         self._separator_()
 
     @tatsumasu()
-    def _existence_expression_(self):  # noqa
+    def _existence_expression_(self):
         self._token('evaluation-count')
         self._enclosed_expression_()
         self._separator_()
 
     @tatsumasu()
-    def _enclosed_expression_(self):  # noqa
+    def _enclosed_expression_(self):
         self._token('{')
         self._xPath_()
         self._token('}')
 
     @tatsumasu()
-    def _name_(self):  # noqa
+    def _name_(self):
         self._NCNAME_FRAG_()
 
     @tatsumasu()
-    def _language_(self):  # noqa
+    def _language_(self):
         self._pattern(r'[A-Za-z]{2}(-[A-Za-z]{2})?')
 
     @tatsumasu()
-    def _quoted_anyURI_(self):  # noqa
+    def _quoted_anyURI_(self):
         self._quoted_url_()
 
     @tatsumasu()
-    def _quoted_url_(self):  # noqa
+    def _quoted_url_(self):
         self._quoted_string_()
 
     @tatsumasu()
-    def _localname_(self):  # noqa
+    def _localname_(self):
         self._name_()
 
     @tatsumasu()
-    def _variable_ref_(self):  # noqa
+    def _variable_ref_(self):
         self._token('$')
         self._variable_name_()
 
     @tatsumasu()
-    def _variable_name_(self):  # noqa
+    def _variable_name_(self):
         self._name_()
 
     @tatsumasu()
-    def _non_negative_integer_(self):  # noqa
+    def _non_negative_integer_(self):
         self._pattern(r'[0-9]+')
 
     @tatsumasu()
-    def _date_time_constant_(self):  # noqa
+    def _date_time_constant_(self):
         self._pattern(r'\b(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z)?\b')
 
     @tatsumasu()
-    def _date_constant_(self):  # noqa
+    def _date_constant_(self):
         self._pattern(r'\b(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])\b')
 
     @tatsumasu()
-    def _quoted_string_(self):  # noqa
+    def _quoted_string_(self):
         self._pattern(r'("([^\\"]|\\.)*"|\'([^\\\']|\\.)*\')')
 
     @tatsumasu()
-    def _regexp_pattern_(self):  # noqa
+    def _regexp_pattern_(self):
         self._pattern(r'\/([^\\\/]|\\.)*\/')
 
     @tatsumasu()
-    def _xPath_(self):  # noqa
+    def _xPath_(self):
         self._expr_()
 
     @tatsumasu()
-    def _expr_(self):  # noqa
+    def _expr_(self):
         self._exprSingle_()
 
         def block0():
@@ -993,7 +993,7 @@ class XFParser(Parser):
         self._closure(block0)
 
     @tatsumasu()
-    def _exprSingle_(self):  # noqa
+    def _exprSingle_(self):
         with self._choice():
             with self._option():
                 self._forExpr_()
@@ -1006,13 +1006,13 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _forExpr_(self):  # noqa
+    def _forExpr_(self):
         self._simpleForClause_()
         self._token('return')
         self._exprSingle_()
 
     @tatsumasu()
-    def _simpleForClause_(self):  # noqa
+    def _simpleForClause_(self):
         self._token('for')
         self._token('$')
         self._varName_()
@@ -1028,7 +1028,7 @@ class XFParser(Parser):
         self._closure(block0)
 
     @tatsumasu()
-    def _quantifiedExpr_(self):  # noqa
+    def _quantifiedExpr_(self):
         with self._group():
             with self._choice():
                 with self._option():
@@ -1052,7 +1052,7 @@ class XFParser(Parser):
         self._exprSingle_()
 
     @tatsumasu()
-    def _ifExpr_(self):  # noqa
+    def _ifExpr_(self):
         self._token('if')
         self._token('(')
         self._expr_()
@@ -1063,7 +1063,7 @@ class XFParser(Parser):
         self._exprSingle_()
 
     @tatsumasu()
-    def _orExpr_(self):  # noqa
+    def _orExpr_(self):
         self._andExpr_()
 
         def block0():
@@ -1072,7 +1072,7 @@ class XFParser(Parser):
         self._closure(block0)
 
     @tatsumasu()
-    def _andExpr_(self):  # noqa
+    def _andExpr_(self):
         self._comparisonExpr_()
 
         def block0():
@@ -1081,7 +1081,7 @@ class XFParser(Parser):
         self._closure(block0)
 
     @tatsumasu()
-    def _comparisonExpr_(self):  # noqa
+    def _comparisonExpr_(self):
         self._rangeExpr_()
         with self._optional():
             with self._group():
@@ -1096,14 +1096,14 @@ class XFParser(Parser):
             self._rangeExpr_()
 
     @tatsumasu()
-    def _rangeExpr_(self):  # noqa
+    def _rangeExpr_(self):
         self._additiveExpr_()
         with self._optional():
             self._token('to')
             self._additiveExpr_()
 
     @tatsumasu()
-    def _additiveExpr_(self):  # noqa
+    def _additiveExpr_(self):
         self._multiplicativeExpr_()
 
         def block0():
@@ -1118,7 +1118,7 @@ class XFParser(Parser):
         self._closure(block0)
 
     @tatsumasu()
-    def _multiplicativeExpr_(self):  # noqa
+    def _multiplicativeExpr_(self):
         self._unionExpr_()
 
         def block0():
@@ -1137,7 +1137,7 @@ class XFParser(Parser):
         self._closure(block0)
 
     @tatsumasu()
-    def _unionExpr_(self):  # noqa
+    def _unionExpr_(self):
         self._intersectExceptExpr_()
 
         def block0():
@@ -1152,7 +1152,7 @@ class XFParser(Parser):
         self._closure(block0)
 
     @tatsumasu()
-    def _intersectExceptExpr_(self):  # noqa
+    def _intersectExceptExpr_(self):
         self._instanceofExpr_()
 
         def block0():
@@ -1167,7 +1167,7 @@ class XFParser(Parser):
         self._closure(block0)
 
     @tatsumasu()
-    def _instanceofExpr_(self):  # noqa
+    def _instanceofExpr_(self):
         self._treatExpr_()
         with self._optional():
             self._token('instance')
@@ -1175,7 +1175,7 @@ class XFParser(Parser):
             self._sequenceType_()
 
     @tatsumasu()
-    def _treatExpr_(self):  # noqa
+    def _treatExpr_(self):
         self._castableExpr_()
         with self._optional():
             self._token('treat')
@@ -1183,7 +1183,7 @@ class XFParser(Parser):
             self._sequenceType_()
 
     @tatsumasu()
-    def _castableExpr_(self):  # noqa
+    def _castableExpr_(self):
         self._castExpr_()
         with self._optional():
             self._token('castable')
@@ -1191,7 +1191,7 @@ class XFParser(Parser):
             self._singleType_()
 
     @tatsumasu()
-    def _castExpr_(self):  # noqa
+    def _castExpr_(self):
         self._unaryExpr_()
         with self._optional():
             self._token('cast')
@@ -1199,7 +1199,7 @@ class XFParser(Parser):
             self._singleType_()
 
     @tatsumasu()
-    def _unaryExpr_(self):  # noqa
+    def _unaryExpr_(self):
 
         def block0():
             with self._choice():
@@ -1212,11 +1212,11 @@ class XFParser(Parser):
         self._valueExpr_()
 
     @tatsumasu()
-    def _valueExpr_(self):  # noqa
+    def _valueExpr_(self):
         self._pathExpr_()
 
     @tatsumasu()
-    def _generalComp_(self):  # noqa
+    def _generalComp_(self):
         with self._choice():
             with self._option():
                 self._token('=')
@@ -1233,7 +1233,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _valueComp_(self):  # noqa
+    def _valueComp_(self):
         with self._choice():
             with self._option():
                 self._token('eq')
@@ -1250,7 +1250,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _nodeComp_(self):  # noqa
+    def _nodeComp_(self):
         with self._choice():
             with self._option():
                 self._token('is')
@@ -1261,7 +1261,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _pathExpr_(self):  # noqa
+    def _pathExpr_(self):
         with self._choice():
             with self._option():
                 with self._group():
@@ -1277,7 +1277,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _relativePathExpr_(self):  # noqa
+    def _relativePathExpr_(self):
         self._stepExpr_()
 
         def block0():
@@ -1292,7 +1292,7 @@ class XFParser(Parser):
         self._closure(block0)
 
     @tatsumasu()
-    def _stepExpr_(self):  # noqa
+    def _stepExpr_(self):
         with self._choice():
             with self._option():
                 self._filterExpr_()
@@ -1301,7 +1301,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _axisStep_(self):  # noqa
+    def _axisStep_(self):
         with self._group():
             with self._choice():
                 with self._option():
@@ -1312,7 +1312,7 @@ class XFParser(Parser):
         self._predicateList_()
 
     @tatsumasu()
-    def _forwardStep_(self):  # noqa
+    def _forwardStep_(self):
         with self._choice():
             with self._option():
                 with self._group():
@@ -1323,7 +1323,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _forwardAxis_(self):  # noqa
+    def _forwardAxis_(self):
         with self._choice():
             with self._option():
                 with self._group():
@@ -1360,13 +1360,13 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _abbrevForwardStep_(self):  # noqa
+    def _abbrevForwardStep_(self):
         with self._optional():
             self._token('@')
         self._nodeTest_()
 
     @tatsumasu()
-    def _reverseStep_(self):  # noqa
+    def _reverseStep_(self):
         with self._choice():
             with self._option():
                 with self._group():
@@ -1377,7 +1377,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _reverseAxis_(self):  # noqa
+    def _reverseAxis_(self):
         with self._choice():
             with self._option():
                 with self._group():
@@ -1402,11 +1402,11 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _abbrevReverseStep_(self):  # noqa
+    def _abbrevReverseStep_(self):
         self._token('..')
 
     @tatsumasu()
-    def _nodeTest_(self):  # noqa
+    def _nodeTest_(self):
         with self._choice():
             with self._option():
                 self._kindTest_()
@@ -1415,7 +1415,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _nameTest_(self):  # noqa
+    def _nameTest_(self):
         with self._choice():
             with self._option():
                 self._qname_()
@@ -1424,7 +1424,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _wildcard_(self):  # noqa
+    def _wildcard_(self):
         with self._choice():
             with self._option():
                 self._token('*')
@@ -1441,25 +1441,25 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _filterExpr_(self):  # noqa
+    def _filterExpr_(self):
         self._primaryExpr_()
         self._predicateList_()
 
     @tatsumasu()
-    def _predicateList_(self):  # noqa
+    def _predicateList_(self):
 
         def block0():
             self._predicate_()
         self._closure(block0)
 
     @tatsumasu()
-    def _predicate_(self):  # noqa
+    def _predicate_(self):
         self._token('[')
         self._expr_()
         self._token(']')
 
     @tatsumasu()
-    def _primaryExpr_(self):  # noqa
+    def _primaryExpr_(self):
         with self._choice():
             with self._option():
                 self._literal_()
@@ -1474,7 +1474,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _literal_(self):  # noqa
+    def _literal_(self):
         with self._choice():
             with self._option():
                 self._numericLiteral_()
@@ -1483,7 +1483,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _numericLiteral_(self):  # noqa
+    def _numericLiteral_(self):
         with self._choice():
             with self._option():
                 self._integerLiteral_()
@@ -1494,27 +1494,27 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _varRef_(self):  # noqa
+    def _varRef_(self):
         self._token('$')
         self._varName_()
 
     @tatsumasu()
-    def _varName_(self):  # noqa
+    def _varName_(self):
         self._qname_()
 
     @tatsumasu()
-    def _parenthesizedExpr_(self):  # noqa
+    def _parenthesizedExpr_(self):
         self._token('(')
         with self._optional():
             self._expr_()
         self._token(')')
 
     @tatsumasu()
-    def _contextItemExpr_(self):  # noqa
+    def _contextItemExpr_(self):
         self._token('.')
 
     @tatsumasu()
-    def _functionCall_(self):  # noqa
+    def _functionCall_(self):
         self._qname_()
         self._token('(')
         with self._optional():
@@ -1527,13 +1527,13 @@ class XFParser(Parser):
         self._token(')')
 
     @tatsumasu()
-    def _singleType_(self):  # noqa
+    def _singleType_(self):
         self._atomicType_()
         with self._optional():
             self._token('?')
 
     @tatsumasu()
-    def _sequenceType_(self):  # noqa
+    def _sequenceType_(self):
         with self._choice():
             with self._option():
                 with self._group():
@@ -1548,7 +1548,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _occurrenceIndicator_(self):  # noqa
+    def _occurrenceIndicator_(self):
         with self._choice():
             with self._option():
                 self._token('?')
@@ -1559,7 +1559,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _itemType_(self):  # noqa
+    def _itemType_(self):
         with self._choice():
             with self._option():
                 self._kindTest_()
@@ -1573,11 +1573,11 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _atomicType_(self):  # noqa
+    def _atomicType_(self):
         self._qname_()
 
     @tatsumasu()
-    def _kindTest_(self):  # noqa
+    def _kindTest_(self):
         with self._choice():
             with self._option():
                 self._documentTest_()
@@ -1600,13 +1600,13 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _anyKindTest_(self):  # noqa
+    def _anyKindTest_(self):
         self._token('node')
         self._token('(')
         self._token(')')
 
     @tatsumasu()
-    def _documentTest_(self):  # noqa
+    def _documentTest_(self):
         self._token('document-node')
         self._token('(')
         with self._optional():
@@ -1619,19 +1619,19 @@ class XFParser(Parser):
         self._token(')')
 
     @tatsumasu()
-    def _textTest_(self):  # noqa
+    def _textTest_(self):
         self._token('text')
         self._token('(')
         self._token(')')
 
     @tatsumasu()
-    def _commentTest_(self):  # noqa
+    def _commentTest_(self):
         self._token('comment')
         self._token('(')
         self._token(')')
 
     @tatsumasu()
-    def _pITest_(self):  # noqa
+    def _pITest_(self):
         self._token('processing-instruction')
         self._token('(')
         with self._optional():
@@ -1644,7 +1644,7 @@ class XFParser(Parser):
         self._token(')')
 
     @tatsumasu()
-    def _attributeTest_(self):  # noqa
+    def _attributeTest_(self):
         self._token('attribute')
         self._token('(')
         with self._optional():
@@ -1655,7 +1655,7 @@ class XFParser(Parser):
         self._token(')')
 
     @tatsumasu()
-    def _attribNameOrWildcard_(self):  # noqa
+    def _attribNameOrWildcard_(self):
         with self._choice():
             with self._option():
                 self._attributeName_()
@@ -1664,18 +1664,18 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _schemaAttributeTest_(self):  # noqa
+    def _schemaAttributeTest_(self):
         self._token('schema-attribute')
         self._token('(')
         self._attributeDeclaration_()
         self._token(')')
 
     @tatsumasu()
-    def _attributeDeclaration_(self):  # noqa
+    def _attributeDeclaration_(self):
         self._attributeName_()
 
     @tatsumasu()
-    def _elementTest_(self):  # noqa
+    def _elementTest_(self):
         self._token('element')
         self._token('(')
         with self._optional():
@@ -1688,7 +1688,7 @@ class XFParser(Parser):
         self._token(')')
 
     @tatsumasu()
-    def _elementNameOrWildcard_(self):  # noqa
+    def _elementNameOrWildcard_(self):
         with self._choice():
             with self._option():
                 self._elementName_()
@@ -1697,34 +1697,34 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _schemaElementTest_(self):  # noqa
+    def _schemaElementTest_(self):
         self._token('schema-element')
         self._token('(')
         self._elementDeclaration_()
         self._token(')')
 
     @tatsumasu()
-    def _elementDeclaration_(self):  # noqa
+    def _elementDeclaration_(self):
         self._elementName_()
 
     @tatsumasu()
-    def _attributeName_(self):  # noqa
+    def _attributeName_(self):
         self._qname_()
 
     @tatsumasu()
-    def _elementName_(self):  # noqa
+    def _elementName_(self):
         self._qname_()
 
     @tatsumasu()
-    def _typeName_(self):  # noqa
+    def _typeName_(self):
         self._qname_()
 
     @tatsumasu()
-    def _integerLiteral_(self):  # noqa
+    def _integerLiteral_(self):
         self._DIGITS_()
 
     @tatsumasu()
-    def _decimalLiteral_(self):  # noqa
+    def _decimalLiteral_(self):
         with self._choice():
             with self._option():
                 with self._group():
@@ -1737,7 +1737,7 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _doubleLiteral_(self):  # noqa
+    def _doubleLiteral_(self):
         with self._group():
             with self._choice():
                 with self._option():
@@ -1753,7 +1753,7 @@ class XFParser(Parser):
         self._DIGITS_()
 
     @tatsumasu()
-    def _stringLiteral_(self):  # noqa
+    def _stringLiteral_(self):
         with self._choice():
             with self._option():
                 with self._group():
@@ -1784,15 +1784,15 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _ESCAPEQUOT_(self):  # noqa
+    def _ESCAPEQUOT_(self):
         self._token('""')
 
     @tatsumasu()
-    def _ESCAPEAPOS_(self):  # noqa
+    def _ESCAPEAPOS_(self):
         self._token("''")
 
     @tatsumasu()
-    def _qname_(self):  # noqa
+    def _qname_(self):
         with self._choice():
             with self._option():
                 with self._group():
@@ -1804,401 +1804,401 @@ class XFParser(Parser):
             self._error('no available options')
 
     @tatsumasu()
-    def _ncname_(self):  # noqa
+    def _ncname_(self):
         self._NCNAME_FRAG_()
 
     @tatsumasu()
-    def _NCNAME_FRAG_(self):  # noqa
+    def _NCNAME_FRAG_(self):
         self._pattern(r'([A-Z]|_|[a-z]|[\u00C0-\u00D6]|[\u00D8-\u00F6]|[\u00F8-\u02FF]|[\u0370-\u037D]|[\u037F-\u1FFF]|[\u200C-\u200D]|[\u2070-\u218F]|[\u2C00-\u2FEF]|[\u3001-\uD7FF]|[\uF900-\uFDCF]|[\uFDF0-\uFFFD]|[\U00010000-\U000EFFFF])([A-Z]|_|[a-z]|[\u00C0-\u00D6]|[\u00D8-\u00F6]|[\u00F8-\u02FF]|[\u0370-\u037D]|[\u037F-\u1FFF]|[\u200C-\u200D]|[\u2070-\u218F]|[\u2C00-\u2FEF]|[\u3001-\uD7FF]|[\uF900-\uFDCF]|[\uFDF0-\uFFFD]|[\U00010000-\U000EFFFF]|-|\.|[0-9]|\u00B7|[\u0300-\u036F]|[\u203F-\u2040])*')
 
     @tatsumasu()
-    def _DIGITS_(self):  # noqa
+    def _DIGITS_(self):
         self._pattern(r'[0-9]+')
 
 
 class XFSemantics(object):
-    def module(self, ast):  # noqa
+    def module(self, ast):
         return ast
 
-    def separator(self, ast):  # noqa
+    def separator(self, ast):
         return ast
 
-    def namespace_declaration(self, ast):  # noqa
+    def namespace_declaration(self, ast):
         return ast
 
-    def default(self, ast):  # noqa
+    def default(self, ast):
         return ast
 
-    def severity(self, ast):  # noqa
+    def severity(self, ast):
         return ast
 
-    def message_severity(self, ast):  # noqa
+    def message_severity(self, ast):
         return ast
 
-    def parameter(self, ast):  # noqa
+    def parameter(self, ast):
         return ast
 
-    def filter_declaration(self, ast):  # noqa
+    def filter_declaration(self, ast):
         return ast
 
-    def filter(self, ast):  # noqa
+    def filter(self, ast):
         return ast
 
-    def concept_filter(self, ast):  # noqa
+    def concept_filter(self, ast):
         return ast
 
-    def general_filter(self, ast):  # noqa
+    def general_filter(self, ast):
         return ast
 
-    def period_filter(self, ast):  # noqa
+    def period_filter(self, ast):
         return ast
 
-    def dimension_filter(self, ast):  # noqa
+    def dimension_filter(self, ast):
         return ast
 
-    def dimension_axis(self, ast):  # noqa
+    def dimension_axis(self, ast):
         return ast
 
-    def unit_filter(self, ast):  # noqa
+    def unit_filter(self, ast):
         return ast
 
-    def entity_filter(self, ast):  # noqa
+    def entity_filter(self, ast):
         return ast
 
-    def match_filter(self, ast):  # noqa
+    def match_filter(self, ast):
         return ast
 
-    def relative_filter(self, ast):  # noqa
+    def relative_filter(self, ast):
         return ast
 
-    def tuple_filter(self, ast):  # noqa
+    def tuple_filter(self, ast):
         return ast
 
-    def value_filter(self, ast):  # noqa
+    def value_filter(self, ast):
         return ast
 
-    def boolean_filter(self, ast):  # noqa
+    def boolean_filter(self, ast):
         return ast
 
-    def aspect_cover_filter(self, ast):  # noqa
+    def aspect_cover_filter(self, ast):
         return ast
 
-    def concept_relation_filter(self, ast):  # noqa
+    def concept_relation_filter(self, ast):
         return ast
 
-    def relation_axis(self, ast):  # noqa
+    def relation_axis(self, ast):
         return ast
 
-    def declared_filter_reference(self, ast):  # noqa
+    def declared_filter_reference(self, ast):
         return ast
 
-    def fact_variable(self, ast):  # noqa
+    def fact_variable(self, ast):
         return ast
 
-    def general_variable(self, ast):  # noqa
+    def general_variable(self, ast):
         return ast
 
-    def function_declaration(self, ast):  # noqa
+    def function_declaration(self, ast):
         return ast
 
-    def assertion(self, ast):  # noqa
+    def assertion(self, ast):
         return ast
 
-    def label(self, ast):  # noqa
+    def label(self, ast):
         return ast
 
-    def message(self, ast):  # noqa
+    def message(self, ast):
         return ast
 
-    def referenced_parameter(self, ast):  # noqa
+    def referenced_parameter(self, ast):
         return ast
 
-    def precondition(self, ast):  # noqa
+    def precondition(self, ast):
         return ast
 
-    def value_expression(self, ast):  # noqa
+    def value_expression(self, ast):
         return ast
 
-    def existence_expression(self, ast):  # noqa
+    def existence_expression(self, ast):
         return ast
 
-    def enclosed_expression(self, ast):  # noqa
+    def enclosed_expression(self, ast):
         return ast
 
-    def name(self, ast):  # noqa
+    def name(self, ast):
         return ast
 
-    def language(self, ast):  # noqa
+    def language(self, ast):
         return ast
 
-    def quoted_anyURI(self, ast):  # noqa
+    def quoted_anyURI(self, ast):
         return ast
 
-    def quoted_url(self, ast):  # noqa
+    def quoted_url(self, ast):
         return ast
 
-    def localname(self, ast):  # noqa
+    def localname(self, ast):
         return ast
 
-    def variable_ref(self, ast):  # noqa
+    def variable_ref(self, ast):
         return ast
 
-    def variable_name(self, ast):  # noqa
+    def variable_name(self, ast):
         return ast
 
-    def non_negative_integer(self, ast):  # noqa
+    def non_negative_integer(self, ast):
         return ast
 
-    def date_time_constant(self, ast):  # noqa
+    def date_time_constant(self, ast):
         return ast
 
-    def date_constant(self, ast):  # noqa
+    def date_constant(self, ast):
         return ast
 
-    def quoted_string(self, ast):  # noqa
+    def quoted_string(self, ast):
         return ast
 
-    def regexp_pattern(self, ast):  # noqa
+    def regexp_pattern(self, ast):
         return ast
 
-    def xPath(self, ast):  # noqa
+    def xPath(self, ast):
         return ast
 
-    def expr(self, ast):  # noqa
+    def expr(self, ast):
         return ast
 
-    def exprSingle(self, ast):  # noqa
+    def exprSingle(self, ast):
         return ast
 
-    def forExpr(self, ast):  # noqa
+    def forExpr(self, ast):
         return ast
 
-    def simpleForClause(self, ast):  # noqa
+    def simpleForClause(self, ast):
         return ast
 
-    def quantifiedExpr(self, ast):  # noqa
+    def quantifiedExpr(self, ast):
         return ast
 
-    def ifExpr(self, ast):  # noqa
+    def ifExpr(self, ast):
         return ast
 
-    def orExpr(self, ast):  # noqa
+    def orExpr(self, ast):
         return ast
 
-    def andExpr(self, ast):  # noqa
+    def andExpr(self, ast):
         return ast
 
-    def comparisonExpr(self, ast):  # noqa
+    def comparisonExpr(self, ast):
         return ast
 
-    def rangeExpr(self, ast):  # noqa
+    def rangeExpr(self, ast):
         return ast
 
-    def additiveExpr(self, ast):  # noqa
+    def additiveExpr(self, ast):
         return ast
 
-    def multiplicativeExpr(self, ast):  # noqa
+    def multiplicativeExpr(self, ast):
         return ast
 
-    def unionExpr(self, ast):  # noqa
+    def unionExpr(self, ast):
         return ast
 
-    def intersectExceptExpr(self, ast):  # noqa
+    def intersectExceptExpr(self, ast):
         return ast
 
-    def instanceofExpr(self, ast):  # noqa
+    def instanceofExpr(self, ast):
         return ast
 
-    def treatExpr(self, ast):  # noqa
+    def treatExpr(self, ast):
         return ast
 
-    def castableExpr(self, ast):  # noqa
+    def castableExpr(self, ast):
         return ast
 
-    def castExpr(self, ast):  # noqa
+    def castExpr(self, ast):
         return ast
 
-    def unaryExpr(self, ast):  # noqa
+    def unaryExpr(self, ast):
         return ast
 
-    def valueExpr(self, ast):  # noqa
+    def valueExpr(self, ast):
         return ast
 
-    def generalComp(self, ast):  # noqa
+    def generalComp(self, ast):
         return ast
 
-    def valueComp(self, ast):  # noqa
+    def valueComp(self, ast):
         return ast
 
-    def nodeComp(self, ast):  # noqa
+    def nodeComp(self, ast):
         return ast
 
-    def pathExpr(self, ast):  # noqa
+    def pathExpr(self, ast):
         return ast
 
-    def relativePathExpr(self, ast):  # noqa
+    def relativePathExpr(self, ast):
         return ast
 
-    def stepExpr(self, ast):  # noqa
+    def stepExpr(self, ast):
         return ast
 
-    def axisStep(self, ast):  # noqa
+    def axisStep(self, ast):
         return ast
 
-    def forwardStep(self, ast):  # noqa
+    def forwardStep(self, ast):
         return ast
 
-    def forwardAxis(self, ast):  # noqa
+    def forwardAxis(self, ast):
         return ast
 
-    def abbrevForwardStep(self, ast):  # noqa
+    def abbrevForwardStep(self, ast):
         return ast
 
-    def reverseStep(self, ast):  # noqa
+    def reverseStep(self, ast):
         return ast
 
-    def reverseAxis(self, ast):  # noqa
+    def reverseAxis(self, ast):
         return ast
 
-    def abbrevReverseStep(self, ast):  # noqa
+    def abbrevReverseStep(self, ast):
         return ast
 
-    def nodeTest(self, ast):  # noqa
+    def nodeTest(self, ast):
         return ast
 
-    def nameTest(self, ast):  # noqa
+    def nameTest(self, ast):
         return ast
 
-    def wildcard(self, ast):  # noqa
+    def wildcard(self, ast):
         return ast
 
-    def filterExpr(self, ast):  # noqa
+    def filterExpr(self, ast):
         return ast
 
-    def predicateList(self, ast):  # noqa
+    def predicateList(self, ast):
         return ast
 
-    def predicate(self, ast):  # noqa
+    def predicate(self, ast):
         return ast
 
-    def primaryExpr(self, ast):  # noqa
+    def primaryExpr(self, ast):
         return ast
 
-    def literal(self, ast):  # noqa
+    def literal(self, ast):
         return ast
 
-    def numericLiteral(self, ast):  # noqa
+    def numericLiteral(self, ast):
         return ast
 
-    def varRef(self, ast):  # noqa
+    def varRef(self, ast):
         return ast
 
-    def varName(self, ast):  # noqa
+    def varName(self, ast):
         return ast
 
-    def parenthesizedExpr(self, ast):  # noqa
+    def parenthesizedExpr(self, ast):
         return ast
 
-    def contextItemExpr(self, ast):  # noqa
+    def contextItemExpr(self, ast):
         return ast
 
-    def functionCall(self, ast):  # noqa
+    def functionCall(self, ast):
         return ast
 
-    def singleType(self, ast):  # noqa
+    def singleType(self, ast):
         return ast
 
-    def sequenceType(self, ast):  # noqa
+    def sequenceType(self, ast):
         return ast
 
-    def occurrenceIndicator(self, ast):  # noqa
+    def occurrenceIndicator(self, ast):
         return ast
 
-    def itemType(self, ast):  # noqa
+    def itemType(self, ast):
         return ast
 
-    def atomicType(self, ast):  # noqa
+    def atomicType(self, ast):
         return ast
 
-    def kindTest(self, ast):  # noqa
+    def kindTest(self, ast):
         return ast
 
-    def anyKindTest(self, ast):  # noqa
+    def anyKindTest(self, ast):
         return ast
 
-    def documentTest(self, ast):  # noqa
+    def documentTest(self, ast):
         return ast
 
-    def textTest(self, ast):  # noqa
+    def textTest(self, ast):
         return ast
 
-    def commentTest(self, ast):  # noqa
+    def commentTest(self, ast):
         return ast
 
-    def pITest(self, ast):  # noqa
+    def pITest(self, ast):
         return ast
 
-    def attributeTest(self, ast):  # noqa
+    def attributeTest(self, ast):
         return ast
 
-    def attribNameOrWildcard(self, ast):  # noqa
+    def attribNameOrWildcard(self, ast):
         return ast
 
-    def schemaAttributeTest(self, ast):  # noqa
+    def schemaAttributeTest(self, ast):
         return ast
 
-    def attributeDeclaration(self, ast):  # noqa
+    def attributeDeclaration(self, ast):
         return ast
 
-    def elementTest(self, ast):  # noqa
+    def elementTest(self, ast):
         return ast
 
-    def elementNameOrWildcard(self, ast):  # noqa
+    def elementNameOrWildcard(self, ast):
         return ast
 
-    def schemaElementTest(self, ast):  # noqa
+    def schemaElementTest(self, ast):
         return ast
 
-    def elementDeclaration(self, ast):  # noqa
+    def elementDeclaration(self, ast):
         return ast
 
-    def attributeName(self, ast):  # noqa
+    def attributeName(self, ast):
         return ast
 
-    def elementName(self, ast):  # noqa
+    def elementName(self, ast):
         return ast
 
-    def typeName(self, ast):  # noqa
+    def typeName(self, ast):
         return ast
 
-    def integerLiteral(self, ast):  # noqa
+    def integerLiteral(self, ast):
         return ast
 
-    def decimalLiteral(self, ast):  # noqa
+    def decimalLiteral(self, ast):
         return ast
 
-    def doubleLiteral(self, ast):  # noqa
+    def doubleLiteral(self, ast):
         return ast
 
-    def stringLiteral(self, ast):  # noqa
+    def stringLiteral(self, ast):
         return ast
 
-    def ESCAPEQUOT(self, ast):  # noqa
+    def ESCAPEQUOT(self, ast):
         return ast
 
-    def ESCAPEAPOS(self, ast):  # noqa
+    def ESCAPEAPOS(self, ast):
         return ast
 
-    def qname(self, ast):  # noqa
+    def qname(self, ast):
         return ast
 
-    def ncname(self, ast):  # noqa
+    def ncname(self, ast):
         return ast
 
-    def NCNAME_FRAG(self, ast):  # noqa
+    def NCNAME_FRAG(self, ast):
         return ast
 
-    def DIGITS(self, ast):  # noqa
+    def DIGITS(self, ast):
         return ast
 
 

--- a/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
@@ -1394,4 +1394,3 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
         modelXbrl.saveInstance(overrideFilepath=loadDBsaveToFile, encoding="utf-8")
         self.showStatus(_("Saved extracted instance"), 5000)
         return modelXbrl.modelDocument
-

--- a/arelle/plugin/xbrlDB/XbrlSemanticRdfDB.py
+++ b/arelle/plugin/xbrlDB/XbrlSemanticRdfDB.py
@@ -1047,4 +1047,3 @@ class XbrlSemanticRdfDatabaseConnection():
                     continue
                 g.add( (objUri, XBRL.ref, messageUri) )
                 g.add( (messageUri, XBRL.message, objUri) )
-

--- a/arelle/plugin/xbrlDB/XbrlSemanticSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlSemanticSqlDB.py
@@ -1174,4 +1174,3 @@ countryOfState = {
     "WI": "US","WY": "US","DC": "US","PR": "US","VI": "US","AS": "US","GU": "US","MP": "US",
     "AB": "CA","BC": "CA","MB": "CA","NB": "CA","NL": "CA","NS": "CA","ON": "CA","PE": "CA",
     "QC": "CA","SK": "CA","NT": "CA","NU": "CA","YT": "CA"}
-

--- a/arelle/plugin/xbrlDB/primaryDocumentFacts.py
+++ b/arelle/plugin/xbrlDB/primaryDocumentFacts.py
@@ -168,6 +168,3 @@ def loadPrimaryDocumentFacts(dts, rssItem, entityInformation):
                                                    attributes=[("contextRef", cntx.id)],
                                                    text=text[itemSpan.start:itemSpan.end])
                             break
-
-
-

--- a/arelle/plugin/xbrlDB/tableFacts.py
+++ b/arelle/plugin/xbrlDB/tableFacts.py
@@ -63,4 +63,3 @@ def tableFacts(dts):
 
         return roleURIcodeFacts
     return None
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,9 @@
 cx_Oracle==8.3.0
 Sphinx==5.1.1
 
+flake8==5.0.4
+flake8-noqa==1.2.9
+
 mock==4.0.3
 mypy==0.971
 pytest==7.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,86 @@
 source-dir = apidocs
 build-dir  = apidocs/_build
 all_files  = 1
+
+[flake8]
+exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
+doctests = True
+noqa-require-code = True
+
+ignore =
+    E101, # indentation contains mixed spaces and tabs
+    E111, # indentation is not a multiple of 4
+    E114, # indentation is not a multiple of 4 (comment)
+    E115, # expected an indented block (comment)
+    E116, # E116 unexpected indentation (comment)
+    E117, # over-indented
+    E121, # continuation line under-indented for hanging indent
+    E122, # continuation line missing indentation or outdented
+    E123, # closing bracket does not match indentation of opening bracket's line
+    E124, # closing bracket does not match visual indentation
+    E125, # continuation line with same indent as next logical line
+    E126, # continuation line over-indented for hanging indent
+    E127, # continuation line over-indented for visual indent
+    E128, # continuation line under-indented for visual indent
+    E129, # visually indented line with same indent as next logical line
+    E131, # continuation line unaligned for hanging indent
+    E201, # whitespace after '('
+    E202, # whitespace before ')'
+    E203, # whitespace before ':'
+    E211, # whitespace before '('
+    E221, # multiple spaces before operator
+    E222, # multiple spaces after operator
+    E225, # missing whitespace around operator
+    E226, # missing whitespace around arithmetic operator
+    E227, # missing whitespace around bitwise or shift operator
+    E228, # missing whitespace around modulo operator
+    E231, # missing whitespace after ':'
+    E241, # multiple spaces after ','
+    E251, # unexpected spaces around keyword / parameter equals
+    E252, # missing whitespace around parameter equals
+    E261, # at least two spaces before inline comment
+    E262, # inline comment should start with '# '
+    E265, # block comment should start with '# '
+    E266, # too many leading '#' for block comment
+    E271, # multiple spaces after keyword
+    E272, # multiple spaces before keyword
+    E275, # missing whitespace after keyword
+    E301, # expected 1 blank line
+    E302, # expected 2 blank lines
+    E303, # too many blank lines
+    E305, # expected 2 blank lines after class or function definition
+    E306, # expected 1 blank line before a nested definition, found n
+    E401, # multiple imports on one line
+    E402, # module level import not at top of file
+    E501, # line too long
+    E502, # the backslash is redundant between brackets
+    E701, # multiple statements on one line (colon)
+    E702, # multiple statements on one line (semicolon)
+    E703, # statement ends with a semicolon
+    E704, # multiple statements on one line (def)
+    E711, # comparison to None should be 'if cond is not None:'
+    E712, # comparison to True should be 'if cond is True:' or 'if cond:'
+    E713, # test for membership should be 'not in'
+    E714, # test for object identity should be 'is not'
+    E721, # do not compare types, use 'isinstance()'
+    E722, # do not use bare 'except'
+    E731, # do not assign a lambda expression, use a def
+    E741, # ambiguous variable name
+
+    F401, # imported but unused
+    F402, # import 'xxx' from line 15 shadowed by loop variable
+    F403, # 'from xxx import *' used; unable to detect undefined names
+    F405, # xxx may be undefined, or defined from star imports: xxx
+    F504, # '...'  ... has unused named argument(s)
+    F523, # '...'.format(...) has unused arguments at position(s): n
+    F524, # '...'.format(...) is missing argument(s) for placeholder(s): n
+    F601, # dictionary key 'xs' repeated with different values
+    F811, # redefinition of unused 'xxx' from line 31
+    F821, # undefined name
+    F823, # local variable 'id' defined as a builtin referenced before assignment
+    F841, # local variable name is assigned to but never used
+
+    W191, # indentation contains tabs
+    W503, # line break before binary operator
+    W504, # line break after binary operator
+    W605 # invalid escape sequence '\d'

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py39, typing
+envlist = py39, lint, typing
 skip_missing_interpreters = False
 
 [gh-actions]
 python =
-  3.9: py39, typing
+  3.9: py39, lint, typing
 
 [testenv]
 commands =
@@ -12,8 +12,11 @@ commands =
 deps =
   -rrequirements-dev.txt
 
+[testenv:lint]
+basepython = python3
+commands =
+  flake8 arelle
+
 [testenv:typing]
 commands =
   mypy arelle --namespace-packages
-deps =
-  -rrequirements-dev.txt


### PR DESCRIPTION
#### Reason for change
After the big whitespace cleanup, I figured it'd be a good idea to avoid adding that again. One way of doing that is to use flake8 in the CI/CD.

#### Description of change
This PR:
- Adds flake8 to the dev requirements.
- Runs flake8 as a part of tox.
- Adds flake8 settings that makes it pass for the existing code base.
- Removes trailing new lines for a set of files.

#### Steps to Test
Add whitespace to an arbitrary Python file in the `<repo root>/arelle/` directory and run `flake8 arelle`. You should be seeing this:
```
(.venv) vscode ➜ /workspaces/Arelle (master) $ flake8 arelle
arelle/PackageManager.py:37:41: W291 trailing whitespace
```

My VS code settings cleans up white space automatically so I had to use a text editor to add the white space before testing.

**review**:
@Arelle/arelle
