### PR TITLE
Replace all 're' imports

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -11,7 +11,7 @@ This module is Arelle's controller in command line non-interactive mode
 from arelle import PythonUtil # define 2.x or 3.x string types
 import gettext, time, datetime, os, shlex, sys, traceback, fnmatch, threading, json, logging, platform
 from optparse import OptionParser, SUPPRESS_HELP
-import re
+import regex as re
 from arelle import (Cntlr, FileSource, ModelDocument, RenderingEvaluator, XmlUtil, XbrlConst, Version,
                     ViewFileDTS, ViewFileFactList, ViewFileFactTable, ViewFileConcepts,
                     ViewFileFormulae, ViewFileRelationshipSet, ViewFileTests, ViewFileRssFeed,

--- a/arelle/DialogFind.py
+++ b/arelle/DialogFind.py
@@ -9,10 +9,7 @@ try:
     from tkinter.ttk import Frame, Button
 except ImportError:
     from ttk import Frame, Button
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from arelle.UiUtil import gridHdr, gridCell, gridCombobox, label, checkbox, radiobutton
 from arelle.CntlrWinTooltip import ToolTip
 from arelle import ModelDocument, XPathContext, XPathParser, XmlUtil

--- a/arelle/DialogFormulaParameters.py
+++ b/arelle/DialogFormulaParameters.py
@@ -9,10 +9,7 @@ try:
     from tkinter.ttk import Frame, Button
 except ImportError:
     from ttk import Frame, Button
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from arelle.UiUtil import (gridHdr, gridCell, gridCombobox, label, checkbox)
 
 '''

--- a/arelle/DialogLanguage.py
+++ b/arelle/DialogLanguage.py
@@ -14,10 +14,7 @@ from arelle.CntlrWinTooltip import ToolTip
 from arelle.Locale import setDisableRTL
 from arelle.UiUtil import gridHdr, gridCell, gridCombobox, label, checkbox
 import gettext
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from arelle.Locale import getLanguageCodes, languageCodes, getUserLocale, availableLocales
 
 '''

--- a/arelle/DialogNewFactItem.py
+++ b/arelle/DialogNewFactItem.py
@@ -9,10 +9,7 @@ try:
     from tkinter.ttk import Frame, Button
 except ImportError:
     from ttk import Frame, Button
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from arelle.ModelInstanceObject import NewFactItemOptions
 from arelle.ModelValue import dateTime
 from arelle import XmlUtil

--- a/arelle/DialogOpenArchive.py
+++ b/arelle/DialogOpenArchive.py
@@ -11,10 +11,7 @@ except ImportError:
     from ttk import Frame, Button, Treeview, Scrollbar
 import os, sys
 from collections import defaultdict
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from arelle.Cntlr import Cntlr
 from arelle.CntlrWinTooltip import ToolTip
 from arelle.UrlUtil import isHttpUrl

--- a/arelle/DialogPackageManager.py
+++ b/arelle/DialogPackageManager.py
@@ -13,10 +13,7 @@ except ImportError:
 from arelle import PackageManager, DialogURL, DialogOpenArchive
 from arelle.CntlrWinTooltip import ToolTip
 import os, time, json, sys, traceback
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 
 STANDARD_PACKAGES_URL = "https://taxonomies.xbrl.org/api/v0/taxonomy"
 

--- a/arelle/DialogPluginManager.py
+++ b/arelle/DialogPluginManager.py
@@ -16,10 +16,7 @@ except ImportError:
 from arelle import PluginManager, DialogURL, DialogOpenArchive
 from arelle.CntlrWinTooltip import ToolTip
 import os, time
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 EMPTYLIST = []
 GROUPSEP = '\x01d'
 

--- a/arelle/DialogRssWatch.py
+++ b/arelle/DialogRssWatch.py
@@ -11,10 +11,7 @@ except ImportError:
     from ttk import Frame, Button
 import tkinter.filedialog
 import os
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from arelle.ModelValue import dateTime
 from arelle import XmlUtil
 from arelle.UiUtil import gridCell, gridCombobox, label, checkbox

--- a/arelle/DialogURL.py
+++ b/arelle/DialogURL.py
@@ -10,10 +10,7 @@ try:
 except ImportError:
     from ttk import Frame, Button, Label, Entry
 from arelle.CntlrWinTooltip import ToolTip
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 
 '''
 caller checks accepted, if True, caller retrieves url

--- a/arelle/DialogUserPassword.py
+++ b/arelle/DialogUserPassword.py
@@ -12,10 +12,7 @@ except ImportError:
 from arelle.CntlrWinTooltip import ToolTip
 from arelle.UiUtil import checkbox, gridCombobox
 import sys
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 
 '''
 caller checks accepted, if True, caller retrieves url

--- a/arelle/FunctionIxt.py
+++ b/arelle/FunctionIxt.py
@@ -6,10 +6,7 @@ Created on July 5, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from arelle.PluginManager import pluginClassMethods
 from arelle.XmlValidate import decimalPattern
 from arelle import XPathContext

--- a/arelle/HtmlUtil.py
+++ b/arelle/HtmlUtil.py
@@ -4,10 +4,7 @@ Created on April 14, 2011
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 
 def attrValue(str, name):
     # retrieves attribute in a string, such as xyz="abc" or xyz='abc' or xyz=abc;

--- a/arelle/LeiUtil.py
+++ b/arelle/LeiUtil.py
@@ -7,10 +7,7 @@ Created on Apr 25, 2015
 Implementation of ISO 17442:2012(E) Appendix A
 
 '''
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 
 LEI_VALID = 0
 LEI_INVALID_LEXICAL = 1

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -11,10 +11,7 @@ system-wide settings.  (The system settings can remain in 'C' locale.)
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 '''
 import sys, subprocess
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 try:
     from collections.abc import Mapping
 except:

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -11,10 +11,7 @@ from decimal import Decimal
 from functools import total_ordering
 from typing import Any, Optional
 
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 XmlUtil = None
 
 def qname(value: ModelObject | str | QName | Any | None, name: str | ModelObject | None = None, noPrefixIsNoNamespace: bool = False, castException: Exception | None = None, prefixException: Exception | None = None) -> QName | None:

--- a/arelle/TableStructure.py
+++ b/arelle/TableStructure.py
@@ -4,10 +4,7 @@ Created on Feb 02, 2014
 @author: Mark V Systems Limited
 (c) Copyright 2014 Mark V Systems Limited, All rights reserved.
 '''
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from collections import defaultdict
 import os, io, json
 from datetime import datetime, timedelta

--- a/arelle/UrlUtil.py
+++ b/arelle/UrlUtil.py
@@ -6,10 +6,7 @@ Created on Oct 22, 2010
 '''
 from __future__ import annotations
 import os, sys
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 if sys.version[0] >= '3':
     from urllib.request import pathname2url
     from urllib.parse import urldefrag, unquote, quote, urljoin

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -5,10 +5,7 @@ Created on Oct 17, 2010
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
 from __future__ import annotations
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from typing import Any
 from arelle import (ModelDocument, XmlUtil, XbrlUtil, XbrlConst,
                 ValidateXbrlCalcs, ValidateXbrlDimensions, ValidateXbrlDTS, ValidateFormula, ValidateUtr)

--- a/arelle/ValidateXbrlDTS.py
+++ b/arelle/ValidateXbrlDTS.py
@@ -13,10 +13,7 @@ from arelle.PluginManager import pluginClassMethods
 from arelle.XhtmlValidate import ixMsgCode
 from lxml import etree
 from collections import defaultdict
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 
 instanceSequence = {"schemaRef":1, "linkbaseRef":2, "roleRef":3, "arcroleRef":4}
 schemaTop = {"import", "include", "redefine"}

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -5,10 +5,7 @@ Created on Oct 22, 2010
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
 import datetime
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from lxml import etree
 from arelle.XbrlConst import ixbrlAll, qnLinkFootnote, xhtml, xml, xsd, xhtml
 from arelle.ModelObject import ModelObject, ModelComment

--- a/arelle/examples/plugin/testcaseIxExpectedHtmlFixup.py
+++ b/arelle/examples/plugin/testcaseIxExpectedHtmlFixup.py
@@ -6,10 +6,7 @@ It also provides an error code when a testcase variation does not load any iXBRL
 
 (c) Copyright 2019 Mark V Systems Limited, All rights reserved.
 '''
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from arelle.ModelDocument import Type
 from arelle.XhtmlValidate import htmlEltUriAttrs, resolveHtmlUri
 

--- a/arelle/plugin/internet/proxyNTLM/HTTPNtlmAuthHandler.py
+++ b/arelle/plugin/internet/proxyNTLM/HTTPNtlmAuthHandler.py
@@ -18,7 +18,7 @@ try:
     from . import ntlm
 except ValueError:
     import ntlm
-import re
+import regex as re
 
 class AbstractNtlmAuthHandler:
 

--- a/arelle/plugin/internet/proxyNTLM/ntlm.py
+++ b/arelle/plugin/internet/proxyNTLM/ntlm.py
@@ -21,7 +21,7 @@ except ValueError:
 import hashlib
 import hmac
 import random
-import re
+import regex as re
 import binascii
 from socket import gethostname
 

--- a/arelle/plugin/logging/dqcParameters.py
+++ b/arelle/plugin/logging/dqcParameters.py
@@ -10,7 +10,7 @@ from arelle.ModelObject import ModelObject
 from arelle.PythonUtil import flattenSequence
 from arelle.XmlUtil import xmlstring, descendantAttr
 from arelle import XbrlConst, XmlUtil
-import re
+import regex as re
 from collections import defaultdict
 from decimal import Decimal
 

--- a/arelle/plugin/transforms/SEC/text2num.py
+++ b/arelle/plugin/transforms/SEC/text2num.py
@@ -25,7 +25,7 @@
 #
 # HF: 2019-02-07 modified word split pattern for transformation dash pattern
 
-import re
+import regex as re
 
 Small = {
     'zero': 0,

--- a/arelle/plugin/validate/EBA/__init__.py
+++ b/arelle/plugin/validate/EBA/__init__.py
@@ -16,10 +16,7 @@ from arelle.ModelValue import qname, qnameEltPfxName
 from arelle.ValidateUtr import ValidateUtr
 from arelle.XbrlConst import qnEnumerationItemTypes
 from arelle.ModelInstanceObject import ModelFact
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from lxml import etree
 from collections import defaultdict
 

--- a/arelle/plugin/validate/EFM/Consts.py
+++ b/arelle/plugin/validate/EFM/Consts.py
@@ -4,7 +4,7 @@ Created on Jun 30, 2018
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
-import re
+import regex as re
 from arelle.PythonUtil import attrdict
 
 #qnFasbExtensibleListItemTypes = (qname("{http://fasb.org/us-types/2017-01-31}us-types:extensibleListItemType"),

--- a/arelle/plugin/validate/EFM/Document.py
+++ b/arelle/plugin/validate/EFM/Document.py
@@ -4,7 +4,7 @@ Created on Dec 12, 2013
 @author: Mark V Systems Limited
 (c) Copyright 2013 Mark V Systems Limited, All rights reserved.
 '''
-import re
+import regex as re
 from arelle import ModelDocument, UrlUtil, XbrlConst, XmlUtil
 from arelle.ModelObject import ModelObject
 from arelle.ValidateXbrlDTS import arcFromConceptQname, arcToConceptQname

--- a/arelle/plugin/validate/EFM/__init__.py
+++ b/arelle/plugin/validate/EFM/__init__.py
@@ -109,10 +109,7 @@ from arelle.UrlUtil import authority, relativeUri
 from arelle.ValidateFilingText import referencedFiles
 from .Document import checkDTSdocument
 from .Filing import validateFiling
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from collections import defaultdict
 
 

--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -9,10 +9,7 @@ Filer Guidelines: esma32-60-254_esef_reporting_manual.pdf
 (c) Copyright 2022 Workiva, All rights reserved.
 '''
 from __future__ import annotations
-try:
-    import regex as re
-except ImportError:
-    import re #  type: ignore[no-redef]
+import regex as re #  type: ignore[no-redef]
 from typing import Any, Callable
 from arelle.ModelValue import qname
 from arelle.XbrlConst import all, notAll, hypercubeDimension, dimensionDomain, domainMember, dimensionDefault, widerNarrower

--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -9,7 +9,7 @@ Filer Guidelines: esma32-60-254_esef_reporting_manual.pdf
 (c) Copyright 2022 Workiva, All rights reserved.
 '''
 from __future__ import annotations
-import regex as re #  type: ignore[no-redef]
+import regex as re
 from typing import Any, Callable
 from arelle.ModelValue import qname
 from arelle.XbrlConst import all, notAll, hypercubeDimension, dimensionDomain, domainMember, dimensionDefault, widerNarrower

--- a/arelle/plugin/validate/ESEF/DTS.py
+++ b/arelle/plugin/validate/ESEF/DTS.py
@@ -12,10 +12,7 @@ Taxonomy package expected to be installed:
 '''
 from __future__ import annotations
 import unicodedata
-try:
-    import regex as re
-except ImportError:
-    import re  # type: ignore[no-redef]
+import regex as re  # type: ignore[no-redef]
 from collections import defaultdict
 from arelle import XbrlConst, ModelDocument as ModelDocumentFile
 from arelle.ModelDtsObject import ModelConcept, ModelType

--- a/arelle/plugin/validate/ESEF/DTS.py
+++ b/arelle/plugin/validate/ESEF/DTS.py
@@ -12,7 +12,7 @@ Taxonomy package expected to be installed:
 '''
 from __future__ import annotations
 import unicodedata
-import regex as re  # type: ignore[no-redef]
+import regex as re
 from collections import defaultdict
 from arelle import XbrlConst, ModelDocument as ModelDocumentFile
 from arelle.ModelDtsObject import ModelConcept, ModelType

--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -16,7 +16,7 @@ from arelle.PrototypeDtsObject import PrototypeObject
 from arelle import XbrlConst
 from .Const import LineItemsNotQualifiedLinkrole, DefaultDimensionLinkroles
 from .Util import isExtension, isInEsefTaxonomy
-import regex as re  # type: ignore[no-redef]
+import regex as re
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.ModelDtsObject import ModelConcept
 from arelle.typing import TypeGetText

--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -16,10 +16,7 @@ from arelle.PrototypeDtsObject import PrototypeObject
 from arelle import XbrlConst
 from .Const import LineItemsNotQualifiedLinkrole, DefaultDimensionLinkroles
 from .Util import isExtension, isInEsefTaxonomy
-try:
-    import regex as re
-except ImportError:
-    import re  # type: ignore[no-redef]
+import regex as re  # type: ignore[no-redef]
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.ModelDtsObject import ModelConcept
 from arelle.typing import TypeGetText

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -44,10 +44,7 @@ Client with curl:
 '''
 from __future__ import annotations
 import os, base64
-try:
-    import regex as re
-except ImportError:
-    import re  # type: ignore[no-redef]
+import regex as re  # type: ignore[no-redef]
 from collections import defaultdict
 from math import isnan
 from lxml.etree import _ElementTree, _Comment, _ProcessingInstruction, EntityBase, _Element

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -44,7 +44,7 @@ Client with curl:
 '''
 from __future__ import annotations
 import os, base64
-import regex as re  # type: ignore[no-redef]
+import regex as re
 from collections import defaultdict
 from math import isnan
 from lxml.etree import _ElementTree, _Comment, _ProcessingInstruction, EntityBase, _Element

--- a/arelle/plugin/validate/HMRC/__init__.py
+++ b/arelle/plugin/validate/HMRC/__init__.py
@@ -18,10 +18,7 @@ from arelle import ModelDocument, XmlUtil
 from arelle.ModelValue import qname, dateTime, DATE
 from arelle.ValidateXbrlCalcs import inferredDecimals, rangeValue, insignificantDigits
 from arelle.XbrlConst import xbrli, qnXbrliXbrl
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from collections import defaultdict
 
 memNameNumPattern = re.compile(r"^([A-Za-z-]+)([0-9]+)$")

--- a/arelle/plugin/validate/SBRnl/CustomLoader.py
+++ b/arelle/plugin/validate/SBRnl/CustomLoader.py
@@ -4,7 +4,7 @@ Created on Oct 05, 2012
 @author: Mark V Systems Limited
 (c) Copyright 2012 Mark V Systems Limited, All rights reserved.
 '''
-import re
+import regex as re
 
 def checkForBOMs(modelXbrl, file, mappedUri, filepath, *args, **kwargs):
     # callback is for all opened docs, must only process when SBRNL validation active

--- a/arelle/plugin/validate/SBRnl/Document.py
+++ b/arelle/plugin/validate/SBRnl/Document.py
@@ -11,7 +11,7 @@ from arelle.ModelObject import ModelObject, ModelComment
 from arelle.ValidateXbrlDTS import arcFromConceptQname, arcToConceptQname
 from arelle import XmlValidate
 from lxml import etree
-import re
+import regex as re
 
 xsd1_1datatypes = {qname(XbrlConst.xsd,'anyAtomicType'), qname(XbrlConst.xsd,'yearMonthDuration'), qname(XbrlConst.xsd,'dayTimeDuration'), qname(XbrlConst.xsd,'dateTimeStamp'), qname(XbrlConst.xsd,'precisionDecimal')}
 

--- a/arelle/plugin/validate/SBRnl/Filing.py
+++ b/arelle/plugin/validate/SBRnl/Filing.py
@@ -4,7 +4,7 @@ Created on Oct 05, 2012
 @author: Mark V Systems Limited
 (c) Copyright 2012 Mark V Systems Limited, All rights reserved.
 '''
-import re
+import regex as re
 from collections import defaultdict
 from arelle import (ModelDocument, ModelValue,
                 ModelRelationshipSet, XmlUtil, XbrlConst)

--- a/arelle/plugin/validate/SBRnl/__init__.py
+++ b/arelle/plugin/validate/SBRnl/__init__.py
@@ -7,10 +7,7 @@ Created on Dec 12, 2013
 import os
 from arelle import ModelDocument, ModelValue, XmlUtil
 from arelle.ModelValue import qname
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from collections import defaultdict
 from .CustomLoader import checkForBOMs
 from .Document import checkDTSdocument

--- a/arelle/plugin/validate/USSecTagging.py
+++ b/arelle/plugin/validate/USSecTagging.py
@@ -1,10 +1,7 @@
 from arelle import PluginManager
 from arelle.ModelValue import qname
 from arelle import XbrlConst
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from collections import defaultdict
 
 def compile(list, traceRows):

--- a/arelle/plugin/validateSBRnl.py
+++ b/arelle/plugin/validateSBRnl.py
@@ -13,10 +13,7 @@ from arelle.ModelDtsObject import ModelConcept, ModelType, ModelLocator, ModelRe
 from arelle.ModelFormulaObject import Aspect
 from arelle.ModelObject import ModelObject
 from arelle.ModelValue import qname
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 from lxml import etree
 from collections import defaultdict
 

--- a/arelle/pyparsing/pyparsing_py2.py2
+++ b/arelle/pyparsing/pyparsing_py2.py2
@@ -67,7 +67,7 @@ from weakref import ref as wkref
 import copy
 import sys
 import warnings
-import re
+import regex as re
 import sre_constants
 #~ sys.stderr.write( "testing pyparsing module, version %s, %s\n" % (__version__,__versionTime__ ) )
 

--- a/arelle/pyparsing/pyparsing_py3.py
+++ b/arelle/pyparsing/pyparsing_py3.py
@@ -68,10 +68,7 @@ from weakref import ref as wkref
 import copy
 import sys
 import warnings
-try:
-    import regex as re
-except ImportError:
-    import re
+import regex as re
 import sre_constants
 import collections
 #~ sys.stderr.write( "testing pyparsing module, version %s, %s\n" % (__version__,__versionTime__ ) )


### PR DESCRIPTION
#### Reason for change
#159

#### Description of change
Replace conditional `regex` imports with direct imports. Replace `re` imports with `regex as re` imports.

#### Steps to Test
Regex is used fairly ubiquitously, test a handful of functionality that uses it.

**review**:
@Arelle/arelle
