### PR TITLE
Fix long Updater module

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -96,7 +96,7 @@ class Cntlr:
         True if a system platform clipboard is implemented on current platform
 
         .. attribute:: updateURL
-        URL string of application download file (on arelle.org server).  Usually redirected to latest released application installable module.
+        URL string of application download file (on arelle.org) or None if update installs not supported by platform.
 
     """
     __version__ = "1.6.0"
@@ -109,6 +109,7 @@ class Cntlr:
         self.isCGI = False
         self.systemWordSize = int(round(math.log(sys.maxsize, 2)) + 1) # e.g., 32 or 64
         self.uiLangDir = "ltr"
+        self.updateURL = None
 
         # sys.setrecursionlimit(10000) # 1000 default exceeded in some inline documents
 
@@ -166,7 +167,7 @@ class Cntlr:
             # note that cache is in ~/Library/Caches/Arelle
             self.contextMenuClick = "<Button-2>"
             self.hasClipboard = hasGui  # clipboard always only if Gui (not command line mode)
-            self.updateURL = "http://arelle.org/download/1005"
+            self.updateURL = "https://arelle.org/download/1005"
         elif sys.platform.startswith("win"):
             self.isMac = False
             self.isMSW = True
@@ -192,9 +193,9 @@ class Cntlr:
                 self.hasClipboard = False
             self.contextMenuClick = "<Button-3>"
             if "64 bit" in sys.version:
-                self.updateURL = "http://arelle.org/download/1008"
+                self.updateURL = "https://arelle.org/download/1008"
             else: # 32 bit
-                self.updateURL = "http://arelle.org/download/1011"
+                self.updateURL = "https://arelle.org/download/1011"
         else: # Unix/Linux
             self.isMac = False
             self.isMSW = False

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -6,6 +6,8 @@ This module is Arelle's controller in windowing interactive UI mode
 @author: Mark V Systems Limited
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
+from __future__ import annotations
+
 from arelle import PythonUtil # define 2.x or 3.x string types
 import os, sys, subprocess, pickle, time, locale, re, fnmatch, platform
 
@@ -1424,7 +1426,7 @@ class CntlrWinMain (Cntlr.Cntlr):
             view.view()
 
     # worker threads showStatus
-    def showStatus(self, message, clearAfter=None):
+    def showStatus(self, message: str, clearAfter: int | None = None) -> None:
         self.uiThreadQueue.put((self.uiShowStatus, [message, clearAfter]))
 
     # ui thread showStatus

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -4,14 +4,23 @@ Created on May 30, 2010
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
 """
+from __future__ import annotations
+
+import gettext
 import os
 import threading
 import tkinter.messagebox
+import typing
+
+if typing.TYPE_CHECKING:
+    from arelle.CntlrWinMain import CntlrWinMain
+
+_ = gettext.gettext
 
 _MESSAGE_HEADER = "arelle\u2122 - Updater"
 
 
-def checkForUpdates(cntlr):
+def checkForUpdates(cntlr: CntlrWinMain) -> None:
     if not cntlr.webCache.workOffline:
         # check for updates in background
         import threading
@@ -21,7 +30,7 @@ def checkForUpdates(cntlr):
         thread.start()
 
 
-def backgroundCheckForUpdates(cntlr):
+def backgroundCheckForUpdates(cntlr: CntlrWinMain) -> None:
     cntlr.showStatus(_("Checking for updates to Arelle"))
     try:
         attachmentFileName = cntlr.webCache.getAttachmentFilename(cntlr.updateURL)
@@ -33,7 +42,7 @@ def backgroundCheckForUpdates(cntlr):
     cntlr.showStatus("")  # clear web loading status entry
 
 
-def checkUpdateUrl(cntlr, attachmentFileName):
+def checkUpdateUrl(cntlr: CntlrWinMain, attachmentFileName: str) -> None:
     # get latest header file
     try:
         from arelle import WebCache, Version
@@ -74,7 +83,7 @@ def checkUpdateUrl(cntlr, attachmentFileName):
         pass
 
 
-def backgroundDownload(cntlr, url):
+def backgroundDownload(cntlr: CntlrWinMain, url: str) -> None:
     filepathTmp = cntlr.webCache.getfilename(cntlr.updateURL, reload=True)
     if not filepathTmp:
         _showWarning(cntlr, _("Failed to download update."))
@@ -85,7 +94,7 @@ def backgroundDownload(cntlr, url):
     cntlr.uiThreadQueue.put((install, [cntlr, filepath]))
 
 
-def install(cntlr, filepath):
+def install(cntlr: CntlrWinMain, filepath: str) -> None:
     import sys
 
     if sys.platform.startswith("win"):
@@ -104,9 +113,9 @@ def install(cntlr, filepath):
     cntlr.uiThreadQueue.put((cntlr.quit, []))
 
 
-def _showInfo(cntlr, msg):
+def _showInfo(cntlr: CntlrWinMain, msg: str) -> None:
     tkinter.messagebox.showinfo(_(_MESSAGE_HEADER), msg, parent=cntlr.parent)
 
 
-def _showWarning(cntlr, msg):
+def _showWarning(cntlr: CntlrWinMain, msg: str) -> None:
     tkinter.messagebox.showwarning(_(_MESSAGE_HEADER), msg, parent=cntlr.parent)

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -8,9 +8,13 @@ from __future__ import annotations
 
 import gettext
 import os
+import subprocess
+import sys
 import threading
 import tkinter.messagebox
 import typing
+
+from arelle import Version
 
 if typing.TYPE_CHECKING:
     from arelle.CntlrWinMain import CntlrWinMain
@@ -23,8 +27,6 @@ _MESSAGE_HEADER = "arelle\u2122 - Updater"
 def checkForUpdates(cntlr: CntlrWinMain) -> None:
     if not cntlr.webCache.workOffline:
         # check for updates in background
-        import threading
-
         thread = threading.Thread(target=lambda c=cntlr: backgroundCheckForUpdates(c))
         thread.daemon = True
         thread.start()
@@ -45,8 +47,6 @@ def backgroundCheckForUpdates(cntlr: CntlrWinMain) -> None:
 def checkUpdateUrl(cntlr: CntlrWinMain, attachmentFileName: str) -> None:
     # get latest header file
     try:
-        from arelle import WebCache, Version
-
         filename = os.path.basename(attachmentFileName)
         if filename and "-20" in filename:
             i = filename.index("-20") + 1
@@ -93,8 +93,6 @@ def backgroundDownload(cntlr: CntlrWinMain, url: str) -> None:
 
 
 def install(cntlr: CntlrWinMain, filepath: str) -> None:
-    import sys
-
     if sys.platform.startswith("win"):
         os.startfile(filepath)
     else:
@@ -103,8 +101,6 @@ def install(cntlr: CntlrWinMain, filepath: str) -> None:
         else:  # linux/unix
             command = "xdg-open"
         try:
-            import subprocess
-
             subprocess.Popen([command, filepath])
         except:
             pass

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -51,7 +51,7 @@ def checkUpdateUrl(cntlr, attachmentFileName):
                     parent=cntlr.parent,
                 )
                 if reply is None:
-                    return False
+                    return
                 if reply:
                     thread = threading.Thread(
                         target=lambda u=attachmentFileName: backgroundDownload(cntlr, u)
@@ -72,8 +72,6 @@ def checkUpdateUrl(cntlr, attachmentFileName):
                 )
     except:
         pass
-
-    return
 
 
 def backgroundDownload(cntlr, url):

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -1,18 +1,23 @@
-'''
+"""
 Created on May 30, 2010
 
 @author: Mark V Systems Limited
 (c) Copyright 2011 Mark V Systems Limited, All rights reserved.
-'''
-import tkinter.messagebox, webbrowser, os, threading
+"""
+import os
+import threading
+import tkinter.messagebox
+
 
 def checkForUpdates(cntlr):
     if not cntlr.webCache.workOffline:
         # check for updates in background
         import threading
+
         thread = threading.Thread(target=lambda c=cntlr: backgroundCheckForUpdates(c))
         thread.daemon = True
         thread.start()
+
 
 def backgroundCheckForUpdates(cntlr):
     actualUrl = None
@@ -20,67 +25,80 @@ def backgroundCheckForUpdates(cntlr):
     try:
         attachmentFileName = cntlr.webCache.getAttachmentFilename(cntlr.updateURL)
         if attachmentFileName:
-            cntlr.showStatus("") # clear web loading status entry
+            cntlr.showStatus("")  # clear web loading status entry
             cntlr.uiThreadQueue.put((checkUpdateUrl, [cntlr, attachmentFileName]))
     except:
         pass
-    cntlr.showStatus("") # clear web loading status entry
+    cntlr.showStatus("")  # clear web loading status entry
+
 
 def checkUpdateUrl(cntlr, attachmentFileName):
     # get latest header file
     try:
         from arelle import WebCache, Version
+
         filename = os.path.basename(attachmentFileName)
         if filename and "-20" in filename:
             i = filename.index("-20") + 1
-            filenameDate = filename[i:i+10]
+            filenameDate = filename[i : i + 10]
             versionDate = Version.version[0:10]
             if filenameDate > versionDate:
                 # newer
                 reply = tkinter.messagebox.askyesnocancel(
-                            _("arelle\u2122 - Updater"),
-                            _("Update {0} is available, running version is {1}.  \n\nDownload now?    \n\n(Arelle will exit before installing.)").format(
-                                  filenameDate, versionDate),
-                            parent=cntlr.parent)
+                    _("arelle\u2122 - Updater"),
+                    _(
+                        "Update {0} is available, running version is {1}.  \n\nDownload now?    \n\n(Arelle will exit before installing.)"
+                    ).format(filenameDate, versionDate),
+                    parent=cntlr.parent,
+                )
                 if reply is None:
                     return False
                 if reply:
-                    thread = threading.Thread(target=lambda u=actualUrl: backgroundDownload(cntlr, u))
+                    thread = threading.Thread(
+                        target=lambda u=actualUrl: backgroundDownload(cntlr, u)
+                    )
                     thread.daemon = True
                     thread.start()
             else:
                 if filenameDate < versionDate:
-                    msg = _("Arelle running version, {0}, is newer than the downloadable version, {1}.").format(
-                              versionDate, filenameDate)
+                    msg = _(
+                        "Arelle running version, {0}, is newer than the downloadable version, {1}."
+                    ).format(versionDate, filenameDate)
                 else:
-                    msg = _("Arelle running version, {0}, is the same as the downloadable version.").format(
-                              versionDate)
-                tkinter.messagebox.showwarning(_("arelle\u2122 - Updater"), msg, parent=cntlr.parent)
-
+                    msg = _(
+                        "Arelle running version, {0}, is the same as the downloadable version."
+                    ).format(versionDate)
+                tkinter.messagebox.showwarning(
+                    _("arelle\u2122 - Updater"), msg, parent=cntlr.parent
+                )
     except:
         pass
 
     return
+
 
 def backgroundDownload(cntlr, url):
     filepathtmp = cntlr.webCache.getfilename(cntlr.updateURL, reload=True)
     cntlr.modelManager.showStatus(_("Download ompleted"), 5000)
     filepath = os.path.join(os.path.dirname(filepathtmp), os.path.basename(url))
     os.rename(filepathtmp, filepath)
-    cntlr.uiThreadQueue.put((install, [cntlr,filepath]))
+    cntlr.uiThreadQueue.put((install, [cntlr, filepath]))
 
-def install(cntlr,filepath):
+
+def install(cntlr, filepath):
     import sys
+
     if sys.platform.startswith("win"):
         os.startfile(filepath)
     else:
         if sys.platform in ("darwin", "macos"):
-            command = 'open'
-        else: # linux/unix
-            command = 'xdg-open'
+            command = "open"
+        else:  # linux/unix
+            command = "xdg-open"
         try:
             import subprocess
-            subprocess.Popen([command,filepath])
+
+            subprocess.Popen([command, filepath])
         except:
             pass
     cntlr.uiThreadQueue.put((cntlr.quit, []))

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -76,7 +76,7 @@ def checkUpdateUrl(cntlr, attachmentFileName):
 
 def backgroundDownload(cntlr, url):
     filepathtmp = cntlr.webCache.getfilename(cntlr.updateURL, reload=True)
-    cntlr.modelManager.showStatus(_("Download ompleted"), 5000)
+    cntlr.modelManager.showStatus(_("Download completed"), 5000)
     filepath = os.path.join(os.path.dirname(filepathtmp), os.path.basename(url))
     os.rename(filepathtmp, filepath)
     cntlr.uiThreadQueue.put((install, [cntlr, filepath]))

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -138,18 +138,16 @@ def _download(cntlr: CntlrWinMain, url: str) -> None:
 
 
 def _install(cntlr: CntlrWinMain, filepath: str) -> None:
-    if sys.platform.startswith("win"):
+    if sys.platform == "win32":
         os.startfile(filepath)
-    else:
-        if sys.platform in ("darwin", "macos"):
-            command = "open"
-        else:  # linux/unix
-            command = "xdg-open"
+    elif sys.platform == "darwin":
         try:
-            subprocess.Popen([command, filepath])
+            subprocess.Popen(["open", filepath])
         except (OSError, subprocess.SubprocessError):
             _showWarning(cntlr, _("Failed to start updated Arelle instance."))
             return
+    else:
+        raise RuntimeError("Tried to install update on unsupported platform.")
     cntlr.uiThreadQueue.put((cntlr.quit, []))
 
 

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -8,6 +8,8 @@ import os
 import threading
 import tkinter.messagebox
 
+_MESSAGE_HEADER = "arelle\u2122 - Updater"
+
 
 def checkForUpdates(cntlr):
     if not cntlr.webCache.workOffline:
@@ -44,7 +46,7 @@ def checkUpdateUrl(cntlr, attachmentFileName):
             if filenameDate > versionDate:
                 # newer
                 reply = tkinter.messagebox.askyesnocancel(
-                    _("arelle\u2122 - Updater"),
+                    _(_MESSAGE_HEADER),
                     _(
                         "Update {0} is available, running version is {1}.  \n\nDownload now?    \n\n(Arelle will exit before installing.)"
                     ).format(filenameDate, versionDate),
@@ -67,18 +69,19 @@ def checkUpdateUrl(cntlr, attachmentFileName):
                     msg = _(
                         "Arelle running version, {0}, is the same as the downloadable version."
                     ).format(versionDate)
-                tkinter.messagebox.showwarning(
-                    _("arelle\u2122 - Updater"), msg, parent=cntlr.parent
-                )
+                _showInfo(cntlr, msg)
     except:
         pass
 
 
 def backgroundDownload(cntlr, url):
-    filepathtmp = cntlr.webCache.getfilename(cntlr.updateURL, reload=True)
+    filepathTmp = cntlr.webCache.getfilename(cntlr.updateURL, reload=True)
+    if not filepathTmp:
+        _showWarning(cntlr, _("Failed to download update."))
+        return
     cntlr.modelManager.showStatus(_("Download completed"), 5000)
-    filepath = os.path.join(os.path.dirname(filepathtmp), os.path.basename(url))
-    os.rename(filepathtmp, filepath)
+    filepath = os.path.join(os.path.dirname(filepathTmp), os.path.basename(url))
+    os.rename(filepathTmp, filepath)
     cntlr.uiThreadQueue.put((install, [cntlr, filepath]))
 
 
@@ -99,3 +102,11 @@ def install(cntlr, filepath):
         except:
             pass
     cntlr.uiThreadQueue.put((cntlr.quit, []))
+
+
+def _showInfo(cntlr, msg):
+    tkinter.messagebox.showinfo(_(_MESSAGE_HEADER), msg, parent=cntlr.parent)
+
+
+def _showWarning(cntlr, msg):
+    tkinter.messagebox.showwarning(_(_MESSAGE_HEADER), msg, parent=cntlr.parent)

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -25,8 +25,7 @@ _MESSAGE_HEADER = "arelle\u2122 - Updater"
 
 
 def checkForUpdates(cntlr: CntlrWinMain) -> None:
-    thread = threading.Thread(target=lambda c=cntlr: backgroundCheckForUpdates(c))
-    thread.daemon = True
+    thread = threading.Thread(daemon=True, target=lambda c=cntlr: backgroundCheckForUpdates(c))
     thread.start()
 
 
@@ -76,9 +75,9 @@ def checkUpdateUrl(cntlr: CntlrWinMain, attachmentFileName: str) -> None:
             )
             if reply:
                 thread = threading.Thread(
+                    daemon=True,
                     target=lambda u=attachmentFileName: backgroundDownload(cntlr, u)
                 )
-                thread.daemon = True
                 thread.start()
         else:
             if filenameDate < versionDate:

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -54,15 +54,13 @@ def checkUpdateUrl(cntlr: CntlrWinMain, attachmentFileName: str) -> None:
             versionDate = Version.version[0:10]
             if filenameDate > versionDate:
                 # newer
-                reply = tkinter.messagebox.askyesnocancel(
+                reply = tkinter.messagebox.askokcancel(
                     _(_MESSAGE_HEADER),
                     _(
                         "Update {0} is available, running version is {1}.  \n\nDownload now?    \n\n(Arelle will exit before installing.)"
                     ).format(filenameDate, versionDate),
                     parent=cntlr.parent,
                 )
-                if reply is None:
-                    return
                 if reply:
                     thread = threading.Thread(
                         target=lambda u=attachmentFileName: backgroundDownload(cntlr, u)

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -91,10 +91,7 @@ def _checkUpdateUrl(cntlr: CntlrWinMain, attachmentFileName: str) -> None:
             parent=cntlr.parent,
         )
         if reply:
-            thread = threading.Thread(
-                daemon=True, target=lambda u=attachmentFileName: _download(cntlr, u)
-            )
-            thread.start()
+            _backgroundDownload(cntlr, attachmentFileName)
     elif updateVersion < currentVersion:
         _showInfo(
             cntlr,
@@ -116,6 +113,13 @@ def _parseVersion(versionStr: str) -> date:
     if versionDateMatch is None:
         raise ValueError(f"Unable to parse version date from {versionStr}")
     return date.fromisoformat(versionDateMatch.group("date"))
+
+
+def _backgroundDownload(cntlr: CntlrWinMain, attachmentFileName: str) -> None:
+    thread = threading.Thread(
+        daemon=True, target=lambda u=attachmentFileName: _download(cntlr, u)
+    )
+    thread.start()
 
 
 def _download(cntlr: CntlrWinMain, url: str) -> None:

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -25,14 +25,26 @@ _MESSAGE_HEADER = "arelle\u2122 - Updater"
 
 
 def checkForUpdates(cntlr: CntlrWinMain) -> None:
-    if not cntlr.webCache.workOffline:
-        # check for updates in background
-        thread = threading.Thread(target=lambda c=cntlr: backgroundCheckForUpdates(c))
-        thread.daemon = True
-        thread.start()
+    thread = threading.Thread(target=lambda c=cntlr: backgroundCheckForUpdates(c))
+    thread.daemon = True
+    thread.start()
 
 
 def backgroundCheckForUpdates(cntlr: CntlrWinMain) -> None:
+    if cntlr.updateURL is None:
+        _showInfo(
+            cntlr,
+            _(
+                """
+                Operating system not supported by update checker.
+                Please go to arelle.org to check for updates.
+                """
+            ),
+        )
+        return
+    if cntlr.webCache.workOffline:
+        _showInfo(cntlr, _("Disable offline mode to check for updates."))
+        return
     cntlr.showStatus(_("Checking for updates to Arelle"))
     try:
         attachmentFileName = cntlr.webCache.getAttachmentFilename(cntlr.updateURL)

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -20,7 +20,6 @@ def checkForUpdates(cntlr):
 
 
 def backgroundCheckForUpdates(cntlr):
-    actualUrl = None
     cntlr.showStatus(_("Checking for updates to Arelle"))
     try:
         attachmentFileName = cntlr.webCache.getAttachmentFilename(cntlr.updateURL)
@@ -55,7 +54,7 @@ def checkUpdateUrl(cntlr, attachmentFileName):
                     return False
                 if reply:
                     thread = threading.Thread(
-                        target=lambda u=actualUrl: backgroundDownload(cntlr, u)
+                        target=lambda u=attachmentFileName: backgroundDownload(cntlr, u)
                     )
                     thread.daemon = True
                     thread.start()

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -646,14 +646,12 @@ class WebCache:
                 pass
         return None
 
-    def getAttachmentFilename(self, url: str) -> str | None:  # get the filename attachment from the header
-        if url and isHttpUrl(url):
-            try:
-                fp = self.opener.open(url, timeout=self.timeout)
-                return cgi.parse_header(fp.headers.get("Content-Disposition"))[1]["filename"]
-            except Exception:
-                pass
-        return None
+    def getAttachmentFilename(self, url: str) -> str:  # get the filename attachment from the header
+        try:
+            fp = self.opener.open(url, timeout=self.timeout)
+            return cgi.parse_header(fp.headers.get("Content-Disposition"))[1]["filename"]
+        except (URLError, IndexError, KeyError) as e:
+            raise RuntimeError(f"Unable to to retrieve filename from headers for {url}") from e
 
     def retrieve(self, url, filename=None, filestream=None, reporthook=None, data=None):
         # return filename, headers (in dict), initial file bytes (to detect logon requests)

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -8,6 +8,8 @@ For SEC EDGAR data access see: https://www.sec.gov/os/accessing-edgar-data
 e.g., User-Agent: Sample Company Name AdminContact@<sample company domain>.com
 
 '''
+from __future__ import annotations
+
 import os, posixpath, sys, re, shutil, time, calendar, io, json, logging, shutil, cgi, zlib
 if sys.version[0] >= '3':
     from urllib.parse import quote, unquote
@@ -328,7 +330,10 @@ class WebCache:
                         .sub(lambda c: chr( int(c.group(0)[1:]) ), # remove ^nnn encoding
                          urlpart) for urlpart in urlparts)
 
-    def getfilename(self, url, base=None, reload=False, checkModifiedTime=False, normalize=False, filenameOnly=False):
+    def getfilename(
+            self, url: str | None, base: str | None = None,
+            reload: bool = False, checkModifiedTime: bool = False,
+            normalize: bool = False, filenameOnly: bool = False) -> str | None:
         if url is None:
             return url
         if base is not None or normalize:
@@ -641,7 +646,7 @@ class WebCache:
                 pass
         return None
 
-    def getAttachmentFilename(self, url):  # get the filename attachment from the header
+    def getAttachmentFilename(self, url: str) -> str | None:  # get the filename attachment from the header
         if url and isHttpUrl(url):
             try:
                 fp = self.opener.open(url, timeout=self.timeout)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = [
     'arelle.plugin.validate.ESEF.*',
+    'arelle.Updater',
 ]
 ignore_errors = false
 strict = true

--- a/tests/unit_tests/arelle/test_updater.py
+++ b/tests/unit_tests/arelle/test_updater.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import queue
+from unittest.mock import Mock, call, patch
+
+from arelle import Updater
+
+OLD_FILENAME = "arelle-macOS-2021-01-01.dmg"
+NEW_FILENAME = "arelle-macOS-2022-01-01.dmg"
+
+OLD_VERSION = "2021-01-01 12:00 UTC"
+NEW_VERSION = "2022-01-01 12:00 UTC"
+
+DOWNLOAD_URL = "https://arelle.org/download/X"
+
+
+def _mockCntlrWinMain(
+    updateUrl: str | None = DOWNLOAD_URL,
+    workOffline: bool = False,
+    updateFilename: str | RuntimeError | None = OLD_FILENAME,
+):
+    webCache = Mock(
+        getAttachmentFilename=Mock(side_effect=[updateFilename]),
+        getfilename=Mock(side_effect=[updateFilename]),
+        workOffline=workOffline,
+    )
+    return Mock(
+        uiThreadQueue=queue.Queue(),
+        updateURL=updateUrl,
+        webCache=webCache,
+    )
+
+
+class TestUpdater:
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    def test_check_for_updates(self, showWarning, showInfo):
+        cntlr = _mockCntlrWinMain()
+
+        Updater._checkForUpdates(cntlr)
+
+        assert not showInfo.called
+        assert not showWarning.called
+        assert not cntlr.uiThreadQueue.empty()
+        assert cntlr.uiThreadQueue.get_nowait() == (
+            Updater._checkUpdateUrl,
+            [cntlr, OLD_FILENAME],
+        )
+        assert cntlr.uiThreadQueue.empty()
+
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    def test_check_for_updates_no_update_url(self, showWarning, showInfo):
+        cntlr = _mockCntlrWinMain(
+            updateUrl=None,
+        )
+
+        Updater._checkForUpdates(cntlr)
+
+        assert showInfo.called
+        assert not showWarning.called
+        assert cntlr.uiThreadQueue.empty()
+
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    def test_check_for_updates_work_offline(self, showWarning, showInfo):
+        cntlr = _mockCntlrWinMain(
+            workOffline=True,
+        )
+
+        Updater._checkForUpdates(cntlr)
+
+        assert showInfo.called
+        assert not showWarning.called
+        assert cntlr.uiThreadQueue.empty()
+
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    def test_check_for_updates_attachment_exception(self, showWarning, showInfo):
+        cntlr = _mockCntlrWinMain(
+            updateFilename=RuntimeError(),
+        )
+
+        Updater._checkForUpdates(cntlr)
+
+        assert not showInfo.called
+        assert showWarning.called
+        assert cntlr.uiThreadQueue.empty()
+
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    @patch("tkinter.messagebox.askokcancel")
+    @patch("arelle.Updater.Version")
+    @patch("arelle.Updater._backgroundDownload")
+    def test_check_update_url_update_user_install(
+        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+    ):
+        cntlr = _mockCntlrWinMain()
+        newFilename = NEW_FILENAME
+        version.version = OLD_VERSION
+        askokcancel.return_value = True
+
+        Updater._checkUpdateUrl(cntlr, newFilename)
+
+        assert not showInfo.called
+        assert not showWarning.called
+        assert askokcancel.called
+        assert backgroundDownload.called
+
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    @patch("tkinter.messagebox.askokcancel")
+    @patch("arelle.Updater.Version")
+    @patch("arelle.Updater._backgroundDownload")
+    def test_check_update_url_update_user_no_install(
+        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+    ):
+        cntlr = _mockCntlrWinMain()
+        newFilename = NEW_FILENAME
+        version.version = OLD_VERSION
+        askokcancel.return_value = False
+
+        Updater._checkUpdateUrl(cntlr, newFilename)
+
+        assert not showInfo.called
+        assert not showWarning.called
+        assert askokcancel.called
+        assert not backgroundDownload.called
+
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    @patch("tkinter.messagebox.askokcancel")
+    @patch("arelle.Updater.Version")
+    @patch("arelle.Updater._backgroundDownload")
+    def test_check_update_url_update_older(
+        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+    ):
+        cntlr = _mockCntlrWinMain()
+        newFilename = OLD_FILENAME
+        version.version = NEW_VERSION
+
+        Updater._checkUpdateUrl(cntlr, newFilename)
+
+        assert showInfo.called
+        assert not showWarning.called
+        assert not askokcancel.called
+        assert not backgroundDownload.called
+
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    @patch("tkinter.messagebox.askokcancel")
+    @patch("arelle.Updater.Version")
+    @patch("arelle.Updater._backgroundDownload")
+    def test_check_update_url_update_same(
+        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+    ):
+        cntlr = _mockCntlrWinMain()
+        newFilename = NEW_FILENAME
+        version.version = NEW_VERSION
+
+        Updater._checkUpdateUrl(cntlr, newFilename)
+
+        assert showInfo.called
+        assert not showWarning.called
+        assert not askokcancel.called
+        assert not backgroundDownload.called
+
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    @patch("tkinter.messagebox.askokcancel")
+    @patch("arelle.Updater.Version")
+    @patch("arelle.Updater._backgroundDownload")
+    def test_check_update_url_fail_parse_current(
+        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+    ):
+        cntlr = _mockCntlrWinMain()
+        newFilename = NEW_FILENAME
+        version.version = "invalid version string"
+
+        Updater._checkUpdateUrl(cntlr, newFilename)
+
+        assert not showInfo.called
+        assert showWarning.called
+        assert not askokcancel.called
+        assert not backgroundDownload.called
+
+    @patch("tkinter.messagebox.showinfo")
+    @patch("tkinter.messagebox.showwarning")
+    @patch("tkinter.messagebox.askokcancel")
+    @patch("arelle.Updater.Version")
+    @patch("arelle.Updater._backgroundDownload")
+    def test_check_update_url_fail_parse_update(
+        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+    ):
+        cntlr = _mockCntlrWinMain()
+        newFilename = "filename-without-version-string"
+        version.version = OLD_VERSION
+
+        Updater._checkUpdateUrl(cntlr, newFilename)
+
+        assert not showInfo.called
+        assert showWarning.called
+        assert not askokcancel.called
+        assert not backgroundDownload.called
+
+    @patch("os.rename")
+    @patch("tkinter.messagebox.showwarning")
+    def test_download(self, showWarning, rename):
+        cntlr = _mockCntlrWinMain(
+            updateFilename=NEW_FILENAME,
+        )
+
+        Updater._download(cntlr, DOWNLOAD_URL)
+
+        assert not showWarning.called
+        assert not cntlr.uiThreadQueue.empty()
+        assert cntlr.uiThreadQueue.get_nowait() == (
+            Updater._install,
+            [cntlr, "X"],
+        )
+        assert cntlr.uiThreadQueue.empty()
+
+    @patch("os.rename")
+    @patch("tkinter.messagebox.showwarning")
+    def test_download_failed(self, showWarning, rename):
+        cntlr = _mockCntlrWinMain(
+            updateFilename=None,
+        )
+
+        Updater._download(cntlr, DOWNLOAD_URL)
+
+        assert showWarning.called
+        assert cntlr.uiThreadQueue.empty()
+
+    @patch("os.rename")
+    @patch("tkinter.messagebox.showwarning")
+    def test_download_process_failed(self, showWarning, rename):
+        cntlr = _mockCntlrWinMain(
+            updateFilename=NEW_FILENAME,
+        )
+        rename.side_effect = OSError()
+
+        Updater._download(cntlr, DOWNLOAD_URL)
+
+        assert showWarning.called
+        assert cntlr.uiThreadQueue.empty()
+
+    @patch("sys.platform", "win32")
+    @patch("subprocess.Popen")
+    @patch("os.startfile", create=True)
+    @patch("tkinter.messagebox.showwarning")
+    def test_install_windows(self, showWarning, startfile, Popen):
+        cntlr = _mockCntlrWinMain()
+        filepath = "filepath"
+
+        Updater._install(cntlr, filepath)
+
+        assert not showWarning.called
+        assert startfile.called
+        assert startfile.call_args == call(filepath)
+        assert not Popen.called
+        assert not cntlr.uiThreadQueue.empty()
+        assert cntlr.uiThreadQueue.get_nowait() == (cntlr.quit, [])
+        assert cntlr.uiThreadQueue.empty()
+
+    @patch("sys.platform", "darwin")
+    @patch("subprocess.Popen")
+    @patch("os.startfile", create=True)
+    @patch("tkinter.messagebox.showwarning")
+    def test_install_mac(self, showWarning, startfile, Popen):
+        cntlr = _mockCntlrWinMain()
+        filepath = "filepath"
+
+        Updater._install(cntlr, filepath)
+
+        assert not showWarning.called
+        assert not startfile.called
+        assert Popen.called
+        assert Popen.call_args == call(["open", filepath])
+        assert not cntlr.uiThreadQueue.empty()
+        assert cntlr.uiThreadQueue.get_nowait() == (cntlr.quit, [])
+        assert cntlr.uiThreadQueue.empty()
+
+    @patch("sys.platform", "darwin")
+    @patch("subprocess.Popen")
+    @patch("os.startfile", create=True)
+    @patch("tkinter.messagebox.showwarning")
+    def test_install_mac_exception(self, showWarning, startfile, Popen):
+        cntlr = _mockCntlrWinMain()
+        filepath = "filepath"
+        Popen.side_effect = OSError()
+
+        Updater._install(cntlr, filepath)
+
+        assert showWarning.called
+        assert not startfile.called
+        assert Popen.called
+        assert Popen.call_args == call(["open", filepath])
+        assert cntlr.uiThreadQueue.empty()


### PR DESCRIPTION
#### Reason for change
#247 

#### Description of change
* For the Updater module:
	* Makes it work again on mac and windows
	* Adds warning messages when something goes wrong
	* Adds type hints
	* Adds test coverage

#### Steps to Test
* load the GUI (`python arelleGUI.pyw`)
* use the check for updates feature in the help menu
* experiment with changing the date in `arelle/Version.version` to be:
	* older than the latest update
	* newer than the latest update
	* the same as the latest update

**review**:
@Arelle/arelle
