### PR TITLE
Add type hints for arelle.UrlUtil

### DIFF
--- a/arelle/UrlUtil.py
+++ b/arelle/UrlUtil.py
@@ -365,7 +365,7 @@ def isAbsolute(url: str) -> bool:
 def isHttpUrl(url: str) -> bool:
     return isinstance(url,str) and (url.startswith("http://") or url.startswith("https://"))
 
-def ensureUrl(maybeUrl: str) -> Any:
+def ensureUrl(maybeUrl: str) -> str:
     if isAbsolute(maybeUrl) or isHttpUrl(maybeUrl):
         return maybeUrl
     # probably a local file

--- a/arelle/UrlUtil.py
+++ b/arelle/UrlUtil.py
@@ -5,18 +5,10 @@ Created on Oct 22, 2010
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
 from __future__ import annotations
-import os, sys
+import os
 import regex as re
-if sys.version[0] >= '3':
-    from urllib.request import pathname2url
-    from urllib.parse import urldefrag, unquote, quote, urljoin
-    isPy3 = True
-else:
-    from urlparse import urldefrag, urljoin
-    from urllib import quote
-    from urllib import pathname2url
-    from arelle.PythonUtil import py3unquote as unquote
-    isPy3 = False
+from urllib.request import pathname2url
+from urllib.parse import urldefrag, unquote, quote, urljoin
 
 def authority(url, includeScheme=True):
     if url:
@@ -50,21 +42,14 @@ def splitDecodeFragment(url):
     if url is None: # urldefrag returns byte strings for none, instead of unicode strings
         return _STR_UNICODE(""), _STR_UNICODE("")
     urlPart, fragPart = urldefrag(url)
-    if isPy3:
-        return (urlPart, unquote(fragPart, "utf-8", errors=None))
-    else:
-        return _STR_UNICODE(urlPart), unquote(_STR_UNICODE(fragPart), "utf-8", errors=None)
+    return (urlPart, unquote(fragPart, "utf-8", errors=None))
 
 def anyUriQuoteForPSVI(uri):
     # only quote if quotable character found
     if any(c in {' ', '<', '>', '"', '{', '}', '|', '\\', '^', '~', '`'} or
            not '\x1f' < c < '\x7f'
            for c in uri):
-        if not isPy3:  # patch for unicode per http://hg.python.org/cpython/rev/1e21d94e05f4/
-            return quote(uri.encode(b'utf-8', b'strict'),
-                         safe=b"/_.-%#!~*'();?:@&=+$,")  # b'str' converts to 2.7 str type which is required here
-        else:
-            return quote(uri, safe="/_.-%#!~*'();?:@&=+$,")
+        return quote(uri, safe="/_.-%#!~*'();?:@&=+$,")
     return uri
 
 def isValidAbsolute(url):

--- a/arelle/UrlUtil.py
+++ b/arelle/UrlUtil.py
@@ -6,11 +6,14 @@ Created on Oct 22, 2010
 '''
 from __future__ import annotations
 import os
+from typing import Any
 import regex as re
 from urllib.request import pathname2url
 from urllib.parse import urldefrag, unquote, quote, urljoin
+from email.utils import parsedate
+from datetime import datetime
 
-def authority(url, includeScheme=True):
+def authority(url: str, includeScheme: bool=True) -> str:
     if url:
         authSep = url.find(':')
         if authSep > -1:
@@ -38,13 +41,13 @@ absoluteUrlPattern = None
 # This regular expression is only partial validation.
 relativeUrlPattern = re.compile(r"^(urn:|(([a-zA-Z][a-zA-Z0-9.+-]+):)?(//([^/\?#]*))?(?![^:/]*:[^/]*(/|$)))([^\?#]*)(\?([^#]*))?(#([^#]*))?$")
 
-def splitDecodeFragment(url):
+def splitDecodeFragment(url: str) -> tuple[str, str]:
     if url is None: # urldefrag returns byte strings for none, instead of unicode strings
-        return _STR_UNICODE(""), _STR_UNICODE("")
+        return _STR_UNICODE(""), _STR_UNICODE("") # type: ignore[name-defined]
     urlPart, fragPart = urldefrag(url)
-    return (urlPart, unquote(fragPart, "utf-8", errors=None))
+    return (urlPart, unquote(fragPart, "utf-8"))
 
-def anyUriQuoteForPSVI(uri):
+def anyUriQuoteForPSVI(uri: str) -> str:
     # only quote if quotable character found
     if any(c in {' ', '<', '>', '"', '{', '}', '|', '\\', '^', '~', '`'} or
            not '\x1f' < c < '\x7f'
@@ -52,7 +55,7 @@ def anyUriQuoteForPSVI(uri):
         return quote(uri, safe="/_.-%#!~*'();?:@&=+$,")
     return uri
 
-def isValidAbsolute(url):
+def isValidAbsolute(url: str) -> bool:
     global absoluteUrlPattern
     if absoluteUrlPattern is None:
         absoluteUrlPattern = re.compile(
@@ -347,10 +350,10 @@ def isValidAbsolute(url):
             )
     return absoluteUrlPattern.match(url) is not None
 
-def isValidUriReference(url):
+def isValidUriReference(url: str) -> bool:
     return relativeUrlPattern.match(url) is not None
 
-def isAbsolute(url):
+def isAbsolute(url: str) -> bool:
     if url:
         scheme, sep, path = url.partition(":")
         if scheme in ("http", "https", "ftp"):
@@ -359,18 +362,16 @@ def isAbsolute(url):
             return True
     return False
 
-def isHttpUrl(url):
+def isHttpUrl(url: str) -> bool:
     return isinstance(url,str) and (url.startswith("http://") or url.startswith("https://"))
 
-def ensureUrl(maybeUrl):
+def ensureUrl(maybeUrl: str) -> Any:
     if isAbsolute(maybeUrl) or isHttpUrl(maybeUrl):
         return maybeUrl
     # probably a local file
     return urljoin('file:', pathname2url(maybeUrl))
 
-def parseRfcDatetime(rfc2822date):
-    from email.utils import parsedate
-    from datetime import datetime
+def parseRfcDatetime(rfc2822date: str) -> datetime | None:
     if rfc2822date:
         d = parsedate(rfc2822date)
         if d:
@@ -378,7 +379,7 @@ def parseRfcDatetime(rfc2822date):
     return None
 
 zipRelativeFilePattern = re.compile(r".*[.]zip[/\\](.*)$")
-def relativeUri(baseUri, relativeUri): # return uri relative to this modelDocument uri
+def relativeUri(baseUri: str, relativeUri: str) -> str: # return uri relative to this modelDocument uri
     if isHttpUrl(relativeUri):
         return relativeUri
     # check if base is zip-relative and relativeUri is not

--- a/arelle/UrlUtil.py
+++ b/arelle/UrlUtil.py
@@ -43,7 +43,7 @@ relativeUrlPattern = re.compile(r"^(urn:|(([a-zA-Z][a-zA-Z0-9.+-]+):)?(//([^/\?#
 
 def splitDecodeFragment(url: str) -> tuple[str, str]:
     if url is None: # urldefrag returns byte strings for none, instead of unicode strings
-        return _STR_UNICODE(""), _STR_UNICODE("") # type: ignore[name-defined]
+        return "", ""
     urlPart, fragPart = urldefrag(url)
     return (urlPart, unquote(fragPart, "utf-8"))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ module = [
     'arelle.plugin.validate.ESEF.*',
     'arelle.Cntlr',
     'arelle.Updater',
+    'arelle.UrlUtil',
     'arelle.ValidateXbrl',
 ]
 ignore_errors = false


### PR DESCRIPTION
#### Reason for change
This continues the work of adding type hints.

#### Description of change
I've started looking into a few other files and noted functions herein are quite commonly used so I though it'd make sense to add type hints to it.

I've also removed the Python 2-related code from the file. Although this is not strictly related to adding type hints, it helps me by not having to filter `urlparse` due to lacking type stubs.

#### Steps to Test

**review**:
@Arelle/arelle
