### PR TITLE
Add type hints arelle.ModelObject.py

### DIFF
--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -6,18 +6,18 @@ Refactored on Jun 11, 2011 to ModelDtsObject, ModelInstanceObject, ModelTestcase
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
 from lxml import etree
-from collections import namedtuple
 from arelle import Locale
-XmlUtil = None
+from arelle.ModelValue import qname, qnameEltPfxName, QName
+import arelle.XmlUtil
+
+
 VALID_NO_CONTENT = None
 
 emptySet = set()
 
 def init(): # init globals
-    global XmlUtil, VALID_NO_CONTENT
-    if XmlUtil is None:
-        from arelle import XmlUtil
-        from arelle.XmlValidate import VALID_NO_CONTENT
+    global VALID_NO_CONTENT
+    from arelle.XmlValidate import VALID_NO_CONTENT
 
 class ModelObject(etree.ElementBase):
     """ModelObjects represent the XML elements within a document, and are implemented as custom
@@ -312,8 +312,7 @@ class ModelObject(etree.ElementBase):
             elif id in doc.idObjects:
                 return doc.idObjects[id]
             else:
-                from arelle.XmlUtil import xpointerElement
-                xpointedElement = xpointerElement(doc,id)
+                xpointedElement = arelle.XmlUtil.xpointerElement(doc,id)
                 # find element
                 for docModelObject in doc.xmlRootElement.iter():
                     if docModelObject == xpointedElement:
@@ -344,13 +343,11 @@ class ModelObject(etree.ElementBase):
     @property
     def propertyView(self):
         return (("QName", self.elementQname),) + tuple(
-                (XmlUtil.clarkNotationToPrefixedName(self, _tag, isAttribute=True), _value)
+                (arelle.XmlUtil.clarkNotationToPrefixedName(self, _tag, isAttribute=True), _value)
                 for _tag, _value in self.items())
 
     def __repr__(self):
         return ("{0}[{1}, {2} line {3})".format(type(self).__name__, self.objectIndex, self.modelDocument.basename, self.sourceline))
-
-from arelle.ModelValue import qname, qnameEltPfxName, QName
 
 class ModelComment(etree.CommentBase):
     """ModelConcept is a custom proxy objects for etree.

--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -255,9 +255,8 @@ class ModelObject(etree.ElementBase):
 
 
     @property
-    def id(self) -> str:
-        _id = self.get("id")
-        return cast(str, _id)
+    def id(self) -> str | None:
+        return self.get("id")
 
     @property
     def stringValue(self) -> str:    # "string value" of node, text of all Element descendants

--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -106,7 +106,7 @@ class ModelObject(etree.ElementBase):
         Dict by attrTag of ModelAttribute objects (see below) of specified and default attributes of this element.
     """
 
-    _elementQname: QName | None
+    _elementQname: QName
     _parentQname: QName | None
     _elementSequence: int
     _namespaceURI: str | None
@@ -203,7 +203,7 @@ class ModelObject(etree.ElementBase):
 
     # qname of concept of fact or element for all but concept element, type, attr, param, override to the name parameter
     @property
-    def qname(self) -> QName | None:
+    def qname(self) -> QName:
         try:
             return self._elementQname
         except AttributeError:
@@ -212,14 +212,14 @@ class ModelObject(etree.ElementBase):
 
     # qname is overridden for concept, type, attribute, and formula parameter, elementQname is unambiguous
     @property
-    def elementQname(self) -> QName | None:
+    def elementQname(self) -> QName:
         try:
             return self._elementQname
         except AttributeError:
-            self._elementQname = qname(self)
+            self._elementQname = cast(QName, qname(self))
             return self._elementQname
 
-    def vQname(self, validationModelXbrl: ModelXbrl | None = None) -> QName | None:
+    def vQname(self, validationModelXbrl: ModelXbrl | None = None) -> QName:
         if validationModelXbrl is not None and validationModelXbrl != self.modelXbrl:
             # use physical element declaration in specified modelXbrl
             return self.elementQname
@@ -255,8 +255,9 @@ class ModelObject(etree.ElementBase):
 
 
     @property
-    def id(self) -> str | None:
-        return self.get("id")
+    def id(self) -> str:
+        _id = self.get("id")
+        return cast(str, _id)
 
     @property
     def stringValue(self) -> str:    # "string value" of node, text of all Element descendants

--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -328,7 +328,7 @@ class ModelObject(etree.ElementBase):
             hrefElt,doc,id = hrefObject
         elif uri:
             from arelle import UrlUtil
-            url, id = UrlUtil.splitDecodeFragment(uri) # type: ignore[no-untyped-call]
+            url, id = UrlUtil.splitDecodeFragment(uri)
             if url == "":
                 doc = self.modelDocument
             else:

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -945,6 +945,7 @@ class ValidateXbrl:
                     self.modelXbrl.error("xbrl.4.7.2:contextDateError",
                         _("Context %(contextID)s instant date: %(error)s"),
                         modelObject=cntx, contextID=cntx.id, error=err)
+            assert cntx.id is not None
             self.segmentScenario(cntx.segment, cntx.id, "segment", "4.7.3.2")
             self.segmentScenario(cntx.scenario, cntx.id, "scenario", "4.7.4")
 

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -42,7 +42,7 @@ def isInEsefTaxonomy(val: ValidateXbrl, modelObject: ModelObject | None) -> bool
 
     assert modelObject.qname is not None
     ns = modelObject.qname.namespaceURI
-    assert ns  is not None
+    assert ns is not None
     return (any(ns.startswith(esefNsPrefix) for esefNsPrefix in esefTaxonomyNamespaceURIs))
 
 supportedImgTypes: dict[bool, tuple[str, ...]] = {

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -39,7 +39,10 @@ def isExtension(val: ValidateXbrl, modelObject: ModelObject | ModelDocument | st
 def isInEsefTaxonomy(val: ValidateXbrl, modelObject: ModelObject | None) -> bool:
     if modelObject is None:
         return False
+
+    assert modelObject.qname is not None
     ns = modelObject.qname.namespaceURI
+    assert ns  is not None
     return (any(ns.startswith(esefNsPrefix) for esefNsPrefix in esefTaxonomyNamespaceURIs))
 
 supportedImgTypes: dict[bool, tuple[str, ...]] = {

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -696,11 +696,11 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
         if contextsWithPeriodTime:
             modelXbrl.error("ESEF.2.1.2.periodWithTimeContent",
                 _("The xbrli:startDate, xbrli:endDate and xbrli:instant elements MUST identify periods using whole days (i.e. specified without a time content): %(contextIds)s"),
-                modelObject=contextsWithPeriodTime, contextIds=", ".join(c.id for c in contextsWithPeriodTime))
+                modelObject=contextsWithPeriodTime, contextIds=", ".join(c.id for c in contextsWithPeriodTime if c.id is not None))
         if contextsWithPeriodTimeZone:
             modelXbrl.error("ESEF.2.1.2.periodWithTimeZone",
                 _("The xbrli:startDate, xbrli:endDate and xbrli:instant elements MUST identify periods using whole days (i.e. specified without a time zone): %(contextIds)s"),
-                modelObject=contextsWithPeriodTimeZone, contextIds=", ".join(c.id for c in contextsWithPeriodTimeZone))
+                modelObject=contextsWithPeriodTimeZone, contextIds=", ".join(c.id for c in contextsWithPeriodTimeZone if c.id is not None))
 
         # identify unique contexts and units
         mapContext = {}

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -696,11 +696,11 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
         if contextsWithPeriodTime:
             modelXbrl.error("ESEF.2.1.2.periodWithTimeContent",
                 _("The xbrli:startDate, xbrli:endDate and xbrli:instant elements MUST identify periods using whole days (i.e. specified without a time content): %(contextIds)s"),
-                modelObject=contextsWithPeriodTime, contextIds=", ".join(c.id for c in contextsWithPeriodTime if c.id is not None))
+                modelObject=contextsWithPeriodTime, contextIds=", ".join(c.id for c in contextsWithPeriodTime if c.id))
         if contextsWithPeriodTimeZone:
             modelXbrl.error("ESEF.2.1.2.periodWithTimeZone",
                 _("The xbrli:startDate, xbrli:endDate and xbrli:instant elements MUST identify periods using whole days (i.e. specified without a time zone): %(contextIds)s"),
-                modelObject=contextsWithPeriodTimeZone, contextIds=", ".join(c.id for c in contextsWithPeriodTimeZone if c.id is not None))
+                modelObject=contextsWithPeriodTimeZone, contextIds=", ".join(c.id for c in contextsWithPeriodTimeZone if c.id))
 
         # identify unique contexts and units
         mapContext = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ ignore_errors = true
 module = [
     'arelle.plugin.validate.ESEF.*',
     'arelle.Cntlr',
+    'arelle.ModelObject',
     'arelle.Updater',
     'arelle.ValidateXbrl',
 ]


### PR DESCRIPTION
#### Reason for change
Adding more type hints.

#### Description of change
- Doing some cleanup of circular imports
- Adding type hints to `arelle.ModelObject`

#### Steps to Test

**review**:
@Arelle/arelle
