### PR TITLE
Add type hints to arelle/FileSource.py

### DIFF
--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -119,7 +119,7 @@ def resourcesFilePath(modelManager: ModelManager, fileName: str) -> str:
     return os.path.join(_resourcesDir, fileName)
 
 def loadAuthorityValidations(modelXbrl: ModelXbrl) -> list[Any] | dict[Any, Any]:
-    _file = openFileStream(modelXbrl.modelManager.cntlr, resourcesFilePath(modelXbrl.modelManager, "authority-validations.json"), 'rt', encoding='utf-8')  # type: ignore[no-untyped-call]
+    _file = openFileStream(modelXbrl.modelManager.cntlr, resourcesFilePath(modelXbrl.modelManager, "authority-validations.json"), 'rt', encoding='utf-8')
     validations = json.load(_file) # {localName: date, ...}
     _file.close()
     return cast(Union[dict[Any, Any], list[Any]], validations)

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -82,6 +82,7 @@ from arelle.ModelInstanceObject import ModelInlineFootnote
 from arelle.ModelInstanceObject import ModelContext
 from typing import Any, cast
 from collections.abc import Generator
+import zipfile
 
 _: TypeGetText  # Handle gettext
 
@@ -120,7 +121,7 @@ def modelXbrlBeforeLoading(modelXbrl: ModelXbrl, normalizedUri: str, filepath: s
                     modelXbrl.fileSource.selection.endswith(".xml") and
                     # Ignoring for now: Argument 1 to "identify" of "Type" has incompatible type "FileSource"; expected "Type".
                     # It is not entirely clear why self isn't used in the identify-method.
-                    ModelDocument.Type.identify(modelXbrl.fileSource, modelXbrl.fileSource.url) in ( # type: ignore[arg-type]
+                    ModelDocument.Type.identify(modelXbrl.fileSource, modelXbrl.fileSource.url) in (
                         ModelDocument.Type.TESTCASESINDEX, ModelDocument.Type.TESTCASE)):
                     return None # allow zipped test case to load normally
                 if not validateTaxonomyPackage(modelXbrl.modelManager.cntlr, modelXbrl.fileSource):
@@ -223,6 +224,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
 
     reportPackageMaxMB = val.authParam["reportPackageMaxMB"]
     if reportPackageMaxMB is not None and modelXbrl.fileSource.fs: # must be a zip to be a report package
+        assert isinstance(modelXbrl.fileSource.fs, zipfile.ZipFile)
         maxMB = float(reportPackageMaxMB)
         if val.authParam["reportPackageMeasurement"] == "unzipped":
             _size = sum(zi.file_size for zi in modelXbrl.fileSource.fs.infolist())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,19 @@ ignore_errors = true
 module = [
     'arelle.plugin.validate.ESEF.*',
     'arelle.Cntlr',
+    'arelle.FileSource',
     'arelle.Updater',
     'arelle.UrlUtil',
     'arelle.ValidateXbrl',
 ]
 ignore_errors = false
 strict = true
+
+# --- Modules lacking stubs ---
+# Add any module missing library stubs or not having
+# the py.typed marker here
+[[tool.mypy.overrides]]
+module = [
+    'google.appengine.api.*',
+]
+ignore_missing_imports = true


### PR DESCRIPTION
#### Reason for change
Adding type hints.

#### Description of change
This PR adds type hints to `arelle/FileSource.py`.

Note quite done yet so I'm keeping it as a draft for now. There are 13 errors left, mostly around IO return types.

#### Steps to Test

**review**:
@Arelle/arelle
