### PR TITLE
Log error and avoid crash on plugin load failure

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -73,6 +73,10 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.labelLang = overrideLang if overrideLang else self.modelManager.defaultLang
         self.data = {}
 
+        # Background processes communicate with UI thread through this queue
+        # Prepare early so messages encountered during initialization can be queued for logging
+        self.uiThreadQueue = queue.Queue()
+
         if self.isMac: # mac Python fonts bigger than other apps (terminal, text edit, Word), and to windows Arelle
             _defaultFont = tkFont.nametofont("TkDefaultFont") # label, status bar, treegrid
             _defaultFont.configure(size=11)
@@ -429,7 +433,6 @@ class CntlrWinMain (Cntlr.Cntlr):
 
         self.logFile = None
 
-        self.uiThreadQueue = queue.Queue()     # background processes communicate with ui thread
         self.uiThreadChecker(self.statusbar)    # start background queue
 
         self.modelManager.loadCustomTransforms() # load if custom transforms not loaded

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -447,7 +447,7 @@ def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
                     logPluginTrace(_msg, error=True)
             for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
                 loadModule(importModuleInfo, packageImportPrefix)
-        except (AttributeError, ImportError, ModuleNotFoundError, TypeError, SystemError) as err:
+        except (AttributeError, ImportError, FileNotFoundError, ModuleNotFoundError, TypeError, SystemError) as err:
             # Send a summary of the error to the logger and retain the stacktrace for stderr
             _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -157,14 +157,14 @@ moduleInfo = {
 def logPluginTrace(message: str, level: Number) -> None:
     """
     If plugin trace file logging is configured, logs `message` to it.
-    Otherwise, only logs to controller logger if log is an error.
+    Only logs to controller logger if log is an error.
     :param message: Message to be logged
     :param level: Log level of message (e.g. logging.INFO)
     """
     global pluginTraceFileLogger
     if pluginTraceFileLogger:
         pluginTraceFileLogger.log(level, message)
-    elif level >= logging.ERROR:
+    if level >= logging.ERROR:
         _cntlr.addToLog(message=message, level=level, messageCode='arelle:pluginLoadingError')
 
 


### PR DESCRIPTION
#### Reason for change
Closes #252 

#### Description of change
FileNotFoundError was not being captured/logged on plug-in execution exception like other exception types.
Also consolidated and updated logging around plug-in initialization.

#### Steps to Test
- Move, rename, or otherwise make unfindable a non-repo plugin (like EdgarRenderer) referenced in `plugins.json`
- Launch `arelleGUI.pyw` from repo
- Should launch successfully with "Unable to load module ____" visible in messages window

**review**:
@Arelle/arelle
