### PR TITLE
Add type hints to arelle.XbrlUtil

### DIFF
--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -110,6 +110,9 @@ class ModelObject(etree.ElementBase):
     _parentQname: QName | None
     _elementSequence: int
     _namespaceURI: str | None
+    _hashSEqual: int
+    _hashXpathEqual: int
+    
     xlinkLabel: str
 
     def _init(self) -> None:

--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -112,7 +112,8 @@ class ModelObject(etree.ElementBase):
     _namespaceURI: str | None
     _hashSEqual: int
     _hashXpathEqual: int
-    
+    sValue = str
+    xValue = Any # this can be any thing
     xlinkLabel: str
 
     def _init(self) -> None:

--- a/arelle/XbrlUtil.py
+++ b/arelle/XbrlUtil.py
@@ -63,7 +63,8 @@ def equalityHash(
                 return cast(int, getattr(elt, '_hashXpathEqual'))
         except AttributeError:
             dts = elt.modelXbrl
-            assert isinstance(dts, ModelXbrl)
+            from arelle.ModelXbrl import ModelXbrl
+            assert isinstance(dts, ModelXbrl), 'dts is not an instance of ModelXbrl'
             if not hasattr(elt,"xValid"):
                 xmlValidate(dts, elt)  # type: ignore[no-untyped-call]
             hashableValue = getattr(elt, 'sValue') if equalMode == S_EQUAL else getattr(elt, 'xValue')

--- a/arelle/XbrlUtil.py
+++ b/arelle/XbrlUtil.py
@@ -67,7 +67,7 @@ def equalityHash(
             assert isinstance(dts, ModelXbrl), 'dts is not an instance of ModelXbrl'
             if not hasattr(elt,"xValid"):
                 xmlValidate(dts, elt)  # type: ignore[no-untyped-call]
-            hashableValue = getattr(elt, 'sValue') if equalMode == S_EQUAL else getattr(elt, 'xValue')
+            hashableValue = elt.sValue if equalMode == S_EQUAL else elt.xValue
             if isinstance(hashableValue,float) and math.isnan(hashableValue):
                 hashableValue = (hashableValue,elt)    # ensure this NaN only compares to itself and no other NaN
             _hash = hash((elt.elementQname,
@@ -132,7 +132,7 @@ def attributeDict(
     exclusions: set[str] = set(),
     equalMode: int = S_EQUAL,
     excludeIDs: int = NO_IDs_EXCLUDED,
-    ns2ns1Tbl: dict[str, str] | None= None,
+    ns2ns1Tbl: dict[str, str] | None = None,
     keyByTag: bool = False,
     distinguishNaNs: bool = False
 ) -> dict[QName, Any]:  # value can be any element value
@@ -195,8 +195,7 @@ def xEqual(elt1: ModelObject, elt2: ModelObject, equalMode: int = S_EQUAL) -> bo
         elt2_xValue = elt2.xValue
         if isinstance(elt1_xValue, DateTime) \
             and isinstance(elt2_xValue, DateTime) \
-                and getattr(elt1_xValue, 'dateOnly') \
-                    != getattr(elt2_xValue, 'dateOnly'):
+                and elt1_xValue.dateOnly != elt2_xValue.dateOnly:  # type: ignore[attr-defined]
             return False
         return elt1_xValue == elt2_xValue
 

--- a/arelle/XbrlUtil.py
+++ b/arelle/XbrlUtil.py
@@ -5,7 +5,7 @@ Created on Nov 26, 2010
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
 from __future__ import annotations
-from typing import Any, Sequence, TYPE_CHECKING, cast
+from typing import Any, Sequence, TYPE_CHECKING
 import math
 from arelle.ModelValue import QName, DateTime
 from arelle.ModelObject import ModelObject, ModelAttribute
@@ -189,23 +189,23 @@ def xEqual(elt1: ModelObject, elt2: ModelObject, equalMode: int = S_EQUAL) -> bo
     if equalMode == VALIDATE_BY_STRING_VALUE:
         return elt1.stringValue == elt2.stringValue
     elif equalMode == S_EQUAL: # formula WG e-mail 2018-09-06: or (equalMode == S_EQUAL2 and not isinstance(elt1.sValue, QName)):
-        return cast(bool, getattr(elt1, 'sValue') == getattr(elt2, 'sValue'))
+        return elt1.sValue == elt2.sValue
     else: # includes dimension S-equal2, use xpath-2 equality.
-        elt1_xValue = getattr(elt1, 'xValue')
-        elt2_xValue = getattr(elt2, 'xValue')
+        elt1_xValue = elt1.xValue
+        elt2_xValue = elt2.xValue
         if isinstance(elt1_xValue, DateTime) \
             and isinstance(elt2_xValue, DateTime) \
                 and getattr(elt1_xValue, 'dateOnly') \
                     != getattr(elt2_xValue, 'dateOnly'):
             return False
-        return cast(bool, elt1_xValue == elt2_xValue)
+        return elt1_xValue == elt2_xValue
 
 def vEqual(elt1: ModelObject, elt2: ModelObject) -> bool:
     if not hasattr(elt1,"xValid"):
         xmlValidate(elt1.modelXbrl, elt1)  # type: ignore[no-untyped-call]
     if not hasattr(elt2,"xValid"):
         xmlValidate(elt2.modelXbrl, elt2)  # type: ignore[no-untyped-call]
-    return cast(bool, getattr(elt1, 'sValue') == getattr(elt2, 'sValue'))
+    return elt1.sValue == elt2.sValue
 
 def typedValue(
     dts: ModelXbrl | None,

--- a/arelle/XbrlUtil.py
+++ b/arelle/XbrlUtil.py
@@ -58,9 +58,9 @@ def equalityHash(
     if isinstance(elt, ModelObject):
         try:
             if equalMode == S_EQUAL:
-                return cast(int, getattr(elt, '_hashSEqual'))
+                return elt._hashSEqual
             else:
-                return cast(int, getattr(elt, '_hashXpathEqual'))
+                return elt._hashXpathEqual
         except AttributeError:
             dts = elt.modelXbrl
             from arelle.ModelXbrl import ModelXbrl
@@ -77,9 +77,9 @@ def equalityHash(
                           tuple(equalityHash(child,equalMode,excludeIDs) for child in childElements(elt))
                           ))
             if equalMode == S_EQUAL:
-                setattr(elt, '_hashSEqual', _hash)
+                elt._hashSEqual = _hash
             else:
-                setattr(elt, '_hashXpathEqual', _hash)
+                elt._hashXpathEqual = _hash
             return _hash
     elif isinstance(elt, (tuple,list,set)):
         return hash( tuple(equalityHash(i) for i in elt) )

--- a/arelle/XbrlUtil.py
+++ b/arelle/XbrlUtil.py
@@ -5,22 +5,32 @@ Created on Nov 26, 2010
 (c) Copyright 2010 Mark V Systems Limited, All rights reserved.
 '''
 from __future__ import annotations
-from typing import Any
+from typing import Any, Sequence, TYPE_CHECKING, cast
 import math
 from arelle.ModelValue import QName, DateTime
 from arelle.ModelObject import ModelObject, ModelAttribute
 from arelle.XmlValidate import UNKNOWN, VALID, VALID_ID, validate as xmlValidate
 
-S_EQUAL = 0 # ordinary S-equality from 2.1 spec
-S_EQUAL2 = 1 # XDT definition adds QName comparisions
-XPATH_EQ = 2 # XPath EQ on all types
-VALIDATE_BY_STRING_VALUE = 3
+if TYPE_CHECKING:
+    from arelle.ModelXbrl import ModelXbrl
 
-NO_IDs_EXCLUDED = 0
-ALL_IDs_EXCLUDED = 1
-TOP_IDs_EXCLUDED = 2 # only ancestor IDs are excluded
+S_EQUAL: int = 0 # ordinary S-equality from 2.1 spec
+S_EQUAL2: int = 1 # XDT definition adds QName comparisons
+XPATH_EQ: int = 2 # XPath EQ on all types
+VALIDATE_BY_STRING_VALUE: int = 3
 
-def nodesCorrespond(dts1, elt1, elt2, dts2=None, equalMode=XPATH_EQ, excludeIDs=ALL_IDs_EXCLUDED):
+NO_IDs_EXCLUDED: int = 0
+ALL_IDs_EXCLUDED: int = 1
+TOP_IDs_EXCLUDED: int = 2 # only ancestor IDs are excluded
+
+def nodesCorrespond(
+    dts1: ModelXbrl,
+    elt1: ModelObject | ModelAttribute | None,
+    elt2: ModelObject | ModelAttribute | None,
+    dts2: ModelXbrl | None = None,
+    equalMode: int = XPATH_EQ,
+    excludeIDs: int = ALL_IDs_EXCLUDED
+) -> bool:
     if elt1 is None:
         return elt2 is None #both can be empty sequences (no element) and true
     elif elt2 is None or not isinstance(elt1, (ModelObject,ModelAttribute)) or not isinstance(elt2, (ModelObject,ModelAttribute)):
@@ -37,40 +47,53 @@ def nodesCorrespond(dts1, elt1, elt2, dts2=None, equalMode=XPATH_EQ, excludeIDs=
     return sEqual(dts1, elt1, elt2, equalMode=equalMode, dts2=dts2, excludeIDs=ALL_IDs_EXCLUDED)
 
 # dts1 is modelXbrl for first element
-# dts2 is for second element assumed same unless dts2 and ns2 to ns1 maping table provided
+# dts2 is for second element assumed same unless dts2 and ns2 to ns1 mapping table provided
 #   (as used in versioning reports and multi instance
 
-def equalityHash(elt, equalMode=S_EQUAL, excludeIDs=NO_IDs_EXCLUDED):
+def equalityHash(
+    elt: ModelObject | Sequence[ModelObject],
+    equalMode: int = S_EQUAL,
+    excludeIDs: int = NO_IDs_EXCLUDED
+) -> int:
     if isinstance(elt, ModelObject):
         try:
             if equalMode == S_EQUAL:
-                return elt._hashSEqual
+                return cast(int, getattr(elt, '_hashSEqual'))
             else:
-                return elt._hashXpathEqual
+                return cast(int, getattr(elt, '_hashXpathEqual'))
         except AttributeError:
             dts = elt.modelXbrl
+            assert isinstance(dts, ModelXbrl)
             if not hasattr(elt,"xValid"):
-                xmlValidate(dts, elt)
-            hashableValue = elt.sValue if equalMode == S_EQUAL else elt.xValue
+                xmlValidate(dts, elt)  # type: ignore[no-untyped-call]
+            hashableValue = getattr(elt, 'sValue') if equalMode == S_EQUAL else getattr(elt, 'xValue')
             if isinstance(hashableValue,float) and math.isnan(hashableValue):
                 hashableValue = (hashableValue,elt)    # ensure this NaN only compares to itself and no other NaN
             _hash = hash((elt.elementQname,
                           hashableValue,
-                          tuple(sorted(attributeDict(dts, elt, (), equalMode, excludeIDs, distinguishNaNs=True).items(),
+                          tuple(sorted(attributeDict(dts, elt, set(), equalMode, excludeIDs, distinguishNaNs=True).items(),
                                        key=lambda item: item[0])), # must sort so attrs always hashed in same order
                           tuple(equalityHash(child,equalMode,excludeIDs) for child in childElements(elt))
                           ))
             if equalMode == S_EQUAL:
-                elt._hashSEqual = _hash
+                setattr(elt, '_hashSEqual', _hash)
             else:
-                elt._hashXpathEqual = _hash
+                setattr(elt, '_hashXpathEqual', _hash)
             return _hash
     elif isinstance(elt, (tuple,list,set)):
         return hash( tuple(equalityHash(i) for i in elt) )
     else:
         return hash(None)
 
-def sEqual(dts1, elt1, elt2, equalMode=S_EQUAL, excludeIDs=NO_IDs_EXCLUDED, dts2=None, ns2ns1Tbl=None):
+def sEqual(
+    dts1: ModelXbrl,
+    elt1: ModelObject,
+    elt2: ModelObject,
+    equalMode: int = S_EQUAL,
+    excludeIDs: int = NO_IDs_EXCLUDED,
+    dts2: ModelXbrl | None = None,
+    ns2ns1Tbl: dict[str, str] | None = None
+) -> bool:
     if dts2 is None: dts2 = dts1
     if elt1.localName != elt2.localName:
         return False
@@ -80,9 +103,9 @@ def sEqual(dts1, elt1, elt2, equalMode=S_EQUAL, excludeIDs=NO_IDs_EXCLUDED, dts2
     elif elt1.namespaceURI != elt2.namespaceURI:
         return False
     if not hasattr(elt1,"xValid"):
-        xmlValidate(dts1, elt1)
+        xmlValidate(dts1, elt1)  # type: ignore[no-untyped-call]
     if not hasattr(elt2,"xValid"):
-        xmlValidate(dts2, elt2)
+        xmlValidate(dts2, elt2)  # type: ignore[no-untyped-call]
     children1 = childElements(elt1)
     children2 = childElements(elt2)
     if len(children1) != len(children2):
@@ -93,8 +116,8 @@ def sEqual(dts1, elt1, elt2, equalMode=S_EQUAL, excludeIDs=NO_IDs_EXCLUDED, dts2
                    # VALIDATE_BY_STRING_VALUE if len(children1) and elt1.xValid == VALID else
                    equalMode
                    ) or
-        attributeDict(dts1, elt1, (), equalMode, excludeIDs) !=
-        attributeDict(dts2, elt2, (), equalMode, excludeIDs, ns2ns1Tbl)):
+        attributeDict(dts1, elt1, set(), equalMode, excludeIDs) !=
+        attributeDict(dts2, elt2, set(), equalMode, excludeIDs, ns2ns1Tbl)):
         return False
     excludeChildIDs = excludeIDs if excludeIDs != TOP_IDs_EXCLUDED else NO_IDs_EXCLUDED
     for i in range( len(children1) ):
@@ -102,12 +125,21 @@ def sEqual(dts1, elt1, elt2, equalMode=S_EQUAL, excludeIDs=NO_IDs_EXCLUDED, dts2
             return False
     return True
 
-def attributeDict(modelXbrl, elt, exclusions=set(), equalMode=S_EQUAL, excludeIDs=NO_IDs_EXCLUDED, ns2ns1Tbl=None, keyByTag=False, distinguishNaNs=False):
+def attributeDict(
+    modelXbrl: ModelXbrl,
+    elt: ModelObject,
+    exclusions: set[str] = set(),
+    equalMode: int = S_EQUAL,
+    excludeIDs: int = NO_IDs_EXCLUDED,
+    ns2ns1Tbl: dict[str, str] | None= None,
+    keyByTag: bool = False,
+    distinguishNaNs: bool = False
+) -> dict[QName, Any]:  # value can be any element value
     if not hasattr(elt,"xValid"):
-        xmlValidate(modelXbrl, elt)
+        xmlValidate(modelXbrl, elt)  # type: ignore[no-untyped-call]
     attrs = {}
     # TBD: replace with validated attributes
-    for modelAttribute in elt.xAttributes.values():
+    for modelAttribute in getattr(elt, 'xAttributes', {}).values():
         attrTag = modelAttribute.attrTag
         ns, sep, localName = attrTag.partition('}')
         attrNsURI = ns[1:] if sep else None
@@ -135,45 +167,60 @@ def attributeDict(modelXbrl, elt, exclusions=set(), equalMode=S_EQUAL, excludeID
                 pass  # what should be done if attribute failed to have psvi value
     return attrs
 
-def attributes(modelXbrl, elt, exclusions=set(), ns2ns1Tbl=None, keyByTag=False) -> tuple[Any, Any]:
+def attributes(
+    modelXbrl: ModelXbrl,
+    elt: ModelObject,
+    exclusions: set[str] = set(),
+    ns2ns1Tbl: dict[str, str] | None = None,
+    keyByTag: bool = False
+) -> tuple[tuple[QName, Any], ...]:
     a = attributeDict(modelXbrl, elt, exclusions, ns2ns1Tbl=ns2ns1Tbl, keyByTag=keyByTag)
     return tuple( (k,a[k]) for k in sorted(a.keys()) )
 
-def childElements(elt):
+def childElements(elt: ModelObject) -> list[ModelObject]:
     return [child for child in elt if isinstance(child,ModelObject)]
 
-def xEqual(elt1, elt2, equalMode=S_EQUAL):
+def xEqual(elt1: ModelObject, elt2: ModelObject, equalMode: int = S_EQUAL) -> bool:
     if not hasattr(elt1,"xValid"):
-        xmlValidate(elt1.modelXbrl, elt1)
+        xmlValidate(elt1.modelXbrl, elt1)  # type: ignore[no-untyped-call]
     if not hasattr(elt2,"xValid"):
-        xmlValidate(elt2.modelXbrl, elt2)
+        xmlValidate(elt2.modelXbrl, elt2)  # type: ignore[no-untyped-call]
     if equalMode == VALIDATE_BY_STRING_VALUE:
         return elt1.stringValue == elt2.stringValue
     elif equalMode == S_EQUAL: # formula WG e-mail 2018-09-06: or (equalMode == S_EQUAL2 and not isinstance(elt1.sValue, QName)):
-        return elt1.sValue == elt2.sValue
+        return cast(bool, getattr(elt1, 'sValue') == getattr(elt2, 'sValue'))
     else: # includes dimension S-equal2, use xpath-2 equality.
-        if isinstance(elt1.xValue, DateTime) and isinstance(elt2.xValue, DateTime) and elt1.xValue.dateOnly != elt2.xValue.dateOnly:
+        elt1_xValue = getattr(elt1, 'xValue')
+        elt2_xValue = getattr(elt2, 'xValue')
+        if isinstance(elt1_xValue, DateTime) \
+            and isinstance(elt2_xValue, DateTime) \
+                and getattr(elt1_xValue, 'dateOnly') \
+                    != getattr(elt2_xValue, 'dateOnly'):
             return False
-        return elt1.xValue == elt2.xValue
+        return cast(bool, elt1_xValue == elt2_xValue)
 
-def vEqual(elt1, elt2):
+def vEqual(elt1: ModelObject, elt2: ModelObject) -> bool:
     if not hasattr(elt1,"xValid"):
-        xmlValidate(elt1.modelXbrl, elt1)
+        xmlValidate(elt1.modelXbrl, elt1)  # type: ignore[no-untyped-call]
     if not hasattr(elt2,"xValid"):
-        xmlValidate(elt2.modelXbrl, elt2)
-    return elt1.sValue == elt2.sValue
+        xmlValidate(elt2.modelXbrl, elt2)  # type: ignore[no-untyped-call]
+    return cast(bool, getattr(elt1, 'sValue') == getattr(elt2, 'sValue'))
 
-def typedValue(dts, element, attrQname=None):
+def typedValue(
+    dts: ModelXbrl | None,
+    element: ModelObject,
+    attrQname: QName | None = None
+) -> Any:  # This can by any type
     try:
         if attrQname: # PSVI attribute value
-            modelAttribute = element.xAttributes[attrQname.clarkNotation]
+            modelAttribute = getattr(element, 'xAttributes')[attrQname.clarkNotation]
             if modelAttribute.xValid >= VALID:
                 return modelAttribute.xValue
         else: # PSVI element value (of text)
-            if element.xValid >= VALID:
-                return element.xValue
+            if getattr(element, 'xValid') >= VALID:
+                return getattr(element, 'xValue')
     except (AttributeError, KeyError):
         if dts:
-            xmlValidate(dts, element, recurse=False, attrQname=attrQname)
+            xmlValidate(dts, element, recurse=False, attrQname=attrQname)  # type: ignore[no-untyped-call]
             return typedValue(None, element, attrQname=attrQname)
     return None

--- a/arelle/XbrlUtil.py
+++ b/arelle/XbrlUtil.py
@@ -191,13 +191,11 @@ def xEqual(elt1: ModelObject, elt2: ModelObject, equalMode: int = S_EQUAL) -> bo
     elif equalMode == S_EQUAL: # formula WG e-mail 2018-09-06: or (equalMode == S_EQUAL2 and not isinstance(elt1.sValue, QName)):
         return elt1.sValue == elt2.sValue
     else: # includes dimension S-equal2, use xpath-2 equality.
-        elt1_xValue = elt1.xValue
-        elt2_xValue = elt2.xValue
-        if isinstance(elt1_xValue, DateTime) \
-            and isinstance(elt2_xValue, DateTime) \
-                and elt1_xValue.dateOnly != elt2_xValue.dateOnly:  # type: ignore[attr-defined]
+        if isinstance(elt1.xValue, DateTime) \
+            and isinstance(elt2.xValue, DateTime) \
+                and elt1.xValue.dateOnly != elt2.xValue.dateOnly:  # type: ignore[attr-defined]
             return False
-        return elt1_xValue == elt2_xValue
+        return elt1.xValue == elt2.xValue
 
 def vEqual(elt1: ModelObject, elt2: ModelObject) -> bool:
     if not hasattr(elt1,"xValid"):
@@ -218,7 +216,7 @@ def typedValue(
                 return modelAttribute.xValue
         else: # PSVI element value (of text)
             if getattr(element, 'xValid') >= VALID:
-                return getattr(element, 'xValue')
+                return element.xValue
     except (AttributeError, KeyError):
         if dts:
             xmlValidate(dts, element, recurse=False, attrQname=attrQname)  # type: ignore[no-untyped-call]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ module = [
     'arelle.Updater',
     'arelle.UrlUtil',
     'arelle.ValidateXbrl',
+    'arelle.XbrlUtil',
     'arelle.XmlUtil',
 ]
 ignore_errors = false


### PR DESCRIPTION
#### Reason for change
Add type hints to arelle.XbrlUtil

#### Description of change
This pr includes 9 type ignores, all of them for `xmlValidate` function form `XmlValidate` module

#### Steps to Test

**review**:
@Arelle/arelle
