### PR TITLE
Update openpyxl library version to match requirements.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     'isodate==0.*',
     'lxml==4.*',
     'numpy==1.*',
-    'openpyxl==2.*',
+    'openpyxl==3.*',
     'regex==2022.*',
 ]
 


### PR DESCRIPTION
#### Reason for change
Library version range of openpyxl doesn't include the application version specified in [requirements.txt](https://github.com/Arelle/Arelle/blob/79513a89efe2d526a05f80ee4a12d09793fd5179/requirements.txt#L3)


#### Description of change
Update version range of openpyxl used in the python package

#### Steps to Test
* CI

**review**:
@Arelle/arelle
