### PR TITLE
Add initial support for system info reporting

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -24,6 +24,8 @@ from arelle import PluginManager
 from arelle.PluginManager import pluginClassMethods
 from arelle.UrlUtil import isHttpUrl
 from arelle.WebCache import proxyTuple
+from arelle.SystemInfo import get_system_info
+from pprint import pprint
 import logging
 from lxml import etree
 win32file = win32api = win32process = pywintypes = None
@@ -382,6 +384,8 @@ def parseAndRun(args):
     parser.add_option("-a", "--about",
                       action="store_true", dest="about",
                       help=_("Show product version, copyright, and license."))
+    parser.add_option("--diagnostics", action="store_true", dest="diagnostics",
+                      help=_("output system diagnostics information"))
 
     if not args and cntlr.isGAE:
         args = ["--webserver=::gae"]
@@ -435,6 +439,8 @@ def parseAndRun(args):
                 ).format(Version.__version__, cntlr.systemWordSize, Version.copyrightLatestYear,
                          _("\n   Bottle (c) 2011-2013 Marcel Hellkamp") if hasWebServer else "",
                          sys.version_info, etree.LXML_VERSION, platform.machine()))
+    elif options.diagnostics:
+        pprint(get_system_info())
     elif options.disclosureSystemName in ("help", "help-verbose"):
         text = _("Disclosure system choices: \n{0}").format(' \n'.join(cntlr.modelManager.disclosureSystem.dirlist(options.disclosureSystemName)))
         try:

--- a/arelle/SystemInfo.py
+++ b/arelle/SystemInfo.py
@@ -1,0 +1,35 @@
+"""
+Created on Sep 24, 2022
+
+@author: Mark V Systems Limited
+(c) Copyright 2022 Mark V Systems Limited, All rights reserved.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from typing import Any
+
+from arelle.Version import __version__
+
+
+def get_system_info() -> dict[str, Any]:
+    """Return info about the system."""
+    info_object = {
+        "arch": platform.machine(),
+        "docker": False,
+        "os_name": platform.system(),
+        "version_arelle": __version__,
+        "version_os": platform.release(),
+        "version_python": platform.python_version(),
+        "virtualenv": getattr(sys, "base_prefix", sys.prefix) != sys.prefix
+        or hasattr(sys, "real_prefix"),
+    }
+
+    if platform.system() == "Darwin":
+        info_object["os_version"] = platform.mac_ver()[0]
+    elif platform.system() == "Linux":
+        info_object["docker"] = os.path.isfile("/.dockerenv")
+
+    return info_object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ module = [
     'arelle.plugin.validate.ESEF.*',
     'arelle.Cntlr',
     'arelle.ModelObject',
+    'arelle.SystemInfo',
     'arelle.Updater',
     'arelle.UrlUtil',
     'arelle.ValidateXbrl',

--- a/tests/unit_tests/arelle/test_system_info.py
+++ b/tests/unit_tests/arelle/test_system_info.py
@@ -1,0 +1,22 @@
+"""Tests for system info."""
+from arelle.SystemInfo import get_system_info
+
+
+def test_get_system_info() -> None:
+    """Test that function get_system_info returns."""
+    function_result = get_system_info()
+
+    expected_keys = {
+        "arch",
+        "docker",
+        "os_name",
+        "version_arelle",
+        "version_os",
+        "version_python",
+        "virtualenv"
+    }
+
+    resulting_keys = set(function_result.keys())
+
+    missing_keys = expected_keys - resulting_keys
+    assert len(missing_keys) == 0, f"Missing keys {missing_keys}"


### PR DESCRIPTION
#### Reason for change
As discussed in https://github.com/Arelle/Arelle/issues/320.

It doesn't solve the entire issue, but at least it's a start to be amended with additional information as needed.

#### Description of change
Adding a function to return some basic system information. I threw in a trivial unit test as well, just checking that the function returns. Given that the test is run on Mac, Windows and Linux it feels like an opportunity to create a flaky test to start checking what actual system values are returned by the function.

#### Steps to Test
```python -m arelleCmdLine --diagnostics```

Should return something like this:
```
{
'arch': 'aarch64',
 'docker': True,
 'os_name': 'Linux',
 'version_arelle': '1.2020.05.10',
 'version_os': '5.10.104-linuxkit',
 'version_python': '3.9.13',
 'virtualenv': True
}
```

**review**:
@Arelle/arelle
