### PR TITLE
Use setuptools_scm to manage semver

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout arelle
         uses: actions/checkout@v3.0.2
+        with:
+          fetch-depth: 0
       - name: Checkout EdgarRenderer
         uses: actions/checkout@v3.0.2
         with:

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -35,7 +35,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3.0.2
+      - name: Checkout arelle
+        uses: actions/checkout@v3.0.2
+        with:
+          fetch-depth: 0
       - name: Install Python
         uses: actions/setup-python@v4.2.0
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
     - name: Checkout arelle
       uses: actions/checkout@v3.0.2
+      with:
+        fetch-depth: 0
     - name: Checkout EdgarRenderer
       uses: actions/checkout@v3.0.2
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,10 @@ jobs:
   build-and-publish-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.0.2
+      - name: Checkout arelle
+        uses: actions/checkout@v3.0.2
+        with:
+          fetch-depth: 0
       - name: Install Python 3
         uses: actions/setup-python@v4.2.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 dist
 buildRenameX64.bat
 buildRenameX86.bat
+arelle/_version.py
 arelle/Version.py
 arelle/plugin/EdgarRenderer
 arelle/plugin/EdgarRendererWithBuiltinHtml

--- a/distro.py
+++ b/distro.py
@@ -128,4 +128,9 @@ else:
 setup(
     executables=[guiExecutable, cliExecutable],
     options=options,
+    setup_requires=["setuptools_scm~=7.0"],
+    use_scm_version={
+        "tag_regex": r"^(?:[\w-]+-?)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
+        "write_to": os.path.normcase("arelle/version.py"),
+    },
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=65.3", "wheel~=0.37"]
+requires = ["setuptools~=65.3", "wheel~=0.37", "setuptools_scm[toml]~=7.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -72,11 +72,12 @@ arelleGUI = "arelle.CntlrWinMain:main"
 [tool.setuptools]
 platforms = ["any"]
 
-[tool.setuptools.dynamic]
-version = {attr = "arelle.Version.__version__"}
-
 [tool.setuptools.packages.find]
 namespaces = false
+
+[tool.setuptools_scm]
+tag_regex = "^(?:[\\w-]+-?)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
+write_to = "arelle/_version.py"
 
 [tool.pytest.ini_options]
 xfail_strict = true

--- a/scripts/buildLinuxDist.sh
+++ b/scripts/buildLinuxDist.sh
@@ -30,4 +30,6 @@ cp -p "$(find /lib /usr -name libxml2.so.2)" "${BUILD_DIR}/"
 cp -p "$(find /lib /usr -name libxslt.so.1)" "${BUILD_DIR}/"
 cp -p "$(find /lib /usr -name libz.so.1)" "${BUILD_DIR}/"
 
-tar -czf "${DIST_DIR}/arelle-${DISTRO}-x86_64-$(date +%Y-%m-%d).tgz" --directory "${BUILD_DIR}" .
+VERSION=$(python3 -c "import arelle._version; print(arelle._version.version)")
+
+tar -czf "${DIST_DIR}/arelle-${DISTRO}-${VERSION}.tgz" --directory "${BUILD_DIR}" .


### PR DESCRIPTION
#### Reason for change
#364 

#### Description of change
Generates `arelle/_version.py` for build using setuptools_scm (version will be something along the lines of `9.2.2.dev1065+ge3c25915.d20220926` until we tag an official release after #365).

#### Steps to Test
* Verify python package is tagged with the setuptools_scm version.
* Verify python package includes `arelle/_version.py`.
* Verify `lib/arelle/_version.pyc` is included in the cx_Freeze builds for [Linux](https://github.com/Arelle/Arelle/actions/runs/3130795840), [macOS](https://github.com/Arelle/Arelle/actions/runs/3130796548), and [Windows](https://github.com/Arelle/Arelle/actions/runs/3130797166).

**review**:
@Arelle/arelle
