### PR TITLE
Make distribution artifact names consistent

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -133,5 +133,5 @@ jobs:
           hdiutil convert dist_dmg/arelle_tmp.dmg -format UDZO -imagekey zlib-level=9 -o dist_dmg/arelle-${{ matrix.os }}.dmg
       - uses: actions/upload-artifact@v3.1.0
         with:
-          name: arelle-${{ matrix.os }}
+          name: macos distribution
           path: dist_dmg/arelle-${{ matrix.os }}.dmg

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -115,5 +115,5 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v3.1.0
       with:
-        name: dist
+        name: windows distribution
         path: dist


### PR DESCRIPTION
#### Reason for change
Closes #337 

#### Description of change
Update artifact names

#### Steps to Test
Generate builds and ensure artifact download links have "{os} distribution" names as described in #337 
**review**:
@Arelle/arelle
