### PR TITLE
Handle semver versions in Updater.py

### DIFF
--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -30,6 +30,9 @@ _MESSAGE_HEADER = "arelle\u2122 - Updater"
 _ISO_DATE_PATTERN = regex.compile(
     r"(?P<date>(?P<year>[0-9]{4})-(?P<month>0[1-9]|1[0-2])-(?P<day>0[1-9]|[12][0-9]|3[01]))"
 )
+_SEMVER_PATTERN = regex.compile(
+    r"(?P<semver>(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+))"
+)
 
 
 class ArelleVersioningScheme(enum.IntEnum):
@@ -134,11 +137,19 @@ def _checkUpdateUrl(cntlr: CntlrWinMain, attachmentFileName: str) -> None:
         )
 
 
-def _parseVersion(versionStr: str) -> datetime.date:
-    versionDateMatch = _ISO_DATE_PATTERN.search(versionStr)
-    if versionDateMatch is None:
-        raise ValueError(f"Unable to parse version date from {versionStr}")
-    return datetime.date.fromisoformat(versionDateMatch.group("date"))
+def _parseVersion(versionStr: str) -> ArelleVersion:
+    dateMatch = _ISO_DATE_PATTERN.search(versionStr)
+    if dateMatch:
+        versionDate = datetime.date.fromisoformat(dateMatch.group("date"))
+        return dateVersion(date=versionDate)
+    semverMatch = _SEMVER_PATTERN.search(versionStr)
+    if semverMatch:
+        return semverVersion(
+            major=int(semverMatch.group("major")),
+            minor=int(semverMatch.group("minor")),
+            patch=int(semverMatch.group("patch")),
+        )
+    raise ValueError(f"Unable to parse version from {versionStr}")
 
 
 def _backgroundDownload(cntlr: CntlrWinMain, attachmentFileName: str) -> None:

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -6,7 +6,6 @@ Created on May 30, 2010
 """
 from __future__ import annotations
 
-import gettext
 import os
 import subprocess
 import sys
@@ -18,11 +17,12 @@ from datetime import date
 import regex
 
 from arelle import Version
+from arelle.typing import TypeGetText
 
 if typing.TYPE_CHECKING:
     from arelle.CntlrWinMain import CntlrWinMain
 
-_ = gettext.gettext
+_: TypeGetText
 
 _MESSAGE_HEADER = "arelle\u2122 - Updater"
 _ISO_DATE_PATTERN = regex.compile(

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -6,20 +6,22 @@ Created on May 30, 2010
 """
 from __future__ import annotations
 
+import datetime
+import enum
 import os
 import subprocess
 import sys
 import threading
 import tkinter.messagebox
-import typing
-from datetime import date
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import regex
 
 from arelle import Version
 from arelle.typing import TypeGetText
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from arelle.CntlrWinMain import CntlrWinMain
 
 _: TypeGetText
@@ -28,6 +30,30 @@ _MESSAGE_HEADER = "arelle\u2122 - Updater"
 _ISO_DATE_PATTERN = regex.compile(
     r"(?P<date>(?P<year>[0-9]{4})-(?P<month>0[1-9]|1[0-2])-(?P<day>0[1-9]|[12][0-9]|3[01]))"
 )
+
+
+class ArelleVersioningScheme(enum.IntEnum):
+    DATE = 1
+    SEMVER = 2
+
+
+@dataclass(eq=True, frozen=True, order=True)
+class ArelleVersion:
+    versioningScheme: ArelleVersioningScheme
+    major: int
+    minor: int
+    patch: int
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+def dateVersion(date: datetime.date) -> ArelleVersion:
+    return ArelleVersion(ArelleVersioningScheme.DATE, date.year, date.month, date.day)
+
+
+def semverVersion(major: int, minor: int, patch: int) -> ArelleVersion:
+    return ArelleVersion(ArelleVersioningScheme.SEMVER, major, minor, patch)
 
 
 def checkForUpdates(cntlr: CntlrWinMain) -> None:
@@ -108,11 +134,11 @@ def _checkUpdateUrl(cntlr: CntlrWinMain, attachmentFileName: str) -> None:
         )
 
 
-def _parseVersion(versionStr: str) -> date:
+def _parseVersion(versionStr: str) -> datetime.date:
     versionDateMatch = _ISO_DATE_PATTERN.search(versionStr)
     if versionDateMatch is None:
         raise ValueError(f"Unable to parse version date from {versionStr}")
-    return date.fromisoformat(versionDateMatch.group("date"))
+    return datetime.date.fromisoformat(versionDateMatch.group("date"))
 
 
 def _backgroundDownload(cntlr: CntlrWinMain, attachmentFileName: str) -> None:

--- a/tests/unit_tests/arelle/conftest.py
+++ b/tests/unit_tests/arelle/conftest.py
@@ -1,0 +1,10 @@
+import builtins
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_gettext(monkeypatch):
+    monkeypatch.setitem(builtins.__dict__, "_", lambda s: s)
+    yield
+    monkeypatch.delitem(builtins.__dict__, "_")

--- a/tests/unit_tests/arelle/test_updater.py
+++ b/tests/unit_tests/arelle/test_updater.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import datetime
 import queue
 from unittest.mock import Mock, call, patch
 
 import pytest
 
 from arelle import Updater
+from arelle.Updater import dateVersion, semverVersion
 
 OLD_FILENAME = "arelle-macOS-2021-01-01.dmg"
 NEW_FILENAME = "arelle-macOS-2022-01-01.dmg"
@@ -31,6 +33,64 @@ def _mockCntlrWinMain(
         updateURL=updateUrl,
         webCache=webCache,
     )
+
+
+class TestArelleVersion:
+    @pytest.mark.parametrize(
+        "olderVersion, newerVersion",
+        [
+            (
+                dateVersion(date=datetime.date.min),
+                dateVersion(date=datetime.date.max),
+            ),
+            (
+                dateVersion(date=datetime.date(2021, 12, 31)),
+                dateVersion(date=datetime.date(2022, 1, 1)),
+            ),
+            (
+                dateVersion(date=datetime.date(2022, 2, 9)),
+                dateVersion(date=datetime.date(2022, 3, 1)),
+            ),
+            (
+                dateVersion(date=datetime.date(2022, 2, 9)),
+                dateVersion(date=datetime.date(2022, 2, 11)),
+            ),
+            (
+                dateVersion(date=datetime.date(2022, 2, 9)),
+                dateVersion(date=datetime.date(2022, 10, 1)),
+            ),
+            (
+                dateVersion(date=datetime.date.max),
+                semverVersion(major=0, minor=0, patch=0),
+            ),
+            (
+                semverVersion(major=0, minor=0, patch=0),
+                semverVersion(major=0, minor=0, patch=1),
+            ),
+            (
+                semverVersion(major=0, minor=0, patch=9),
+                semverVersion(major=0, minor=1, patch=0),
+            ),
+            (
+                semverVersion(major=0, minor=9, patch=9),
+                semverVersion(major=1, minor=0, patch=0),
+            ),
+            (
+                semverVersion(major=1, minor=1, patch=3),
+                semverVersion(major=1, minor=1, patch=10),
+            ),
+            (
+                semverVersion(major=1, minor=2, patch=9),
+                semverVersion(major=1, minor=10, patch=1),
+            ),
+            (
+                semverVersion(major=2, minor=9, patch=9),
+                semverVersion(major=10, minor=1, patch=1),
+            ),
+        ],
+    )
+    def test_arelleVersionCompare(self, olderVersion, newerVersion):
+        assert olderVersion < newerVersion
 
 
 class TestUpdater:

--- a/tests/unit_tests/arelle/test_updater.py
+++ b/tests/unit_tests/arelle/test_updater.py
@@ -9,11 +9,17 @@ import pytest
 from arelle import Updater
 from arelle.Updater import dateVersion, semverVersion
 
-OLD_FILENAME = "arelle-macOS-2021-01-01.dmg"
-NEW_FILENAME = "arelle-macOS-2022-01-01.dmg"
+OLD_DATE_FILENAME = "arelle-macOS-2021-01-01.dmg"
+NEW_DATE_FILENAME = "arelle-macOS-2022-01-01.dmg"
 
-OLD_VERSION = "2021-01-01 12:00 UTC"
-NEW_VERSION = "2022-01-01 12:00 UTC"
+OLD_DATE_VERSION = "2021-01-01 12:00 UTC"
+NEW_DATE_VERSION = "2022-01-01 12:00 UTC"
+
+OLD_SEMVER_FILENAME = "arelle-macOS-2.0.0.dmg"
+NEW_SEMVER_FILENAME = "arelle-macOS-2.1.0.dmg"
+
+OLD_SEMVER_VERSION = "2.0.0"
+NEW_SEMVER_VERSION = "2.1.0"
 
 DOWNLOAD_URL = "https://arelle.org/download/X"
 
@@ -21,7 +27,7 @@ DOWNLOAD_URL = "https://arelle.org/download/X"
 def _mockCntlrWinMain(
     updateUrl: str | None = DOWNLOAD_URL,
     workOffline: bool = False,
-    updateFilename: str | RuntimeError | None = OLD_FILENAME,
+    updateFilename: str | RuntimeError | None = OLD_SEMVER_FILENAME,
 ):
     webCache = Mock(
         getAttachmentFilename=Mock(side_effect=[updateFilename]),
@@ -106,7 +112,7 @@ class TestUpdater:
         assert not cntlr.uiThreadQueue.empty()
         assert cntlr.uiThreadQueue.get_nowait() == (
             Updater._checkUpdateUrl,
-            [cntlr, OLD_FILENAME],
+            [cntlr, OLD_SEMVER_FILENAME],
         )
         assert cntlr.uiThreadQueue.empty()
 
@@ -149,17 +155,31 @@ class TestUpdater:
         assert showWarning.called
         assert cntlr.uiThreadQueue.empty()
 
+    @pytest.mark.parametrize(
+        "currentVersion, newFilename",
+        [
+            (OLD_DATE_VERSION, NEW_DATE_FILENAME),
+            (OLD_SEMVER_VERSION, NEW_SEMVER_FILENAME),
+            (NEW_DATE_VERSION, OLD_SEMVER_FILENAME),
+        ],
+    )
     @patch("tkinter.messagebox.showinfo")
     @patch("tkinter.messagebox.showwarning")
     @patch("tkinter.messagebox.askokcancel")
     @patch("arelle.Updater.Version")
     @patch("arelle.Updater._backgroundDownload")
     def test_check_update_url_update_user_install(
-        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+        self,
+        backgroundDownload,
+        version,
+        askokcancel,
+        showWarning,
+        showInfo,
+        currentVersion,
+        newFilename,
     ):
         cntlr = _mockCntlrWinMain()
-        newFilename = NEW_FILENAME
-        version.version = OLD_VERSION
+        version.version = currentVersion
         askokcancel.return_value = True
 
         Updater._checkUpdateUrl(cntlr, newFilename)
@@ -169,17 +189,31 @@ class TestUpdater:
         assert askokcancel.called
         assert backgroundDownload.called
 
+    @pytest.mark.parametrize(
+        "currentVersion, newFilename",
+        [
+            (OLD_DATE_VERSION, NEW_DATE_FILENAME),
+            (OLD_SEMVER_VERSION, NEW_SEMVER_FILENAME),
+            (NEW_DATE_VERSION, OLD_SEMVER_FILENAME),
+        ],
+    )
     @patch("tkinter.messagebox.showinfo")
     @patch("tkinter.messagebox.showwarning")
     @patch("tkinter.messagebox.askokcancel")
     @patch("arelle.Updater.Version")
     @patch("arelle.Updater._backgroundDownload")
     def test_check_update_url_update_user_no_install(
-        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+        self,
+        backgroundDownload,
+        version,
+        askokcancel,
+        showWarning,
+        showInfo,
+        currentVersion,
+        newFilename,
     ):
         cntlr = _mockCntlrWinMain()
-        newFilename = NEW_FILENAME
-        version.version = OLD_VERSION
+        version.version = currentVersion
         askokcancel.return_value = False
 
         Updater._checkUpdateUrl(cntlr, newFilename)
@@ -189,17 +223,31 @@ class TestUpdater:
         assert askokcancel.called
         assert not backgroundDownload.called
 
+    @pytest.mark.parametrize(
+        "currentVersion, newFilename",
+        [
+            (NEW_DATE_VERSION, OLD_DATE_FILENAME),
+            (NEW_SEMVER_VERSION, OLD_SEMVER_FILENAME),
+            (OLD_SEMVER_VERSION, NEW_DATE_FILENAME),
+        ],
+    )
     @patch("tkinter.messagebox.showinfo")
     @patch("tkinter.messagebox.showwarning")
     @patch("tkinter.messagebox.askokcancel")
     @patch("arelle.Updater.Version")
     @patch("arelle.Updater._backgroundDownload")
     def test_check_update_url_update_older(
-        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+        self,
+        backgroundDownload,
+        version,
+        askokcancel,
+        showWarning,
+        showInfo,
+        currentVersion,
+        newFilename,
     ):
         cntlr = _mockCntlrWinMain()
-        newFilename = OLD_FILENAME
-        version.version = NEW_VERSION
+        version.version = currentVersion
 
         Updater._checkUpdateUrl(cntlr, newFilename)
 
@@ -208,17 +256,32 @@ class TestUpdater:
         assert not askokcancel.called
         assert not backgroundDownload.called
 
+    @pytest.mark.parametrize(
+        "currentVersion, newFilename",
+        [
+            (OLD_DATE_VERSION, OLD_DATE_FILENAME),
+            (OLD_SEMVER_VERSION, OLD_SEMVER_FILENAME),
+            (NEW_DATE_VERSION, NEW_DATE_FILENAME),
+            (NEW_SEMVER_VERSION, NEW_SEMVER_FILENAME),
+        ],
+    )
     @patch("tkinter.messagebox.showinfo")
     @patch("tkinter.messagebox.showwarning")
     @patch("tkinter.messagebox.askokcancel")
     @patch("arelle.Updater.Version")
     @patch("arelle.Updater._backgroundDownload")
     def test_check_update_url_update_same(
-        self, backgroundDownload, version, askokcancel, showWarning, showInfo
+        self,
+        backgroundDownload,
+        version,
+        askokcancel,
+        showWarning,
+        showInfo,
+        currentVersion,
+        newFilename,
     ):
         cntlr = _mockCntlrWinMain()
-        newFilename = NEW_FILENAME
-        version.version = NEW_VERSION
+        version.version = currentVersion
 
         Updater._checkUpdateUrl(cntlr, newFilename)
 
@@ -236,7 +299,7 @@ class TestUpdater:
         self, backgroundDownload, version, askokcancel, showWarning, showInfo
     ):
         cntlr = _mockCntlrWinMain()
-        newFilename = NEW_FILENAME
+        newFilename = NEW_SEMVER_FILENAME
         version.version = "invalid version string"
 
         Updater._checkUpdateUrl(cntlr, newFilename)
@@ -256,7 +319,7 @@ class TestUpdater:
     ):
         cntlr = _mockCntlrWinMain()
         newFilename = "filename-without-version-string"
-        version.version = OLD_VERSION
+        version.version = OLD_SEMVER_VERSION
 
         Updater._checkUpdateUrl(cntlr, newFilename)
 
@@ -269,7 +332,7 @@ class TestUpdater:
     @patch("tkinter.messagebox.showwarning")
     def test_download(self, showWarning, rename):
         cntlr = _mockCntlrWinMain(
-            updateFilename=NEW_FILENAME,
+            updateFilename=NEW_SEMVER_FILENAME,
         )
 
         Updater._download(cntlr, DOWNLOAD_URL)
@@ -298,7 +361,7 @@ class TestUpdater:
     @patch("tkinter.messagebox.showwarning")
     def test_download_process_failed(self, showWarning, rename):
         cntlr = _mockCntlrWinMain(
-            updateFilename=NEW_FILENAME,
+            updateFilename=NEW_SEMVER_FILENAME,
         )
         rename.side_effect = OSError()
 


### PR DESCRIPTION
#### Reason for change
Resolves #361 

#### Description of change
Accommodate both the older date based (still used when parsing older arelle.org downloads) and newer SemVer based versions in Updater.py.

#### Steps to Test
##### With [existing "older" date based version](https://github.com/Arelle/Arelle/blob/1636f764654a7c4fda0a5719bd46235339fc82f3/arelle/Version.py#L9) (`2020-05-10 16:47 UTC`)
* Start the GUI `python arelleGUI.pyw`
* Check for updates `help` -> `Check for updates`
* Should prompt to update to "newer" version
* Close Arelle

##### With oldest possible SemVer version
* Modify `arelle.Version.version` to `0.0.0`
* Start the GUI `python arelleGUI.pyw`
* Check for updates `help` -> `Check for updates`
* Should prompt that current version is newer than update
* Close Arelle

##### With next planned SemVer version
* Modify `arelle.Version.version` to `2.0.0`
* Start the GUI `python arelleGUI.pyw`
* Check for updates `help` -> `Check for updates`
* Should prompt that current version is newer than update
* Close Arelle

**review**:
@Arelle/arelle
