### PR TITLE
Update python package workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,10 +3,11 @@ name: Build and publish python package
 on:
   pull_request:
   release:
-    types: [created]
+    types: [released]
 
 jobs:
   build-and-publish-package:
+    environment: release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout arelle


### PR DESCRIPTION
#### Reason for change
* "created" release event isn't triggered for draft releases which are then published.
* release environment is required for twine secrets

#### Description of change
Work to get pypi package published

#### Steps to Test
Publish a release

**review**:
@Arelle/arelle
