### PR TITLE
For the python package workflow, split building from uploading.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,8 +6,7 @@ on:
     types: [released]
 
 jobs:
-  build-and-publish-package:
-    environment: release
+  build-package:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout arelle
@@ -22,16 +21,32 @@ jobs:
           python-version: '3.9'
       - name: Build python package
         run: |
-          pip install setuptools wheel twine build
+          pip install -U setuptools wheel
+          pip install build
           python -m build
-      - name: Upload build artifact
+      - name: Upload tar artifact
         uses: actions/upload-artifact@v3.1.0
         with:
           name: arelle.tar.gz
           path: dist/*.tar.gz
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: arelle.whl
+          path: dist/*.whl
+
+  publish-package:
+    if: startsWith(github.ref, 'refs/tags')
+    needs: build-package
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install twine
+        run: pip install -U twine
+      - name: Download artifacts
+        uses: actions/download-artifact@v3.0.0
       - name: Publish package on release
-        if: startsWith(github.ref, 'refs/tags')
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-        run: twine upload dist/*
+        run: twine upload */*


### PR DESCRIPTION
#### Steps to Test
Verify that this doesn't prompt for a release deployment.  Maybe test the twine upload.

**review**:
@Arelle/arelle
