### PR TITLE
Reorganize locale calls for new ModelManagers

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -274,6 +274,10 @@ class Cntlr:
                 'windowGeometry': "{0}x{1}+{2}+{3}".format(800, 500, 200, 100),
             }
 
+        # start language translation for domain
+        self.setUiLanguage(uiLang or self.config.get("userInterfaceLangOverride",None), fallbackToDefault=True)
+        setDisableRTL(self.config.get('disableRtl', False))
+
         self.webCache = WebCache(self, self.config.get("proxySettings"))
 
         # start plug in server (requres web cache initialized, but not logger)
@@ -281,10 +285,6 @@ class Cntlr:
 
         # requires plug ins initialized
         self.modelManager = ModelManager.initialize(self)
-
-        # start language translation for domain
-        self.setUiLanguage(uiLang or self.config.get("userInterfaceLangOverride",None), fallbackToDefault=True)
-        setDisableRTL(self.config.get('disableRtl', False))
 
         # start taxonomy package server (requres web cache initialized, but not logger)
         PackageManager.init(self, loadPackagesConfig=hasGui)
@@ -325,8 +325,6 @@ class Cntlr:
                 self.uiLangDir = "ltr"
                 gettext.install("arelle",
                                 self.localeDir)
-
-        self.modelManager.setLocale() # reset the modelManager uiLang locale
 
     def startLogging(
         self,

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -70,6 +70,7 @@ class ModelManager:
         self.loadedModelXbrls = []
         self.customTransforms = None
         self.isLocaleSet = False
+        self.setLocale()
 
     def shutdown(self):
         self.status = "shutdown"


### PR DESCRIPTION
#### Reason for change
Currently the locale code causes new ModelManagers to blow up if certain calls have not been made prior to their instantiation. This affects XULE and potentially any other plugin that instantiates a ModelManager outside of a Cntlr.

#### Description of change
I reorganized locale calls so that new modelManagers dont blow up

#### Steps to Test
Work with Derek on his machine to illustrate the issue using XULE.

**review**:
@Arelle/arelle
