### PR TITLE
Use correct version for frozen builds

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -78,6 +78,8 @@ jobs:
           cd ../..
           mv tmp/ixbrl-viewer/iXBRLViewerPlugin arelle/plugin/
           rm -rf tmp
+      - name: Capture version before localization
+        run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=$(python -W ignore distro.py --version)" >> $GITHUB_ENV
       - name: Rebuild messages.pot internationalization file
         run: python pygettext.py -v -o arelle/locale/messages.pot arelle/*.pyw arelle/*.py
       - name: Regenerate messages catalog (doc/messagesCatalog.xml)

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -93,6 +93,8 @@ jobs:
         pip install wheel
         pip install -r requirements-dev.txt
         pip install -r requirements-windows-build.txt
+    - name: Capture version before localization
+      run: echo ("SETUPTOOLS_SCM_PRETEND_VERSION=" + (python -W ignore distro.py --version)) >> $env:GITHUB_ENV
     - name: Make directories
       run: mkdir build,dist
     - name: Rebuild messages.pot internationalization file

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ arelle/plugin/validate/eforms.py
 arelle/plugin/validate/ESEF-DQC.py
 arelle/plugin/xule
 Arelle.egg-info
+arelleGUI.py
 .eggs
 *.iml
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ arelle/plugin/xule
 Arelle.egg-info
 arelleGUI.py
 .eggs
+.python-version
 *.iml
 
 .tox

--- a/scripts/buildLinuxDist.sh
+++ b/scripts/buildLinuxDist.sh
@@ -5,6 +5,10 @@ set -xeu
 DISTRO="${1:-linux}"
 BUILD_DIR=build/exe.linux-x86_64-3.9
 DIST_DIR=dist
+# setuptools_scm detects the current version based on the distance from latest
+# git tag and if there are uncommitted changes. Capture version prior to
+# localization build scripts which will create uncommitted changes.
+VERSION=$(python3 -W ignore distro.py --version)
 
 rm -rf "${BUILD_DIR}" "${DIST_DIR}"
 mkdir -p "${BUILD_DIR}" "${DIST_DIR}"
@@ -13,7 +17,7 @@ cp -p arelleGUI.pyw arelleGUI.py
 
 python3 pygettext.py -v -o arelle/locale/messages.pot arelle/*.pyw arelle/*.py
 python3 generateMessagesCatalog.py
-python3 distro.py build_exe
+SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION} python3 distro.py build_exe
 
 cp -p arelle/scripts-unix/* "${BUILD_DIR}/"
 cp -pR libs/linux/Tktable2.11 "${BUILD_DIR}/lib/"


### PR DESCRIPTION
#### Reason for change
Resolves #401 

#### Description of change
setuptools_scm detects the current version by looking at the most recent git tag and checking for newer commits and uncommitted changes. The frozen builds run localization update scripts right before the build step which creates uncommitted changes and causes setuptools_scm to detect the version as an untagged dev release which is slightly newer than the actual git tag.

This updates the frozen build workflows to capture the version before running the localization scripts and set it using an environment variable.

#### Steps to Test
Verify that a proper SemVer version (2.0.1) is used for tagged builds ([Linux](https://github.com/austinmatherne-wk/Arelle/actions/runs/3194081712), [macOS](https://github.com/austinmatherne-wk/Arelle/actions/runs/3194082197), and [Windows](https://github.com/austinmatherne-wk/Arelle/actions/runs/3194082608)).

**review**:
@Arelle/arelle
