### PR TITLE
Python 3.10 Support

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -16,9 +16,14 @@ on:
         description: 'Node.js version to use'
         required: true
         type: string
-      python_version:
+      python_version_rhel:
         default: 3.9.14
-        description: 'Python version to use'
+        description: 'RHEL Python version to use'
+        required: true
+        type: string
+      python_version_ubuntu:
+        default: 3.10.7
+        description: 'Ubuntu Python version to use'
         required: true
         type: string
       tcltk_version:
@@ -95,11 +100,18 @@ jobs:
           password: ${{ secrets.REDHAT_PASSWORD }}
       - name: Docker setup buildx
         uses: docker/setup-buildx-action@v2.0.0
+      - name: Set distro Python version
+        run: |
+          if [[ ${{ matrix.distro }} == "ubuntu" ]]; then
+            echo "PYTHON_VERSION=${{ inputs.python_version_ubuntu }}" >> $GITHUB_ENV
+          else
+            echo "PYTHON_VERSION=${{ inputs.python_version_rhel }}" >> $GITHUB_ENV
+          fi
       - name: Docker build
         uses: docker/build-push-action@v3.1.1
         with:
           build-args: |
-            "PYTHON_VERSION=${{ inputs.python_version }}"
+            "PYTHON_VERSION=${{ env.PYTHON_VERSION }}"
             "TCLTK_VERSION=${{ inputs.tcltk_version }}"
           context: .
           file: docker/${{ matrix.distro }}.Dockerfile

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -17,7 +17,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.9'
+        default: '3.10'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,7 +17,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.9'
+        default: '3.10'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           cache: 'pip' # caching pip dependencies
           check-latest: true
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           cache: 'pip' # caching pip dependencies
           check-latest: true
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Build python package
         run: |
           pip install -U setuptools wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,8 @@ return it. Once we receive it, we'll be able to accept your pull requests.
 
 ### Setting up an environment
 1. Install [pyenv](https://github.com/pyenv/pyenv#installation)
-2. Install a [supported version of Python](https://github.com/Arelle/Arelle/blob/master/README.md#installation). For example, `pyenv install 3.9.9`
-3. Create a virtual env using the minimum python version. For example, `PYENV_VERSION=3.9.9 pyenv exec python -m venv venv`
+2. Install a [supported version of Python](https://github.com/Arelle/Arelle/blob/master/README.md#installation). For example, `pyenv install 3.10.7`
+3. Create a virtual env using the minimum python version. For example, `PYENV_VERSION=3.10.7 pyenv exec python -m venv venv`
 4. Activate your environment `source venv/bin/activate`
 5. Install dependencies `pip install -r requirements-dev.txt`
 6. Verify you can run the app

--- a/README.md
+++ b/README.md
@@ -1,91 +1,110 @@
-<div align="center">
-  <img src="http://arelle.org/arelle/wp-content/themes/platform/images/logo-platform.png">
-</div>
+# Arelle
 
 [![pypi-version](https://img.shields.io/pypi/v/arelle-release.svg)](https://pypi.org/project/arelle-release/)
 [![Python Version](https://img.shields.io/pypi/pyversions/arelle-release.svg)](https://pypi.org/project/arelle-release/)
 
-- [Arelle](#arelle)
-  - [Features](#features)
-- [Installation](#installation)
-  - [Install PyPI package](#install-pypi-package)
-  - [Install development version from github](#install-development-version-from-github)
-  - [Install distributions](#install-distributions)
-- [Reporting Issues](#reporting-issues)
-- [Contribution guidelines](#contribution-guidelines)
-- [License](#license)
+[![Arelle Banner](https://arelle.org/arelle/wp-content/themes/platform/images/logo-platform.png)](https://arelle.org/)
 
-# Arelle
-[Arelle](https://arelle.org/arelle/) is an end-to-end open source XBRL platform,
+## Table of contents
+
+- [Arelle](#arelle)
+  - [Table of contents](#table-of-contents)
+  - [Description](#description)
+  - [Features](#features)
+  - [Installation](#installation)
+    - [Install PyPI package](#install-pypi-package)
+    - [Install development version from GitHub](#install-development-version-from-github)
+    - [Install distributions](#install-distributions)
+  - [Reporting issues](#reporting-issues)
+  - [Contribution guidelines](#contribution-guidelines)
+  - [License](#license)
+
+## Description
+
+[Arelle](https://arelle.org/) is an end-to-end open source XBRL platform,
 which provides the XBRL community with an easy to use set of tools.  It supports
 XBRL and its extension features in an extensible manner.  It does this in a
 compact yet robust framework that can be used as a desktop application and can
 be integrated with other applications and languages utilizing its web service.
 
 ## Features
-* Support for XBRL versioning. Validation tool for versioning reports and a
+
+- Support for XBRL versioning. Validation tool for versioning reports and a
   production tool to generate the basics of a versioning report that can be
   inferred by diffing two DTSs.
-* Edgar and Global Filer Manual validation
-* Base Specification, Dimensions, Generic linkbase validation
-* Formula validation including support for extension modules
-* Instance creation is supported using forms defined by the table linkbase (Eurofiling version).
-* RSS Watch facility
-* Users can explore the functionality and features from an interactive GUI,
+- Edgar and Global Filer Manual validation
+- Base Specification, Dimensions, Generic linkbase validation
+- Formula validation including support for extension modules
+- Instance creation is supported using forms defined by the table linkbase
+  (Eurofiling version).
+- RSS Watch facility
+- Users can explore the functionality and features from an interactive GUI,
   command line interface, or web services, and can develop their own controller
   interfaces as needed.
-* The Web Service API allows XBRL integration with applications, such as those in
+- The Web Service API allows XBRL integration with applications, such as those in
   Excel, Java or Oracle.
-* QuickBooks is supported by XBRL-GL.
+- QuickBooks is supported by XBRL-GL.
 
+## Installation
 
-# Installation
+The implementation is in Python 3.9 and is intended for Windows, macOS, or
+Linux (tested against Ubuntu and RHEL). The standard desktop installation
+includes a GUI, a RESTful web server, and CLI. We try to support all operating
+system versions that still receive security updates from their development teams.
 
-The implementation is in Python 3.9 and is intended for Windows, macOS, or Linux (tested against Ubuntu and RHEL). The standard desktop installation includes a GUI, a RESTful web server, and CLI. We try to support all operating system versions that still receive security updates from their development teams.
+### Install PyPI package
 
-## Install PyPI package
-The Arelle python package defines optional extra dependencies for various plugins and use cases.
-* Crypto (security plugin dependencies)
-* DB (database plugin dependencies)
-* EFM (EdgarRenderer plugin dependencies - does not include the EdgarRenderer, just the dependencies required to run it)
-* ObjectMaker (ObjectMaker plugin dependencies)
-* WebServer (dependencies for running the Arelle web server)
+The Arelle python package defines optional extra dependencies for various
+plugins and use cases.
+
+- Crypto (security plugin dependencies)
+- DB (database plugin dependencies)
+- EFM (EdgarRenderer plugin dependencies - does not include the EdgarRenderer,
+  just the dependencies required to run it)
+- ObjectMaker (ObjectMaker plugin dependencies)
+- WebServer (dependencies for running the Arelle web server)
+
 ```shell
 pip install arelle-release
 # or for all extra dependencies
 pip install arelle-release[Crypto,DB,EFM,ObjectMaker,WebServer]
 ```
 
-## Install development version from github
+### Install development version from GitHub
+
 ```shell
 pip install git+https://git@github.com/arelle/arelle.git@master
 ```
 
-## Install distributions
+### Install distributions
+
 Distributions include Python version and resources needed to run Arelle.
 
 Arelle provides distributions for the following operating systems:
-* Windows
-* macOS (Intel)
-* Linux (Ubuntu and Red Hat Enterprise Linux)
+
+- Windows
+- macOS (Intel)
+- Linux (Ubuntu and Red Hat Enterprise Linux)
 
 Distributions can be downloaded from:
-* [Arelle website](https://arelle.org/arelle/pub/)
-* [GitHub releases](https://github.com/Arelle/Arelle/releases)
 
-# Reporting Issues
+- [Arelle website](https://arelle.org/arelle/pub/)
+- [GitHub releases](https://github.com/Arelle/Arelle/releases)
+
+## Reporting issues
+
 Please report issues to the [issue tracker](https://github.com/arelle/arelle/issues).
 
-* Check that the issue has not already been reported.
-* Check that the issue has not already been fixed in the latest code.
-* Be clear and precise (do not prose, but name functions and commands exactly).
-* Include the version of Arelle.
+- Check that the issue has not already been reported.
+- Check that the issue has not already been fixed in the latest code.
+- Be clear and precise (do not prose, but name functions and commands exactly).
+- Include the version of Arelle.
 
-# Contribution guidelines
+## Contribution guidelines
 
 If you want to contribute to Arelle, be sure to review the
 [contribution guidelines](https://github.com/Arelle/Arelle/blob/master/CONTRIBUTING.md).
 
-# License
+## License
 
 [Apache License 2.0](https://github.com/Arelle/Arelle/blob/master/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ pip install git+https://git@github.com/arelle/arelle.git@master
 
 ### Install distributions
 
-Distributions include Python version and resources needed to run Arelle.
+Distributions are self contained builds that come bundled with their own Python runtime and resources needed to run Arelle.
 
-Arelle provides distributions for the following operating systems:
+Distributions are provided for the following operating systems:
 
 - Windows
 - macOS (Intel)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ be integrated with other applications and languages utilizing its web service.
 
 ## Installation
 
-The implementation is in Python 3.9 and is intended for Windows, macOS, or
+The implementation is in Python 3.10 and is intended for Windows, macOS, or
 Linux (tested against Ubuntu and RHEL). The standard desktop installation
 includes a GUI, a RESTful web server, and CLI. We try to support all operating
 system versions that still receive security updates from their development teams.

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -11,10 +11,7 @@ import regex as re
 from typing import Generator, cast, Any, Callable
 from fractions import Fraction
 from arelle.typing import TypeGetText, LocaleDict
-try:
-    from collections.abc import Mapping
-except:
-    from collections import Mapping
+from collections.abc import Mapping
 import unicodedata
 
 _: TypeGetText

--- a/installWin64.nsi
+++ b/installWin64.nsi
@@ -75,7 +75,7 @@ Section "Arelle" SecArelle
   RMDir /r "$INSTDIR\plugin\validate\ESMA"
   
   ;ADD YOUR OWN FILES HERE...
-  File /r build\exe.win-amd64-3.9\*.*
+  File /r build\exe.win-amd64-3.10\*.*
   
   ;Store installation folder
   WriteRegStr HKLM "Software\Arelle" "" $INSTDIR

--- a/installWin86.nsi
+++ b/installWin86.nsi
@@ -71,7 +71,7 @@ Section "Arelle" SecArelle
   RMDir /r "$INSTDIR\plugin\validate\ESMA"
   
   ;ADD YOUR OWN FILES HERE...
-  File /r build\exe.win32-3.9\*.*
+  File /r build\exe.win32-3.10\*.*
   
   ;Store installation folder
   WriteRegStr HKLM "Software\Arelle" "" $INSTDIR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,11 @@ classifiers = [
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'Operating System :: OS Independent',
     'Topic :: Text Processing :: Markup :: XML'
 ]
-requires-python = ">=3.7,<3.10"
+requires-python = ">=3.7"
 dependencies = [
     'isodate==0.*',
     'lxml==4.*',
@@ -89,7 +90,7 @@ empty_parameter_set_mark = "fail_at_collect"
 # Warn when a # type: ignore comment does not specify any error codes
 enable_error_code = "ignore-without-code"
 
-python_version = "3.9"
+python_version = "3.10"
 
 show_error_codes = true
 

--- a/requirements-mac-build.txt
+++ b/requirements-mac-build.txt
@@ -1,3 +1,3 @@
 # https://github.com/marcelotduarte/cx_Freeze/issues/849
 --extra-index-url https://marcelotduarte.github.io/packages/
-cx_Freeze==6.12.0dev1
+cx_Freeze==6.12.0dev2

--- a/scripts/buildLinuxDist.sh
+++ b/scripts/buildLinuxDist.sh
@@ -3,7 +3,7 @@
 set -xeu
 
 DISTRO="${1:-linux}"
-BUILD_DIR=build/exe.linux-x86_64-3.9
+BUILD_DIR=build
 DIST_DIR=dist
 # setuptools_scm detects the current version based on the distance from latest
 # git tag and if there are uncommitted changes. Capture version prior to
@@ -19,20 +19,22 @@ python3 pygettext.py -v -o arelle/locale/messages.pot arelle/*.pyw arelle/*.py
 python3 generateMessagesCatalog.py
 SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION} python3 distro.py build_exe
 
-cp -p arelle/scripts-unix/* "${BUILD_DIR}/"
-cp -pR libs/linux/Tktable2.11 "${BUILD_DIR}/lib/"
+DISTRO_DIR=$(find build -name "exe.linux-*")
+
+cp -p arelle/scripts-unix/* "${DISTRO_DIR}/"
+cp -pR libs/linux/Tktable2.11 "${DISTRO_DIR}/lib/"
 
 SITE_PACKAGES=$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
-cp -pR "${SITE_PACKAGES}/mpl_toolkits" "${BUILD_DIR}/lib/"
-cp -pR "${SITE_PACKAGES}/numpy.libs" "${BUILD_DIR}/lib/"
-cp -pR "${SITE_PACKAGES}/Pillow.libs" "${BUILD_DIR}/lib/"
+cp -pR "${SITE_PACKAGES}/mpl_toolkits" "${DISTRO_DIR}/lib/"
+cp -pR "${SITE_PACKAGES}/numpy.libs" "${DISTRO_DIR}/lib/"
+cp -pR "${SITE_PACKAGES}/Pillow.libs" "${DISTRO_DIR}/lib/"
 
-cp -p "$(find /lib /usr -name libexslt.so.0)" "${BUILD_DIR}/"
-cp -p "$(find /lib /usr -name libxml2.so)" "${BUILD_DIR}/"
-cp -p "$(find /lib /usr -name libxml2.so.2)" "${BUILD_DIR}/"
-cp -p "$(find /lib /usr -name libxslt.so.1)" "${BUILD_DIR}/"
-cp -p "$(find /lib /usr -name libz.so.1)" "${BUILD_DIR}/"
+cp -p "$(find /lib /usr -name libexslt.so.0)" "${DISTRO_DIR}/"
+cp -p "$(find /lib /usr -name libxml2.so)" "${DISTRO_DIR}/"
+cp -p "$(find /lib /usr -name libxml2.so.2)" "${DISTRO_DIR}/"
+cp -p "$(find /lib /usr -name libxslt.so.1)" "${DISTRO_DIR}/"
+cp -p "$(find /lib /usr -name libz.so.1)" "${DISTRO_DIR}/"
 
 VERSION=$(python3 -c "import arelle._version; print(arelle._version.version)")
 
-tar -czf "${DIST_DIR}/arelle-${DISTRO}-${VERSION}.tgz" --directory "${BUILD_DIR}" .
+tar -czf "${DIST_DIR}/arelle-${DISTRO}-${VERSION}.tgz" --directory "${DISTRO_DIR}" .

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, lint, typing
+envlist = py37, py38, py39, py310, lint, typing
 isolated_build = True
 skip_missing_interpreters = False
 
@@ -7,7 +7,8 @@ skip_missing_interpreters = False
 python =
   3.7: py37
   3.8: py38
-  3.9: py39, lint, typing
+  3.9: py39
+  3.10: py310, lint, typing
 
 [testenv]
 commands =


### PR DESCRIPTION
#### Reason for change
resolves #373

#### Description of change
Enable Python 3.10 support. The various workflows are updated to use 3.10 with the exception of the RHEL build. We have to support RHEL 7 which ships an older OpenSSL library (1.0.2) that is not compatible with Python 3.10 (requires OpenSSL >= 1.1.1).

#### Steps to Test
Test the various builds (python package with 3.10 and frozen builds)

**review**:
@Arelle/arelle
