### PR TITLE
Use explicit str for python versions in workflows

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           cache: 'pip' # caching pip dependencies
           check-latest: true
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
#### Reason for change
When parsed as a number 3.10 can be interpreted as 3.1

#### Description of change
Explicitly define python versions as strings.

#### Steps to Test
CI

**review**:
@Arelle/arelle
