### PR TITLE
Add type hints to arelle.XmlValidate

### DIFF
--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -2,7 +2,7 @@
 See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Generator, Optional, cast
+from typing import TYPE_CHECKING, Any, Generator, cast
 from lxml import etree
 from arelle import Locale
 from arelle.ModelValue import qname, qnameEltPfxName, QName
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from arelle.ModelDocument import ModelDocument
     from arelle.ModelXbrl import ModelXbrl
     from arelle.ModelDtsObject import ModelConcept
-    from arelle.ModelValue import AnyURI
     from arelle.ModelDtsObject import ModelLink
     from arelle.ModelDtsObject import ModelLocator
     from arelle.ModelDtsObject import ModelResource
@@ -19,6 +18,7 @@ if TYPE_CHECKING:
     from arelle.ModelInstanceObject import ModelInlineFootnote
     from arelle.ModelInstanceObject import ModelInlineFact
     from arelle.ModelInstanceObject import ModelDimensionValue
+    from arelle.ModelValue import TypeSValue, TypeXValue
 
 XmlUtil: Any = None
 VALID_NO_CONTENT = None
@@ -110,8 +110,8 @@ class ModelObject(etree.ElementBase):
     _namespaceURI: str | None
     _hashSEqual: int
     _hashXpathEqual: int
-    sValue = str
-    xValue = Any # this can be any thing
+    sValue: TypeSValue
+    xValue: TypeXValue
     xlinkLabel: str
 
     def _init(self) -> None:
@@ -438,8 +438,8 @@ class ModelAttribute:
         | ModelInlineFootnote,
         attrTag: str,
         xValid: int,
-        xValue: QName | AnyURI | int | str | None,
-        sValue: str | None,
+        xValue: TypeXValue,
+        sValue: TypeSValue,
         text: str,
     ):
         self.modelElement = modelElement

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import datetime, isodate
 from decimal import Decimal
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, Type, cast, overload, Dict, Optional, Union, List
+from typing import TYPE_CHECKING, Any, Type, cast, overload, Dict, Optional, Union, List, Pattern
 from decimal import Decimal
-from re import Pattern
 from fractions import Fraction
 
 if TYPE_CHECKING:
@@ -933,10 +932,9 @@ TypeSValue = Union[
 ]
 TypeXValue = Union[
     datetime.datetime,
+    datetime.time,
     Decimal,
-    # Note 2022-10-13:
-    # Replace with Dict[str, Pattern[str]] when dropping support for Python 3.8
-    Dict[str, Pattern],
+    Dict[str, Pattern[str]],
     float,
     gDay,
     gMonth,
@@ -946,10 +944,9 @@ TypeXValue = Union[
     Fraction,
     List[Optional[QName]],
     None,
-    # Note 2022-10-13:
-    # Replace with Pattern[str] when dropping support for Python 3.8
-    Pattern,
+    Pattern[str],
     str,
-    datetime.time,
     QName,
+    # Note 2022-10-14
+    # We would also want to have XsdPattern here
 ]

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -934,7 +934,9 @@ TypeSValue = Union[
 TypeXValue = Union[
     datetime.datetime,
     Decimal,
-    Dict[str, Pattern[str]],
+    # Note 2022-10-13:
+    # Replace with Dict[str, Pattern[str]] when dropping support for Python 3.8
+    Dict[str, Pattern],
     float,
     gDay,
     gMonth,
@@ -944,7 +946,9 @@ TypeXValue = Union[
     Fraction,
     List[Optional[QName]],
     None,
-    Pattern[str],
+    # Note 2022-10-13:
+    # Replace with Pattern[str] when dropping support for Python 3.8
+    Pattern,
     str,
     datetime.time,
     QName,

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from arelle.ModelFormulaObject import ModelCustomFunctionSignature
     from arelle.ModelDtsObject import ModelType
     from arelle.ModelInstanceObject import ModelInlineFact
+    from arelle.XmlValidate import XsdPattern
 
 import regex as re
 XmlUtil = None
@@ -947,6 +948,5 @@ TypeXValue = Union[
     Pattern[str],
     str,
     QName,
-    # Note 2022-10-14
-    # We would also want to have XsdPattern here
+    'XsdPattern',
 ]

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import datetime, isodate
 from decimal import Decimal
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, Type, cast, overload
+from typing import TYPE_CHECKING, Any, Type, cast, overload, Dict, Optional, Union, List
+from decimal import Decimal
+from re import Pattern
+from fractions import Fraction
 
 if TYPE_CHECKING:
     from arelle.ModelObject import ModelObject
@@ -136,7 +139,7 @@ def qnameEltPfxName(
     | ModelInlineFact
     | ModelObject,
     prefixedName: str,
-    prefixException: Exception | None = None,
+    prefixException: type[Exception] | None = None,
 ) -> QName | None:
     prefix: str | None
     namespaceURI: str | None
@@ -919,3 +922,30 @@ class InvalidValue(str):
         return str.__new__(cls, value)
 
 INVALIDixVALUE = InvalidValue("(ixTransformValueError)")
+
+TypeSValue = Union[
+    bool,
+    float,
+    int,
+    InvalidValue,
+    None,
+    str,
+]
+TypeXValue = Union[
+    datetime.datetime,
+    Decimal,
+    Dict[str, Pattern[str]],
+    float,
+    gDay,
+    gMonth,
+    gMonthDay,
+    gYearMonth,
+    gYear,
+    Fraction,
+    List[Optional[QName]],
+    None,
+    Pattern[str],
+    str,
+    datetime.time,
+    QName,
+]

--- a/arelle/XbrlUtil.py
+++ b/arelle/XbrlUtil.py
@@ -63,10 +63,10 @@ def equalityHash(
             from arelle.ModelXbrl import ModelXbrl
             assert isinstance(dts, ModelXbrl), 'dts is not an instance of ModelXbrl'
             if not hasattr(elt,"xValid"):
-                xmlValidate(dts, elt)  # type: ignore[no-untyped-call]
+                xmlValidate(dts, elt)
             hashableValue = elt.sValue if equalMode == S_EQUAL else elt.xValue
             if isinstance(hashableValue,float) and math.isnan(hashableValue):
-                hashableValue = (hashableValue,elt)    # ensure this NaN only compares to itself and no other NaN
+                hashableValue = (hashableValue,elt)  # type: ignore[assignment]    # ensure this NaN only compares to itself and no other NaN
             _hash = hash((elt.elementQname,
                           hashableValue,
                           tuple(sorted(attributeDict(dts, elt, set(), equalMode, excludeIDs, distinguishNaNs=True).items(),
@@ -101,9 +101,9 @@ def sEqual(
     elif elt1.namespaceURI != elt2.namespaceURI:
         return False
     if not hasattr(elt1,"xValid"):
-        xmlValidate(dts1, elt1)  # type: ignore[no-untyped-call]
+        xmlValidate(dts1, elt1)
     if not hasattr(elt2,"xValid"):
-        xmlValidate(dts2, elt2)  # type: ignore[no-untyped-call]
+        xmlValidate(dts2, elt2)
     children1 = childElements(elt1)
     children2 = childElements(elt2)
     if len(children1) != len(children2):
@@ -134,7 +134,7 @@ def attributeDict(
     distinguishNaNs: bool = False
 ) -> dict[QName, Any]:  # value can be any element value
     if not hasattr(elt,"xValid"):
-        xmlValidate(modelXbrl, elt)  # type: ignore[no-untyped-call]
+        xmlValidate(modelXbrl, elt)
     attrs = {}
     # TBD: replace with validated attributes
     for modelAttribute in getattr(elt, 'xAttributes', {}).values():
@@ -180,9 +180,9 @@ def childElements(elt: ModelObject) -> list[ModelObject]:
 
 def xEqual(elt1: ModelObject, elt2: ModelObject, equalMode: int = S_EQUAL) -> bool:
     if not hasattr(elt1,"xValid"):
-        xmlValidate(elt1.modelXbrl, elt1)  # type: ignore[no-untyped-call]
+        xmlValidate(elt1.modelXbrl, elt1)
     if not hasattr(elt2,"xValid"):
-        xmlValidate(elt2.modelXbrl, elt2)  # type: ignore[no-untyped-call]
+        xmlValidate(elt2.modelXbrl, elt2)
     if equalMode == VALIDATE_BY_STRING_VALUE:
         return elt1.stringValue == elt2.stringValue
     elif equalMode == S_EQUAL: # formula WG e-mail 2018-09-06: or (equalMode == S_EQUAL2 and not isinstance(elt1.sValue, QName)):
@@ -196,9 +196,9 @@ def xEqual(elt1: ModelObject, elt2: ModelObject, equalMode: int = S_EQUAL) -> bo
 
 def vEqual(elt1: ModelObject, elt2: ModelObject) -> bool:
     if not hasattr(elt1,"xValid"):
-        xmlValidate(elt1.modelXbrl, elt1)  # type: ignore[no-untyped-call]
+        xmlValidate(elt1.modelXbrl, elt1)
     if not hasattr(elt2,"xValid"):
-        xmlValidate(elt2.modelXbrl, elt2)  # type: ignore[no-untyped-call]
+        xmlValidate(elt2.modelXbrl, elt2)
     return elt1.sValue == elt2.sValue
 
 def typedValue(
@@ -216,6 +216,6 @@ def typedValue(
                 return element.xValue
     except (AttributeError, KeyError):
         if dts:
-            xmlValidate(dts, element, recurse=False, attrQname=attrQname)  # type: ignore[no-untyped-call]
+            xmlValidate(dts, element, recurse=False, attrQname=attrQname)
             return typedValue(None, element, attrQname=attrQname)
     return None

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -3,7 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 import logging
-from typing import TYPE_CHECKING, Any, cast, overload
+from typing import TYPE_CHECKING, Any, cast
 from lxml import etree
 from re import Match, compile as re_compile
 from decimal import Decimal, InvalidOperation

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -504,9 +504,7 @@ def validateValue(
                         if value in xmlSchemaPatterns:
                             xValue = xmlSchemaPatterns[value]
                         else:
-                            # Adding XsdPattern to TypeXValue causes a circular import
-                            # thus ignoring this error
-                            xValue = XsdPattern().compile(value)  # type: ignore[assignment]
+                            xValue = XsdPattern().compile(value)
                     except Exception as err:
                         raise ValueError(err)
                 elif baseXsdType == "fraction":

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -640,13 +640,7 @@ class lxmlSchemaResolver(etree.Resolver):
         self.cntlr = cntlr
         self.modelXbrl = modelXbrl
 
-    @overload
-    def resolve(self, url: str | None, id: str, context: Any) -> Any: ...
-
-    @overload
-    def resolve(self, system_url: str, public_id: str) -> Any: ...
-
-    def resolve(self, url: str | None, id: str, context: Any) -> Any: #  type: ignore[misc]
+    def resolve(self, url: str | None, id: str, context: Any) -> Any: #  type: ignore[override]
         if self.modelXbrl is None or not self.modelXbrl.fileSource.isInArchive(url):  # type: ignore[has-type]
             url = self.cntlr.webCache.getfilename(url)
         if url: # may be None if file doesn't exist

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -1,12 +1,9 @@
 '''
 See COPYRIGHT.md for copyright information.
 '''
-import os, logging
+import logging
 from lxml import etree
-try:
-    from regex import compile as re_compile
-except ImportError:
-    from re import compile as re_compile
+from regex import compile as re_compile
 from decimal import Decimal, InvalidOperation
 from fractions import Fraction
 from arelle import XbrlConst, XmlUtil
@@ -16,6 +13,8 @@ from arelle.ModelValue import (qname, qnameEltPfxName, qnameClarkName, qnameHref
 from arelle.ModelObject import ModelObject, ModelAttribute
 from arelle.PythonUtil import strTruncate
 from arelle import UrlUtil
+
+
 validateElementSequence = None  #dynamic import to break dependency loops
 modelGroupCompositorTitle = None
 ModelInlineValueObject = None

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -9,7 +9,7 @@ from re import Match, compile as re_compile
 from decimal import Decimal, InvalidOperation
 from fractions import Fraction
 from arelle import XbrlConst, XmlUtil
-from arelle.ModelValue import (QName, qname, qnameEltPfxName, qnameClarkName, qnameHref,
+from arelle.ModelValue import (qname, qnameEltPfxName, qnameClarkName, qnameHref,
                                dateTime, DATE, DATETIME, DATEUNION, time,
                                anyURI, INVALIDixVALUE, gYearMonth, gMonthDay, gYear, gMonth, gDay, isoDuration)
 from arelle.ModelObject import ModelObject, ModelAttribute
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from arelle.typing import TypeGetText
     from arelle.ModelValue import TypeXValue, TypeSValue
     from arelle.ModelDtsObject import ModelType
+    from arelle.ModelValue import QName
 
 _: TypeGetText
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ module = [
     'arelle.XbrlConst',
     'arelle.XbrlUtil',
     'arelle.XmlUtil',
+    'arelle.XmlValidate',
 ]
 ignore_errors = false
 strict = true


### PR DESCRIPTION
#### Reason for change
Adding more type hints.

#### Description of change
- Mainly adding type hints to `arelle.XmlValidate`
- Introducing shared types for `XValue` and `SValue` as they appear to be shared in multiple files
- Removing type ignore files that are no longer needed

#### Steps to Test

**review**:
@Arelle/arelle
