### PR TITLE
Add type hints to arelle.XmlValidateSchema

### DIFF
--- a/arelle/XmlValidateSchema.py
+++ b/arelle/XmlValidateSchema.py
@@ -1,13 +1,9 @@
 '''
 See COPYRIGHT.md for copyright information.
 '''
-import time
-from arelle import ModelXbrl, XbrlConst, XmlValidate
+from arelle import XbrlConst
 from arelle.ModelObject import ModelObject
 from arelle.ModelDtsObject import ModelAttribute, ModelConcept, ModelType
-from arelle.ModelValue import qname
-from arelle.Locale import format_string
-from lxml import etree
 
 XMLSchemaURI = "http://www.w3.org/2001/XMLSchema.xsd"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ module = [
     'arelle.SystemInfo',
     'arelle.Updater',
     'arelle.UrlUtil',
+    'arelle.XmlValidateSchema',
     'arelle.ValidateXbrl',
     'arelle.XbrlConst',
     'arelle.XbrlUtil',


### PR DESCRIPTION
#### Reason for change
Type hints.

#### Description of change
Adding type hints to `arelle.XmlValidateSchema.py`

#### Steps to Test

**review**:
@Arelle/arelle
