### PR TITLE
Correct gYearMonth, gMonthDay, gYear, gMonth, and gDay types

### DIFF
--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -631,7 +631,7 @@ class Time(datetime.time):
 
 
 class gYearMonth:
-    def __init__(self, year: int, month: int) -> None:
+    def __init__(self, year: int | str, month: int | str) -> None:
         self.year = int(year)  # may be negative
         self.month = int(month)
 
@@ -674,7 +674,7 @@ class gYearMonth:
 
 
 class gMonthDay:
-    def __init__(self, month: int, day: int) -> None:
+    def __init__(self, month: int | str, day: int | str) -> None:
         self.month = int(month)
         self.day = int(day)
 
@@ -719,7 +719,7 @@ class gMonthDay:
 
 
 class gYear:
-    def __init__(self, year: int):
+    def __init__(self, year: int | str):
         self.year = int(year)  # may be negative
 
     def __repr__(self) -> str:
@@ -763,7 +763,7 @@ class gYear:
 
 
 class gMonth:
-    def __init__(self, month: int):
+    def __init__(self, month: int | str):
         self.month = int(month)
 
     def __repr__(self) -> str:
@@ -807,7 +807,7 @@ class gMonth:
 
 
 class gDay:
-    def __init__(self, day: int) -> None:
+    def __init__(self, day: int | str) -> None:
         self.day = int(day)
 
     def __repr__(self) -> str:

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -629,176 +629,226 @@ class Time(datetime.time):
         time.hour24 = hour24
         return time
 
-class gYearMonth():
+
+class gYearMonth:
     def __init__(self, year: int, month: int) -> None:
-        self.year = int(year) # may be negative
+        self.year = int(year)  # may be negative
         self.month = int(month)
+
     def __repr__(self) -> str:
         return self.__str__()
+
     def __str__(self) -> str:
-        return "{0:0{2}}-{1:02}".format(self.year, self.month, 5 if self.year < 0 else 4) # may be negative
-    def __eq__(self,other: Any) -> bool:
+        return "{0:0{2}}-{1:02}".format(self.year, self.month, 5 if self.year < 0 else 4)  # may be negative
+
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
         return self.year == other.year and self.month == other.month
-    def __ne__(self,other: Any) -> bool:
+
+    def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)
+
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
         return (self.year < other.year) or (self.year == other.year and self.month < other.month)
+
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
         return (self.year < other.year) or (self.year == other.year and self.month <= other.month)
+
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
         return (self.year > other.year) or (self.year == other.year and self.month > other.month)
+
     def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
         return (self.year > other.year) or (self.year == other.year and self.month >= other.month)
+
     def __bool__(self) -> bool:
         return self.year != 0 or self.month != 0
 
 
-class gMonthDay():
+class gMonthDay:
     def __init__(self, month: int, day: int) -> None:
         self.month = int(month)
         self.day = int(day)
+
     def __repr__(self) -> str:
         return self.__str__()
+
     def __str__(self) -> str:
         return "--{0:02}-{1:02}".format(self.month, self.day)
-    def __eq__(self,other: Any) -> bool:
+
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
         return self.month == other.month and self.day == other.day
-    def __ne__(self,other: Any) -> bool:
+
+    def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
         return not self.__eq__(other)
-    def __lt__(self,other: Any) -> bool:
+
+    def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
         return (self.month < other.month) or (self.month == other.month and self.day < other.day)
-    def __le__(self,other: Any) -> bool:
+
+    def __le__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
         return (self.month < other.month) or (self.month == other.month and self.day <= other.day)
-    def __gt__(self,other: Any) -> bool:
+
+    def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
         return (self.month > other.month) or (self.month == other.month and self.day > other.day)
-    def __ge__(self,other: Any) -> bool:
+
+    def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
         return (self.month > other.month) or (self.month == other.month and self.day >= other.day)
+
     def __bool__(self) -> bool:
         return self.month != 0 or self.day != 0
 
-class gYear():
+
+class gYear:
     def __init__(self, year: int):
-        self.year = int(year) # may be negative
+        self.year = int(year)  # may be negative
+
     def __repr__(self) -> str:
         return self.__str__()
+
     def __str__(self) -> str:
-        return "{0:0{1}}".format(self.year, 5 if self.year < 0 else 4) # may be negative
-    def __eq__(self,other: Any) -> bool:
+        return "{0:0{1}}".format(self.year, 5 if self.year < 0 else 4)  # may be negative
+
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
         return self.year == other.year
-    def __ne__(self,other: Any) -> bool:
+
+    def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
         return not self.__eq__(other)
+
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
         return self.year < other.year
-    def __le__(self,other: Any) -> bool:
+
+    def __le__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
         return self.year <= other.year
-    def __gt__(self,other: Any) -> bool:
+
+    def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
         return self.year > other.year
-    def __ge__(self,other: Any) -> bool:
+
+    def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
         return self.year >= other.year
+
     def __bool__(self) -> bool:
         return self.year != 0 != 0
 
-class gMonth():
+
+class gMonth:
     def __init__(self, month: int):
         self.month = int(month)
+
     def __repr__(self) -> str:
         return self.__str__()
+
     def __str__(self) -> str:
         return "--{0:02}".format(self.month)
-    def __eq__(self,other: Any) -> bool:
+
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
         return self.month == other.month
-    def __ne__(self,other: Any) -> bool:
+
+    def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
         return not self.__eq__(other)
+
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
         return self.month < other.month
-    def __le__(self,other: Any) -> bool:
+
+    def __le__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
         return self.month <= other.month
-    def __gt__(self,other: Any) -> bool:
+
+    def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
         return self.month > other.month
-    def __ge__(self,other: Any) -> bool:
+
+    def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
         return self.month >= other.month
+
     def __bool__(self) -> bool:
         return self.month != 0
 
-class gDay():
+
+class gDay:
     def __init__(self, day: int) -> None:
         self.day = int(day)
+
     def __repr__(self) -> str:
         return self.__str__()
+
     def __str__(self) -> str:
         return "---{0:02}".format(self.day)
-    def __eq__(self,other: Any) -> bool:
+
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
         return self.day == other.day
-    def __ne__(self,other: Any) -> bool:
+
+    def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
         return not self.__eq__(other)
+
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
         return self.day < other.day
-    def __le__(self,other: Any) -> bool:
+
+    def __le__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
         return self.day <= other.day
-    def __gt__(self,other: Any) -> bool:
+
+    def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
         return self.day > other.day
-    def __ge__(self,other: Any) -> bool:
+
+    def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
         return self.day >= other.day
+
     def __bool__(self) -> bool:
         return self.day != 0
+
 
 isoDurationPattern = re.compile(
     r"^(?P<sign>[+-])?"

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -3,7 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from lxml import etree
 from re import Match, compile as re_compile
 from decimal import Decimal, InvalidOperation
@@ -541,19 +541,19 @@ def validateValue(
                             month, day, zSign, zHrMin, zHr, zMin = match.groups()
                             if int(day) > {2:29, 4:30, 6:30, 9:30, 11:30, 1:31, 3:31, 5:31, 7:31, 8:31, 10:31, 12:31}[int(month)]:
                                 raise ValueError("invalid day {0} for month {1}".format(day, month))
-                            xValue = gMonthDay(cast(int, month), cast(int, day))
+                            xValue = gMonthDay(month, day)
                         elif baseXsdType == "gYearMonth":
                             year, month, zSign, zHrMin, zHr, zMin = match.groups()
-                            xValue = gYearMonth(cast(int, year), cast(int, month))
+                            xValue = gYearMonth(year, month)
                         elif baseXsdType == "gYear":
                             year, zSign, zHrMin, zHr, zMin = match.groups()
-                            xValue = gYear(cast(int, year))
+                            xValue = gYear(year)
                         elif baseXsdType == "gMonth":
                             month, zSign, zHrMin, zHr, zMin = match.groups()
-                            xValue = gMonth(cast(int, month))
+                            xValue = gMonth(month)
                         elif baseXsdType == "gDay":
                             day, zSign, zHrMin, zHr, zMin = match.groups()
-                            xValue = gDay(cast(int, day))
+                            xValue = gDay(day)
                         elif baseXsdType == "duration":
                             xValue = isoDuration(value)
                         else:


### PR DESCRIPTION
#### Reason for change
`gYearMonth`, `gMonthDay`, `gYear`, `gMonth`, and `gDay` classes can accept `str` init params.

#### Description of change
Type updates

#### Steps to Test
* CI/mypy

**review**:
@Arelle/arelle
