### PR TITLE
Code sign and notarize Mac build

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -108,11 +108,12 @@ jobs:
           # move python modules to Resources
           for f in config doc examples images locale plugin scripts Tktable2.11 ;
             do
-              mv build/Arelle.app/Contents/MacOS/$f build/Arelle.app/Contents/Resources
+              mv build/Arelle.app/Contents/MacOS/$f build/Arelle.app/Contents/Resources/
             done
+          mkdir build/Arelle.app/Contents/Resources/lib
           for f in `ls build/Arelle.app/Contents/MacOS/lib | grep -v "Python\|encodings\|codecs\|collections\|importlib\|matplotlib\|zlib\|library.zip\|so$"`
             do
-              mv build/Arelle.app/Contents/MacOS/lib/$f build/Arelle.app/Contents/Resources/lib
+              mv build/Arelle.app/Contents/MacOS/lib/$f build/Arelle.app/Contents/Resources/lib/
             done
           
           # code signing

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -87,6 +87,8 @@ jobs:
       - run: cp -p arelleGUI.pyw arelleGUI.py
       - name: Build app
         run: python distro.py bdist_mac
+      - name: Remove git directories
+        run: find build/Arelle.app/Contents -name .git -exec rm -fR {} \;
       - name: Install certificate and sign code
         env:
           MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
@@ -94,18 +96,25 @@ jobs:
           MAC_BUILD_CERTIFICATE_PASSWORD: ${{ secrets.MAC_BUILD_CERTIFICATE_PASSWORD }}
           MAC_BUILD_KEYCHAIN_PASSWORD: 'LOCAL_KEYCHAIN_PASS'
         run: |
+          # Decode and write base64 p12 certificate to file.
           echo $MAC_BUILD_CERTIFICATE_BASE64 | base64 --decode > certificate.p12
+          
+          # Create local keychain
           security create-keychain -p "$MAC_BUILD_KEYCHAIN_PASSWORD" build.keychain -v
           security set-keychain-settings -lut 21600 build.keychain
           security default-keychain -s build.keychain
+          
+          # Import certificate into keychain
           security unlock-keychain -p "$MAC_BUILD_KEYCHAIN_PASSWORD" build.keychain
           security import certificate.p12 -k build.keychain -T /usr/bin/codesign -P "$MAC_BUILD_CERTIFICATE_PASSWORD"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MAC_BUILD_KEYCHAIN_PASSWORD" build.keychain
+          
+          # Confirm certificate
           security find-identity
           security find-certificate -a -p | openssl x509 -subject -noout
           echo MAC_BUILD_CERTIFICATE_NAME="$MAC_BUILD_CERTIFICATE_NAME"
           
-          # move python modules to Resources
+          # Move python modules to Resources
           for f in config doc examples images locale plugin scripts Tktable2.11 ;
             do
               mv build/Arelle.app/Contents/MacOS/$f build/Arelle.app/Contents/Resources/
@@ -116,7 +125,7 @@ jobs:
               mv build/Arelle.app/Contents/MacOS/lib/$f build/Arelle.app/Contents/Resources/lib/
             done
           
-          # code signing
+          # Code signing (*.so, *.dylib, etc)
           for i in $(find build/Arelle.app -type f -perm +111 -exec file "{}" \; | \
             grep -v "(for architecture" | \
             grep -v -E "^- Mach-O" | \
@@ -136,16 +145,15 @@ jobs:
             --sign "$MAC_BUILD_CERTIFICATE_NAME" \
             {} \;
           
-          # Create symlinks 
+          # Create symlinks (some libraries can't be code signed in /MacOS but need to be found within it)
           ln -s ../../Resources/lib/tcltk build/Arelle.app/Contents/MacOS/lib/tcltk
           ln -s ../../Resources/lib/tkinter build/Arelle.app/Contents/MacOS/lib/tkinter
+          # Symlink plugins folder so /Resources/plugin is found when searching in default /MacOS/plugin location
           ln -s ../Resources/plugin build/Arelle.app/Contents/MacOS/plugin
           
+          # Executable code signing (slightly redundant, but ensures all necessary files are code signed)
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleCmdLine
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleGUI
-
-      - name: Remove git directories
-        run: find build/Arelle.app/Contents/Resources -name .git -exec rm -fR {} \;
       - name: Notarize app
         uses: aaroncameron-wk/xcode-notarize@7b185cbfd79cf1fc2d2eaa597541329e18a44ba0
         with:

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   build-distribution:
+    environment: release
     strategy:
       matrix:
         os: [ macos-12 ]
@@ -86,8 +87,75 @@ jobs:
       - run: cp -p arelleGUI.pyw arelleGUI.py
       - name: Build app
         run: python distro.py bdist_mac
+      - name: Install certificate and sign code
+        env:
+          MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
+          MAC_BUILD_CERTIFICATE_NAME: 'Developer ID Application: Workiva Inc. (5ZF66U48UD)'
+          MAC_BUILD_CERTIFICATE_PASSWORD: ${{ secrets.MAC_BUILD_CERTIFICATE_PASSWORD }}
+          MAC_BUILD_KEYCHAIN_PASSWORD: 'LOCAL_KEYCHAIN_PASS'
+        run: |
+          echo $MAC_BUILD_CERTIFICATE_BASE64 | base64 --decode > certificate.p12
+          security create-keychain -p "$MAC_BUILD_KEYCHAIN_PASSWORD" build.keychain -v
+          security set-keychain-settings -lut 21600 build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$MAC_BUILD_KEYCHAIN_PASSWORD" build.keychain
+          security import certificate.p12 -k build.keychain -T /usr/bin/codesign -P "$MAC_BUILD_CERTIFICATE_PASSWORD"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MAC_BUILD_KEYCHAIN_PASSWORD" build.keychain
+          security find-identity
+          security find-certificate -a -p | openssl x509 -subject -noout
+          echo MAC_BUILD_CERTIFICATE_NAME="$MAC_BUILD_CERTIFICATE_NAME"
+          
+          # move python modules to Resources
+          for f in config doc examples images locale plugin scripts Tktable2.11 ;
+            do
+              mv build/Arelle.app/Contents/MacOS/$f build/Arelle.app/Contents/Resources
+            done
+          for f in `ls build/Arelle.app/Contents/MacOS/lib | grep -v "Python\|encodings\|codecs\|collections\|importlib\|matplotlib\|zlib\|library.zip\|so$"`
+            do
+              mv build/Arelle.app/Contents/MacOS/lib/$f build/Arelle.app/Contents/Resources/lib
+            done
+          
+          # code signing
+          for i in $(find build/Arelle.app -type f -perm +111 -exec file "{}" \; | \
+            grep -v "(for architecture" | \
+            grep -v -E "^- Mach-O" | \
+            grep -E "Mach-O executable|Mach-O 64-bit executable|Mach-O 64-bit bundle|Mach-O 64-bit dynamically linked shared library" | \
+            awk -F":" '{print $1}' | \
+            uniq)
+          do
+            codesign --deep --force --verify --verbose --timestamp \
+            --options runtime \
+            --sign "$MAC_BUILD_CERTIFICATE_NAME" \
+            "$i"
+          done
+          
+          find build/Arelle.app -type f -name "*.dylib*" -exec \
+            codesign --deep --force --verify --verbose --timestamp \
+            --options runtime \
+            --sign "$MAC_BUILD_CERTIFICATE_NAME" \
+            {} \;
+          
+          # Create symlinks 
+          ln -s ../../Resources/lib/tcltk build/Arelle.app/Contents/MacOS/lib/tcltk
+          ln -s ../../Resources/lib/tkinter build/Arelle.app/Contents/MacOS/lib/tkinter
+          
+          codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleCmdLine
+          codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleGUI
+
       - name: Remove git directories
         run: find build/Arelle.app/Contents/Resources -name .git -exec rm -fR {} \;
+      - name: Notarize app
+        uses: aaroncameron-wk/xcode-notarize@7b185cbfd79cf1fc2d2eaa597541329e18a44ba0
+        with:
+          product-path: build/Arelle.app
+          appstore-connect-username: ${{ secrets.MAC_BUILD_NOTARIZATION_USERNAME }}
+          appstore-connect-password: ${{ secrets.MAC_BUILD_NOTARIZATION_PASSWORD }}
+          verbose: true
+      - name: Staple notarization ticket
+        uses: devbotsxyz/xcode-staple@v1.0.0
+        with:
+          product-path: build/Arelle.app
+          verbose: true
       - name: Build DMG
         run: |
           pwd

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -138,6 +138,7 @@ jobs:
           # Create symlinks 
           ln -s ../../Resources/lib/tcltk build/Arelle.app/Contents/MacOS/lib/tcltk
           ln -s ../../Resources/lib/tkinter build/Arelle.app/Contents/MacOS/lib/tkinter
+          ln -s ../Resources/plugin build/Arelle.app/Contents/MacOS/plugin
           
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleCmdLine
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleGUI


### PR DESCRIPTION
#### Reason for change
Resolves #271 
In order to get Mac build running without Mac showing "damaged" and/or "malware" warnings, we need to both code sign and notarize the build.

#### Description of change
Code sign and notarize automated mac build using configured secrets.

#### Steps to Test
[Link to successful build action](https://github.com/Arelle/Arelle/actions/runs/3268343917)
Run build on Mac OS, make sure everything works out of the box. (No needing to right-click/Open, move plugins, change configurations)

**review**:
@Arelle/arelle
