### PR TITLE
Add certifi as a python package dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     'lxml==4.*',
     'numpy==1.*',
     'openpyxl==3.*',
-    'regex==2022.*',
+    'regex',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
+    'certifi',
     'isodate==0.*',
     'lxml==4.*',
     'numpy==1.*',


### PR DESCRIPTION
#### Reason for change
Missed adding certifi as a dependency for the python package in #418. Additionally, relaxed the python package dependency restriction for regex since it (and certifi) doesn't follow SemVer and is unnecessarily restrictive.

#### Description of change
Require certifi and permit more versions of the regex library.

#### Steps to Test
1. `pip install git+https://git@github.com/austinmatherne-wk/arelle.git@python-package-deps`
2. Clear the arelle cache
3. `arelleCmdLine --validate --file <any-filing>`
4. Confirm no `certifi` import errors

**review**:
@Arelle/arelle
