### PR TITLE
Pin GitHub runner OS versions

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   build-linux:
     environment: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         distro: [

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   build-windows:
     environment: release
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       contents: write
 

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -3,7 +3,7 @@ on: pull_request_target
 
 jobs:
   find-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.build-test-matrix.outputs.matrix }}
     steps:
@@ -26,14 +26,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-22.04
         test: ${{ fromJson(needs.find-tests.outputs.matrix) }}
         include:
-          - os: windows-latest
+          - os: windows-2022
             test:
               name: xbrl_conformance_suite
               path: tests/integration_tests/validation/XBRL/test_xbrl_conformance_suite.py
-          - os: macos-latest
+          - os: macos-12
             test:
               name: xbrl_conformance_suite
               path: tests/integration_tests/validation/XBRL/test_xbrl_conformance_suite.py

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   add-to-project:
     name: PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/add-to-project@v0.3.0
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-package:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout arelle
         uses: actions/checkout@v3.1.0
@@ -43,7 +43,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     needs: build-package
     environment: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install twine
         run: pip install -U twine

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5.21.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Build and publish python package
         uses: benc-uk/workflow-dispatch@v1.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         os:
           - macos-11
-          - ubuntu-latest
-          - windows-latest
+          - ubuntu-22.04
+          - windows-2022
         python-version:
           - '3.7'
           - '3.8'


### PR DESCRIPTION
#### Reason for change
#437 highlighted the ability of our workflows to fail because the backing OS version used by "x-latest" version can change. This pins all runner OS versions to actual latest with the exception of macos for unit tests (because of actions/runner-images#6442 that should be fixed in the next release).

#### Description of change
Pins GitHub workflow runner OS versions

#### Steps to Test
CI

**review**:
@Arelle/arelle
