### PR TITLE
EFM Filesource bug

### DIFF
--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -607,7 +607,7 @@ class FileSource:
             if isinstance(archiveFileSource.basefile, str) and filepath.startswith(archiveFileSource.basefile):
                 archiveFileName = filepath[len(archiveFileSource.basefile) + 1:]
             else: # filepath.startswith(self.baseurl)
-                assert isinstance(archiveFileSource.baseurl, list)
+                assert isinstance(archiveFileSource.baseurl, str)
                 archiveFileName = filepath[len(archiveFileSource.baseurl) + 1:]
             if (archiveFileSource.isZip or archiveFileSource.isTarGz or
                 archiveFileSource.isEis or archiveFileSource.isXfd or


### PR DESCRIPTION
#### Reason for change
~~1. `holidays` module is not included in dependencies, resulting in an error when using validate/EFM:
`[arelle:pluginLoadingError] Exception loading plug-in Validate EFM: No module named 'holidays'`~~
_edit: holidays already in optional deps_
2. Running EFM validataion results in the following error (after insalling `holidays` module):
```bash
# command
arelleCmdLine -f https://www.sec.gov/Archives/edgar/data/789019/000156459021020891/0001564590-21-020891-xbrl.zip --validate --plugin "inlineXbrlDocumentSet|validate/EFM|transforms/SEC" --disclosureSystem efm-strict-all-years

# error
Traceback (most recent call last):
  File "/home/sherif/projects/final/Arelle_src/arelleCmdLine.py", line 20, in <module>
    CntlrCmdLine.main()
  File "/home/sherif/projects/final/Arelle_src/arelle/CntlrCmdLine.py", line 48, in main
    parseAndRun(args)
  File "/home/sherif/projects/final/Arelle_src/arelle/CntlrCmdLine.py", line 494, in parseAndRun
    cntlr.run(options)
  File "/home/sherif/projects/final/Arelle_src/arelle/CntlrCmdLine.py", line 982, in run
    pluginXbrlMethod(self, options, modelXbrl, _entrypoint, responseZipStream=responseZipStream)
  File "/home/sherif/projects/final/Arelle_src/arelle/plugin/validate/EFM/__init__.py", line 301, in xbrlLoaded
    efmFiling.addReport(modelXbrl)
  File "/home/sherif/projects/final/Arelle_src/arelle/plugin/validate/EFM/__init__.py", line 589, in addReport
    _report = Report(modelXbrl)
  File "/home/sherif/projects/final/Arelle_src/arelle/plugin/validate/EFM/__init__.py", line 649, in __init__
    self.reportedFiles |= referencedFiles(modelXbrl)
  File "/home/sherif/projects/final/Arelle_src/arelle/ValidateFilingText.py", line 997, in referencedFiles
    addReferencedFile(elt, elt)
  File "/home/sherif/projects/final/Arelle_src/arelle/ValidateFilingText.py", line 978, in addReferencedFile
    if normalizedUri and (modelXbrl.fileSource.isInArchive(normalizedUri, checkExistence=True) or modelXbrl.fileSource.exists(normalizedUri)):
  File "/home/sherif/projects/final/Arelle_src/arelle/FileSource.py", line 610, in exists
    assert isinstance(archiveFileSource.baseurl, list)
AssertionError
```

#### Description of change
~~a85c82980584e58ba85fb708279f8bc7dc2281c8 add `holidays` module to dependencies~~
e8ade81efe6d316dd6bb23c72bb22bf8ee0373a5 change asset type from `list` to `str` in `FileSource.exists`

#### Steps to Test
Run command:
```bash
python arelleCmdLine.py -f https://www.sec.gov/Archives/edgar/data/789019/000156459021020891/0001564590-21-020891-xbrl.zip --validate --plugin "inlineXbrlDocumentSet|validate/EFM|transforms/SEC" --disclosureSystem efm-strict-all-years
```

**review**:
@Arelle/arelle
