### PR TITLE
PackageManager Windows - don't replace mapping path separators for http urls 

### DIFF
--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -12,7 +12,7 @@ from lxml import etree
 from urllib.parse import urljoin
 openFileSource = None
 from arelle import Locale, XmlUtil
-from arelle.UrlUtil import isAbsolute
+from arelle.UrlUtil import isAbsolute, isHttpUrl
 from arelle.XmlValidate import lxmlResolvingParser
 ArchiveFileIOError = None
 try:
@@ -195,7 +195,8 @@ def parsePackage(cntlr, filesource, metadataFile, fileBase, errors=[]):
                         if not isAbsolute(replaceValue):
                             if not os.path.isabs(replaceValue):
                                 replaceValue = fileBase + replaceValue
-                            replaceValue = replaceValue.replace("/", os.sep)
+                            if not isHttpUrl(replaceValue):
+                                replaceValue = replaceValue.replace("/", os.sep)
                     _normedValue = cntlr.webCache.normalizeUrl(replaceValue)
                     if replaceValue.endswith(os.sep) and not _normedValue.endswith(os.sep):
                         _normedValue += os.sep


### PR DESCRIPTION
#### Reason for change
resolves #413 

#### Description of change
PackageManager was rewriting path separators for both local files and http paths (changing `https://...` to `https:\\...`). This checks the mapping path to see if it's a http url before rewriting.

#### Steps to Test
The failing scenario (on Windows) from #413 should now pass.
```python
python arelleCmdLine.py -f https://filings.xbrl.org/5299004SWFL5JAN4W830/2022-06-30/ESEF/DK/0/5299004SWFL5JAN4W830-2022-06-30-en.zip --plugin inlineXbrlDocumentSet
```


**review**:
@Arelle/arelle
