### PR TITLE
Use correct Callable import for Python 3.10

### DIFF
--- a/arelle/TkTableWrapper.py
+++ b/arelle/TkTableWrapper.py
@@ -141,7 +141,7 @@ class Table(tkinter.Widget):
 
         res = ()
         for k, v in cnf.items():
-            if isinstance(v, collections.Callable):
+            if isinstance(v, collections.abc.Callable):
                 if k in self._tabsubst_commands:
                     v = "%s %s" % (self._register(v, self._tabsubst),
                                    ' '.join(self._tabsubst_format))


### PR DESCRIPTION
#### Reason for change
Callable is no longer importable from collections as of Python 3.10

#### Description of change
Updates import for Python 3.10

#### Steps to Test
Load a table linkbase test from the GUI. Any random instance from the 1000 directory of the conformance suite should do (e.g. `instance-dual-x-axes.xml`)

**review**:
@Arelle/arelle
