### PR TITLE
ESEF 2022 validation changes

### DIFF
--- a/arelle/plugin/validate/ESEF_2022/DTS.py
+++ b/arelle/plugin/validate/ESEF_2022/DTS.py
@@ -203,7 +203,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, visited: lis
         #        _("Line items that do not require any dimensional information to tag data MUST be linked to \"Line items not dimensionally qualified\" hypercube in http://www.esma.europa.eu/xbrl/esef/role/esef_role-999999 declared in esef_cor.xsd: concept %(concepts)s."),
         #        modelObject=extLineItemsWithoutHypercube, concepts=", ".join(str(c.qname) for c in extLineItemsWithoutHypercube))
         if extLineItemsNotAnchored:
-            val.modelXbrl.error("ESEF.3.3.1.extensionConceptsNotAnchored",
+            val.modelXbrl.warning("ESEF.3.3.1.extensionConceptsNotAnchored",
                 _("Extension concepts SHALL be anchored to concepts in the ESEF taxonomy:  %(concepts)s."),
                 modelObject=extLineItemsNotAnchored, concepts=", ".join(str(c.qname) for c in extLineItemsNotAnchored))
         if extLineItemsWronglyAnchored:

--- a/arelle/plugin/validate/ESEF_2022/DTS.py
+++ b/arelle/plugin/validate/ESEF_2022/DTS.py
@@ -203,7 +203,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, visited: lis
         #        _("Line items that do not require any dimensional information to tag data MUST be linked to \"Line items not dimensionally qualified\" hypercube in http://www.esma.europa.eu/xbrl/esef/role/esef_role-999999 declared in esef_cor.xsd: concept %(concepts)s."),
         #        modelObject=extLineItemsWithoutHypercube, concepts=", ".join(str(c.qname) for c in extLineItemsWithoutHypercube))
         if extLineItemsNotAnchored:
-            val.modelXbrl.warning("ESEF.3.3.1.extensionConceptsNotAnchored",
+            val.modelXbrl.error("ESEF.3.3.1.extensionConceptsNotAnchored",
                 _("Extension concepts SHALL be anchored to concepts in the ESEF taxonomy:  %(concepts)s."),
                 modelObject=extLineItemsNotAnchored, concepts=", ".join(str(c.qname) for c in extLineItemsNotAnchored))
         if extLineItemsWronglyAnchored:

--- a/arelle/plugin/validate/ESEF_2022/__init__.py
+++ b/arelle/plugin/validate/ESEF_2022/__init__.py
@@ -778,10 +778,6 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                         modelXbrl.warning("ESEF.2.2.2.percentGreaterThan100",
                             _("A percent fact should have value <= 100: %(element)s in context %(context)s value %(value)s"),
                             modelObject=f, element=f.qname, context=f.context.id, value=f.xValue)
-                    elif f.concept.balance is not None and f.xValue < 0:
-                        modelXbrl.warning("ESEF.1.6.1.negativeAmountWithBalance",
-                            _("A fact with balance should be a positive number: %(element)s in context %(context)s value %(value)s"),
-                            modelObject=f, element=f.qname, context=f.context.id, value=f.xValue)
                 elif f.concept is not None and f.concept.type is not None:
                     if f.concept.type.isOimTextFactType:
                         lang = f.xmlLang


### PR DESCRIPTION
#### Reason for change

Some rules were too restrictive and gave false positives. They have been cleaned to better fit the latest ESEF manual. 

#### Description of change

Newly implemented rule ESEF.1.6.1 was too restrictive. It has been removed again.

ESEF.3.3.1.extensionConceptsNotAnchored has been demoted to a warning because as of section 1.4.1 of the ESEF manual, _'Please note that the RTS on ESEF does not set an anchoring requirement for the Notes to the financial statements. Therefore, if issuers decide on a voluntary basis to create detailed tag extension elements to mark-up their Notes, there is no obligation to anchor such extension elements.'_

#### Steps to Test
For ESEF.1.6.1, if you create a taxonomy extension with a concept having a balance attribute and create an instance containing a a fact corresponding to the newly created concept with a negative amount, no warning ESEF.1.6.1 is issued.

For ESEF.3.3.1.extensionConceptsNotAnchored, create a taxonomy extension with a custom concept not anchored to any IFRS or ESEF concept. The ESEF.3.3.1.extensionConceptsNotAnchored is now counted as a **_warning_** and no longer an **_error_**.

**review**:
@Arelle/arelle
