### PR TITLE
Pin build workflow node_version inputs to 16

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -17,7 +17,7 @@ on:
         required: true
         type: string
       node_version:
-        default: lts/*
+        default: 16
         description: 'Node.js version to use'
         required: true
         type: string

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       node_version:
-        default: lts/*
+        default: 16
         description: 'Node.js version to use'
         required: true
         type: string

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       node_version:
-        default: lts/*
+        default: 16
         description: 'Node.js version to use'
         required: true
         type: string


### PR DESCRIPTION
#### Reason for change
Resolves #457 
Mitigates apparent OpenSSL issue with node/webpack building ixbrl-viewer

#### Description of change
Pin node_version to version 16

#### Steps to Test
Run Linux, Mac, and Windows build scripts

**review**:
@Arelle/arelle
