### PR TITLE
re xsd pattern value error

### DIFF
--- a/arelle/DialogAbout.py
+++ b/arelle/DialogAbout.py
@@ -6,10 +6,7 @@ try:
     from tkinter.ttk import Label, Button, Frame
 except ImportError:
     from ttk import Label, Button, Frame
-try:
-    from regex import match as re_match
-except ImportError:
-    from re import match as re_match
+from regex import match as re_match
 '''
 caller checks accepted, if True, caller retrieves url
 '''

--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -6,10 +6,7 @@ from collections import defaultdict
 from math import (log10, isnan, isinf, fabs, floor, pow)
 import decimal
 from typing import TYPE_CHECKING
-try:
-    from regex import compile as re_compile
-except ImportError:
-    from re import compile as re_compile
+from regex import compile as re_compile
 import hashlib
 from arelle import Locale, XbrlConst, XbrlUtil
 from arelle.ModelObject import ObjectPropertyViewWrapper

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 from lxml import etree
-from re import Match, compile as re_compile
+from regex import Match, compile as re_compile
 from decimal import Decimal, InvalidOperation
 from fractions import Fraction
 from arelle import XbrlConst, XmlUtil

--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -18,10 +18,7 @@ Example to run from web server:
 '''
 import os, sys, io, time, traceback, json, csv, logging, zipfile, datetime, isodate
 from math import isnan, log10
-try:
-    from regex import compile as re_compile, match as re_match, sub as re_sub, DOTALL as re_DOTALL
-except ImportError:
-    from re import compile as re_compile, match as re_match, sub as re_sub, DOTALL as re_DOTALL
+from regex import compile as re_compile, match as re_match, sub as re_sub, DOTALL as re_DOTALL
 from lxml import etree
 from collections import defaultdict, OrderedDict
 from arelle.ModelDocument import Type, create as createModelDocument

--- a/arelle/plugin/transforms/SEC/__init__.py
+++ b/arelle/plugin/transforms/SEC/__init__.py
@@ -19,10 +19,7 @@ from arelle.XPathContext import FunctionArgType
 #local copy of text2num.py from https://github.com/ghewgill/text2num
 from .text2num import text2num, NumberException
 
-try:
-    from regex import compile as re_compile
-except ImportError:
-    from re import compile as re_compile
+from regex import compile as re_compile
 
 # these five transformations take as input a number and output either an exception, or a value in xs:duration type
 # they handle zero values and also negative values

--- a/arelle/plugin/validate/EFM-htm/Const.py
+++ b/arelle/plugin/validate/EFM-htm/Const.py
@@ -1,10 +1,7 @@
 '''
 See COPYRIGHT.md for copyright information.
 '''
-try:
-    from regex import compile as re_compile, match as re_match, DOTALL as re_DOTALL
-except ImportError:
-    from re import compile as re_compile, match as re_match, DOTALL as re_DOTALL
+from regex import compile as re_compile, match as re_match, DOTALL as re_DOTALL
 
 edgarAdditionalTags = {
     "listing",

--- a/arelle/plugin/validate/EFM-htm/__init__.py
+++ b/arelle/plugin/validate/EFM-htm/__init__.py
@@ -3,10 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 import os, io
 from lxml.etree import HTMLParser, parse, DTD, _ElementTree, _Comment, _ProcessingInstruction
-try:
-    from regex import compile as re_compile, match as re_match, DOTALL as re_DOTALL
-except ImportError:
-    from re import compile as re_compile, match as re_match, DOTALL as re_DOTALL
+from regex import compile as re_compile, match as re_match, DOTALL as re_DOTALL
 from arelle import ValidateFilingText
 from arelle.ModelDocument import Type, create as createModelDocument
 from arelle.UrlUtil import isHttpUrl, scheme


### PR DESCRIPTION
#### Reason for change
Using `re` instead of `regex` in XmlValidate.py is causing a value error when loading the DEI 2021 Q4 schema:

`[xmlSchema:valueError] Element xs:pattern type xsd-pattern value error: [\p{L}\p{N}].*, bad escape \p at position 1 - https://xbrl.sec.gov/dei/2021q4/dei-2021q4.xsd 382`

#### Description of change
Replace `re` imports

#### Steps to Test
Load [workiva.zip](https://github.com/Arelle/Arelle/files/9912079/workiva.zip) and confirm `xmlSchema:valueError` isn't recorded for dei-2021q4.xsd

**review**:
@Arelle/arelle


