### PR TITLE
Update test runner to macos 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11
+          - macos-12
           - ubuntu-22.04
           - windows-2022
         python-version:


### PR DESCRIPTION
#### Reason for change
macos 12 runner has been fixed to symlink shared tcl/tk libraries.
https://github.com/actions/runner-images/issues/6442#issuecomment-1300784080

#### Description of change
Update macos test workflow runner to macos-12

#### Steps to Test
* CI

**review**:
@Arelle/arelle
