### PR TITLE
Fix light text on light background in macOS dark mode

### DIFF
--- a/arelle/ViewWinTree.py
+++ b/arelle/ViewWinTree.py
@@ -21,9 +21,18 @@ class ViewTree:
         hScrollbar = Scrollbar(self.viewFrame, orient=HORIZONTAL)
         self.treeView = Treeview(self.viewFrame, xscrollcommand=hScrollbar.set, yscrollcommand=vScrollbar.set)
         self.treeView.grid(row=0, column=0, sticky=(N, S, E, W))
-        self.treeView.tag_configure("ELR", background="#E0F0FF")
-        self.treeView.tag_configure("even", background="#F0F0F0")
-        self.treeView.tag_configure("odd", background="#FFFFFF")
+        try:
+            _isDarkTheme = bool(self.viewFrame.tk.call("tk::unsupported::MacWindowStyle", "isdark", "."))
+        except TclError:
+            _isDarkTheme = False
+        if _isDarkTheme:
+            self.treeView.tag_configure("ELR", background="#2D3033")
+            self.treeView.tag_configure("even", background="#303030")
+            self.treeView.tag_configure("odd", background="#212121")
+        else:
+            self.treeView.tag_configure("ELR", background="#E0F0FF")
+            self.treeView.tag_configure("even", background="#F0F0F0")
+            self.treeView.tag_configure("odd", background="#FFFFFF")
         if modelXbrl.modelManager.cntlr.isMac or modelXbrl.modelManager.cntlr.isMSW:
             highlightColor = "#%04x%04x%04x" % self.treeView.winfo_rgb("SystemHighlight")
         else:


### PR DESCRIPTION
#### Reason for change
The tree views in Arelle use a light text on light background on macOS when dark mode is enabled.

#### Before:
<img width="912" alt="Screen Shot 2022-11-03 at 12 57 08 AM" src="https://user-images.githubusercontent.com/46454775/199665646-5d337c1a-0e1e-4e9a-a942-8ae6a6c886bc.png">

#### After:
<img width="912" alt="Screen Shot 2022-11-03 at 1 04 15 AM" src="https://user-images.githubusercontent.com/46454775/199665660-1f739692-48ba-4c48-b87c-735dbb4b1648.png">


#### Description of change
Use dark background colors if running on macOS with dark mode enabled.

#### Steps to Test
* On macOS ([frozen build](https://github.com/Arelle/Arelle/actions/runs/3383591503)) with dark mode enabled, verify that tree views in the GUI are legible.
* On macOS ([frozen build](https://github.com/Arelle/Arelle/actions/runs/3383591503)) with dark mode disabled, verify that tree views are unchanged.
* On any non macOS platform ([linux](https://github.com/Arelle/Arelle/actions/runs/3383590704) and [windows](https://github.com/Arelle/Arelle/actions/runs/3383592245) frozen builds), verify that the tree views are unchanged.

**review**:
@Arelle/arelle
