### PR TITLE
Version frozen build artifact file names

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       openssl_version:
-        default: '1.1.1q'
+        default: '1.1.1s'
         description: 'OpenSSL version to use'
         required: true
         type: string

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,22 +12,22 @@ on:
         required: false
         type: string
       openssl_version:
-        default: 1.1.1q
+        default: '1.1.1q'
         description: 'OpenSSL version to use'
         required: true
         type: string
       node_version:
-        default: 16
+        default: '16'
         description: 'Node.js version to use'
         required: true
         type: string
       python_version:
-        default: 3.10.8
+        default: '3.10.8'
         description: 'Python version to use'
         required: true
         type: string
       tcltk_version:
-        default: 8.6.12
+        default: '8.6.12'
         description: 'tcl/tk version to use'
         required: true
         type: string

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -39,10 +39,12 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4.3.0
         with:
-          cache: 'pip' # caching pip dependencies
+          cache: 'pip'
           check-latest: true
           python-version: ${{ inputs.python_version }}
-      - run: pip install -r requirements-build.txt
+      - run: |
+          pip install --upgrade pip setuptools wheel
+          pip install -r requirements-build.txt
       - uses: actions/checkout@v3.1.0
         with:
           repository: Arelle/EdgarRenderer

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       node_version:
-        default: 16
+        default: '16'
         description: 'Node.js version to use'
         required: true
         type: string

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -29,11 +29,7 @@ on:
 jobs:
   build-distribution:
     environment: release
-    strategy:
-      matrix:
-        os: [ macos-12 ]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-12
 
     steps:
       - name: Checkout arelle
@@ -78,6 +74,8 @@ jobs:
           cd ../..
           mv tmp/ixbrl-viewer/iXBRLViewerPlugin arelle/plugin/
           rm -rf tmp
+      - name: Capture build version
+        run: echo "BUILD_VERSION=$(python -W ignore distro.py --version)" >> $GITHUB_ENV
       - name: Build app
         run: ./scripts/buildMacDist.sh
       - name: Remove git directories
@@ -200,14 +198,14 @@ jobs:
           ' | osascript
           sync
           hdiutil detach "${DEVICE}"
-          hdiutil convert dist_dmg/arelle_tmp.dmg -format UDZO -imagekey zlib-level=9 -o dist_dmg/arelle-${{ matrix.os }}.dmg
+          hdiutil convert dist_dmg/arelle_tmp.dmg -format UDZO -imagekey zlib-level=9 -o dist_dmg/arelle-macos-${{ env.BUILD_VERSION }}.dmg
       - uses: actions/upload-artifact@v3.1.1
         with:
           name: macos distribution
-          path: dist_dmg/arelle-${{ matrix.os }}.dmg
+          path: dist_dmg/arelle-macos-${{ env.BUILD_VERSION }}.dmg
       - name: Upload release artifact
         uses: softprops/action-gh-release@v0.1.14
         if: startsWith(github.ref, 'refs/tags/')
         with:
           fail_on_unmatched_files: true
-          files: dist_dmg/*.dmg
+          files: dist_dmg/arelle-macos-${{ env.BUILD_VERSION }}.dmg

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -88,6 +88,8 @@ jobs:
       run: |
         pip install wheel
         pip install -r requirements-build.txt
+    - name: Capture build version
+      run: echo ("BUILD_VERSION=" + (python -W ignore distro.py --version)) >> $env:GITHUB_ENV
     - name: Build exe
       run: ./scripts/buildWinDist.bat
     - name: Copy Tktable2.11
@@ -97,6 +99,8 @@ jobs:
       run: if exist "build\exe.win-amd64-${{ inputs.python_version }}\.git" rmdir /s /q build\exe.win-amd64-${{ inputs.python_version }}\.git
     - name: Make installer
       run: makensis installWin64.nsi
+    - name: Version installer
+      run: mv dist\arelle-win-x64.exe dist\arelle-win-${{ env.BUILD_VERSION }}.exe
     - name: Zip distribution
       run: 7z a -tzip ..\..\dist\arelle-win-x64.zip *
     - name: Upload artifacts
@@ -109,4 +113,4 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         fail_on_unmatched_files: true
-        files: dist\*
+        files: dist\arelle-win-${{ env.BUILD_VERSION }}.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -79,14 +79,14 @@ jobs:
     - name: Set up Python ${{ inputs.python_version }}
       uses: actions/setup-python@v4.3.0
       with:
-        cache: 'pip' # caching pip dependencies
+        cache: 'pip'
         check-latest: true
         python-version: ${{ inputs.python_version }}
     - name: Install NSIS
       run: choco install nsis
     - name: Install requirements
       run: |
-        pip install wheel
+        pip install --upgrade pip setuptools wheel
         pip install -r requirements-build.txt
     - name: Capture build version
       run: echo ("BUILD_VERSION=" + (python -W ignore distro.py --version)) >> $env:GITHUB_ENV

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       node_version:
-        default: 16
+        default: '16'
         description: 'Node.js version to use'
         required: true
         type: string

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -75,12 +75,12 @@ jobs:
       - name: Install Python 3
         uses: actions/setup-python@v4.3.0
         with:
-          cache: 'pip' # caching pip dependencies
+          cache: 'pip'
           check-latest: true
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip setuptools wheel
           pip install -r requirements-dev.txt
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1.7.0

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4.3.0
         with:
-          cache: 'pip' # caching pip dependencies
+          cache: 'pip'
           check-latest: true
           python-version: ${{ inputs.python_version }}
       - name: Build python package
         run: |
-          pip install -U setuptools wheel
+          pip install --upgrade pip setuptools wheel
           pip install build
           python -m build
       - name: Upload tar artifact

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_REPOSITORY: ${{ github.repository == 'Arelle/Arelle' && 'pypi' || 'testpypi' }}
         run: twine upload */*
       - name: Upload release artifact
         uses: softprops/action-gh-release@v0.1.14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Install Python 3
         uses: actions/setup-python@v4.3.0
         with:
-          cache: 'pip' # caching pip dependencies
+          cache: 'pip'
           check-latest: true
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          pip install --upgrade pip setuptools wheel
           pip install tox tox-gh-actions
       - name: Test with tox
         run: tox


### PR DESCRIPTION
#### Reason for change
Files that are uploaded to S3 and Alli Cloud need to have unique names.

Additionally, when testing the python package workflow on my fork I always tweak it to upload to [testpypi](https://test.pypi.org/project/arelle-release/). I changed the workflow to automatically do that when run from a fork.

#### Description of change
Build artifacts now include the version in their filename. Also did a little workflow cleanup.

#### Steps to Test
* Verify that the build release assets on the [testing release from my fork](https://github.com/austinmatherne-wk/Arelle/releases/tag/2.2.10) include the version number (mac build will be missing because I don't have a signing cert configured for my fork).
* Verify that the [macos build](https://github.com/Arelle/Arelle/actions/runs/3420483665) includes the version in the dmg filename when extracted from the zip.
* Smoke test the builds

**review**:
@Arelle/arelle
