### PR TITLE
Use cast forward reference for TYPE_CHECKING only import

### DIFF
--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -935,7 +935,7 @@ def isStandardArcElement(element: ModelObject) -> bool:
 
 def isStandardArcInExtLinkElement(element: ModelObject) -> bool:
     return (
-        isStandardArcElement(element) and isStandardResourceOrExtLinkElement(cast(ModelObject, element.getparent()))
+        isStandardArcElement(element) and isStandardResourceOrExtLinkElement(cast('ModelObject', element.getparent()))
     ) or element.qname == qnIXbrl11Relationship
 
 


### PR DESCRIPTION
#### Reason for change
`ModelObject` import is behind `TYPE_CHECKING`, but is used within a cast.

#### Description of change
Use a forward reference cast to avoid importing `ModelObject` at runtime.

#### Steps to Test
* CI/mypy

**review**:
@Arelle/arelle
