### PR TITLE
Handle HMRC 2022 mandatory items

### DIFF
--- a/arelle/plugin/validate/HMRC/__init__.py
+++ b/arelle/plugin/validate/HMRC/__init__.py
@@ -19,6 +19,7 @@ from arelle.XbrlConst import xbrli, qnXbrliXbrl
 import regex as re
 from collections import defaultdict
 
+FRC_2022_NAMESPACE = re.compile('^http://xbrl.frc.org.uk/.+/2022')
 memNameNumPattern = re.compile(r"^([A-Za-z-]+)([0-9]+)$")
 compTxmyNamespacePattern = re.compile(r"http://www.govtalk.gov.uk/uk/fr/tax/uk-hmrc-ct/[0-9-]{10}")
 # capture background-image or list-style-image with URL function
@@ -29,6 +30,13 @@ _6_APR_2008 = dateTime("2008-04-06", type=DATE)
 commonMandatoryItems = {
     "EntityCurrentLegalOrRegisteredName", "StartDateForPeriodCoveredByReport",
     "EndDateForPeriodCoveredByReport", "BalanceSheetDate"}
+
+COMMON_MANDATORY_FRS_ITEMS = commonMandatoryItems | {
+    "DateAuthorisationFinancialStatementsForIssue", "DirectorSigningFinancialStatements",
+    "EntityDormantTruefalse", "EntityTradingStatus", "EntityTradingStatus",
+    "AccountingStandardsApplied", "AccountsStatusAuditedOrUnaudited",
+    "LegalFormEntity", "DescriptionPrincipalActivities"
+}
 mandatoryItems = {
     "ukGAAP": commonMandatoryItems | {
         "DateApprovalAccounts", "NameDirectorSigningAccounts", "EntityDormant", "EntityTrading",
@@ -41,12 +49,9 @@ mandatoryItems = {
     "ukIFRS": commonMandatoryItems | {
         "DateAuthorisationFinancialStatementsForIssue", "ExplanationOfBodyOfAuthorisation",
         "EntityDormant", "EntityTrading", "DateSigningDirectorsReport", "DirectorSigningReport"},
-    "FRS": commonMandatoryItems | {
-        "DateAuthorisationFinancialStatementsForIssue", "DirectorSigningFinancialStatements",
-        "EntityDormantTruefalse", "EntityTradingStatus", "EntityTradingStatus",
-        "AccountingStandardsApplied", "AccountsStatusAuditedOrUnaudited", "AccountsTypeFullOrAbbreviated",
-        "LegalFormEntity", "DescriptionPrincipalActivities"}
-    }
+    "FRS": COMMON_MANDATORY_FRS_ITEMS | {"AccountsTypeFullOrAbbreviated"},
+    "FRS-2022": COMMON_MANDATORY_FRS_ITEMS | {"AccountsType"}
+}
 
 genericDimensionValidation = {
     # "taxonomyType": { "LocalName": (range of numbers if any, first item name, 2nd choice item name if any)
@@ -167,6 +172,7 @@ def validateXbrlStart(val, parameters=None, *args, **kwargs):
             if ns.startswith("http://www.xbrl.org/uk/char/"): val.txmyType = "charities"
             elif ns.startswith("http://www.xbrl.org/uk/gaap/"): val.txmyType = "ukGAAP"
             elif ns.startswith("http://www.xbrl.org/uk/ifrs/"): val.txmyType = "ukIFRS"
+            elif FRC_2022_NAMESPACE.search(ns): val.txmyType = "FRS-2022"
             elif ns.startswith("http://xbrl.frc.org.uk/"): val.txmyType = "FRS"
             else: continue
             break

--- a/arelle/plugin/validate/HMRC/__init__.py
+++ b/arelle/plugin/validate/HMRC/__init__.py
@@ -166,19 +166,20 @@ def validateXbrlStart(val, parameters=None, *args, **kwargs):
         val.isAccounts = not val.isComputation
 
     val.txmyType = None
-    if any((concept.qname.namespaceURI.startswith(FRC_URL_DOMAIN) and concept.modelDocument.inDTS)
-           for concept in val.modelXbrl.nameConcepts.get("AccountsType", ())):
-        val.txmyType = "FRS-2022"
-    else:
-        for doc in val.modelXbrl.modelDocument.referencesDocument:
-            ns = doc.targetNamespace
-            if ns:
-                if ns.startswith("http://www.xbrl.org/uk/char/"): val.txmyType = "charities"
-                elif ns.startswith("http://www.xbrl.org/uk/gaap/"): val.txmyType = "ukGAAP"
-                elif ns.startswith("http://www.xbrl.org/uk/ifrs/"): val.txmyType = "ukIFRS"
-                elif ns.startswith(FRC_URL_DOMAIN): val.txmyType = "FRS"
-                else: continue
-                break
+    for doc in val.modelXbrl.modelDocument.referencesDocument:
+        ns = doc.targetNamespace
+        if ns:
+            if ns.startswith("http://www.xbrl.org/uk/char/"): val.txmyType = "charities"
+            elif ns.startswith("http://www.xbrl.org/uk/gaap/"): val.txmyType = "ukGAAP"
+            elif ns.startswith("http://www.xbrl.org/uk/ifrs/"): val.txmyType = "ukIFRS"
+            elif ns.startswith(FRC_URL_DOMAIN):
+                if any((concept.qname.namespaceURI.startswith(FRC_URL_DOMAIN) and concept.modelDocument.inDTS)
+                       for concept in val.modelXbrl.nameConcepts.get("AccountsType", ())):
+                    val.txmyType = "FRS-2022"
+                else:
+                    val.txmyType = "FRS"
+            else: continue
+            break
     if val.txmyType:
         val.modelXbrl.debug("debug",
                             "HMRC taxonomy type %(taxonomyType)s",


### PR DESCRIPTION
#### Reason for change
The new HMRC 2022 taxonomies deprecated a concept that was required for 2021. The replacement concept needs to be tested for in 2022 taxonomies.

#### Description of change
Updated HMRC validation plugin to handle HMRC 2022 mandatory items for JFCVC.3312

#### Steps to Test
Run the provided docs against the HMRC validation plugin
- Run this 2021 [doc](https://github.com/Arelle/Arelle/files/9993494/arelle-HMRC-val-2021.zip) and verify that the JFCVC.3312 validation that fires does not include `AccountsTypeFullOrAbbreviated` in the list of missing mandatory items.
- Run this 2022 [doc](https://github.com/Arelle/Arelle/files/9993503/arelle-HMRC-val-2022-2.zip) and verify that the JFCVC.3312 validation that fires includes `AccountsType` in the list of missing mandatory items but does not include `AccountsTypeFullOrAbbreviated`.

**review**:
@Arelle/arelle
