### PR TITLE
Address paths change from softprops/action-gh-release@0.1.15

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -130,8 +130,8 @@ jobs:
       with:
         fail_on_unmatched_files: true
         files: |
-          ${{ env.EXE_BUILD_ARTIFACT_PATH }}
-          ${{ env.ZIP_BUILD_ARTIFACT_PATH }}
+          dist/${{ env.EXE_ARTIFACT_VERSIONED_NAME }}
+          dist/${{ env.ZIP_ARTIFACT_VERSIONED_NAME }}
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1.7.0
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
#### Description of change
fixes #493 

#### Reason for change
softprops/action-gh-release@0.1.15 (#488) updated dependencies that changed how paths are handled on Windows.
> \\ is now only used as an escape character, and never as a path separator in glob patterns, so that Windows users have a way to match against filenames containing literal glob pattern characters.
https://github.com/isaacs/node-glob/blob/main/changelog.md#80

#### Steps to Test
* Verify that the zip and exe builds are attached to the [test release on my fork](https://github.com/austinmatherne-wk/Arelle/releases/tag/9.999.999).

**review**:
@Arelle/arelle
