### PR TITLE
Freeze crypto on linux builds only (breaks Windows)

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -44,26 +44,9 @@ includeLibs = [
     "PIL",
     "pycountry",
     "pymysql",
-    # for now won't cx_freeze right on red hat
-    #"rdflib.extras",
-    #"rdflib.plugins.memory",
-    #"rdflib.plugins.parsers",
-    #"rdflib.plugins.serializers.rdfxml",
-    #"rdflib.plugins.serializers.turtle",
-    #"rdflib.plugins.serializers.xmlwriter",
-    #"rdflib.plugins.serializers",
-    #"rdflib.plugins.sparql",
-    #"rdflib.plugins.stores",
-    #"rdflib.plugins",
-    #"rdflib.tools",
-    #"rdflib",
     "regex",
     "sqlite3",
     "zlib",
-    # for plugin/security modules only
-    'Crypto',  # install pycrypto not another crypto module
-    'Crypto.Cipher', 
-    'Crypto.Cipher.AES'
 ]
 options = {
     "build_exe": {
@@ -86,6 +69,9 @@ if os.path.exists("arelle/plugin/EdgarRenderer"):
 
 if sys.platform == LINUX_PLATFORM:
     guiExecutable = Executable(script="arelleGUI.py", target_name="arelleGUI")
+    includeLibs.append("Crypto")
+    includeLibs.append("Crypto.Cipher")
+    includeLibs.append("Crypto.Cipher.AES")
     includeFiles.append(("arelle/scripts-unix", "scripts"))
     if os.path.exists("/etc/redhat-release"):
         includeFiles.append(("/usr/lib64/libexslt.so.0", "libexslt.so"))


### PR DESCRIPTION
#### Reason for change
#492 broke the windows build. Freezing PyCryptodome on Windows ([which doesn't even work?](https://github.com/Legrandin/pycryptodome/issues/14)) causes the Microsoft Visual C++ redistributable not to be included in the root of the build. If a user doesn't already have it installed the application will fail to start.

#### Description of change
Limit the crypto libs to the linux/red hat build.

#### Steps to Test
* verify that `vcruntime140` is included in the root of [the zip build for this branch](https://github.com/Arelle/Arelle/actions/runs/3589245654)

**review**:
@Arelle/arelle
