### PR TITLE
Use public Red Hat universal base image for docker build

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -110,9 +110,6 @@ jobs:
           context: .
           file: docker/${{ matrix.distro }}.Dockerfile
           load: true
-          secrets: |
-            "redhat_username=${{ secrets.REDHAT_USERNAME }}"
-            "redhat_password=${{ secrets.REDHAT_PASSWORD }}"
           tags: arelle:arelle
       - name: Docker copy build artifact
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -92,12 +92,6 @@ jobs:
         run: mv ixbrl-viewer/iXBRLViewerPlugin arelle/plugin/
       - name: Cleanup ixbrl-viewer
         run: rm -rf ixbrl-viewer
-      - name: Docker registry login
-        uses: docker/login-action@v2.1.0
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.REDHAT_USERNAME }}
-          password: ${{ secrets.REDHAT_PASSWORD }}
       - name: Docker setup buildx
         uses: docker/setup-buildx-action@v2.2.1
       - name: Docker build

--- a/docker/redhat.Dockerfile
+++ b/docker/redhat.Dockerfile
@@ -1,22 +1,16 @@
 # Use oldest LTS release for linked glibc compatibility
-FROM registry.redhat.io/rhel7:7.9
+FROM registry.access.redhat.com/ubi7:7.9
 
 ARG OPENSSL_VERSION
 ARG PYTHON_VERSION
 ARG TCLTK_VERSION
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-RUN --mount=type=secret,id=redhat_username \
-    --mount=type=secret,id=redhat_password \
-    subscription-manager register \
-    --username $(cat /run/secrets/redhat_username) \
-    --password $(cat /run/secrets/redhat_password) \
-    --auto-attach \
-    && yum -y update \
-    && yum -y groupinstall "Development Tools" \
+RUN yum -y update \
     && yum -y install \
         bzip2-devel \
         gcc \
+    	gcc-c++ \
         gdbm-devel \
         git \
         libffi-devel \
@@ -24,6 +18,7 @@ RUN --mount=type=secret,id=redhat_username \
         libX11-devel \
         libxml2-devel \
         libxslt-devel \
+    	make \
         ncurses-devel \
         readline-devel \
         sqlite-devel \
@@ -31,8 +26,7 @@ RUN --mount=type=secret,id=redhat_username \
         wget \
     && yum autoremove -y \
     && yum clean all \
-    && rm -rf /var/cache/yum \
-    ; subscription-manager unregister
+    && rm -rf /var/cache/yum
 
 WORKDIR /tmp
 


### PR DESCRIPTION
#### Reason for change
The Red Hat [build failed](https://github.com/Arelle/Arelle/actions/runs/3594677421/jobs/6053986372) after the latest tag of the docker image we were using was updated last night. It no longer supports registering from within the docker container (Red Hat expects the container to run from within a registered Red Hat host... which GitHub doesn't provide a runner for.)

#### Description of change
Use the public Red Hat universal base image which doesn't require registering with Red Hat. Initially we had problems with tcl/tk provided from the UBI image, but we're compiling it now anyway.
This also makes running the build locally much easier, as you no longer need a Red Hat account.

#### Steps to Test
* Smoke test the [Red Hat build](https://github.com/austinmatherne-wk/Arelle/actions/runs/3596826987)

**review**:
@Arelle/arelle
