### PR TITLE
Edgar 22.4 update: ecd-cef-dei2022 compatibility and DocFinStmtRstmtFlag

### DIFF
--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -1293,10 +1293,10 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                     for name in names:
                         f = sevFact(sev, name)
                         fr = sevFact(sev, referenceTag, f) # dependent fact is of context of f or for "c" inherited context (less disaggregatedd)
-                        if ((f is not None and ((f.xValue == value) ^ (fr is not None))) or
-                            (f is None and fr is not None)):
+                        if ((fr is not None and ((fr.xValue == referenceValue) ^ (f is not None))) or
+                            (fr is None and f is not None)):
                             _facts = [_f for _f in (f, fr) if _f is not None]
-                            sevMessage(sev, subType=submissionType, modelObject=_facts, tag=name, otherTag=referenceTag, value=value, contextID=_facts[0].contextID )
+                            sevMessage(sev, subType=submissionType, modelObject=_facts, tag=name, otherTag=referenceTag, value=referenceValue, contextID=_facts[0].contextID )
                 elif validation in ("n2e",):
                     for name in names:
                         f = sevFact(sev, name)

--- a/arelle/plugin/validate/EFM/resources/dei-validations.json
+++ b/arelle/plugin/validate/EFM/resources/dei-validations.json
@@ -1248,6 +1248,21 @@
     },
     {
         "sub-types": ["@10-K", "@10-KT", "@20-F", "@40-F"],
+        "xbrl-names": [
+            "DocumentFinStmtErrorCorrectionFlag",
+            "DocumentFinStmtRestatementRecoveryAnalysisFlag"
+            ],
+        "efm": "6.5.40",
+        "validation": "taxonomy-version-required",
+        "value": 2,
+        "earliest-taxonomy": "dei/2022q4",
+        "check-after": "2024-01-27",
+        "source": "both",
+        "dei/cover": "dei",
+        "comment": "value is number of name elements required in taxonomy"
+    },
+    {
+        "sub-types": ["@10-K", "@10-KT", "@20-F", "@40-F"],
         "xbrl-names": "DocumentFinStmtErrorCorrectionFlag",
         "efm": "6.5.49",
         "validation": "r",
@@ -1256,12 +1271,11 @@
     },
     {
         "sub-types": ["@10-K", "@10-KT", "@20-F", "@40-F"],
-        "xbrl-names": "DocumentFinStmtErrorCorrectionFlag",
-        "value": true,
+        "xbrl-names": "DocumentFinStmtRestatementRecoveryAnalysisFlag",
         "efm": "6.5.49",
         "validation": "rt",
-        "value": true,
-        "references": "DocumentFinStmtRestatementRecoveryAnalysisFlag",
+        "references": "DocumentFinStmtErrorCorrectionFlag",
+        "reference-value": true,
         "source": "inline",
         "dei/cover": "cover"
     },

--- a/arelle/plugin/validate/EFM/resources/taxonomy-compatibility.json
+++ b/arelle/plugin/validate/EFM/resources/taxonomy-compatibility.json
@@ -41,7 +41,7 @@
     		"dei/2022", "country/2022", "currency/2022", "exch/2022", "naics/2022", "sic/2022", "stpr/2022"
     	],
         "stx-2022q4": [
-            "dei/2022q4", "country/2022", "currency/2022", "exch/2022", "naics/2022", "sic/2022", "stpr/2022"
+            "dei/2022", "dei/2022q4", "country/2022", "currency/2022", "exch/2022", "naics/2022", "sic/2022", "stpr/2022"
        ],
         
 
@@ -64,7 +64,7 @@
         "rr/2022": ["@stx-2022"],
 
         "comment2": "latest us-gaap is compatible with prior year ifrs from Q1 to Q2, after Q2 must use same-year ifrs",
-        "ecd/2022q4" : ["@stx-2022q4", "us-gaap/2022q3", "us-gaap/2022", "srt/2022q3", "srt/2022", "ifrs/2022"],
+        "ecd/2022q4" : ["@stx-2022q4", "us-gaap/2022q3", "us-gaap/2022", "srt/2022q3", "srt/2022", "ifrs/2022", "cef/2022"],
         "us-gaap/2021": ["@stx-2021", "srt/2021", "ifrs/2021", "cef/2021q4"],
         "us-gaap/2022": ["us-gaap/2022q3", "@stx-2022", "srt/2022", "srt/2022q3", "ifrs/2022", "cef/2022"],
         "us-gaap/2022q3": ["us-gaap/2022", "@stx-2022", "srt/2022q3", "srt/2022", "ifrs/2022", "cef/2022"],


### PR DESCRIPTION
#### Reason for change

ECD updates based on public comments, allow compatibility with def and dev/2022, improve validation of DocumentFinStmtRestatementRecoveryAnalysisFlag

#### Description of change

Taxonomy compatibilities updated.   DocumentFinStmtRestatementRecoveryAnalysisFlag validation updated.

#### Steps to Test

SEC conformance suite (release with these updates is planned for 2022-12-19), or ecd samples with updates based on public comments (when available).

**review**:
@Arelle/arelle
