### PR TITLE
Downgrade packaging to fix Windows builds.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,4 @@ updates:
         versions:
           - ">=6"
       - dependency-name: "cx_Freeze"
+      - dependency-name: "packaging"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,4 @@
 cx-Freeze==6.13.1
-requests-negotiate-sspi==0.5.2; sys_platform == 'win32'
+requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
 -r requirements.txt

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,6 @@
 cx-Freeze==6.13.1
+# A dependency of cx_Freeze that we specify explicitly in order to pin
+packaging==21.3
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
 -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # https://github.com/sphinx-doc/sphinx/issues/10241
-Sphinx==5.3.0; python_version >= "3.8"
-Sphinx==4.3.1; python_version < "3.8"
+Sphinx==5.3.0 ; python_version >= "3.8"
+Sphinx==4.3.1 ; python_version < "3.8"
 
 flake8==5.0.4
 flake8-noqa==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,10 @@ Cheroot==8.6.0
 pycountry==22.3.5
 # plugins
 # EdgarRenderer plugin
-NumPy==1.21.6; python_version < "3.8"
-NumPy==1.23.4; python_version >= "3.8"
-Matplotlib==3.5.3; python_version < "3.8"
-Matplotlib==3.6.1; python_version >= "3.8"
+NumPy==1.21.6 ; python_version < "3.8"
+NumPy==1.23.4 ; python_version >= "3.8"
+Matplotlib==3.5.3 ; python_version < "3.8"
+Matplotlib==3.6.1 ; python_version >= "3.8"
 holidays==0.16
 Tornado==6.2
 # security plugin


### PR DESCRIPTION
#### Reason for change
vcruntime140.dll isn't being copied to the root of the Windows build.

#### Steps to Test
Run a Windows build.

**review**:
@Arelle/arelle
