### PR TITLE
Run tests and build python package with Python 3.11

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           cache: 'pip'
           check-latest: true
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       python_version:
-        default: '3.10'
+        default: '3.11'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,6 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
-        exclude:
-          # lxml doesn't have Windows wheels yet: https://bugs.launchpad.net/lxml/+bug/1977998
-          - os: windows-2022
-            python-version: 3.11
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,8 @@ return it. Once we receive it, we'll be able to accept your pull requests.
 
 ### Setting up an environment
 1. Install [pyenv](https://github.com/pyenv/pyenv#installation)
-2. Install a [supported version of Python](https://github.com/Arelle/Arelle/blob/master/README.md#installation). For example, `pyenv install 3.10.7`
-3. Create a virtual env using the minimum python version. For example, `PYENV_VERSION=3.10.7 pyenv exec python -m venv venv`
+2. Install a [supported version of Python](https://github.com/Arelle/Arelle/blob/master/README.md#installation). For example, `pyenv install 3.11.1`
+3. Create a virtual env using the minimum python version. For example, `PYENV_VERSION=3.11.1 pyenv exec python -m venv venv`
 4. Activate your environment `source venv/bin/activate`
 5. Install dependencies `pip install -r requirements-dev.txt`
 6. Verify you can run the app

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ be integrated with other applications and languages utilizing its web service.
 
 ## Installation
 
-The implementation is in Python 3.10 and is intended for Windows, macOS, or
+The implementation is in Python >= 3.7 and is intended for Windows, macOS, or
 Linux (tested against Ubuntu and RHEL). The standard desktop installation
 includes a GUI, a RESTful web server, and CLI. We try to support all operating
 system versions that still receive security updates from their development teams.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Operating System :: OS Independent',
     'Topic :: Text Processing :: Markup :: XML'
 ]
@@ -92,7 +93,7 @@ empty_parameter_set_mark = "fail_at_collect"
 # Warn when a # type: ignore comment does not specify any error codes
 enable_error_code = "ignore-without-code"
 
-python_version = "3.10"
+python_version = "3.11"
 
 show_error_codes = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core modules
 certifi==2022.12.7
-lxml==4.9.1
+lxml==4.9.2
 OpenPyXL==3.0.10
 pyparsing==3.0.9
 regex==2022.10.31

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ python =
   3.7: py37
   3.8: py38
   3.9: py39
-  3.10: py310, lint, typing
-  3.11: py311
+  3.10: py310
+  3.11: py311, lint, typing
 
 [testenv]
 commands =


### PR DESCRIPTION
#### Reason for change
lxml provides a Windows Python 3.11 wheel with the new 4.9.2 release. We're still waiting on Python 3.11 support from cx_Freeze before moving the frozen builds over, but we can move the Python package, linting, and conformance suites.

#### Description of change
* Updates lxml to version with wheel support for Python 3.11 on Windows
* Run unit tests on Windows with 3.11
* Build Python package with 3.11
* Run conformance suites with 3.11
* Run type checking and linting with 3.11

#### Steps to Test
* CI

**review**:
@Arelle/arelle
