### PR TITLE
Reset locale after changing

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -15,7 +15,7 @@ from arelle import (Cntlr, FileSource, ModelDocument, RenderingEvaluator, XmlUti
                     ViewFileRoleTypes,
                     ModelManager)
 from arelle.ModelValue import qname
-from arelle.Locale import format_string, setDisableRTL
+from arelle.Locale import format_string, setApplicationLocale, setDisableRTL
 from arelle.ModelFormulaObject import FormulaOptions
 from arelle import PluginManager
 from arelle.PluginManager import pluginClassMethods
@@ -45,6 +45,7 @@ def main():
         args = sys.argv[1:]
 
     gettext.install("arelle") # needed for options messages
+    setApplicationLocale()
     parseAndRun(args)
 
 def wsgiApplication(extraArgs=[]): # for example call wsgiApplication(["--plugins=EdgarRenderer"])

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -26,8 +26,7 @@ import tkinter.tix
 import tkinter.filedialog
 import tkinter.messagebox, traceback
 import tkinter.simpledialog
-from arelle.FileSource import saveFile as writeToFile
-from arelle.Locale import format_string
+from arelle.Locale import format_string, setApplicationLocale
 from arelle.CntlrWinTooltip import ToolTip
 from arelle import XbrlConst
 from arelle.PluginManager import pluginClassMethods
@@ -1605,6 +1604,7 @@ def main():
         restartMain = False
         try:
             application = Tk()
+            setApplicationLocale()
             cntlrWinMain = CntlrWinMain(application)
             application.protocol("WM_DELETE_WINDOW", cntlrWinMain.quit)
             if sys.platform == "darwin" and not __file__.endswith(".app/Contents/MacOS/arelleGUI"):

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -286,6 +286,17 @@ def languageCodes() -> dict[str, str]:  # dynamically initialize after gettext i
         }
         return _languageCodes
 
+
+def setApplicationLocale() -> None:
+    """
+    Sets the locale to C, to be used when running Arelle as a standalone application
+    (e.g., `arelleCmdLine`, `arelleGUI`.)
+    :return:
+    """
+    import locale
+    locale.setlocale(locale.LC_ALL, 'C')
+
+
 _disableRTL: bool = False # disable for implementations where tkinter supports rtl
 def setDisableRTL(disableRTL: bool) -> None:
     global _disableRTL

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -25,8 +25,6 @@ LC_MONETARY = 4
 LC_NUMERIC = 1
 LC_TIME = 2
 
-C_LOCALE = None # culture-invariant locale
-
 defaultLocaleCodes = {
     "af": "ZA", "ar": "AE", "be": "BY", "bg": "BG", "ca": "ES", "cs": "CZ",
     "da": "DK", "de": "DE", "el": "GR", "en": "GB", "es": "ES", "et": "EE",
@@ -40,7 +38,6 @@ defaultLocaleCodes = {
 def getUserLocale(localeCode: str = '') -> tuple[LocaleDict, str | None]:
     # get system localeconv and reset system back to default
     import locale
-    global C_LOCALE
     conv = None
     localeSetupMessage = None
     localeCode = localeCode.replace('-', '_')
@@ -78,8 +75,6 @@ def getUserLocale(localeCode: str = '') -> tuple[LocaleDict, str | None]:
     if conv is None:  # some other issue prevents getting culture code, use 'C' defaults (no thousands sep, no currency, etc)
         localeSetupMessage = f"locale code \"{localeCode}\" is not available on this system"
         conv = locale.localeconv() # use 'C' environment, e.g., en_US
-    if C_LOCALE is None:  # load culture-invariant C locale
-        C_LOCALE = locale.localeconv()
     return cast(LocaleDict, conv), localeSetupMessage
 
 def getLanguageCode() -> str:

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -613,7 +613,7 @@ class ModelXbrl:
         xbrlElt = self.modelDocument.xmlRootElement
         if cast(str, afterSibling) == AUTO_LOCATE_ELEMENT:
             afterSibling = XmlUtil.lastChild(xbrlElt, XbrlConst.xbrli, ("schemaLocation", "roleType", "arcroleType", "context"))
-        cntxId = id if id else 'c-{0:02n}'.format( len(self.contexts) + 1)
+        cntxId = id if id else 'c-{0:02}'.format( len(self.contexts) + 1)
         newCntxElt = XmlUtil.addChild(xbrlElt, XbrlConst.xbrli, "context", attributes=("id", cntxId),
                                       afterSibling=cast(Optional[ModelObject], afterSibling), beforeSibling=beforeSibling)
         entityElt = XmlUtil.addChild(newCntxElt, XbrlConst.xbrli, "entity")
@@ -723,7 +723,7 @@ class ModelXbrl:
         xbrlElt = self.modelDocument.xmlRootElement
         if afterSibling == cast('ModelObject', AUTO_LOCATE_ELEMENT):
             afterSibling = XmlUtil.lastChild(xbrlElt, XbrlConst.xbrli, ("schemaLocation", "roleType", "arcroleType", "context", "unit"))
-        unitId = id if id else 'u-{0:02n}'.format( len(self.units) + 1)
+        unitId = id if id else 'u-{0:02}'.format( len(self.units) + 1)
         newUnitElt = XmlUtil.addChild(xbrlElt, XbrlConst.xbrli, "unit", attributes=("id", unitId),
                                       afterSibling=afterSibling, beforeSibling=beforeSibling)
         if len(divideBy) == 0:

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -999,12 +999,12 @@ def dateunionValue(
         d = datetimeValue
         if subtractOneDay and not isDate: d -= datetime.timedelta(1)
         if dateOnlyHour is None:
-            return "{0:04n}-{1:02n}-{2:02n}{3}".format(d.year, d.month, d.day, tz)
+            return "{0:04}-{1:02}-{2:02}{3}".format(d.year, d.month, d.day, tz)
         else: # show explicit hour on date-only value (e.g., 24:00:00 for end date)
-            return "{0:04n}-{1:02n}-{2:02n}T{3:02n}:00:00{4}".format(
+            return "{0:04}-{1:02}-{2:02}T{3:02}:00:00{4}".format(
                 d.year, d.month, d.day, dateOnlyHour, tz)
     else:
-        return "{0:04n}-{1:02n}-{2:02n}T{3:02n}:{4:02n}:{5:02n}{6}".format(
+        return "{0:04}-{1:02}-{2:02}T{3:02}:{4:02}:{5:02}{6}".format(
             datetimeValue.year,
             datetimeValue.month,
             datetimeValue.day,

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -131,10 +131,10 @@ def saveLoadableOIM(modelXbrl, oimFile, outputZip=None,
         else: # instant
             s = e = cntx.instantDatetime
         return({str(qnOimPeriodAspect):
-                ("{0:04n}-{1:02n}-{2:02n}T{3:02n}:{4:02n}:{5:02n}{6}/".format(
+                ("{0:04}-{1:02}-{2:02}T{3:02}:{4:02}:{5:02}{6}/".format(
                          s.year, s.month, s.day, s.hour, s.minute, s.second, tzinfoStr(s))
                     if cntx.isStartEndPeriod else "") +
-                "{0:04n}-{1:02n}-{2:02n}T{3:02n}:{4:02n}:{5:02n}{6}".format(
+                "{0:04}-{1:02}-{2:02}T{3:02}:{4:02}:{5:02}{6}".format(
                          e.year, e.month, e.day, e.hour, e.minute, e.second, tzinfoStr(e))
                 })
 

--- a/arelle/plugin/xbrlDB/XbrlDpmSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlDpmSqlDB.py
@@ -1272,17 +1272,6 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                         elif isinstance(dec, str) and '.' in dec:
                             dec = dec.partition('.')[0] # drop .0 from any SQLite string
                         attrs["decimals"] = str(dec)  # somehow it is float from the database
-                    '''
-                    num = roundValue(numVal, None, dec) # round using reported decimals
-                    if dec is None or dec == "INF":  # show using decimals or reported format
-                        dec = abs(Decimal(str(numVal)).as_tuple().exponent)
-                    else: # max decimals at 28
-                        try:
-                            dec = max( min(int(float(dec)), 28), -28)
-                        except ValueError:
-                            dec = 0
-                    text = Locale.format(Locale.C_LOCALE, "%.*f", (dec, num)) # culture-invariant locale
-                    '''
                     try:
                         text = str(numVal)
                         if c == 'm':

--- a/attic/CntlrGenVersReports.py
+++ b/attic/CntlrGenVersReports.py
@@ -232,7 +232,7 @@ class CntlrGenVersReports(Cntlr.Cntlr):
                         if len(uriFromParts) >= 2:
                             variationId = uriFromParts[1]
                         else:
-                            variationId = "_{0:02n}".format(variationSeq)
+                            variationId = "_{0:02}".format(variationSeq)
                         for i,testcaseElt in enumerate(testcaseElements):
                             variationElement = etree.SubElement(testcaseElt, "{http://xbrl.org/2008/conformance}variation", 
                                                                 attrib={"id": variationId})

--- a/tests/unit_tests/arelle/test_locale.py
+++ b/tests/unit_tests/arelle/test_locale.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Any
+import locale
 import pytest
 from decimal import Decimal
 from arelle.Locale import format_decimal
@@ -62,3 +63,11 @@ d = Decimal('-1234567.8901')
 )
 def test_format_decimal(params: dict[str, Any], result: str) -> None:
     assert format_decimal(**params) == result
+
+
+@pytest.mark.parametrize('locale_code', ['', 'C', 'invalid'])
+def test_get_user_locale_reset(locale_code) -> None:
+    before_locale = locale.getlocale()[0]
+    getUserLocale(locale_code)
+    after_locale = locale.getlocale()[0]
+    assert after_locale == before_locale


### PR DESCRIPTION
#### Reason for change
Resolves #505

#### Description of change
To improve on Arelle's current usage of the locale usage, ensure that the locale is reset to the previous value whenever Arelle makes a change to it.

#### Steps to Test
Unit tests added.
Run Arelle as GUI, as a library, and via command line. Change locale and expect same results.
**review**:
@Arelle/arelle @zaneselvans
