### PR TITLE
Use Node 19 for ixbrl-viewer plugin in frozen builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -17,7 +17,7 @@ on:
         required: true
         type: string
       node_version:
-        default: '16'
+        default: '19'
         description: 'Node.js version to use'
         required: true
         type: string

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       node_version:
-        default: '16'
+        default: '19'
         description: 'Node.js version to use'
         required: true
         type: string

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       node_version:
-        default: '16'
+        default: '19'
         description: 'Node.js version to use'
         required: true
         type: string


### PR DESCRIPTION
#### Reason for change
ixbrl-viewer was updated to use Node 19 for builds (Workiva/ixbrl-viewer/pull/356).
This updates the Arelle pipelines to also use Node 19 for building the plugin as part of the frozen builds.

#### Description of change
Updates frozen build pipelines to use Node 19

#### Steps to Test
* Smoke test ixbrl-viewer in builds ([Linux](https://github.com/Arelle/Arelle/actions/runs/3742218929), [macOS](https://github.com/Arelle/Arelle/actions/runs/3742219751), [Windows](https://github.com/Arelle/Arelle/actions/runs/3742220834))

**review**:
@Arelle/arelle
