### PR TITLE
Use setlocale with None to retrieve existing locale

### DIFF
--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -90,7 +90,7 @@ def getUserLocale(localeCode: str = '') -> tuple[LocaleDict, str | None]:
     :return: Tuple of local conventions dictionary and a user-directed setup message
     """
     import locale
-    currentLocale = locale.getlocale()
+    currentLocale = locale.setlocale(locale.LC_ALL)
     try:
         return _getUserLocaleUnsafe(localeCode)
     finally:

--- a/tests/unit_tests/arelle/test_locale.py
+++ b/tests/unit_tests/arelle/test_locale.py
@@ -67,7 +67,7 @@ def test_format_decimal(params: dict[str, Any], result: str) -> None:
 
 @pytest.mark.parametrize('locale_code', ['', 'C', 'invalid'])
 def test_get_user_locale_reset(locale_code) -> None:
-    before_locale = locale.getlocale()[0]
+    before_locale = locale.setlocale(locale.LC_ALL)
     getUserLocale(locale_code)
-    after_locale = locale.getlocale()[0]
+    after_locale = locale.setlocale(locale.LC_ALL)
     assert after_locale == before_locale


### PR DESCRIPTION
#### Reason for change
The language code and encoding returned by getlocale aren't reliable in all scenarios for restoring the locale.

With the default locale settings in the [python:3.11.1](https://hub.docker.com/layers/library/python/3.11.1/images/sha256-b86507b0c9d182edf164752715e0016184f9972495e670a9218b036ec154529a?context=explore) docker image:
```python
import locale
print(locale.getlocale())
# ('en_US', 'UTF-8')
print(locale.setlocale(locale.LC_ALL))
# LC_CTYPE=C.UTF-8;LC_NUMERIC=C;LC_TIME=C;LC_COLLATE=C;LC_MONETARY=C;LC_MESSAGES=C;LC_PAPER=C;LC_NAME=C;LC_ADDRESS=C;LC_TELEPHONE=C;LC_MEASUREMENT=C;LC_IDENTIFICATION=C
```

#### Description of change
Passing `None` as the locale to `locale.setlocale()` returns the current setting without making changes.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
