### PR TITLE
update ECD efm validation

### DIFF
--- a/arelle/plugin/validate/EFM/resources/dei-validations.json
+++ b/arelle/plugin/validate/EFM/resources/dei-validations.json
@@ -1252,13 +1252,13 @@
             "DocumentFinStmtErrorCorrectionFlag",
             "DocumentFinStmtRestatementRecoveryAnalysisFlag"
             ],
-        "efm": "6.5.40",
+        "efm": "6.5.49",
         "validation": "taxonomy-version-required",
         "value": 2,
         "earliest-taxonomy": "dei/2022q4",
         "check-after": "2024-01-27",
-        "source": "both",
-        "dei/cover": "dei",
+        "source": "inline",
+        "dei/cover": "cover",
         "comment": "value is number of name elements required in taxonomy"
     },
     {


### PR DESCRIPTION
#### Reason for change
22.4 update of EFM sect number for ECD validation (effective in 2024)

#### Description of change
Update EFM ref and validation for future ECD required flags

#### Steps to Test
With date set after 2024-01-27 try a 10-K with dei-2022 (so new flags are not present), expect warning to use dei >= 2022q4 referencing EFM 6.5.49 not 6.5.40

**review**:
@Arelle/arelle
