### PR TITLE
edgar 22.4.1 changes for dei-2022q4 compatibility with all 2022 taxonomies

### DIFF
--- a/arelle/plugin/validate/EFM/config.xml
+++ b/arelle/plugin/validate/EFM/config.xml
@@ -4,7 +4,7 @@
       xsi:noNamespaceSchemaLocation="../../../config/disclosuresystems.xsd" >
   <!-- see ../config/disclosuresystem.xml for full comments -->
    
-<DisclosureSystem 
+  <DisclosureSystem 
      names="US SEC (Edgar Filing Manual, Strict)|efm|efm-strict"
      description="US SEC Edgar Filing Manual v64 Release 22.4\n
      Default language en-US (en allowed in some cases per EFM)\n
@@ -85,7 +85,7 @@
      />
   <DisclosureSystem 
      names="US SEC 2021 Preview with DQCRT applied to us-gaap 2020-2021 (EFM Pragmatic)|efm-preview-dqcrt-testing"
-     description="US SEC Edgar Filing Manual v62 Release 22.2\n
+     description="US SEC Edgar Filing Manual v64 Release 22.4\n
      DQCRT/2021 applied to us-gaap/2020 for testing purposes\n
      Default language en-US (en allowed in some cases per EFM)\n
      CIK identifier patterns\n

--- a/arelle/plugin/validate/EFM/config.xml
+++ b/arelle/plugin/validate/EFM/config.xml
@@ -4,7 +4,7 @@
       xsi:noNamespaceSchemaLocation="../../../config/disclosuresystems.xsd" >
   <!-- see ../config/disclosuresystem.xml for full comments -->
    
-  <DisclosureSystem 
+<DisclosureSystem 
      names="US SEC (Edgar Filing Manual, Strict)|efm|efm-strict"
      description="US SEC Edgar Filing Manual v64 Release 22.4\n
      Default language en-US (en allowed in some cases per EFM)\n

--- a/arelle/plugin/validate/EFM/resources/taxonomy-compatibility.json
+++ b/arelle/plugin/validate/EFM/resources/taxonomy-compatibility.json
@@ -38,11 +38,9 @@
     		"dei/2021", "dei/2021q4", "country/2021", "currency/2021", "exch/2021", "naics/2021", "sic/2021", "stpr/2021"
     	],
     	"stx-2022": [
-    		"dei/2022", "country/2022", "currency/2022", "exch/2022", "naics/2022", "sic/2022", "stpr/2022"
+    		"dei/2022", "dei/2022q4", "country/2022", "currency/2022", "exch/2022", "naics/2022", "sic/2022", "stpr/2022"
     	],
-        "stx-2022q4": [
-            "dei/2022", "dei/2022q4", "country/2022", "currency/2022", "exch/2022", "naics/2022", "sic/2022", "stpr/2022"
-       ],
+
         
 
         "comment2": "entries for previously-supported taxonomies, such as disclosure mode efm-pragmatic-all-years",
@@ -64,7 +62,7 @@
         "rr/2022": ["@stx-2022"],
 
         "comment2": "latest us-gaap is compatible with prior year ifrs from Q1 to Q2, after Q2 must use same-year ifrs",
-        "ecd/2022q4" : ["@stx-2022q4", "us-gaap/2022q3", "us-gaap/2022", "srt/2022q3", "srt/2022", "ifrs/2022", "cef/2022"],
+        "ecd/2022q4" : ["@stx-2022", "us-gaap/2022q3", "us-gaap/2022", "srt/2022q3", "srt/2022", "ifrs/2022", "cef/2022"],
         "us-gaap/2021": ["@stx-2021", "srt/2021", "ifrs/2021", "cef/2021q4"],
         "us-gaap/2022": ["us-gaap/2022q3", "@stx-2022", "srt/2022", "srt/2022q3", "ifrs/2022", "cef/2022"],
         "us-gaap/2022q3": ["us-gaap/2022", "@stx-2022", "srt/2022q3", "srt/2022", "ifrs/2022", "cef/2022"],


### PR DESCRIPTION
#### Reason for change
Change taxonomy-compatibilities so dei-2022q4 works with all SEC 2022 taxonomies.
Fix typo in config.xml

#### Description of change
  "

#### Steps to Test
Use dei-2022q4 with non--ECD filing.

**review**:
@Arelle/arelle
