### PR TITLE
Add ESEF 2022 conformance suite

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_configs.py
+++ b/tests/integration_tests/validation/conformance_suite_configs.py
@@ -1,7 +1,9 @@
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig
 from tests.integration_tests.validation.conformance_suite_configurations.efm_current import config as efm_current
 from tests.integration_tests.validation.conformance_suite_configurations.esef_ixbrl_2021 import config as esef_ixbrl_2021
+from tests.integration_tests.validation.conformance_suite_configurations.esef_ixbrl_2022 import config as esef_ixbrl_2022
 from tests.integration_tests.validation.conformance_suite_configurations.esef_xhtml_2021 import config as esef_xhtml_2021
+from tests.integration_tests.validation.conformance_suite_configurations.esef_xhtml_2022 import config as esef_xhtml_2022
 from tests.integration_tests.validation.conformance_suite_configurations.xbrl_2_1 import config as xbrl_2_1
 from tests.integration_tests.validation.conformance_suite_configurations.xbrl_dimensions_1_0 import config as xbrl_dimensions_1_0
 from tests.integration_tests.validation.conformance_suite_configurations.xbrl_extensible_enumerations_1_0 import config as xbrl_extensible_enumerations_1_0
@@ -25,7 +27,9 @@ from tests.integration_tests.validation.conformance_suite_configurations.xbrl_ut
 ALL_CONFORMANCE_SUITE_CONFIGS: tuple[ConformanceSuiteConfig, ...] = (
     efm_current,
     esef_ixbrl_2021,
+    esef_ixbrl_2022,
     esef_xhtml_2021,
+    esef_xhtml_2022,
     xbrl_2_1,
     xbrl_dimensions_1_0,
     xbrl_extensible_enumerations_1_0,

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
@@ -1,0 +1,21 @@
+from pathlib import PurePath
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig
+
+config = ConformanceSuiteConfig(
+    args=[
+        '--disclosureSystem', 'esef',
+        '--formula', 'run',
+        '--plugins', 'validate/ESEF_2022',
+    ],
+    expected_failure_ids=frozenset([
+        # The following test cases fail because of the `tech_duplicated_facts1` formula which fires
+        # incorrectly because it does not take into account the language attribute on the fact.
+        # A fact can not be a duplicate fact if the language attributes are different.
+        'inline_xbrl/RTS_Annex_IV_Par_12_G2-2-4/TC5_valid'
+    ]),
+    file='esef_conformance_suite_2022/index_inline_xbrl.xml',
+    info_url='https://www.esma.europa.eu/document/conformance-suite-2022',
+    local_filepath='esef_conformance_suite_2022.zip',
+    name=PurePath(__file__).stem,
+    public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2022.zip',
+)

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
@@ -1,0 +1,15 @@
+from pathlib import PurePath
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig
+
+config = ConformanceSuiteConfig(
+    args=[
+        '--disclosureSystem', 'esef-unconsolidated',
+        '--formula', 'none',
+        '--plugins', 'validate/ESEF_2022',
+    ],
+    file='esef_conformance_suite_2022/index_pure_xhtml.xml',
+    info_url='https://www.esma.europa.eu/document/conformance-suite-2022',
+    local_filepath='esef_conformance_suite_2022.zip',
+    name=PurePath(__file__).stem,
+    public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2022.zip',
+)


### PR DESCRIPTION
#### Reason for change
ESEF 2022 has been released and we need to be testing against the ESEF 2022 conformance suite

#### Steps to Test
CI

**review**:
@Arelle/arelle
