### PR TITLE
XPathParser type hints and cleanup

### DIFF
--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -3,6 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 import gc, sys, traceback, logging
 from arelle import ModelXbrl, Validate, DisclosureSystem, PackageManager
@@ -12,6 +13,7 @@ from arelle.typing import LocaleDict
 
 if TYPE_CHECKING:
     from arelle.Cntlr import Cntlr
+    from arelle.ModelValue import QName
 
 def initialize(cntlr: Cntlr) -> ModelManager:
     modelManager = ModelManager(cntlr)
@@ -73,7 +75,7 @@ class ModelManager:
         self.abortOnMajorError = False
         self.collectProfileStats = False
         self.loadedModelXbrls = []
-        self.customTransforms = None
+        self.customTransforms: dict[QName, Callable[[str], str]] | None = None
         self.isLocaleSet = False
         self.setLocale()
 
@@ -100,13 +102,11 @@ class ModelManager:
         """
         self.cntlr.addToLog(message, messageCode=messageCode, file=file, refs=refs, level=level)
 
-    def showStatus(self, message, clearAfter=None) -> str:
+    def showStatus(self, message: str | None, clearAfter: int | None = None) -> None:
         """Provide user feedback on status line of GUI or web page according to type of controller.
 
         :param message: Message to display on status widget.
-        :type message: str
         :param clearAfter: Time, in ms., after which to clear the message (e.g., 5000 for 5 sec.)
-        :type clearAfter: int
         """
         self.cntlr.showStatus(message, clearAfter)
 

--- a/arelle/ModelObjectFactory.py
+++ b/arelle/ModelObjectFactory.py
@@ -163,7 +163,7 @@ class DiscoveringClassLookup(etree.PythonElementClassLookup):
             relativeUrl = XmlUtil.schemaLocation(proxyElement, ns)
             self.discoveryAttempts.add(ns)
             if relativeUrl:
-                doc = ModelDocument.loadSchemalocatedSchema(self.modelXbrl, proxyElement, relativeUrl, ns, self.baseUrl)
+                ModelDocument.loadSchemalocatedSchema(self.modelXbrl, proxyElement, relativeUrl, ns, self.baseUrl)
 
         modelObjectClass = self.modelXbrl.matchSubstitutionGroup(
             qnameNsLocalName(ns, ln), elementSubstitutionModelClass

--- a/arelle/ModelObjectFactory.py
+++ b/arelle/ModelObjectFactory.py
@@ -131,6 +131,8 @@ class KnownNamespacesModelObjectClassLookup(etree.CustomElementClassLookup):
             return etree.PIBase
         elif node_type == "entity":
             return etree.EntityBase
+        # returning None delegates to fallback lookup classes
+        return None
 
 
 class DiscoveringClassLookup(etree.PythonElementClassLookup):

--- a/arelle/ModelObjectFactory.py
+++ b/arelle/ModelObjectFactory.py
@@ -36,15 +36,15 @@ ModelFact = None
 
 def parser(modelXbrl, baseUrl, target=None):
     moduleObject_init()  # init ModelObject globals
-    parser = etree.XMLParser(recover=True, huge_tree=True, target=target)
-    return setParserElementClassLookup(parser, modelXbrl, baseUrl)
+    _parser = etree.XMLParser(recover=True, huge_tree=True, target=target)
+    return setParserElementClassLookup(_parser, modelXbrl, baseUrl)
 
 
-def setParserElementClassLookup(parser, modelXbrl, baseUrl=None):
+def setParserElementClassLookup(_parser, modelXbrl, baseUrl=None):
     classLookup = DiscoveringClassLookup(modelXbrl, baseUrl)
     nsNameLookup = KnownNamespacesModelObjectClassLookup(modelXbrl, fallback=classLookup)
-    parser.set_element_class_lookup(nsNameLookup)
-    return parser, nsNameLookup, classLookup
+    _parser.set_element_class_lookup(nsNameLookup)
+    return _parser, nsNameLookup, classLookup
 
 
 SCHEMA = 1

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -118,7 +118,7 @@ def qnameHref(href: str) -> QName: # namespaceUri#localname
     return QName(None, namespaceURI or None, localName)
 
 
-def qnameNsLocalName(namespaceURI: str, localName: str) -> QName:  # does not handle localNames with prefix
+def qnameNsLocalName(namespaceURI: str | None, localName: str) -> QName:  # does not handle localNames with prefix
     return QName(None, namespaceURI or None, localName)
 
 

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -29,11 +29,14 @@ def qname(value: ModelObject | str | QName, name: str | ModelObject) -> QName: .
 def qname(value: ModelObject | str | QName, name: str | ModelObject | None = None, noPrefixIsNoNamespace: bool = False) -> QName: ...
 
 @overload
+def qname(value: ModelObject, name: QName, noPrefixIsNoNamespace: bool) -> QName: ...
+
+@overload
 def qname(value: ModelObject | str | QName | Any | None, name: str | ModelObject | dict[str, str] | None) -> QName | None : ...
 
 def qname(
     value: ModelObject | str | QName | Any | None,
-    name: str | ModelObject | dict[str, str] | None = None,
+    name: str | QName | ModelObject | dict[str, str] | None = None,
     noPrefixIsNoNamespace: bool = False,
     castException: Exception | None = None,
     prefixException: Exception | None = None,
@@ -91,6 +94,7 @@ def qname(
         else:
             namespaceURI = None
             namespaceDict = None
+        assert isinstance(value, str)
         prefix,sep,localName = value.strip().partition(":")  # must be whitespace collapsed
         if not sep:
             localName = prefix

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -7,7 +7,7 @@ import os, sys, traceback, uuid
 import regex as re
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, cast, Optional
+from typing import TYPE_CHECKING, Any, Type, TypeVar, cast, Optional
 import logging
 from decimal import Decimal
 from arelle import UrlUtil, XmlUtil, ModelValue, XbrlConst, XmlValidate
@@ -131,6 +131,9 @@ def loadSchemalocatedSchemas(modelXbrl: ModelXbrl) -> None:
             for modelDocument in modelDocuments:
                 modelDocument.loadSchemalocatedSchemas()
             modelDocumentsSchemaLocated |= modelDocuments
+
+
+MatchSubstitutionGroupValueType = TypeVar('MatchSubstitutionGroupValueType', Type[ModelObject], bool)
 
 
 class ModelXbrl:
@@ -302,7 +305,7 @@ class ModelXbrl:
 
     def __init__(self,  modelManager: ModelManager, errorCaptureLevel: str | None = None) -> None:
         self.modelManager = modelManager
-        self.skipDTS = modelManager.skipDTS
+        self.skipDTS: bool = modelManager.skipDTS
         self.init(errorCaptureLevel=errorCaptureLevel)
 
     def init(self, keepViews: bool = False, errorCaptureLevel: str | None = None) -> None:
@@ -451,7 +454,7 @@ class ModelXbrl:
                 return cast(str, _roleTypeName)
         return self.roleTypeDefinition(roleURI, lang)
 
-    def matchSubstitutionGroup(self, elementQname: QName, subsGrpMatchTable: dict[QName | None, bool | ModelObject]) -> bool | ModelObject | None:
+    def matchSubstitutionGroup(self, elementQname: QName, subsGrpMatchTable: dict[QName | None, MatchSubstitutionGroupValueType]) -> MatchSubstitutionGroupValueType | None:
         """Resolve a subsitutionGroup for the elementQname from the match table
 
         Used by ModelObjectFactory to return Class type for new ModelObject subclass creation, and isInSubstitutionGroup

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from arelle.ModelRelationshipSet import ModelRelationshipSet as ModelRelationshipSetClass
     from arelle.ModelValue import QName
     from arelle.PrototypeDtsObject import LinkPrototype
-    from arelle.typing import TypeGetText, LocaleDict
+    from arelle.typing import EmptyTuple, TypeGetText, LocaleDict
 
     _: TypeGetText  # Handle gettext
 else:
@@ -46,7 +46,7 @@ AUTO_LOCATE_ELEMENT = '771407c0-1d0c-11e1-be5e-028037ec0200' # singleton meaning
 DEFAULT = sys.intern("default")
 NONDEFAULT = sys.intern("non-default")
 DEFAULTorNONDEFAULT = sys.intern("default-or-non-default")
-EMPTY_TUPLE = ()
+EMPTY_TUPLE: EmptyTuple = ()
 
 
 def load(modelManager: ModelManager, url: str, nextaction: str | None = None, base: str | None = None, useFileSource: FileSourceClass | None = None, errorCaptureLevel: str | None = None, **kwargs: str) -> ModelXbrl:

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -102,9 +102,9 @@ def pushDecimal(sourceStr, loc, toks):
 
 
 def pushQuotedString(sourceStr, loc, toks):
-    str = toks[0]
-    q = str[0]
-    dequotedStr = str[1:-1].replace(q + q, q)
+    _str = toks[0]
+    q = _str[0]
+    dequotedStr = _str[1:-1].replace(q + q, q)
     exprStack.append(dequotedStr)
     return dequotedStr
 

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -34,7 +34,7 @@ from arelle import ModelValue, XbrlConst, XmlUtil
 from arelle.Locale import format_string
 from arelle.PluginManager import pluginClassMethods
 
-FunctionIxt = None
+ixtNamespaceFunctions = None
 
 
 # Debugging flag can be set to either "debug_flag=True" or "debug_flag=False"
@@ -317,7 +317,7 @@ def pushFunction(sourceStr, loc, toks):
         if (
             not name.unprefixed
             and ns not in {XbrlConst.fn, XbrlConst.xfi, XbrlConst.xff, XbrlConst.xsd}
-            and ns not in FunctionIxt.ixtNamespaceFunctions
+            and ns not in ixtNamespaceFunctions
             and name not in modelXbrl.modelManager.customTransforms
         ):
             # indexed by both [qname] and [qname,arity]
@@ -818,9 +818,9 @@ isInitialized = False
 
 
 def initializeParser(modelManager):
-    global isInitialized, FunctionIxt
+    global isInitialized, ixtNamespaceFunctions
     if not isInitialized:
-        from arelle import FunctionIxt
+        from arelle.FunctionIxt import ixtNamespaceFunctions
 
         modelManager.showStatus(_("initializing formula xpath2 grammar"))
         startedAt = time.time()

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -206,8 +206,9 @@ def pushAttr(sourceStr, loc, toks):
         attr = toks[1]
         attr.isAttribute = True
     else:
-        ##### BUG this won't work, wrong arguments !!!!
-        attr = QNameDef(loc, toks[1], isAttribute=True)
+        # BUG this won't work, wrong arguments !!!!
+        # attr = QNameDef(loc, tok[1], isAttribute=True)
+        raise ValueError(f"Unable to create QNameDef from attr: loc {loc} sourceStr {sourceStr}")
     exprStack.append(attr)
     return attr
 

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -264,7 +264,7 @@ class OperationDef:
             self.args = toks[1:]
             '''
         else:  # for others first token is just op code, no expression
-            self.args = toks
+            self.args = toks[:]
 
     def __repr__(self):
         if isinstance(self.name, QNameDef):

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -1032,11 +1032,11 @@ def clearProg(exprStack):
 
 
 def clearNamedProg(ownerObject, progName):
-    clearProg(ownerObject.getattr(progName, []))
+    clearProg(getattr(ownerObject, progName, []))
 
 
 def clearNamedProgs(ownerObject, progsListName):
-    for prog in ownerObject.getattr(progsListName, []):
+    for prog in getattr(ownerObject, progsListName, []):
         clearProg(prog)
 
 

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -840,7 +840,7 @@ def exceptionErrorIndication(exception):
     for line in exception.line.split('\n'):
         if len(source) > 0:
             source += '\n'
-        if errorAt >= 0 and errorAt <= len(line):
+        if 0 <= errorAt <= len(line):
             source += line[:errorAt] + '\u274b' + line[errorAt:]
             source += '\n' + ' ' * (errorAt - 1) + '^ \n'
         else:

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -733,7 +733,7 @@ comparisonExpr = rangeExpr + ZeroOrMore((comparisonOp + rangeExpr).setParseActio
 andExpr = comparisonExpr + ZeroOrMore((andOp + comparisonExpr).setParseAction(pushOperation))
 orExpr = andExpr + ZeroOrMore((orOp + andExpr).setParseAction(pushOperation))
 
-expr << orExpr
+expr <<= orExpr
 # The Forward expression streamline implementation (expr.streamline())
 # streamlines the wrapped expression (self.expr.streamline()). However, the
 # wrapped expression is reassigned by the left shift bitwise operator, but

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -190,7 +190,7 @@ def pushQName(sourceStr, loc, toks):
                     modelObject=xmlElement,
                     name=qname, name2=xmlElement.localName)
     else:
-        nsLocalname = (None, qname)
+        nsLocalname = (None, qname, None)
     q = QNameDef(loc, nsLocalname[2], nsLocalname[0], nsLocalname[1], axis=axis)
     if (qname not in ("INF", "NaN", "for", "some", "every", "return") and
         len(exprStack) == 0 or exprStack[-1] != q):

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -2,18 +2,38 @@
 See COPYRIGHT.md for copyright information.
 '''
 import sys
-from numbers import Number
-
-from arelle import PythonUtil # define 2.x or 3.x string types (only needed when running as unit test from __main__
-from arelle.PluginManager import pluginClassMethods
-from pyparsing import (
-    Word, Keyword, alphas, ParseException, ParseSyntaxException,Literal, CaselessLiteral,Combine, Optional, nums, Forward, Group, ZeroOrMore, StringEnd, alphanums,ParserElement, quotedString,
-    delimitedList, Suppress, Regex
-)
-from arelle.Locale import format_string
-import time, xml.dom, traceback
+import time
+import traceback
+import xml.dom
 from decimal import Decimal
-from arelle import (XmlUtil, ModelValue, XbrlConst)
+
+from pyparsing import (
+    CaselessLiteral,
+    Combine,
+    Forward,
+    Group,
+    Keyword,
+    Literal,
+    Optional,
+    ParseException,
+    ParseSyntaxException,
+    ParserElement,
+    Regex,
+    StringEnd,
+    Suppress,
+    Word,
+    ZeroOrMore,
+    alphanums,
+    alphas,
+    delimitedList,
+    nums,
+    quotedString,
+)
+
+from arelle import ModelValue, XbrlConst, XmlUtil
+from arelle.Locale import format_string
+from arelle.PluginManager import pluginClassMethods
+
 FunctionIxt = None
 
 

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -929,10 +929,10 @@ def parse(modelObject, xpathExpression, element, name, traceType):
             # insert after ProgHeader before ordinary executable expression that may have successfully compiled
             exprStack.insert(1, OperationDef(normalizedExpr, 0,
                                              QNameDef(0, "fn", XbrlConst.fn, "error"),
-                                             (OperationDef(normalizedExpr, 0,
+                                             [OperationDef(normalizedExpr, 0,
                                                            QNameDef(0, "fn", XbrlConst.fn, "QName"),
-                                                           (XbrlConst.xpath2err, "err:XPST0003"), False),
-                                              str(err)), False))
+                                                           [XbrlConst.xpath2err, "err:XPST0003"], False),
+                                              str(err)], False))
         except ValueError as err:
             modelXbrl.error("parser:unableToParse",
                 _("Parsing terminated in %(name)s due to error: %(error)s \n%(source)s"),

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -164,7 +164,7 @@ def pushQName(sourceStr, loc, toks):
             _("Axis %(axis)s is not supported in %(step)s"),
             modelObject=xmlElement,
             axis=axis, step=step)
-        return
+        return None
     if xmlElement is not None:
         if qname == '*':  # prevent simple wildcard from taking the default namespace
             nsLocalname = (None, '*', None)
@@ -181,7 +181,7 @@ def pushQName(sourceStr, loc, toks):
                     _("QName prefix not defined for %(name)s"),
                     modelObject=xmlElement,
                     name=qname)
-                return
+                return None
 
         if (nsLocalname == (XbrlConst.xff, "uncovered-aspect", "xff") and
             xmlElement.localName not in ("formula", "consistencyAssertion", "valueAssertion", "message")):
@@ -361,7 +361,7 @@ def pushRootStep(sourceStr, loc, toks):
     elif toks[0] == '..':
         op = 'contextItemParent'
     else:
-        return
+        return None
     rootStep = OperationDef(sourceStr, loc, op, toks[1:], False)
     # tok[1] or tok[2] is in exprStack (the predicate or next step), replace with composite rootStep
     for tok in toks:

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -1189,6 +1189,7 @@ def parser_unit_test():
         "//*[@id eq 'context-for-xpath-rule']//xbrldi:explicitMember[2]",
     ):
         # Start with a blank exprStack and a blank varStack
+        global exprStack, xmlElement
         exprStack = []
         xmlElement = None
 

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -5,6 +5,7 @@ import sys
 import time
 import traceback
 import xml.dom
+from collections.abc import Iterable
 from decimal import Decimal
 
 from pyparsing import (
@@ -988,7 +989,7 @@ def variableReferences(exprStack, varRefSet, element, rangeVars=None):
             rangeVars.append(var)
             localRangeVars.append(var)
             variableReferences(p.bindingSeq, varRefSet, element, rangeVars)
-        elif hasattr(p, '__iter__') and not isinstance(p, str):
+        elif isinstance(p, Iterable) and not isinstance(p, str):
             variableReferences(p, varRefSet, element, rangeVars)
     for localRangeVar in localRangeVars:
         if localRangeVar in rangeVars:
@@ -1017,7 +1018,7 @@ def prefixDeclarations(exprStack, xmlnsDict, element):
             if var.prefix:
                 xmlnsDict[var.prefix] = var.namespaceURI
             prefixDeclarations(p.bindingSeq, xmlnsDict, element)
-        elif hasattr(p, '__iter__') and not isinstance(p, str):
+        elif isinstance(p, Iterable) and not isinstance(p, str):
             prefixDeclarations(p, xmlnsDict, element)
 
 

--- a/arelle/XPathParser.py
+++ b/arelle/XPathParser.py
@@ -677,7 +677,7 @@ atom = (
         - (satisfiesOp + expr).setParseAction(pushExpr)
     ).setParseAction(pushOperation)
     | (
-        (ifOp - Suppress(lParen) + Group(expr) + Suppress(rParen)).setParseAction(pushExpr)
+        (ifOp - Suppress(lParen) + Group(expr, aslist=True) + Suppress(rParen)).setParseAction(pushExpr)
         - (thenOp + expr).setParseAction(pushOperation)
         - (elseOp + expr).setParseAction(pushOperation)
     ).setParseAction(pushOperation)

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -63,8 +63,8 @@ def targetNamespace(element: ModelObject) -> str | None:
         treeElt = cast(ModelObject, treeElt.getparent())
     return None
 
-def schemaLocation(element: ModelObject, namespace: str, returnElement: bool = False) -> ModelObject | str | None:
-    treeElt = element
+def schemaLocation(element: etree._Element, namespace: str, returnElement: bool = False) -> etree._Element | str | None:
+    treeElt: etree._Element | None = element
     while treeElt is not None:
         sl = treeElt.get("{http://www.w3.org/2001/XMLSchema-instance}schemaLocation")
         if sl:
@@ -78,7 +78,7 @@ def schemaLocation(element: ModelObject, namespace: str, returnElement: bool = F
                     if not returnElement and ns == namespace:
                         return entry
                     ns = None
-        treeElt = cast(ModelObject, treeElt.getparent())
+        treeElt = treeElt.getparent()
     return None
 
 def clarkNotationToPrefixNsLocalname(

--- a/arelle/plugin/formulaLoader.py
+++ b/arelle/plugin/formulaLoader.py
@@ -1283,9 +1283,9 @@ def compileXfsGrammar( cntlr, debugParsing ):
     cntlr.showStatus(_("Compiling Formula Grammar"))
     from pyparsing import (Word, Keyword, alphas,
                  Literal, CaselessLiteral,
-                 Combine, Optional, nums, Or, Forward, Group, ZeroOrMore, OneOrMore, StringEnd, alphanums,
-                 ParserElement, quotedString, dblQuotedString, sglQuotedString, QuotedString,
-                 delimitedList, Suppress, Regex, FollowedBy,
+                 Combine, Opt, nums, Or, Forward, Group, ZeroOrMore, OneOrMore, StringEnd, alphanums,
+                 ParserElement, quoted_string, dbl_quoted_string, sgl_quoted_string, QuotedString,
+                 delimited_list, Suppress, Regex, FollowedBy,
                  lineno, line, col)
 
     ParserElement.enablePackrat()
@@ -1326,17 +1326,17 @@ def compileXfsGrammar( cntlr, debugParsing ):
     exponentLiteral = CaselessLiteral('e')
     plusorminusLiteral = Literal('+') | Literal('-')
     digits = Word(nums)
-    integerLiteral = Combine( Optional(plusorminusLiteral) + digits )
-    decimalFractionLiteral = Combine( Optional(plusorminusLiteral) + decimalPoint + digits )
-    infLiteral = Combine( Optional(plusorminusLiteral) + Keyword("INF") )
+    integerLiteral = Combine( Opt(plusorminusLiteral) + digits )
+    decimalFractionLiteral = Combine( Opt(plusorminusLiteral) + decimalPoint + digits )
+    infLiteral = Combine( Opt(plusorminusLiteral) + Keyword("INF") )
     nanLiteral = Keyword("NaN")
     floatLiteral = ( Combine( integerLiteral +
-                         ( ( decimalPoint + Optional(digits) + exponentLiteral + integerLiteral ) |
+                         ( ( decimalPoint + Opt(digits) + exponentLiteral + integerLiteral ) |
                            ( exponentLiteral + integerLiteral ) )
                          ) |
                      Combine( decimalFractionLiteral + exponentLiteral + integerLiteral ) |
                      infLiteral | nanLiteral )
-    decimalLiteral =  ( Combine( integerLiteral + decimalPoint + Optional(digits) ) |
+    decimalLiteral =  ( Combine( integerLiteral + decimalPoint + Opt(digits) ) |
                         decimalFractionLiteral )
     numberLiteral = (decimalLiteral | floatLiteral | integerLiteral)
 
@@ -1349,27 +1349,27 @@ def compileXfsGrammar( cntlr, debugParsing ):
                Literal("@") | Literal("//") | Literal("/") | Literal("::") | Literal("."))
 
     xpathExpression = (Suppress(Literal("{")) +
-                       ZeroOrMore( (dblQuotedString | sglQuotedString | numberLiteral |
+                       ZeroOrMore( (dbl_quoted_string | sgl_quoted_string | numberLiteral |
                                     xPathFunctionCall | variableRef | qName | xPathOp ) ) +
                        Suppress(Literal("}"))).setParseAction(compileXPathExpression)
     separator = Suppress( Literal(";") )
 
-    namespaceDeclaration = (Suppress(Keyword("namespace")) + ncName + Suppress(Literal("=")) + quotedString + separator
+    namespaceDeclaration = (Suppress(Keyword("namespace")) + ncName + Suppress(Literal("=")) + quoted_string + separator
                             ).setParseAction(compileNamespaceDeclaration).ignore(xfsComment)
     defaultDeclaration = (Suppress(Keyword("unsatisfied-severity") | Keyword("default-language")) + ncName + separator
                          ).setParseAction(compileDefaults).ignore(xfsComment)
 
     parameterDeclaration = (Suppress(Keyword("parameter")) + qName  +
                             Suppress(Literal("{")) +
-                            Optional(Keyword("required")) +
-                            Optional(Keyword("select") + xpathExpression) +
-                            Optional(Keyword("as") + qName) +
+                            Opt(Keyword("required")) +
+                            Opt(Keyword("select") + xpathExpression) +
+                            Opt(Keyword("as") + qName) +
                             Suppress(Literal("}")) + separator
                            ).setParseAction(compileParameterDeclaration).ignore(xfsComment)
 
     occurenceIndicator = Literal("?") | Literal("*") | Literal("+")
 
-    functionParameter = (qName + Suppress(Keyword("as")) + Combine(qName + Optional(occurenceIndicator))
+    functionParameter = (qName + Suppress(Keyword("as")) + Combine(qName + Opt(occurenceIndicator))
                          ).setParseAction(compileFunctionParameter).ignore(xfsComment)
 
     functionStep = (Suppress(Keyword("step")) + variableRef + xpathExpression +
@@ -1381,9 +1381,9 @@ def compileXfsGrammar( cntlr, debugParsing ):
                               Suppress(Literal("}"))).ignore(xfsComment)
 
     functionDeclaration = (Suppress(Keyword("function")) + qName  +
-                           Suppress(Literal("(")) + Optional(delimitedList(functionParameter)) + Suppress(Literal(")")) +
-                              Keyword("as") + Combine(qName + Optional(occurenceIndicator)) +
-                           Optional(functionImplementation) + separator
+                           Suppress(Literal("(")) + Opt(delimited_list(functionParameter)) + Suppress(Literal(")")) +
+                              Keyword("as") + Combine(qName + Opt(occurenceIndicator)) +
+                           Opt(functionImplementation) + separator
                            ).setParseAction(compileFunctionDeclaration).ignore(xfsComment)
 
     packageDeclaration = (Suppress(Keyword("package")) + ncName + separator ).setParseAction(compilePackageDeclaration).ignore(xfsComment)
@@ -1391,7 +1391,7 @@ def compileXfsGrammar( cntlr, debugParsing ):
     severity = ( Suppress(Keyword("unsatisfied-severity")) + ( ncName ) + separator ).setParseAction(compileSeverity).ignore(xfsComment)
 
     label = ( (Keyword("label") | Keyword("unsatisfied-message") | Keyword("satisfied-message")) +
-              Optional( Combine(Literal("(") + Regex("[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*") + Literal(")")) ) +
+              Opt( Combine(Literal("(") + Regex("[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*") + Literal(")")) ) +
               (QuotedString('"',multiline=True,escQuote='""') | QuotedString("'",multiline=True,escQuote="''")) +
               separator).setParseAction(compileLabel).ignore(xfsComment)
 
@@ -1399,24 +1399,24 @@ def compileXfsGrammar( cntlr, debugParsing ):
                         ).setParseAction(compileAspectRuleConcept).ignore(xfsComment)
 
     aspectRuleEntityIdentifier = (Suppress(Keyword("entity-identifier")) +
-                                  Optional( Keyword("scheme") + xpathExpression) +
-                                  Optional( Keyword("identifier") + xpathExpression) + separator
+                                  Opt( Keyword("scheme") + xpathExpression) +
+                                  Opt( Keyword("identifier") + xpathExpression) + separator
                         ).setParseAction(compileAspectRuleEntityIdentifier).ignore(xfsComment)
 
     aspectRulePeriod = (Suppress(Keyword("period")) +
                         ( Keyword("forever") |
                           Keyword("instant") +  xpathExpression |
                           Keyword("duration") +
-                                  Optional( Keyword("start") + xpathExpression) +
-                                  Optional( Keyword("end") + xpathExpression) ) + separator
+                                  Opt( Keyword("start") + xpathExpression) +
+                                  Opt( Keyword("end") + xpathExpression) ) + separator
                         ).setParseAction(compileAspectRulePeriod).ignore(xfsComment)
 
     aspectRuleUnitTerm = ((Keyword("multiply-by") | Keyword("divide-by")) +
-                          Optional( Keyword("source") + qName ) +
-                          Optional( Keyword("measure") + xpathExpression ) + separator
+                          Opt( Keyword("source") + qName ) +
+                          Opt( Keyword("measure") + xpathExpression ) + separator
                         ).setParseAction(compileAspectRuleUnitTerm).ignore(xfsComment)
 
-    aspectRuleUnit = (Suppress(Keyword("unit")) + Optional(Keyword("augment")) + Suppress(Literal("{")) +
+    aspectRuleUnit = (Suppress(Keyword("unit")) + Opt(Keyword("augment")) + Suppress(Literal("{")) +
                       ZeroOrMore( aspectRuleUnitTerm ) + Suppress(Literal("}")) + separator
                         ).setParseAction(compileAspectRuleUnit).ignore(xfsComment)
 
@@ -1431,7 +1431,7 @@ def compileXfsGrammar( cntlr, debugParsing ):
 
     aspectRuleTypedDimensionTerm = (
                          (Keyword("xpath") + xpathExpression |
-                          Keyword("value") + dblQuotedString |
+                          Keyword("value") + dbl_quoted_string |
                           Keyword("omit")) + separator
                         ).setParseAction(compileAspectRuleTypedDimensionTerm).ignore(xfsComment)
 
@@ -1440,7 +1440,7 @@ def compileXfsGrammar( cntlr, debugParsing ):
                         ).setParseAction(compileAspectRuleTypedDimension).ignore(xfsComment)
 
     aspectRules = ( Suppress(Keyword("aspect-rules")) +
-                    Optional( Keyword("source") + qName ) +
+                    Opt( Keyword("source") + qName ) +
                     Suppress(Literal("{")) +
                     ZeroOrMore( aspectRuleConcept |
                                 aspectRuleEntityIdentifier |
@@ -1464,7 +1464,7 @@ def compileXfsGrammar( cntlr, debugParsing ):
 
 
     generalFilter = (
-        Optional( Keyword("complemented") ) +
+        Opt( Keyword("complemented") ) +
         Keyword("general") + xpathExpression + separator
         ).setParseAction(compileGeneralFilter).ignore(xfsComment).setName("general-filter").setDebug(debugParsing)
 
@@ -1473,7 +1473,7 @@ def compileXfsGrammar( cntlr, debugParsing ):
         ZeroOrMore( Keyword("complemented") | Keyword("covering") | Keyword("non-covering") ) +
         (Keyword("period") + xpathExpression |
          (Keyword("period-start") | Keyword("period-end") | Keyword("period-instant")) +
-           (dateTime | Keyword("date") + xpathExpression + Optional(Keyword("time") + xpathExpression)) |
+           (dateTime | Keyword("date") + xpathExpression + Opt(Keyword("time") + xpathExpression)) |
          Keyword("instant-duration") + (Keyword("start") | Keyword("end")) + variableRef
          ) + separator
         ).setParseAction(compilePeriodFilter).ignore(xfsComment).setName("period-filter").setDebug(debugParsing)
@@ -1486,11 +1486,11 @@ def compileXfsGrammar( cntlr, debugParsing ):
                 (Keyword("explicit-dimension") + (qName | xpathExpression) +
                     ZeroOrMore( Keyword("default-member") |
                        (Keyword("member") + (variableRef | qName | xpathExpression) +
-                        Optional(Keyword("linkrole") + quotedString) +
-                        Optional(Keyword("arcrole") + quotedString) +
-                        Optional(Keyword("axis") + dimensionAxis))) + separator) |
+                        Opt(Keyword("linkrole") + quoted_string) +
+                        Opt(Keyword("arcrole") + quoted_string) +
+                        Opt(Keyword("axis") + dimensionAxis))) + separator) |
                 (Keyword("typed-dimension") + (variableRef | qName | xpathExpression) +
-                    Optional( Keyword("test") + xpathExpression )  + separator)
+                    Opt( Keyword("test") + xpathExpression )  + separator)
             )
         ).setParseAction(compileDimensionFilter).ignore(xfsComment).setName("dimension-filter").setDebug(debugParsing)
 
@@ -1505,8 +1505,8 @@ def compileXfsGrammar( cntlr, debugParsing ):
         ZeroOrMore( Keyword("complemented") | Keyword("covering") | Keyword("non-covering") ) +
         (Keyword("entity") + Keyword("scheme") + xpathExpression + Keyword("value") + xpathExpression |
          Keyword("entity-scheme") + xpathExpression |
-         Keyword("entity-scheme-pattern") + quotedString |
-         Keyword("entity-identifier-pattern") + quotedString) + separator
+         Keyword("entity-scheme-pattern") + quoted_string |
+         Keyword("entity-identifier-pattern") + quoted_string) + separator
         ).setParseAction(compileEntityFilter).ignore(xfsComment).setName("entity-filter").setDebug(debugParsing)
 
     matchFilter = (
@@ -1517,11 +1517,11 @@ def compileXfsGrammar( cntlr, debugParsing ):
          Keyword("match-period") + variableRef |
          Keyword("match-unit") + variableRef |
          Keyword("match-dimension") + variableRef + Keyword("dimension") + (qName | xpathExpression)
-        ) + Optional( Keyword("match-any") ) + separator
+        ) + Opt( Keyword("match-any") ) + separator
         ).setParseAction(compileMatchFilter).ignore(xfsComment).setName("match-filter").setDebug(debugParsing)
 
     relativeFilter = (
-        Optional( Keyword("complemented") ) +
+        Opt( Keyword("complemented") ) +
         Keyword("relative") + variableRef + separator
         ).setParseAction(compileRelativeFilter).ignore(xfsComment).setName("relative-filter").setDebug(debugParsing)
 
@@ -1535,12 +1535,12 @@ def compileXfsGrammar( cntlr, debugParsing ):
 
 
     valueFilter = (
-        Optional( Keyword("complemented") ) +
+        Opt( Keyword("complemented") ) +
         Keyword("nilled")
         ).setParseAction(compileValueFilter).ignore(xfsComment).setName("value-filter").setDebug(debugParsing)
 
     aspectCoverFilter = (
-        Optional( Keyword("complemented") ) +
+        Opt( Keyword("complemented") ) +
         Keyword("aspect-cover") +
         OneOrMore( Keyword("all") | Keyword("concept") | Keyword("entity-identifier") | Keyword("location") |
                    Keyword("period") | Keyword("unit") | Keyword("dimensions") |
@@ -1555,19 +1555,19 @@ def compileXfsGrammar( cntlr, debugParsing ):
                     Keyword("sibling-or-self") | Keyword("sibling-or-descendant") | Keyword("sibling") )
 
     conceptRelationFilter = (
-        Optional( Keyword("complemented") ) +
+        Opt( Keyword("complemented") ) +
         Keyword("concept-relation") + (
             (variableRef | qName | xpathExpression) +
-            Optional(Keyword("linkrole") + (quotedString | xpathExpression)) +
-            Optional(Keyword("arcrole") + (quotedString | xpathExpression)) +
-            Optional(Keyword("axis") + relationAxis) +
-            Optional(Keyword("generations") + nonNegativeInteger) +
-            Optional(Keyword("test") + xpathExpression)
+            Opt(Keyword("linkrole") + (quoted_string | xpathExpression)) +
+            Opt(Keyword("arcrole") + (quoted_string | xpathExpression)) +
+            Opt(Keyword("axis") + relationAxis) +
+            Opt(Keyword("generations") + nonNegativeInteger) +
+            Opt(Keyword("test") + xpathExpression)
         ) + separator
         ).setParseAction(compileConceptRelationFilter).ignore(xfsComment).setName("concept-relation-filter").setDebug(debugParsing)
 
     booleanFilter = (
-        Optional( Keyword("complemented") ) +
+        Opt( Keyword("complemented") ) +
         (Keyword("and") | Keyword("or")) + Suppress(Literal("{")) +
          OneOrMore(filter) +
         Suppress(Literal("}")) +
@@ -1606,7 +1606,7 @@ def compileXfsGrammar( cntlr, debugParsing ):
 
 
     generalVariable = (Suppress(Keyword("variable")) + variableRef + Suppress(Literal("{")) +
-                       Optional( Keyword("bind-as-sequence") ) +
+                       Opt( Keyword("bind-as-sequence") ) +
                        Keyword("select") + xpathExpression + separator +
                        Suppress(Literal("}")) + separator).setParseAction(compileGeneralVariable).ignore(xfsComment).setName("general-variable").setDebug(debugParsing)
 
@@ -1638,7 +1638,7 @@ def compileXfsGrammar( cntlr, debugParsing ):
                   ZeroOrMore( filter ) +
                   ZeroOrMore( generalVariable | factVariable | referencedParameter) +
                   ZeroOrMore( precondition ) +
-                  Optional( ( Keyword("test") | Keyword("evaluation-count") ) + xpathExpression + separator) +
+                  Opt( ( Keyword("test") | Keyword("evaluation-count") ) + xpathExpression + separator) +
                   Suppress(Literal("}") + separator)).setParseAction(compileAssertion).ignore(xfsComment).setName("assertion").setDebug(debugParsing)
 
     consistencyAssertion = ( Suppress(Keyword("consistency-assertion")) + ncName + Suppress(Literal("{")) +

--- a/arelle/plugin/functionsMath.py
+++ b/arelle/plugin/functionsMath.py
@@ -3,46 +3,75 @@ Formula math functions plugin.
 
 See COPYRIGHT.md for copyright information.
 '''
+from __future__ import annotations
+
 import math
+from decimal import Decimal
+from typing import Callable, TypeAlias, Union
 
 from arelle import XPathContext
 from arelle.FunctionUtil import numericArg
-from arelle.ModelValue import qname
+from arelle.ModelObject import ModelObject
+from arelle.ModelValue import QName, qname
 from arelle.Version import authorLabel, copyrightLabel
+from arelle.XPathParser import OperationDef
+from arelle.typing import EmptyTuple
 
 INF = float('inf')
 MINUSINF = float('-inf')
 NaN = float('nan')
 
+MATH_FUNCTION_ARGS: TypeAlias = list[list[Union[float, int, Decimal]]]
 
-def xfm_pi(xc, p, contextItem, args):
+
+def xfm_pi(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 0:
-        raise XPathContext.FunctionNumArgs()
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
     return math.pi
 
 
-def xfm_exp(xc, p, contextItem, args):
+def xfm_exp(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         return math.exp(x)
     return ()
 
 
-def xfm_exp10(xc, p, contextItem, args):
+def xfm_exp10(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         return math.pow(10.0, x)
     return ()
 
 
-def xfm_log(xc, p, contextItem, args):
+def xfm_log(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         if x == 0:
             return MINUSINF
@@ -54,10 +83,15 @@ def xfm_log(xc, p, contextItem, args):
     return ()
 
 
-def xfm_log10(xc, p, contextItem, args):
+def xfm_log10(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         if x == 0:
             return MINUSINF
@@ -69,12 +103,17 @@ def xfm_log10(xc, p, contextItem, args):
     return ()
 
 
-def xfm_pow(xc, p, contextItem, args):
+def xfm_pow(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 2:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
-        y = numericArg(xc, p, args, 1)
+        y = numericArg(xc, p, args, 1)  # type: ignore[no-untyped-call]
         if x == 0:
             if math.copysign(1, x) < 0:  # e.g., value is -0.0
                 if y < 0:
@@ -101,10 +140,15 @@ def xfm_pow(xc, p, contextItem, args):
     return ()
 
 
-def xfm_sqrt(xc, p, contextItem, args):
+def xfm_sqrt(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         if x == MINUSINF:
             return NaN
@@ -114,10 +158,15 @@ def xfm_sqrt(xc, p, contextItem, args):
     return ()
 
 
-def xfm_sin(xc, p, contextItem, args):
+def xfm_sin(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         if math.isinf(x):
             return NaN
@@ -125,10 +174,15 @@ def xfm_sin(xc, p, contextItem, args):
     return ()
 
 
-def xfm_cos(xc, p, contextItem, args):
+def xfm_cos(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         if math.isinf(x):
             return NaN
@@ -136,10 +190,15 @@ def xfm_cos(xc, p, contextItem, args):
     return ()
 
 
-def xfm_tan(xc, p, contextItem, args):
+def xfm_tan(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         if math.isinf(x):
             return NaN
@@ -147,10 +206,15 @@ def xfm_tan(xc, p, contextItem, args):
     return ()
 
 
-def xfm_asin(xc, p, contextItem, args):
+def xfm_asin(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         try:
             return math.asin(x)
@@ -159,10 +223,15 @@ def xfm_asin(xc, p, contextItem, args):
     return ()
 
 
-def xfm_acos(xc, p, contextItem, args):
+def xfm_acos(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         try:
             return math.acos(x)
@@ -171,10 +240,15 @@ def xfm_acos(xc, p, contextItem, args):
     return ()
 
 
-def xfm_atan(xc, p, contextItem, args):
+def xfm_atan(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float | EmptyTuple:
     if len(args) != 1:
-        raise XPathContext.FunctionNumArgs()
-    x = numericArg(xc, p, args, 0, emptyFallback=())
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 0, emptyFallback=())  # type: ignore[no-untyped-call]
     if x != ():
         try:
             return math.atan(x)
@@ -183,15 +257,22 @@ def xfm_atan(xc, p, contextItem, args):
     return ()
 
 
-def xfm_atan2(xc, p, contextItem, args):
+def xfm_atan2(
+    xc: XPathContext.XPathContext,
+    p: OperationDef,
+    contextItem: ModelObject,
+    args: MATH_FUNCTION_ARGS,
+) -> float:
     if len(args) != 2:
-        raise XPathContext.FunctionNumArgs()
-    y = numericArg(xc, p, args, 0)
-    x = numericArg(xc, p, args, 1)
+        raise XPathContext.FunctionNumArgs()  # type: ignore[no-untyped-call]
+    y = numericArg(xc, p, args, 0)  # type: ignore[no-untyped-call]
+    x = numericArg(xc, p, args, 1)  # type: ignore[no-untyped-call]
     return math.atan2(y, x)
 
 
-def xfmMathFunctions():
+def xfmMathFunctions() -> dict[
+    QName, Callable[[XPathContext.XPathContext, OperationDef, ModelObject, MATH_FUNCTION_ARGS], float | EmptyTuple]
+]:
     return {
         qname("{http://www.xbrl.org/2008/function/math}xfm:pi"): xfm_pi,
         qname("{http://www.xbrl.org/2008/function/math}xfm:exp"): xfm_exp,

--- a/arelle/plugin/functionsMath.py
+++ b/arelle/plugin/functionsMath.py
@@ -4,35 +4,44 @@ Formula math functions plugin.
 See COPYRIGHT.md for copyright information.
 '''
 import math
-from arelle.ModelValue import qname
-from arelle import XPathContext, XbrlUtil
+
+from arelle import XPathContext
 from arelle.FunctionUtil import numericArg
+from arelle.ModelValue import qname
 from arelle.Version import authorLabel, copyrightLabel
 
 INF = float('inf')
 MINUSINF = float('-inf')
 NaN = float('nan')
 
+
 def xfm_pi(xc, p, contextItem, args):
-    if len(args) != 0: raise XPathContext.FunctionNumArgs()
+    if len(args) != 0:
+        raise XPathContext.FunctionNumArgs()
     return math.pi
 
+
 def xfm_exp(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         return math.exp(x)
     return ()
 
+
 def xfm_exp10(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         return math.pow(10.0, x)
     return ()
 
+
 def xfm_log(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         if x == 0:
@@ -44,8 +53,10 @@ def xfm_log(xc, p, contextItem, args):
         return math.log(x)
     return ()
 
+
 def xfm_log10(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         if x == 0:
@@ -57,24 +68,26 @@ def xfm_log10(xc, p, contextItem, args):
         return math.log10(x)
     return ()
 
+
 def xfm_pow(xc, p, contextItem, args):
-    if len(args) != 2: raise XPathContext.FunctionNumArgs()
+    if len(args) != 2:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         y = numericArg(xc, p, args, 1)
         if x == 0:
-            if math.copysign(1, x) < 0: # e.g., value is -0.0
+            if math.copysign(1, x) < 0:  # e.g., value is -0.0
                 if y < 0:
                     # special case for odd integer exponents
                     _intY = int(y)
-                    if _intY & 1 and y == _intY: # special case for whole numbers
+                    if _intY & 1 and y == _intY:  # special case for whole numbers
                         return MINUSINF
                     return INF
                 elif y == 0:
                     return 1.0
                 else:
                     return -0.0
-            else: # value is +0.0
+            else:  # value is +0.0
                 if y < 0:
                     return INF
                 elif y == 0:
@@ -84,11 +97,13 @@ def xfm_pow(xc, p, contextItem, args):
         try:
             return math.pow(x, y)
         except ValueError:
-            return NaN # pow(-2.5e0, 2.00000001e0) returns xs:double('NaN').
+            return NaN  # pow(-2.5e0, 2.00000001e0) returns xs:double('NaN').
     return ()
 
-def  xfm_sqrt(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+
+def xfm_sqrt(xc, p, contextItem, args):
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         if x == MINUSINF:
@@ -98,8 +113,10 @@ def  xfm_sqrt(xc, p, contextItem, args):
         return math.sqrt(x)
     return ()
 
-def  xfm_sin(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+
+def xfm_sin(xc, p, contextItem, args):
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         if math.isinf(x):
@@ -107,8 +124,10 @@ def  xfm_sin(xc, p, contextItem, args):
         return math.sin(x)
     return ()
 
-def  xfm_cos(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+
+def xfm_cos(xc, p, contextItem, args):
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         if math.isinf(x):
@@ -116,8 +135,10 @@ def  xfm_cos(xc, p, contextItem, args):
         return math.cos(x)
     return ()
 
-def  xfm_tan(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+
+def xfm_tan(xc, p, contextItem, args):
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         if math.isinf(x):
@@ -125,8 +146,10 @@ def  xfm_tan(xc, p, contextItem, args):
         return math.tan(x)
     return ()
 
-def  xfm_asin(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+
+def xfm_asin(xc, p, contextItem, args):
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         try:
@@ -135,8 +158,10 @@ def  xfm_asin(xc, p, contextItem, args):
             return NaN
     return ()
 
-def  xfm_acos(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+
+def xfm_acos(xc, p, contextItem, args):
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         try:
@@ -145,8 +170,10 @@ def  xfm_acos(xc, p, contextItem, args):
             return NaN
     return ()
 
-def  xfm_atan(xc, p, contextItem, args):
-    if len(args) != 1: raise XPathContext.FunctionNumArgs()
+
+def xfm_atan(xc, p, contextItem, args):
+    if len(args) != 1:
+        raise XPathContext.FunctionNumArgs()
     x = numericArg(xc, p, args, 0, emptyFallback=())
     if x != ():
         try:
@@ -155,11 +182,14 @@ def  xfm_atan(xc, p, contextItem, args):
             return NaN
     return ()
 
+
 def xfm_atan2(xc, p, contextItem, args):
-    if len(args) != 2: raise XPathContext.FunctionNumArgs()
+    if len(args) != 2:
+        raise XPathContext.FunctionNumArgs()
     y = numericArg(xc, p, args, 0)
     x = numericArg(xc, p, args, 1)
     return math.atan2(y, x)
+
 
 def xfmMathFunctions():
     return {
@@ -176,8 +206,9 @@ def xfmMathFunctions():
         qname("{http://www.xbrl.org/2008/function/math}xfm:asin"): xfm_asin,
         qname("{http://www.xbrl.org/2008/function/math}xfm:acos"): xfm_acos,
         qname("{http://www.xbrl.org/2008/function/math}xfm:atan"): xfm_atan,
-        qname("{http://www.xbrl.org/2008/function/math}xfm:atan2"): xfm_atan2
+        qname("{http://www.xbrl.org/2008/function/math}xfm:atan2"): xfm_atan2,
     }
+
 
 __pluginInfo__ = {
     'name': 'Formula Math Functions',

--- a/arelle/typing.py
+++ b/arelle/typing.py
@@ -3,8 +3,9 @@ See COPYRIGHT.md for copyright information.
 Type hints for Arelle.
 """
 from __future__ import annotations
+
 import sys
-from typing import Callable, TypeVar
+from typing import Callable, Tuple, TypeVar
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict  # pylint: disable=no-name-in-module
@@ -14,6 +15,8 @@ else:
 TypeGetText = Callable[[str], str]
 
 OptionalString = TypeVar("OptionalString", str, None)
+
+EmptyTuple = Tuple[()]
 
 
 class LocaleDict(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ module = [
     'arelle.XmlUtil',
     'arelle.XmlValidate',
     'arelle.XmlValidateSchema',
+    'arelle.plugin.functionsMath',
     'arelle.plugin.validate.ESEF.*',
     'arelle.plugin.validate.ESEF_2022.*',
     'tests.integration_tests',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ module = [
     'arelle.Updater',
     'arelle.UrlUtil',
     'arelle.ValidateXbrl',
+    'arelle.XPathParser',
     'arelle.XbrlConst',
     'arelle.XbrlUtil',
     'arelle.XmlUtil',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,23 +113,23 @@ ignore_errors = true
 # when the library is converted, the above entry will be replaced (strict is demanded)
 [[tool.mypy.overrides]]
 module = [
-    'arelle.plugin.validate.ESEF.*',
-    'arelle.plugin.validate.ESEF_2022.*',
     'arelle.Cntlr',
     'arelle.FileSource',
     'arelle.Locale',
     'arelle.ModelObject',
-    'arelle.ModelXbrl',
     'arelle.ModelValue',
+    'arelle.ModelXbrl',
     'arelle.SystemInfo',
     'arelle.Updater',
     'arelle.UrlUtil',
-    'arelle.XmlValidateSchema',
     'arelle.ValidateXbrl',
     'arelle.XbrlConst',
     'arelle.XbrlUtil',
     'arelle.XmlUtil',
     'arelle.XmlValidate',
+    'arelle.XmlValidateSchema',
+    'arelle.plugin.validate.ESEF.*',
+    'arelle.plugin.validate.ESEF_2022.*',
     'tests.integration_tests',
 ]
 ignore_errors = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ module = [
     'arelle.FileSource',
     'arelle.Locale',
     'arelle.ModelObject',
+    'arelle.ModelObjectFactory',
     'arelle.ModelValue',
     'arelle.ModelXbrl',
     'arelle.SystemInfo',


### PR DESCRIPTION
#### Reason for change
I found some minor issues in the formula XPath implementation while working on #529.

#### Description of change
* Selectively ran black to improve readability (particularly with the pyparsing grammar)
* Fixed some typos/broken code paths
* Updated deprecated pyparsing class and function names
* Add type hints to modules:
  * XPathParser
  * ModelObjectFactory
  * plugin.functionsMath

#### Steps to Test
* CI

**review**:
@Arelle/arelle
