### PR TITLE
Add option to skip EFM calculation tree walk

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -126,6 +126,8 @@ def parseAndRun(args):
     parser.add_option("--calcdeduplicate", action="store_true", dest="calcDeduplicate", help=SUPPRESS_HELP)
     parser.add_option("--efm", action="store_true", dest="validateEFM",
                       help=_("Select Edgar Filer Manual (U.S. SEC) disclosure system validation (strict)."))
+    parser.add_option("--efm-skip-calc-tree", action="store_false", default=True, dest="validateEFMCalcTree",
+                      help=_("Skip walking of calculation tree during EFM validation."))
     parser.add_option("--gfm", action="store", dest="disclosureSystemName", help=SUPPRESS_HELP)
     parser.add_option("--disclosureSystem", action="store", dest="disclosureSystemName",
                       help=_("Specify a disclosure system name and"

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -68,6 +68,8 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
     if not modelXbrl.modelDocument or not hasattr(modelXbrl.modelDocument, "xmlDocument"): # not parsed
         return
 
+    options = modelXbrl.modelManager.efmFiling.options
+
     datePattern = re.compile(r"([12][0-9]{3})-([01][0-9])-([0-3][0-9])")
     GFMcontextDatePattern = re.compile(r"^[12][0-9]{3}-[01][0-9]-[0-3][0-9]$")
     # note \u20zc = euro, \u00a3 = pound, \u00a5 = yen
@@ -2413,7 +2415,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                             if len(usedCalcPairingsOfConcept & conceptsPresented) > 0:
                                 usedCalcPairingsOfConcept -= conceptsPresented
                     # 6.15.02, 6.15.03 semantics checks for totals and calc arcs (by tree walk)
-                    if validateLoggingSemantic:
+                    if validateLoggingSemantic and options.validateEFMCalcTree:
                         for rootConcept in parentChildRels.rootConcepts:
                             checkCalcsTreeWalk(val, parentChildRels, rootConcept, isStatementSheet, False, conceptsUsed, set())
                     # 6.12.6


### PR DESCRIPTION
#### Reason for change
The recursive calculation tree walk during EFM validation is expensive and not always necessary for every use case. Add an option to filter out this specific validation step.

#### Description of change
Added a `--efm-skip-calc-tree` command line argument that sets the `validateEFMCalcTree` option to `False` (defaults to `True`), causing call to `checkCalcsTreeWalk` to be skipped.

#### Steps to Test
Run an EFM validation with and without `--efm-skip-calc-tree` and confirm `checkCalcsTreeWalk` is not called (via debugger or other method)

**review**:
@Arelle/arelle
