### PR TITLE
Add type hints to ModelDtsObject

### DIFF
--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -153,7 +153,7 @@ class ModelRoleType(ModelObject):
             return self._tableCode
         except AttributeError:
             from arelle import TableStructure
-            TableStructure.evaluateRoleTypesTableCodes(self.modelXbrl)
+            TableStructure.evaluateRoleTypesTableCodes(self.modelXbrl)  # type: ignore[no-untyped-call]
             return self._tableCode
 
     @property
@@ -694,7 +694,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
         labelsRelationshipSet = self.modelXbrl.relationshipSet(XbrlConst.conceptLabel,linkrole)
         if labelsRelationshipSet:
             for _lang in (lang if isinstance(lang, (tuple,list)) else (lang,)):
-                label = labelsRelationshipSet.label(self, preferredLabel, _lang, linkroleHint=linkroleHint)
+                label = labelsRelationshipSet.label(self, preferredLabel, _lang, linkroleHint=linkroleHint)  # type: ignore[no-untyped-call]
                 if label is not None:
                     if strip: return label.strip()  # type: ignore[no-any-return]
                     return Locale.rtlString(label, lang=_lang)

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -83,6 +83,13 @@ class ModelRoleType(ModelObject):
     :param modelDocument: owner document
     :type modelDocument: ModelDocument
     """
+
+    _definition: str | None
+    _maxOccurs: int
+    _minOccurs: int
+    _typeQname: QName
+    _usedOns: set[TypeXValue]
+
     def init(self, modelDocument: ModelDocument) -> None:
         super(ModelRoleType, self).init(modelDocument)
 
@@ -110,7 +117,7 @@ class ModelRoleType(ModelObject):
     def definition(self) -> str | None:
         """(str) -- Text of child definition element (stripped)"""
         try:
-            return self._definition
+            return cast(str, self._definition)
         except AttributeError:
             definition = XmlUtil.child(self, XbrlConst.link, "definition")
             self._definition = definition.textValue.strip() if definition is not None else None
@@ -180,6 +187,11 @@ class ModelNamableTerm(ModelObject):
     :param modelDocument: owner document
     :type modelDocument: ModelDocument
     """
+
+    _attributeWildcards: list[_Element]
+    _defaultAttributeQnames: set[QName]
+    _xsdQname: QName | None
+
     def init(self, modelDocument: ModelDocument) -> None:
         super(ModelNamableTerm, self).init(modelDocument)
 
@@ -190,7 +202,7 @@ class ModelNamableTerm(ModelObject):
     @property
     def qname(self) -> QName:
         try:
-            return self._xsdQname
+            return cast(QName, self._xsdQname)
         except AttributeError:
             name = self.name
             if self.name:
@@ -245,6 +257,10 @@ class ParticlesList(list):
         return ", ".join(particlesList)
 
 class ModelParticle():
+
+    _maxOccurs: int
+    _minOccurs: int
+
     """Represents a particle (for multi-inheritance subclasses of particles)"""
     def addToParticles(self) -> None:
         """Finds particle parent (in xml element ancestry) and appends self to parent particlesList"""
@@ -312,6 +328,31 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
     :param modelDocument: owner document
     :type modelDocument: ModelDocument
     """
+
+    _baseXbrliType: str | None
+    _baseXbrliTypeQname: QName | None
+    _baseXsdType: str
+    _enumDomain: ModelConcept | None
+    _isDimensionItem: bool
+    _isEnum: bool
+    _isEnumDomainUsable: bool
+    _isFraction: bool
+    _isHypercubeItem: bool
+    _isInteger: bool
+    _isItem: bool
+    _isLanguage: bool
+    _isMonetary: bool
+    _isNumeric: bool
+    _typedDomainElement: bool
+    _isLinkPart: bool
+    _isPrimaryItem: bool
+    _isShares: bool
+    _isTuple: bool
+    _isTypedDimension: bool
+    _type: ModelType | None
+    _substitutionGroupQname: QName | None
+    _typeQname: QName | None
+
     def init(self, modelDocument: ModelDocument) -> None:
         super(ModelConcept, self).init(modelDocument)
         if self.name:  # don't index elements with ref and no name
@@ -424,7 +465,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
         is derived from.  If not determinable anyType is returned.  E.g., for monetaryItemType,
         decimal is returned."""
         try:
-            return self._baseXbrliType
+            return cast(str, self._baseXbrliType)
         except AttributeError:
             typeqname = self.typeQname
             if typeqname is not None and typeqname.namespaceURI == XbrlConst.xbrli:
@@ -439,7 +480,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
         is derived from.  If not determinable anyType is returned.  E.g., for monetaryItemType,
         decimal is returned."""
         try:
-            return self._baseXbrliTypeQname
+            return cast(QName, self._baseXbrliTypeQname)
         except AttributeError:
             typeqname = self.typeQname
             if typeqname is not None and typeqname.namespaceURI == XbrlConst.xbrli:
@@ -888,6 +929,12 @@ class ModelAttribute(ModelNamableTerm):
     :param modelDocument: owner document
     :type modelDocument: ModelDocument
     """
+
+    _baseXsdType: str | None
+    _isNumeric: bool
+    _facets: dict[str, Any] | None
+    _type: ModelType | None
+
     def init(self, modelDocument: ModelDocument) -> None:
         super(ModelAttribute, self).init(modelDocument)
         if self.isGlobalDeclaration:
@@ -1000,6 +1047,9 @@ class ModelAttributeGroup(ModelNamableTerm):
     :param modelDocument: owner document
     :type modelDocument: ModelDocument
     """
+
+    _attributes: dict[QName, ModelAttribute]
+
     def init(self, modelDocument: ModelDocument) -> None:
         super(ModelAttributeGroup, self).init(modelDocument)
         if self.isGlobalDeclaration:
@@ -1058,6 +1108,15 @@ class ModelType(ModelNamableTerm):
     :param modelDocument: owner document
     :type modelDocument: ModelDocument
     """
+
+    _attributes: dict[QName, ModelAttribute]
+    _baseXbrliType: str | None
+    _baseXbrliTypeQname: Any
+    _baseXsdType: str
+    _facets: dict[str, TypeXValue] | None
+    _elements: set[QName | None]
+    _requiredAttributeQnames: set[QName]
+
     def init(self, modelDocument: ModelDocument) -> None:
         super(ModelType, self).init(modelDocument)
         self.modelXbrl.qnameTypes.setdefault(self.qname, self) # don't redefine types nested in anonymous types
@@ -1512,6 +1571,10 @@ class ModelAny(ModelObject, ModelParticle):
     :param modelDocument: owner document
     :type modelDocument: ModelDocument
     """
+
+    _isAny: bool
+    _namespaces: list[str]
+
     def init(self, modelDocument: ModelDocument) -> None:
         super(ModelAny, self).init(modelDocument)
         self.addToParticles()
@@ -1548,6 +1611,10 @@ class ModelAnyAttribute(ModelObject):
     :param modelDocument: owner document
     :type modelDocument: ModelDocument
     """
+
+    _isAny: bool
+    _namespaces: list[str]
+
     def init(self, modelDocument: ModelDocument) -> None:
         super(ModelAnyAttribute, self).init(modelDocument)
 
@@ -1726,6 +1793,12 @@ class ModelRelationship(ModelObject):
 
         ModelObject of the xlink:to (dereferenced if via xlink:locator)
     """
+
+    _isComplemented: bool
+    _isCovered: bool
+    _isClosed: bool
+    _usable: str | None
+
     def __init__(self, modelDocument: ModelDocument, arcElement: ModelDocument, fromModelObject: ModelDocument, toModelObject: ModelDocument) -> None:
         # copy model object properties from arcElement
         self.arcElement: ModelDocument = arcElement
@@ -1987,7 +2060,7 @@ class ModelRelationship(ModelObject):
             return self._usable
         except AttributeError:
             if self.arcrole in (XbrlConst.dimensionDomain, XbrlConst.domainMember):
-                self._usable = self.get("{http://xbrl.org/2005/xbrldt}usable") or "true"
+                self._usable = cast(str, self.get("{http://xbrl.org/2005/xbrldt}usable")) or "true"
             else:
                 self._usable = None
             return self._usable

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -68,9 +68,11 @@ from arelle.XmlValidate import UNVALIDATED, VALID
 from arelle.ModelObject import ModelObject
 from arelle.ModelValue import AnyURI, QName, TypeXValue
 from lxml.etree import _Element
+from arelle.typing import TypeGetText
 
 if TYPE_CHECKING:
     from arelle.ModelDocument import ModelDocument
+    _: TypeGetText
 
 ModelFact = None
 

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -205,7 +205,7 @@ class ModelNamableTerm(ModelObject):
         return self.getStripped("name")
 
     @property
-    def qname(self) -> QName:
+    def qname(self) -> QName | None:
         try:
             return cast(QName, self._xsdQname)
         except AttributeError:
@@ -349,13 +349,13 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
     _isLanguage: bool
     _isMonetary: bool
     _isNumeric: bool
-    _typedDomainElement: bool
     _isLinkPart: bool
     _isPrimaryItem: bool
     _isShares: bool
     _isTuple: bool
     _isTypedDimension: bool
     _type: ModelType | None
+    _typedDomainElement: ModelObject
     _substitutionGroupQname: QName | None
     _typeQname: QName | None
 
@@ -454,7 +454,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
             return self._baseXsdType
 
     @property
-    def facets(self) -> dict[str, TypeXValue]:
+    def facets(self) -> dict[str, TypeXValue] | None:
         """(dict) -- Facets declared for element type"""
         return self.type.facets if self.type is not None else None
 
@@ -472,7 +472,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
     '''
 
     @property
-    def baseXbrliType(self) -> str:
+    def baseXbrliType(self) -> str | None:
         """(str) -- Attempts to return the base xsd type localName that this concept's type
         is derived from.  If not determinable anyType is returned.  E.g., for monetaryItemType,
         decimal is returned."""
@@ -487,7 +487,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
             return self._baseXbrliType
 
     @property
-    def baseXbrliTypeQname(self) -> QName:
+    def baseXbrliTypeQname(self) -> QName | None:
         """(qname) -- Attempts to return the base xsd type QName that this concept's type
         is derived from.  If not determinable anyType is returned.  E.g., for monetaryItemType,
         decimal is returned."""
@@ -607,7 +607,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
             return self._substitutionGroupQname
 
     @property
-    def substitutionGroupQnames(self) -> list[QName]:   # ordered list of all substitution group qnames
+    def substitutionGroupQnames(self) -> list[QName | None]:   # ordered list of all substitution group qnames
         """([QName]) -- Ordered list of QNames of substitution groups (recursively)"""
         qnames = []
         subs = self
@@ -700,7 +700,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
                     return Locale.rtlString(label, lang=_lang)
         return str(self.qname) if fallbackToQname else None
 
-    def relationshipToResource(self, resourceObject: ModelObject, arcrole: str) -> ModelRelationship:
+    def relationshipToResource(self, resourceObject: ModelObject, arcrole: str) -> ModelRelationship | None:
         """For specified object and resource (all link roles), returns first
         modelRelationshipObject that relates from this element to specified resourceObject.
 
@@ -872,7 +872,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
         return False
 
     @property
-    def subGroupHeadQname(self) -> QName:
+    def subGroupHeadQname(self) -> QName | None:
         """(QName) -- Head of substitution lineage of element (e.g., xbrli:item)"""
         subs = self
         subNext = subs.substitutionGroup
@@ -969,7 +969,7 @@ class ModelAttribute(ModelNamableTerm):
                 self.modelXbrl.qnameAttributes[ModelValue.QName(None, None, self.name)] = self
 
     @property
-    def typeQname(self) -> QName:
+    def typeQname(self) -> QName | None:
         """(QName) -- QName of type of attribute"""
         if self.get("type"):
             return self.schemaNameQname(self.get("type"))
@@ -992,7 +992,7 @@ class ModelAttribute(ModelNamableTerm):
         return None
 
     @property
-    def type(self) -> ModelType:
+    def type(self) -> ModelType | None:
         """(ModelType) -- Attribute's modelType object (if any)"""
         try:
             return self._type
@@ -1002,7 +1002,7 @@ class ModelAttribute(ModelNamableTerm):
             return self._type
 
     @property
-    def baseXsdType(self) -> str:
+    def baseXsdType(self) -> str | None:
         """(str) -- Attempts to return the base xsd type localName that this attribute's type
         is derived from.  If not determinable *anyType* is returned"""
         try:
@@ -1064,7 +1064,7 @@ class ModelAttribute(ModelNamableTerm):
         if ref:
             qn = self.schemaNameQname(ref, isQualifiedForm=self.isQualifiedForm)
             assert self.modelXbrl is not None
-            return self.modelXbrl.qnameAttributes.get(qn)
+            return cast(ModelAttribute, self.modelXbrl.qnameAttributes.get(qn))
         return self
 
 class ModelAttributeGroup(ModelNamableTerm):
@@ -1127,7 +1127,7 @@ class ModelAttributeGroup(ModelNamableTerm):
         if ref:
             qn = self.schemaNameQname(ref)
             assert self.modelXbrl is not None
-            return self.modelXbrl.qnameAttributeGroups.get(ModelValue.qname(self, ref))
+            return cast(ModelAttributeGroup, self.modelXbrl.qnameAttributeGroups.get(ModelValue.qname(self, ref)))
         return self
 
 class ModelType(ModelNamableTerm):
@@ -1175,7 +1175,7 @@ class ModelType(ModelNamableTerm):
         return True
 
     @property
-    def qnameDerivedFrom(self) -> QName:
+    def qnameDerivedFrom(self) -> list[QName | None] | QName | None:
         """(QName) -- the type that this type is derived from"""
         typeOrUnion = XmlUtil.schemaBaseTypeDerivedFrom(self)
         if isinstance(typeOrUnion,list): # union
@@ -1183,7 +1183,7 @@ class ModelType(ModelNamableTerm):
         return self.schemaNameQname(typeOrUnion)
 
     @property
-    def typeDerivedFrom(self) -> ModelType:
+    def typeDerivedFrom(self) -> list[ModelType | None] | ModelType | None:
         """(ModelType) -- type that this type is derived from"""
         qnameDerivedFrom = self.qnameDerivedFrom
         assert self.modelXbrl is not None
@@ -1290,7 +1290,7 @@ class ModelType(ModelNamableTerm):
             return self._baseXbrliTypeQname
 
     @property
-    def baseXbrliType(self) -> str:
+    def baseXbrliType(self) -> str | None:
         """(str) -- The localName of the parent type in the xbrli namespace, if any, otherwise the localName of the parent in the xsd namespace."""
         try:
             return self._baseXbrliType
@@ -1434,7 +1434,7 @@ class ModelType(ModelNamableTerm):
             return self._attributes
 
     @property
-    def attributeWildcards(self) -> dict[str, str]:
+    def attributeWildcards(self) -> list[str]:
         """(dict) -- List of wildcard namespace strings (e.g., ##other)"""
         try:
             return self._attributeWildcards
@@ -1461,7 +1461,7 @@ class ModelType(ModelNamableTerm):
             return self._defaultAttributeQnames
 
     @property
-    def elements(self) -> list[QName]:
+    def elements(self) -> set[QName | None]:
         """([QName]) -- List of element QNames that are descendants (content elements)"""
         try:
             return self._elements
@@ -1470,7 +1470,7 @@ class ModelType(ModelNamableTerm):
             return self._elements
 
     @property
-    def facets(self) -> dict[str, Any]:
+    def facets(self) -> dict[str, TypeXValue] | None:
         """(dict) -- Dict of facets by their facet name, all are strings except enumeration, which is a set of enumeration values."""
         try:
             return self._facets
@@ -1506,7 +1506,7 @@ class ModelType(ModelNamableTerm):
             typeDerivedFrom.constrainingFacets(facetValues)
         return facetValues
 
-    def fixedOrDefaultAttrValue(self, attrName: str) -> str:
+    def fixedOrDefaultAttrValue(self, attrName: str) -> str | None:
         """(str) -- Descendant attribute declaration value if fixed or default, argument is attribute name (string), e.g., 'precision'."""
         attr = XmlUtil.schemaDescendant(self, XbrlConst.xsd, "attribute", attrName)
         if attr is not None:
@@ -1558,7 +1558,7 @@ class ModelGroupDefinition(ModelNamableTerm, ModelParticle):
         if ref:
             qn = self.schemaNameQname(ref)
             assert self.modelXbrl is not None
-            return self.modelXbrl.qnameGroupDefinitions.get(qn)
+            return cast(ModelGroupDefinition, self.modelXbrl.qnameGroupDefinitions.get(qn))
         return self
 
     @property
@@ -1757,7 +1757,7 @@ class ModelResource(ModelObject):
         return self.get("{http://www.w3.org/1999/xlink}label")
 
     @property
-    def xmlLang(self) -> str:
+    def xmlLang(self) -> str | None:
         """(str) -- xml:lang attribute
         Note that xml.xsd specifies that an empty string xml:lang attribute is an un-declaration of the
         attribute, as if the attribute were not present.  When absent or un-declared, returns None."""
@@ -1797,7 +1797,7 @@ class ModelLocator(ModelResource):
     def init(self, modelDocument: ModelDocument) -> None:
         super(ModelLocator, self).init(modelDocument)
 
-    def dereference(self) -> ModelObject:
+    def dereference(self) -> ModelObject | None:
         """(ModelObject) -- Resolve loc's href if resource is a loc with href document and id modelHref a tuple with
         href's element, modelDocument, id"""
         return self.resolveUri(self.modelHref)
@@ -2117,7 +2117,7 @@ class ModelRelationship(ModelObject):
             return self._isClosed
 
     @property
-    def usable(self) -> str:
+    def usable(self) -> str | None:
         """(str) -- Value of xbrldt:usable (on applicable XDT arcs, defaults to 'true' if absent)"""
         try:
             return self._usable

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -2070,7 +2070,7 @@ class ModelRelationship(ModelObject):
     def variableQname(self) -> QName:
         """(QName) -- resolved name for a formula (or other arc) having a QName name attribute"""
         varName = self.variablename
-        return ModelValue.qname(self.arcElement, varName, noPrefixIsNoNamespace=True) if varName else None  # type: ignore[no-any-return]
+        return ModelValue.qname(self.arcElement, varName, noPrefixIsNoNamespace=True) if varName else None  # type: ignore[no-any-return, call-overload]
 
     @property
     def linkrole(self) -> str:

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -223,7 +223,7 @@ class ModelNamableTerm(ModelObject):
     def isGlobalDeclaration(self) -> bool:
         parent = self.getparent()
         assert parent is not None
-        return parent.namespaceURI == XbrlConst.xsd and parent.localName == "schema"  # type: ignore[attr-defined]
+        return parent.namespaceURI == XbrlConst.xsd and parent.localName == "schema"  # type: ignore[attr-defined, no-any-return]
 
     def schemaNameQname(self, prefixedName: str, isQualifiedForm: bool = True, prefixException: type[Exception] | None = None) -> QName | None:
         """Returns ModelValue.QName of prefixedName using this element and its ancestors' xmlns.
@@ -656,7 +656,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
     @property
     def isRoot(self) -> bool:
         """(bool) -- True if parent of element definition is xsd schema element"""
-        return self.getparent().localName == "schema"  # type: ignore[union-attr]
+        return self.getparent().localName == "schema"  # type: ignore[union-attr, no-any-return]
 
     def label(
         self,
@@ -694,7 +694,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
             for _lang in (lang if isinstance(lang, (tuple,list)) else (lang,)):
                 label = labelsRelationshipSet.label(self, preferredLabel, _lang, linkroleHint=linkroleHint)
                 if label is not None:
-                    if strip: return label.strip()
+                    if strip: return label.strip()  # type: ignore[no-any-return]
                     return Locale.rtlString(label, lang=_lang)
         return str(self.qname) if fallbackToQname else None
 
@@ -714,7 +714,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
         if relationshipSet:
             for modelRel in relationshipSet.fromModelObject(self):
                 if modelRel.toModelObject == resourceObject:
-                    return modelRel
+                    return modelRel  # type: ignore[no-any-return]
         return None
 
     @property
@@ -907,7 +907,7 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
                        tuple((_refPart.localName, _refPart.stringValue.strip())
                              for _refPart in _ref.iterchildren()))
                       for _refRel in sorted(self.modelXbrl.relationshipSet(XbrlConst.conceptReference).fromModelObject(self),
-                                            key=lambda r:r.toModelObject.roleRefPartSortKey())
+                                            key=lambda r:r.toModelObject.roleRefPartSortKey())  # type: ignore[no-any-return]
                       for _ref in (_refRel.toModelObject,))
         _refsStrung = " ".join(_refPart.stringValue.strip()
                                for _refRel in self.modelXbrl.relationshipSet(XbrlConst.conceptReference).fromModelObject(self)
@@ -1039,7 +1039,7 @@ class ModelAttribute(ModelNamableTerm):
         """(bool) -- True if attribute has form attribute qualified or its document default"""
         if self.get("form") is not None: # form is almost never used
             return self.get("form") == "qualified"
-        return self.modelDocument.isQualifiedAttributeFormDefault
+        return self.modelDocument.isQualifiedAttributeFormDefault  # type: ignore[no-any-return]
 
     @property
     def isRequired(self) -> bool:
@@ -1141,7 +1141,7 @@ class ModelType(ModelNamableTerm):
     _attributes: dict[QName, ModelAttribute]
     _attributeWildcards: list[str]
     _baseXbrliType: str | None
-    _baseXbrliTypeQname: Any
+    _baseXbrliTypeQname: QName | None
     _baseXsdType: str
     _facets: dict[str, TypeXValue] | None
     _elements: set[QName | None]
@@ -1252,7 +1252,7 @@ class ModelType(ModelNamableTerm):
             return self._baseXsdType
 
     @property
-    def baseXbrliTypeQname(self) -> QName:
+    def baseXbrliTypeQname(self) -> QName | None:
         """(qname) -- The qname of the parent type in the xbrli namespace, if any, otherwise the localName of the parent in the xsd namespace."""
         try:
             return self._baseXbrliTypeQname
@@ -1894,22 +1894,22 @@ class ModelRelationship(ModelObject):
     @property
     def sourceline(self) -> int:
         """(int) -- Property proxy for sourceline of arc element"""
-        return self.arcElement.sourceline # type: ignore[attr-defined]
+        return self.arcElement.sourceline # type: ignore[attr-defined, no-any-return]
 
     @property
     def tag(self) -> str:
         """(str) -- Property proxy for tag of arc element (clark notation)"""
-        return self.arcElement.tag # type: ignore[attr-defined]
+        return self.arcElement.tag # type: ignore[attr-defined, no-any-return]
 
     @property
     def elementQname(self) -> QName:
         """(QName) -- Property proxy for elementQName of arc element"""
-        return self.arcElement.elementQname # type: ignore[attr-defined]
+        return self.arcElement.elementQname # type: ignore[attr-defined, no-any-return]
 
     @property
     def qname(self) -> QName:
         """(QName) -- Property proxy for qname of arc element"""
-        return self.arcElement.qname
+        return self.arcElement.qname  # type: ignore[no-any-return]
 
     def itersiblings(self, **kwargs: Any) -> Any:
         """Method proxy for itersiblings() of lxml arc element"""
@@ -1917,17 +1917,17 @@ class ModelRelationship(ModelObject):
 
     def getparent(self) -> ModelObject:
         """(_ElementBase) -- Method proxy for getparent() of lxml arc element"""
-        return self.arcElement.getparent() # type: ignore[attr-defined]
+        return self.arcElement.getparent() # type: ignore[attr-defined, no-any-return]
 
     @property
     def fromLabel(self) -> str | None:
         """(str) -- Value of xlink:from attribute"""
-        return self.arcElement.get("{http://www.w3.org/1999/xlink}from") # type: ignore[attr-defined]
+        return self.arcElement.get("{http://www.w3.org/1999/xlink}from") # type: ignore[attr-defined, no-any-return]
 
     @property
     def toLabel(self) -> str | None:
         """(str) -- Value of xlink:to attribute"""
-        return self.arcElement.get("{http://www.w3.org/1999/xlink}to") # type: ignore[attr-defined]
+        return self.arcElement.get("{http://www.w3.org/1999/xlink}to") # type: ignore[attr-defined, no-any-return]
 
     @property
     def fromLocator(self) -> ModelLocator | None:
@@ -1958,13 +1958,13 @@ class ModelRelationship(ModelObject):
     @property
     def arcrole(self) -> str:
         """(str) -- Value of xlink:arcrole attribute"""
-        return self.arcElement.get("{http://www.w3.org/1999/xlink}arcrole")  # type: ignore[attr-defined]
+        return self.arcElement.get("{http://www.w3.org/1999/xlink}arcrole")  # type: ignore[attr-defined, no-any-return]
 
     @property
     def order(self) -> float:
         """(float) -- Value of xlink:order attribute, or 1.0 if not specified"""
         try:
-            return self.arcElement._order # type: ignore[attr-defined]
+            return self.arcElement._order # type: ignore[attr-defined, no-any-return]
         except AttributeError:
             o = self.arcElement.get("order") # type: ignore[attr-defined]
             if o is None:
@@ -1989,7 +1989,7 @@ class ModelRelationship(ModelObject):
     def priority(self) -> int:
         """(int) -- Value of xlink:order attribute, or 0 if not specified"""
         try:
-            return self.arcElement._priority # type: ignore[attr-defined]
+            return self.arcElement._priority # type: ignore[attr-defined, no-any-return]
         except AttributeError:
             p = self.arcElement.get("priority") # type: ignore[attr-defined]
             if p is None:
@@ -2007,7 +2007,7 @@ class ModelRelationship(ModelObject):
     def weight(self) -> float | None:
         """(float) -- Value of xlink:weight attribute, NaN if not convertable to float, or None if not specified"""
         try:
-            return self.arcElement._weight # type: ignore[attr-defined]
+            return self.arcElement._weight # type: ignore[attr-defined, no-any-return]
         except AttributeError:
             w = self.arcElement.get("weight") # type: ignore[attr-defined]
             if w is None:
@@ -2025,7 +2025,7 @@ class ModelRelationship(ModelObject):
     def weightDecimal(self) -> decimal.Decimal | None:
         """(decimal) -- Value of xlink:weight attribute, NaN if not convertable to float, or None if not specified"""
         try:
-            return self.arcElement._weightDecimal # type: ignore[attr-defined]
+            return self.arcElement._weightDecimal # type: ignore[attr-defined, no-any-return]
         except AttributeError:
             w = self.arcElement.get("weight") # type: ignore[attr-defined]
             if w is None:
@@ -2042,7 +2042,7 @@ class ModelRelationship(ModelObject):
     @property
     def use(self) -> str | None:
         """(str) -- Value of use attribute"""
-        return self.get("use")
+        return self.get("use")  # type: ignore[no-any-return]
 
     @property
     def isProhibited(self) -> bool:
@@ -2057,7 +2057,7 @@ class ModelRelationship(ModelObject):
     @property
     def preferredLabel(self) -> str | None:
         """(str) -- preferredLabel attribute or None if absent"""
-        return self.get("preferredLabel")
+        return self.get("preferredLabel")  # type: ignore[no-any-return]
 
     @property
     def variablename(self) -> str | None:
@@ -2068,27 +2068,27 @@ class ModelRelationship(ModelObject):
     def variableQname(self) -> QName:
         """(QName) -- resolved name for a formula (or other arc) having a QName name attribute"""
         varName = self.variablename
-        return ModelValue.qname(self.arcElement, varName, noPrefixIsNoNamespace=True) if varName else None
+        return ModelValue.qname(self.arcElement, varName, noPrefixIsNoNamespace=True) if varName else None  # type: ignore[no-any-return]
 
     @property
     def linkrole(self) -> str:
         """(str) -- Value of xlink:role attribute of parent extended link element"""
-        return self.arcElement.getparent().get("{http://www.w3.org/1999/xlink}role") # type: ignore[attr-defined]
+        return self.arcElement.getparent().get("{http://www.w3.org/1999/xlink}role") # type: ignore[attr-defined, no-any-return]
 
     @property
     def linkQname(self) -> QName:
         """(QName) -- qname of the parent extended link element"""
-        return self.arcElement.getparent().elementQname # type: ignore[attr-defined]
+        return self.arcElement.getparent().elementQname # type: ignore[attr-defined, no-any-return]
 
     @property
     def contextElement(self) -> str:
         """(str) -- Value of xbrldt:contextElement attribute (on applicable XDT arcs)"""
-        return self.get("{http://xbrl.org/2005/xbrldt}contextElement")
+        return self.get("{http://xbrl.org/2005/xbrldt}contextElement")  # type: ignore[no-any-return]
 
     @property
     def targetRole(self) -> str:
         """(str) -- Value of xbrldt:targetRole attribute (on applicable XDT arcs)"""
-        return self.get("{http://xbrl.org/2005/xbrldt}targetRole")
+        return self.get("{http://xbrl.org/2005/xbrldt}targetRole")  # type: ignore[no-any-return]
 
     @property
     def consecutiveLinkrole(self) -> str:

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -440,7 +440,7 @@ class ModelXbrl:
         modelRoles  = self.roleTypes.get(roleURI, ())
         if modelRoles:
             _roleType: ModelRoleType = modelRoles[0]
-            return cast(str, _roleType.genLabel(lang=lang, strip=True) or _roleType.definition or self.roleUriTitle(roleURI))
+            return _roleType.genLabel(lang=lang, strip=True) or _roleType.definition or self.roleUriTitle(roleURI)
         return self.roleUriTitle(roleURI)
 
     def roleTypeName(self, roleURI: str, lang: str | None = None) -> str:

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -203,8 +203,8 @@ class ValidateXbrl:
                                 _("Calculation relationship has zero weight from %(source)s to %(target)s in link role %(linkrole)s"),
                                 modelObject=modelRel,
                                 source=fromConcept.qname, target=toConcept.qname, linkrole=ELR),
-                        fromBalance = fromConcept.balance
-                        toBalance = toConcept.balance
+                        fromBalance = fromConcept.balance # type: ignore[attr-defined]
+                        toBalance = toConcept.balance # type: ignore[attr-defined]
                         if fromBalance and toBalance:
                             if (fromBalance == toBalance and weight < 0) or \
                                (fromBalance != toBalance and weight > 0):
@@ -215,13 +215,13 @@ class ValidateXbrl:
                                     source=fromConcept.qname, target=toConcept.qname, linkrole=ELR,
                                     sourceBalance=fromBalance, targetBalance=toBalance,
                                     messageCodes=("xbrl.5.1.1.2:balanceCalcWeightIllegalNegative", "xbrl.5.1.1.2:balanceCalcWeightIllegalPositive"))
-                        if not fromConcept.isNumeric or not toConcept.isNumeric:
+                        if not fromConcept.isNumeric or not toConcept.isNumeric: # type: ignore[attr-defined]
                             modelXbrl.error("xbrl.5.2.5.2:nonNumericCalc",
                                 _("Calculation relationship has illegal concept from %(source)s%(sourceNumericDecorator)s to %(target)s%(targetNumericDecorator)s in link role %(linkrole)s"),
                                 modelObject=modelRel,
                                 source=fromConcept.qname, target=toConcept.qname, linkrole=ELR,
-                                sourceNumericDecorator="" if fromConcept.isNumeric else _(" (non-numeric)"),
-                                targetNumericDecorator="" if toConcept.isNumeric else _(" (non-numeric)"))
+                                sourceNumericDecorator="" if fromConcept.isNumeric else _(" (non-numeric)"), # type: ignore[attr-defined]
+                                targetNumericDecorator="" if toConcept.isNumeric else _(" (non-numeric)")) # type: ignore[attr-defined]
             # check presentation relationships for preferredLabel issues
             elif arcrole == XbrlConst.parentChild:
                 for modelRel in relsSet.modelRelationships:
@@ -248,13 +248,13 @@ class ValidateXbrl:
                     fromConcept = modelRel.fromModelObject
                     toConcept = modelRel.toModelObject
                     if fromConcept is not None and toConcept is not None:
-                        if fromConcept.type != toConcept.type or fromConcept.periodType != toConcept.periodType:
+                        if fromConcept.type != toConcept.type or fromConcept.periodType != toConcept.periodType: # type: ignore[attr-defined]
                             modelXbrl.error("xbrl.5.2.6.2.2:essenceAliasTypes",
                                 _("Essence-alias relationship from %(source)s to %(target)s in link role %(linkrole)s has different types or periodTypes"),
                                 modelObject=modelRel,
                                 source=fromConcept.qname, target=toConcept.qname, linkrole=ELR)
-                        fromBalance = fromConcept.balance
-                        toBalance = toConcept.balance
+                        fromBalance = fromConcept.balance # type: ignore[attr-defined]
+                        toBalance = toConcept.balance # type: ignore[attr-defined]
                         if fromBalance and toBalance:
                             if fromBalance and toBalance and fromBalance != toBalance:
                                 modelXbrl.error("xbrl.5.2.6.2.2:essenceAliasBalance",  # type: ignore[func-returns-value]

--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -140,7 +140,7 @@ def checkFilingDimensions(val: ValidateXbrl) -> None:
                 val.modelXbrl.error("ESEF.3.3.1.anchoringRelationshipsForDomainMembersDefinedUsingWiderNarrowerArcrole",
                     _("Anchoring relationships MUST be from and to concepts, from %(qname1)s to %(qname2)s"),
                     modelObject=(anchoringRel, fromObj, toObj), qname1=fromObj.qname, qname2=toObj.qname)
-            elif fromObj.isDimensionItem or toObj.isDimensionItem:
+            elif fromObj.isDimensionItem or toObj.isDimensionItem: # type: ignore[attr-defined]
                 val.modelXbrl.error("ESEF.3.3.1.anchoringRelationshipsForDimensionsDefinedUsingWiderNarrowerArcrole",
                     _("Anchoring relationships MUST be from and to concepts, from %(qname1)s to %(qname2)s"),
                     modelObject=(anchoringRel, fromObj, toObj), qname1=fromObj.qname, qname2=toObj.qname)

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -936,15 +936,15 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     fr = rel.fromModelObject
                     to = rel.toModelObject
                     if arcrole in (parentChild, summationItem):
-                        if fr is not None and not fr.isAbstract and fr not in conceptsUsed and isExtension(val, rel):
+                        if fr is not None and not fr.isAbstract and fr not in conceptsUsed and isExtension(val, rel): # type: ignore[attr-defined]
                             unreportedLbElts.add(fr)
-                        if to is not None and not to.isAbstract and to not in conceptsUsed and isExtension(val, rel):
+                        if to is not None and not to.isAbstract and to not in conceptsUsed and isExtension(val, rel): # type: ignore[attr-defined]
                             unreportedLbElts.add(to)
                     elif arcrole in (hc_all, domainMember, dimensionDomain):
                         # all primary items
-                        if fr is not None and not fr.isAbstract and rel.isUsable and fr not in conceptsUsed and isExtension(val, rel) and not fr.type.isDomainItemType:
+                        if fr is not None and not fr.isAbstract and rel.isUsable and fr not in conceptsUsed and isExtension(val, rel) and not fr.type.isDomainItemType: # type: ignore[attr-defined]
                             unreportedLbElts.add(to)
-                        if to is not None and not to.isAbstract and rel.isUsable and to not in conceptsUsed and isExtension(val, rel) and not to.type.isDomainItemType:
+                        if to is not None and not to.isAbstract and rel.isUsable and to not in conceptsUsed and isExtension(val, rel) and not to.type.isDomainItemType: # type: ignore[attr-defined]
                             unreportedLbElts.add(to)
                     reportedEltsNotInLb.discard(fr)
                     reportedEltsNotInLb.discard(to)

--- a/arelle/plugin/validate/ESEF_2022/Dimensions.py
+++ b/arelle/plugin/validate/ESEF_2022/Dimensions.py
@@ -141,7 +141,7 @@ def checkFilingDimensions(val: ValidateXbrl) -> None:
                 val.modelXbrl.error("ESEF.3.3.1.anchoringRelationshipsForDomainMembersDefinedUsingWiderNarrowerArcrole",
                     _("Anchoring relationships MUST be from and to concepts, from %(qname1)s to %(qname2)s"),
                     modelObject=(anchoringRel, fromObj, toObj), qname1=fromObj.qname, qname2=toObj.qname)
-            elif fromObj.isDimensionItem or toObj.isDimensionItem:
+            elif fromObj.isDimensionItem or toObj.isDimensionItem: # type: ignore[attr-defined]
                 val.modelXbrl.error("ESEF.3.3.1.anchoringRelationshipsForDimensionsDefinedUsingWiderNarrowerArcrole",
                     _("Anchoring relationships MUST be from and to concepts, from %(qname1)s to %(qname2)s"),
                     modelObject=(anchoringRel, fromObj, toObj), qname1=fromObj.qname, qname2=toObj.qname)

--- a/arelle/plugin/validate/ESEF_2022/__init__.py
+++ b/arelle/plugin/validate/ESEF_2022/__init__.py
@@ -983,15 +983,15 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     fr = rel.fromModelObject
                     to = rel.toModelObject
                     if arcrole in (parentChild, summationItem):
-                        if fr is not None and not fr.isAbstract and fr not in conceptsUsed and isExtension(val, rel):
+                        if fr is not None and not fr.isAbstract and fr not in conceptsUsed and isExtension(val, rel): # type: ignore[attr-defined]
                             unreportedLbElts.add(fr)
-                        if to is not None and not to.isAbstract and to not in conceptsUsed and isExtension(val, rel):
+                        if to is not None and not to.isAbstract and to not in conceptsUsed and isExtension(val, rel): # type: ignore[attr-defined]
                             unreportedLbElts.add(to)
                     elif arcrole in (hc_all, domainMember, dimensionDomain):
                         # all primary items
-                        if fr is not None and not fr.isAbstract and rel.isUsable and fr not in conceptsUsed and isExtension(val, rel) and not fr.type.isDomainItemType:
+                        if fr is not None and not fr.isAbstract and rel.isUsable and fr not in conceptsUsed and isExtension(val, rel) and not fr.type.isDomainItemType: # type: ignore[attr-defined]
                             unreportedLbElts.add(to)
-                        if to is not None and not to.isAbstract and rel.isUsable and to not in conceptsUsed and isExtension(val, rel) and not to.type.isDomainItemType:
+                        if to is not None and not to.isAbstract and rel.isUsable and to not in conceptsUsed and isExtension(val, rel) and not to.type.isDomainItemType: # type: ignore[attr-defined]
                             unreportedLbElts.add(to)
                     reportedEltsNotInLb.discard(fr)
                     reportedEltsNotInLb.discard(to)
@@ -1017,9 +1017,9 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
             to = rel.toModelObject
 
             if fr is not None and to is not None:
-                if to.isAbstract and isExtension(val, fr):
+                if to.isAbstract and isExtension(val, fr): # type: ignore[attr-defined]
                     anchoringToAbstractConcept.add(fr)
-                if fr.isAbstract and isExtension(val, to):
+                if fr.isAbstract and isExtension(val, to): # type: ignore[attr-defined]
                     anchoringToAbstractConcept.add(to)
 
         for _elem in anchoringToAbstractConcept:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ module = [
     'arelle.Cntlr',
     'arelle.FileSource',
     'arelle.Locale',
+    'arelle.ModelDtsObject',
     'arelle.ModelObject',
     'arelle.ModelXbrl',
     'arelle.ModelValue',


### PR DESCRIPTION
#### Reason for change
Adding type hints.

#### Description of change
Closes #534.

There are quite a few `type: ignore` in here. I believe most of them can be removed when type hints are added to `ModelDocument`.

#### Steps to Test

**review**:
@Arelle/arelle
