### PR TITLE
CIPC reportingModuleAmbiguous validation error with https schema refs

### DIFF
--- a/arelle/plugin/validate/CIPC/__init__.py
+++ b/arelle/plugin/validate/CIPC/__init__.py
@@ -23,7 +23,7 @@ cipcBlockedInlineHtmlElements = {
     'object', 'script'}
 
 namePattern = re.compile(r"^(.*) - ((18|19|20)\d{2}-[0-9]+-(06|07|08|09|10|12|20|21|22|23|24|25|26|30|31)) - (20[1-9]\d)$")
-reportingModulePattern = re.compile(r"http://xbrl.cipc.co.za/taxonomy/.*/\w*(ca_fas|full_ifrs|ifrs_for_smes)\w*[_-]20[12][0-9]-[0-9]{2}-[0-9]{2}.xsd")
+reportingModulePattern = re.compile(r"https?://xbrl.cipc.co.za/taxonomy/.*/\w*(ca_fas|full_ifrs|ifrs_for_smes)\w*[_-]20[12][0-9]-[0-9]{2}-[0-9]{2}.xsd")
 
 def dislosureSystemTypes(disclosureSystem, *args, **kwargs):
     # return ((disclosure system name, variable name), ...)


### PR DESCRIPTION
#### Reason for change
CIPC uses schema ref http matching to determine the reporting module, but doesn't handle https schema refs.

`https://xbrl.cipc.co.za/taxonomy/2022-09-30/rep/cipc/full_cipc_entry_point_full_ifrs_2022-09-30.xsd`
vs.
`http://xbrl.cipc.co.za/taxonomy/2022-09-30/rep/cipc/full_cipc_entry_point_full_ifrs_2022-09-30.xsd`
> [cipc:reportingModuleAmbiguous] Reporting module must specify namespace for FAS, IFRS-FULL or IFRS-SMES - wk - 1234-123456-12 - 2022.xhtml 133

#### Description of change
Changes the CIPC reporting module pattern to match both http and https.

#### Steps to Test
1. `python arelleCmdLine.py -f cipc-https-schema-ref.zip --plugins validate/CIPC --validate --disclosureSystem cipc`
2. Verify `cipc:reportingModuleAmbiguous` validation error isn't recorded

[cipc-https-schema-ref.zip](https://github.com/Arelle/Arelle/files/10440846/cipc-https-schema-ref.zip)

**review**:
@Arelle/arelle
