### PR TITLE
Remove ESEF.2.5.1.imageInIXbrlElementNotEmbedded validation error

### DIFF
--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -402,8 +402,6 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                     (modelXbrl.modelDocument.xmlRootElement,)): # plain xhtml filing
                 ixNStag = getattr(ixdsHtmlRootElt.modelDocument, "ixNStag", ixbrl11)
                 ixTags = set(ixNStag + ln for ln in ("nonNumeric", "nonFraction", "references", "relationship"))
-                ixTextTags = set(ixNStag + ln for ln in ("nonFraction", "continuation", "footnote"))
-                ixExcludeTag = ixNStag + "exclude"
                 ixTupleTag = ixNStag + "tuple"
                 ixFractionTag = ixNStag + "fraction"
 
@@ -430,15 +428,6 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                 modelObject=elt, element=eltTag)
                         elif eltTag == "img":
                             src = elt.get("src","").strip()
-                            hasParentIxTextTag = False # check if image is in an ix text-bearing element
-                            _ancestorElt = elt
-                            while (_ancestorElt is not None):
-                                if _ancestorElt.tag == ixExcludeTag: # excluded from any parent text-bearing ix element
-                                    break
-                                if _ancestorElt.tag in ixTextTags:
-                                    hasParentIxTextTag = True
-                                    break
-                                _ancestorElt = _ancestorElt.getparent()
                             if scheme(src) in ("http", "https", "ftp"):
                                 modelXbrl.error("ESEF.4.1.6.xHTMLDocumentContainsExternalReferences" if val.unconsolidated
                                                 else "ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences",
@@ -446,31 +435,26 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                     modelObject=elt, element=eltTag,
                                     messageCodes=("ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences", "ESEF.4.1.6.xHTMLDocumentContainsExternalReferences"))
                             elif not src.startswith("data:image"):
-                                if hasParentIxTextTag:
-                                    modelXbrl.error("ESEF.2.5.1.imageInIXbrlElementNotEmbedded",
-                                        _("Images appearing within an inline XBRL element MUST be embedded regardless of their size."),
-                                        modelObject=elt)
-                                else:
-                                    # presume it to be an image file, check image contents
-                                    try:
-                                        base = elt.modelDocument.baseForElement(elt)
-                                        normalizedUri = elt.modelXbrl.modelManager.cntlr.webCache.normalizeUrl(src, base)
-                                        if not elt.modelXbrl.fileSource.isInArchive(normalizedUri):
-                                            normalizedUri = elt.modelXbrl.modelManager.cntlr.webCache.getfilename(normalizedUri)
-                                        imglen = 0
-                                        with elt.modelXbrl.fileSource.file(normalizedUri,binary=True)[0] as fh:
-                                            imgContents = fh.read()
-                                            imglen += len(imgContents)
-                                            checkImageContents(modelXbrl, elt, os.path.splitext(src)[1], True, imgContents)
-                                            imgContents = None # deref, may be very large
-                                        #if imglen < browserMaxBase64ImageLength:
-                                        #    modelXbrl.error("ESEF.2.5.1.imageIncludedAndNotEmbeddedAsBase64EncodedString",
-                                        #        _("Images MUST be included in the XHTML document as a base64 encoded string unless their size exceeds support of browsers (%(maxImageSize)s): %(file)s."),
-                                        #        modelObject=elt, maxImageSize=browserMaxBase64ImageLength, file=os.path.basename(normalizedUri))
-                                    except IOError as err:
-                                        modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",
-                                            _("Image file which isn't openable '%(src)s', error: %(error)s"),
-                                            modelObject=elt, src=src, error=err)
+                                # presume it to be an image file, check image contents
+                                try:
+                                    base = elt.modelDocument.baseForElement(elt)
+                                    normalizedUri = elt.modelXbrl.modelManager.cntlr.webCache.normalizeUrl(src, base)
+                                    if not elt.modelXbrl.fileSource.isInArchive(normalizedUri):
+                                        normalizedUri = elt.modelXbrl.modelManager.cntlr.webCache.getfilename(normalizedUri)
+                                    imglen = 0
+                                    with elt.modelXbrl.fileSource.file(normalizedUri,binary=True)[0] as fh:
+                                        imgContents = fh.read()
+                                        imglen += len(imgContents)
+                                        checkImageContents(modelXbrl, elt, os.path.splitext(src)[1], True, imgContents)
+                                        imgContents = None # deref, may be very large
+                                    #if imglen < browserMaxBase64ImageLength:
+                                    #    modelXbrl.error("ESEF.2.5.1.imageIncludedAndNotEmbeddedAsBase64EncodedString",
+                                    #        _("Images MUST be included in the XHTML document as a base64 encoded string unless their size exceeds support of browsers (%(maxImageSize)s): %(file)s."),
+                                    #        modelObject=elt, maxImageSize=browserMaxBase64ImageLength, file=os.path.basename(normalizedUri))
+                                except IOError as err:
+                                    modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",
+                                        _("Image file which isn't openable '%(src)s', error: %(error)s"),
+                                        modelObject=elt, src=src, error=err)
                             else:
                                 m = imgDataMediaBase64Pattern.match(src)
                                 if not m or not m.group(2):

--- a/arelle/plugin/validate/ESEF_2022/__init__.py
+++ b/arelle/plugin/validate/ESEF_2022/__init__.py
@@ -418,8 +418,6 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                     (modelXbrl.modelDocument.xmlRootElement,)): # plain xhtml filing
                 ixNStag = getattr(ixdsHtmlRootElt.modelDocument, "ixNStag", ixbrl11)
                 ixTags = set(ixNStag + ln for ln in ("nonNumeric", "nonFraction", "references", "relationship"))
-                ixTextTags = set(ixNStag + ln for ln in ("nonFraction", "continuation", "footnote"))
-                ixExcludeTag = ixNStag + "exclude"
                 ixTupleTag = ixNStag + "tuple"
                 ixFractionTag = ixNStag + "fraction"
                 hasAbsolutePositioning = False
@@ -448,15 +446,6 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                 modelObject=elt, element=eltTag)
                         elif eltTag == "img":
                             src = elt.get("src","").strip()
-                            hasParentIxTextTag = False # check if image is in an ix text-bearing element
-                            _ancestorElt = elt
-                            while (_ancestorElt is not None):
-                                if _ancestorElt.tag == ixExcludeTag: # excluded from any parent text-bearing ix element
-                                    break
-                                if _ancestorElt.tag in ixTextTags:
-                                    hasParentIxTextTag = True
-                                    break
-                                _ancestorElt = _ancestorElt.getparent()
                             if scheme(src) in ("http", "https", "ftp"):
                                 modelXbrl.error("ESEF.4.1.6.xHTMLDocumentContainsExternalReferences" if val.unconsolidated
                                                 else "ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences",
@@ -464,31 +453,26 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                     modelObject=elt, element=eltTag,
                                     messageCodes=("ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences", "ESEF.4.1.6.xHTMLDocumentContainsExternalReferences"))
                             elif not src.startswith("data:image"):
-                                if hasParentIxTextTag:
-                                    modelXbrl.error("ESEF.2.5.1.imageInIXbrlElementNotEmbedded",
-                                        _("Images appearing within an inline XBRL element MUST be embedded regardless of their size."),
-                                        modelObject=elt)
-                                else:
-                                    # presume it to be an image file, check image contents
-                                    try:
-                                        base = elt.modelDocument.baseForElement(elt)
-                                        normalizedUri = elt.modelXbrl.modelManager.cntlr.webCache.normalizeUrl(src, base)
-                                        if not elt.modelXbrl.fileSource.isInArchive(normalizedUri):
-                                            normalizedUri = elt.modelXbrl.modelManager.cntlr.webCache.getfilename(normalizedUri)
-                                        imglen = 0
-                                        with elt.modelXbrl.fileSource.file(normalizedUri,binary=True)[0] as fh:
-                                            imgContents = fh.read()
-                                            imglen += len(imgContents)
-                                            checkImageContents(modelXbrl, elt, os.path.splitext(src)[1], True, imgContents)
-                                            imgContents = None # deref, may be very large
-                                        #if imglen < browserMaxBase64ImageLength:
-                                        #    modelXbrl.error("ESEF.2.5.1.imageIncludedAndNotEmbeddedAsBase64EncodedString",
-                                        #        _("Images MUST be included in the XHTML document as a base64 encoded string unless their size exceeds support of browsers (%(maxImageSize)s): %(file)s."),
-                                        #        modelObject=elt, maxImageSize=browserMaxBase64ImageLength, file=os.path.basename(normalizedUri))
-                                    except IOError as err:
-                                        modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",
-                                            _("Image file which isn't openable '%(src)s', error: %(error)s"),
-                                            modelObject=elt, src=src, error=err)
+                                # presume it to be an image file, check image contents
+                                try:
+                                    base = elt.modelDocument.baseForElement(elt)
+                                    normalizedUri = elt.modelXbrl.modelManager.cntlr.webCache.normalizeUrl(src, base)
+                                    if not elt.modelXbrl.fileSource.isInArchive(normalizedUri):
+                                        normalizedUri = elt.modelXbrl.modelManager.cntlr.webCache.getfilename(normalizedUri)
+                                    imglen = 0
+                                    with elt.modelXbrl.fileSource.file(normalizedUri,binary=True)[0] as fh:
+                                        imgContents = fh.read()
+                                        imglen += len(imgContents)
+                                        checkImageContents(modelXbrl, elt, os.path.splitext(src)[1], True, imgContents)
+                                        imgContents = None # deref, may be very large
+                                    #if imglen < browserMaxBase64ImageLength:
+                                    #    modelXbrl.error("ESEF.2.5.1.imageIncludedAndNotEmbeddedAsBase64EncodedString",
+                                    #        _("Images MUST be included in the XHTML document as a base64 encoded string unless their size exceeds support of browsers (%(maxImageSize)s): %(file)s."),
+                                    #        modelObject=elt, maxImageSize=browserMaxBase64ImageLength, file=os.path.basename(normalizedUri))
+                                except IOError as err:
+                                    modelXbrl.error("ESEF.2.5.1.imageFileCannotBeLoaded",
+                                        _("Image file which isn't openable '%(src)s', error: %(error)s"),
+                                        modelObject=elt, src=src, error=err)
                             else:
                                 m = imgDataMediaBase64Pattern.match(src)
                                 if not m or not m.group(2):


### PR DESCRIPTION
#### Reason for change
Resolves #564. `imageInIXbrlElementNotEmbedded` was removed from the 2021 ESMA reporting manual.

#### Description of change
Remove the `ESEF.2.5.1.imageInIXbrlElementNotEmbedded` validation from both the 2021 and 2022 ESEF plugins

#### Steps to Test
* Verify ESEF conformance suite tests continue to pass in CI

**review**:
@Arelle/arelle @gmongelli 
