### PR TITLE
Support pip installed plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,4 @@ updates:
           - ">=6"
       - dependency-name: "cx_Freeze"
       - dependency-name: "packaging"
+      - dependency-name: "importlib_metadata"

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -496,7 +496,9 @@ def pluginClassMethods(className: str) -> Iterator[Callable[..., Any]]:
 def addPluginModule(url):
     moduleInfo = None
     unloaded_arelle_plugins = entry_points(group='arelle.plugin', name=url)
-    if unloaded_arelle_plugins and len(unloaded_arelle_plugins) == 1:
+    if unloaded_arelle_plugins:
+        if len(unloaded_arelle_plugins) != 1:
+            raise Exception(f'multiple pip installed plugins with name {url} in group arelle.plugin')
         pluginUrl = unloaded_arelle_plugins[0].load()
         moduleInfo = moduleModuleInfo(pluginUrl())
     if not moduleInfo or not moduleInfo.get("name"):

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -6,7 +6,10 @@ based on pull request 4
 '''
 from __future__ import annotations
 import os, sys, types, time, ast, importlib, io, json, gettext, traceback
-from importlib.metadata import entry_points
+if sys.version_info < (3, 8):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 import importlib.util
 import logging
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -498,7 +498,8 @@ def addPluginModule(url):
     unloaded_arelle_plugins = entry_points(group='arelle.plugin', name=url)
     if unloaded_arelle_plugins:
         if len(unloaded_arelle_plugins) != 1:
-            raise Exception(f'multiple pip installed plugins with name {url} in group arelle.plugin')
+            error_msg = f'Multiple pip installed plugins with name {url} in group arelle.plugin'
+            logPluginTrace(error_msg, logging.ERROR)
         pluginUrl = unloaded_arelle_plugins[0].load()
         moduleInfo = moduleModuleInfo(pluginUrl())
     if not moduleInfo or not moduleInfo.get("name"):

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -6,6 +6,7 @@ based on pull request 4
 '''
 from __future__ import annotations
 import os, sys, types, time, ast, importlib, io, json, gettext, traceback
+from importlib.metadata import entry_points
 import importlib.util
 import logging
 
@@ -71,6 +72,11 @@ def init(cntlr: Cntlr, loadPluginConfig: bool = True) -> None:
         pluginConfigChanged = False # don't save until something is added to pluginConfig
     modulePluginInfos = {}  # dict of loaded module pluginInfo objects by module names
     pluginMethodsForClasses = {} # dict by class of list of ordered callable function objects
+    unloaded_arelle_plugins = entry_points(group='arelle.plugin')
+    if unloaded_arelle_plugins:
+        for unloaded_plugin in unloaded_arelle_plugins:
+            plugin_url = unloaded_plugin.load()
+            addPluginModule(plugin_url())
 
 def reset():  # force reloading modules and plugin infos
     modulePluginInfos.clear()  # dict of loaded module pluginInfo objects by module names

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core modules
 certifi==2022.12.7
-importlib-metadata==6.0.0; python_version < "3.8"
+importlib-metadata==4.2; python_version < "3.8"
 lxml==4.9.2
 OpenPyXL==3.0.10
 pyparsing==3.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # core modules
 certifi==2022.12.7
+importlib-metadata==6.0.0; python_version < "3.8"
 lxml==4.9.2
 OpenPyXL==3.0.10
 pyparsing==3.0.9


### PR DESCRIPTION
There are a few things still up for discussion here, such as documentation, how to enable/disable ect. but this provides a proof of concept and starts the discussion

#### Description of change
Arelle can load and run pip-installed plugins

#### Steps to Test
Pip install corresponding ixbrl-viewer https://github.com/Workiva/ixbrl-viewer/pull/381 branch into this branch

1. Pull both this and https://github.com/Workiva/ixbrl-viewer/pull/381
2. pip install <PATH_TO_ixbrl-viewer-repo>
3. python arelleCmdLine.py -f filing.htm --save-viewer ixbrl-report-viewer.html --viewer-url https://cdn-prod.wdesk.com/ixbrl-viewer/1.1.44/ixbrlviewer.js

**review**:
@Arelle/arelle
