### PR TITLE
Only self-close selected XHTML elements

### DIFF
--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -181,7 +181,7 @@ def textNotStripped(element: ModelObject | PrototypeObject | None) -> str:
         return ""
     return element.textValue  # allows embedded comment nodes, returns '' if None
 
-def selfClosable(elt):
+def selfClosable(elt: ModelObject) -> bool:
     return elt.qname.localName in (
         'area', 'base', 'basefont', 'br', 'col', 'frame', 'hr', 'img',
         'input', 'isindex', 'link', 'meta', 'param'


### PR DESCRIPTION
#### Reason for change

Fixes #574 

#### Description of change

Before this change, all empty elements in `ix:nonNumeric` elements with `escape="true"` were self-closed.  With this change, only those these elements the following elements can be are closed: 'area', 'base', 'basefont', 'br', 'col', 'frame', 'hr', 'img','input', 'isindex', 'link', 'meta', 'param'.  This list is taken from https://www.w3.org/TR/html401/index/elements.html (empty elements).

#### Steps to Test

Create a nonNumeric tag like this:

```xml
<ix:nonNumeric name="eg:StringConcept" contextRef="c1" id="f100" escape="true">
    <div>                
Line 1<br></br>Line 2.  Empty div <div style="color: red"></div> Is this red?
    </div>
</ix:nonNumeric>
```

View the content of the fact in Arelle, and confirm that in the output, the `br` tag becomes `<br />` but the empty `div` remains `<div style="color: red"></div>`.  This is important because if the text block is rendered as HTML (rather than XHTML) a self-closed `div` would be treated as an opening tag, and the "is this red?" text would be incorrectly rendered in red.

**review**:
@Arelle/arelle
