### PR TITLE
IXDS target selection dialog for multi-target GUI loading

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -1320,8 +1320,8 @@ class ModelDocument:
         self.ixNStag = ixNStag = "{" + ixNS + "}" if ixNS else ""
         self.htmlBase = htmlBase
         ixdsTarget = getattr(self.modelXbrl, "ixdsTarget", None)
-        if not any(pluginMethod(self.modelXbrl) == False
-                   for pluginMethod in pluginClassMethods("ModelDocument.DiscoverIxdsDts")):
+        if all(pluginMethod(self.modelXbrl)
+               for pluginMethod in pluginClassMethods("ModelDocument.DiscoverIxdsDts")):
             # load referenced schemas and linkbases (before validating inline HTML
             for inlineElement in htmlElement.iterdescendants(tag=ixNStag + "references"):
                 if inlineElement.get("target") == ixdsTarget:

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -1320,11 +1320,13 @@ class ModelDocument:
         self.ixNStag = ixNStag = "{" + ixNS + "}" if ixNS else ""
         self.htmlBase = htmlBase
         ixdsTarget = getattr(self.modelXbrl, "ixdsTarget", None)
-        # load referenced schemas and linkbases (before validating inline HTML
-        for inlineElement in htmlElement.iterdescendants(tag=ixNStag + "references"):
-            if inlineElement.get("target") == ixdsTarget:
-                self.schemaLinkbaseRefsDiscover(inlineElement)
-                xmlValidate(self.modelXbrl, inlineElement) # validate instance elements
+        if not any(pluginMethod(self.modelXbrl) == False
+                   for pluginMethod in pluginClassMethods("ModelDocument.DiscoverIxdsDts")):
+            # load referenced schemas and linkbases (before validating inline HTML
+            for inlineElement in htmlElement.iterdescendants(tag=ixNStag + "references"):
+                if inlineElement.get("target") == ixdsTarget:
+                    self.schemaLinkbaseRefsDiscover(inlineElement)
+                    xmlValidate(self.modelXbrl, inlineElement) # validate instance elements
         # with DTS loaded, now validate inline HTML (so schema definition of facts is available)
         if htmlElement.namespaceURI == XbrlConst.xhtml:  # must validate xhtml
             XhtmlValidate.xhtmlValidate(self.modelXbrl, htmlElement)  # fails on prefixed content

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -1435,6 +1435,8 @@ class ModelDocument:
 # inline document set level compilation
 # modelIxdsDocument is an inlineDocumentSet or entry inline document (if not a document set)
 def inlineIxdsDiscover(modelXbrl, modelIxdsDocument):
+    for pluginMethod in pluginClassMethods("ModelDocument.SelectIxdsTarget"):
+        pluginMethod(modelXbrl)
     # extract for a single target document
     ixdsTarget = getattr(modelXbrl, "ixdsTarget", None)
     # compile inline result set

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -41,7 +41,7 @@ Example to load multi-document IXDS and save extracted xBRL-XML target document:
      Tools->Save Target Document
      replaced file PASS-multiple-input-multiple-output-ID1_extracted.xbrl now has TARGET target xBRL-XML instance
   For Command Line:
-     arelleCmdLine --plugin inlineXbrlDocumentSet 
+     arelleCmdLine --plugin inlineXbrlDocumentSet
                    --file '[{"ixds":[{"file":".../PASS-multiple-input-multiple-output-ID1.html"},
                                      {"file":".../PASS-multiple-input-multiple-output-ID2.html"}],
                              "ixdsTarget":"(default)"}]'

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -29,6 +29,28 @@ special value "(default)" for the default target (e.g., resources with no @targe
 
 For GUI instance loading a pop up selection dialog is provided when there is no formula parameter and there are multiple targets.
 
+Example to load multi-document IXDS and save extracted xBRL-XML target document:
+
+  For GUI using ix11 conformance suite directory multi-io test case "PASS-multiple-input-multiple-output"
+     File->Open File Inline Doc Set->multi-select PASS-multiple-input-multiple-output-ID1.html and PASS-multiple-input-multiple-output-ID2.html
+     Select Target -> (default)
+     Tools->Save Target Document
+     new file PASS-multiple-input-multiple-output-ID1_extracted.xbrl has (default) target xBRL-XML instance
+     close instance
+     Reopen as above and Select Target -> TARGET
+     Tools->Save Target Document
+     replaced file PASS-multiple-input-multiple-output-ID1_extracted.xbrl now has TARGET target xBRL-XML instance
+  For Command Line:
+     arelleCmdLine --plugin inlineXbrlDocumentSet 
+                   --file '[{"ixds":[{"file":".../PASS-multiple-input-multiple-output-ID1.html"},
+                                     {"file":".../PASS-multiple-input-multiple-output-ID2.html"}],
+                             "ixdsTarget":"(default)"}]'
+                   --saveInstance
+     For second target specify "ixdsTarget":"TARGET"
+     For default target either omit ixdsTarget or specify (default).
+     File will be saved as PASS-multiple-input-multiple-output-ID1_extracted.xbrl regardless of ixdsTarget parameter
+     For EDGAR style encoding of non-ASCII characters add --encodeSavedXmlChars
+
 See COPYRIGHT.md for copyright information.
 '''
 from arelle import FileSource, ModelXbrl, ValidateXbrlDimensions, XbrlConst

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -21,7 +21,7 @@ If the file source is a zip, CmdLine will discover the inline files in the zip a
 
 If the file source is a local directory, CmdLine will discover the inline files in the directory as thus:
     --file '[{"ixds":[{"file":dir1}]}]'
-    
+
 If there is a JSON structure in --file without ixdsTarget the default target is assumed.
 
 If no JSON structure then formula parameter ixdsTarget may be used to specify a non-default target or the
@@ -645,7 +645,7 @@ class TargetChoiceDialog:
         self.parent.focus_set()
         self.selection = self.lb.selection_get()
         self.t.destroy()
-        
+
 def selectTargetDocument(modelXbrl):
     if not hasattr(modelXbrl, "ixdsTarget"): # DTS discoverey deferred until all ix docs loaded
         # find target attributes
@@ -661,7 +661,7 @@ def selectTargetDocument(modelXbrl):
             _target = _targets[0]
             modelXbrl.warning("arelle:unspecifiedTargetDocument",
                               _("Target document not specified, loading %(target)s, found targets %(targets)s"),
-                              modelObject=modelXbrl, target=_target, targets=_targets)                        
+                              modelObject=modelXbrl, target=_target, targets=_targets)
         modelXbrl.ixdsTarget = None if _target == "(default)" else _target or None
         # load referenced schemas and linkbases (before validating inline HTML
         for htmlElt in modelXbrl.ixdsHtmlElements:


### PR DESCRIPTION
When loading an IXDS with multiple targets by GUI without ixdsTarget parameter a dialog is provided to select the desired target.

#### Reason for change
Prior operation required a formula parameter or command line operation.

#### Description of change
Dialog is provided to select target on loading multi-target IXDS from GUI without ixdsTarget parameter.

Documentation in header comment of plugin inlineDocumentSet.py needs to be transferred to arelle.org/pub documentation page(s).

Multi-target operation requires plugin inlineDocumentSet (auto-loaded by EdgarRenderer, validate/EFM and validate/ESEF plugins).

#### Steps to Test
IXDS test suite must still pass (of course!) (requires special test script setup as before this pull request).

Use multi-target single and multi-doc IXDSes, with resources in first or last doc, assure dialog works and formula parameter (tools->formula parameters) still work.

Use attached multi-target multi-doc test [multi-io.zip](https://github.com/Arelle/Arelle/files/10892704/multi-io.zip) to verify that with GUI interactive-user specification of target, which occurs only after all ix docs are loaded, that discovery only happens after this target selection.  (For scripted target selection the IXDS test suite is sufficient, because when target is known in advance of ix doc loading, discovery can proceed during ix doc loading vs after). 

 For ` --file '[{"ixds":[{"file":file1},{"file":file2}...],"ixdsTarget":"xyz"}]'` additional testing is suggested.

**review**:
@Arelle/arelle
