### PR TITLE
Render HTML in fact value tooltips

### DIFF
--- a/arelle/CntlrWinTooltip.py
+++ b/arelle/CntlrWinTooltip.py
@@ -38,6 +38,7 @@ create_contents() : creates the contents of the tooltip window (by default a Tki
 # Ideas gleaned from PySol
 
 import tkinter
+from tkhtmlview import HTMLLabel
 
 class ToolTip:
     def __init__(self, master, text='Your text here', delay=500, **opts):
@@ -153,7 +154,8 @@ class ToolTip:
         opts = self._opts.copy()
         for opt in ('delay', 'follow_mouse', 'state'):
             del opts[opt]
-        label = tkinter.Label(self._tipwindow, **opts)
+        #label = tkinter.Label(self._tipwindow, **opts)
+        label = HTMLLabel(self._tipwindow, html=opts["textvariable"].get() if opts["textvariable"] else opts["text"])
         label.pack()
 
 ##---------demo code-----------------------------------##
@@ -163,7 +165,9 @@ def demo():
     l = tkinter.Listbox(root)
     l.insert('end', "I'm a listbox")
     l.pack(side='top')
-    t1 = ToolTip(l, follow_mouse=1, text="I'm a tooltip with follow_mouse set to 1, so I won't be placed outside my parent")
+    t1 = ToolTip(l, follow_mouse=1, 
+                 text="<html><h1>title</h1><p>para</p><p>para2</p></html>")
+                 #text="I'm a tooltip with follow_mouse set to 1, so I won't be placed outside my parent")
     b = tkinter.Button(root, text='Quit', command=root.quit)
     b.pack(side='bottom')
     t2 = ToolTip(b, text='Enough of this')

--- a/arelle/CntlrWinTooltip.py
+++ b/arelle/CntlrWinTooltip.py
@@ -59,7 +59,7 @@ class ToolTip:
             self._id4 = self.master.bind("<Motion>", self.motion, '+')
             self._follow_mouse = 1
         self._htmlAware = False
-        
+
     def setHtmlAware(self):
         self._htmlAware = True
 
@@ -179,7 +179,7 @@ def demo():
     l = tkinter.Listbox(root)
     l.insert('end', "I'm a listbox")
     l.pack(side='top')
-    t1 = ToolTip(l, follow_mouse=1, 
+    t1 = ToolTip(l, follow_mouse=1,
                  text="<html><h1>title</h1><p>para</p><p>para2</p></html>")
                  #text="I'm a tooltip with follow_mouse set to 1, so I won't be placed outside my parent")
     b = tkinter.Button(root, text='Quit', command=root.quit)

--- a/arelle/ViewWinFactList.py
+++ b/arelle/ViewWinFactList.py
@@ -53,7 +53,7 @@ def viewFacts(modelXbrl, tabWin, lang=None):
 
 class ViewFactList(ViewWinTree.ViewTree):
     def __init__(self, modelXbrl, tabWin, lang):
-        super(ViewFactList, self).__init__(modelXbrl, tabWin, "Fact List", True, lang)
+        super(ViewFactList, self).__init__(modelXbrl, tabWin, "Fact List", ViewWinTree.HTML_TOOLTIP, lang)
 
     def setViewTupleChildMenuItem(self, event=None):
         if event is not None and self.menu is not None:

--- a/arelle/ViewWinFactTable.py
+++ b/arelle/ViewWinFactTable.py
@@ -40,7 +40,7 @@ def viewFacts(modelXbrl, tabWin, header="Fact Table", arcrole=XbrlConst.parentCh
 
 class ViewFactTable(ViewWinTree.ViewTree):
     def __init__(self, modelXbrl, tabWin, header, arcrole, linkrole=None, linkqname=None, arcqname=None, lang=None, expandAll=False):
-        super(ViewFactTable, self).__init__(modelXbrl, tabWin, header, True, lang)
+        super(ViewFactTable, self).__init__(modelXbrl, tabWin, header, ViewWinTree.HTML_TOOLTIP, lang)
         self.arcrole = arcrole
         self.linkrole = linkrole
         self.linkqname = linkqname
@@ -296,3 +296,11 @@ class ViewFactTable(ViewWinTree.ViewTree):
                 self.treeView.selection_set(())
             if self.blockViewModelObject > 0:
                 self.blockViewModelObject -= 1
+
+    def getToolTip(self, tvRowId, tvColId):
+        factId = self.rowColFactId.get(tvRowId + tvColId)
+        if factId:
+            modelFact = self.modelXbrl.modelObject(factId)
+            if isinstance(modelFact, ModelInstanceObject.ModelFact):
+                return modelFact.effectiveValue # for text blocks this includes unstripped HTML
+        return None

--- a/arelle/ViewWinTree.py
+++ b/arelle/ViewWinTree.py
@@ -9,6 +9,8 @@ except ImportError:
 from arelle.CntlrWinTooltip import ToolTip
 import os
 
+HTML_TOOLTIP = 2 # tooltip is aware that there may be HTML content
+
 class ViewTree:
     def __init__(self, modelXbrl, tabWin, tabTitle, hasToolTip=False, lang=None):
         self.tabWin = tabWin
@@ -63,6 +65,8 @@ class ViewTree:
                                    state="disabled")
             self.toolTipColId = None
             self.toolTipRowId = None
+            if hasToolTip == HTML_TOOLTIP:
+                self.toolTip.setHtmlAware()
         self.modelXbrl = modelXbrl
         self.lang = lang
         self.labelrole = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ isodate==0.6.1
 aniso8601==9.0.1
 CherryPy==18.8.0
 Cheroot==9.0.0
-tkhtmlview==0.1.3
+tkhtmlview==0.1.4
 # special note: pip install --no-cache --use-pep517 pycountry
 pycountry==22.3.5
 # plugins

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ isodate==0.6.1
 aniso8601==9.0.1
 CherryPy==18.8.0
 Cheroot==9.0.0
+tkhtmlview==0.1.3
 # special note: pip install --no-cache --use-pep517 pycountry
 pycountry==22.3.5
 # plugins


### PR DESCRIPTION
#### Reason for change
GUI fact list and fact table views weren't able to render HTML content.

#### Description of change
For ViewWinFactList, which showed fact values with HTML constructs, and for ViewWinFactTable, which showed fact values with HTML constructs stripped, provide HTML rendering in scrollable tooltip when there is HTML in the fact's effective value.

Currently uses [python library tkhtmlview](https://pypi.org/project/tkhtmlview/) which has limited html support (for example, no &lt;table> &lt;tr> &lt;td>).   

Note: when merged, tkhtmlview needs to be added to the library licenses documentation (MIT license).

#### Potential enhancement to tkhtmlview library
First attempt at adding table, tr, th and td to library, [use this module](https://github.com/hermfischer/tkhtmlview/blob/hermfischer-1/tkhtmlview/html_parser.py)


#### Alternate libraries
(A brief review of [Chromium Embedded Framework - cefpython](https://github.com/cztomczak/cefpython), shows full HTML support, but the library requires recompilation per platform on each minor release of both Python and Chrome engine, adds over 154MB to the build, eats RAM and 5 - 7 seconds on startup.)

#### Steps to Test
Ensure that fact list and fact table panes properly recognize when a cell has HTML content and use the scrollable HTML tooltip in those cases.

Ensure no other cells are HTML aware (e.g. formula linkbase pane should show XML content when tooltip is over formula linkbase constructs, such as in displaying the LEI package's formula view).

**review**:
@Arelle/arelle
