### PR TITLE
Git ignore new XULE module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ arelle/plugin/validate/DQC_US_Rules
 arelle/plugin/validate/DQC.py
 arelle/plugin/validate/eforms.py
 arelle/plugin/validate/ESEF-DQC.py
+arelle/plugin/Xince.py
 arelle/plugin/xule
 Arelle.egg-info
 arelleGUI.py


### PR DESCRIPTION
#### Reason for change
[Xince.py](https://github.com/xbrlus/xule/blob/main/plugin/Xince.py) is a new module in the XULE repo. It's useful to link the XULE repo into Arelle for dev purposes.

#### Description of change
Git ignore XULE Xince.py module that may be copied into working directory.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
