### PR TITLE
Formula Performance: cache fact aspect comparisons 

### DIFF
--- a/arelle/formula/FactAspectsCache.py
+++ b/arelle/formula/FactAspectsCache.py
@@ -1,0 +1,22 @@
+from collections import defaultdict
+
+
+class FactAspectsMatchCache:
+    def __init__(self):
+        self._matchingAspects = defaultdict(lambda : defaultdict(dict))
+
+    def evaluations(self, fact1, fact2):
+        return self._matchingAspects[fact1][fact2]
+
+    def cacheMatch(self, fact1, fact2, aspect):
+        self._register(fact1, fact2, aspect, True)
+
+    def cacheNotMatch(self, fact1, fact2, aspect):
+        self._register(fact1, fact2, aspect, False)
+
+    def _register(self, fact1, fact2, aspect, value):
+        self._matchingAspects[fact1][fact2][aspect] = value
+        self._matchingAspects[fact2][fact1][aspect] = value
+
+    def __repr__(self):
+        return f"FactAspectsMatchCache(matchingAspects={self._matchingAspects})"

--- a/arelle/formula/FormulaEvaluator.py
+++ b/arelle/formula/FormulaEvaluator.py
@@ -1080,11 +1080,11 @@ def evaluationIsUnnecessary(thisEval, xpCtx):
         # detects evaluations which are not different (duplicate) and extra fallback evaluations
         # vBoundFact may be single fact or tuple of facts
         return any(
-            all([
+            all(
                 vBoundFact == matchingEval[vQn]
                 for vQn, vBoundFact in thisEval.items()
                 if vBoundFact is not None and vQn not in vQnDependentOnOtherVarFallenBackButBoundInOtherEval
-            ]) for matchingEval in matchingEvals
+            ) for matchingEval in matchingEvals
         )
     return False
 

--- a/arelle/formula/ValidateFormula.py
+++ b/arelle/formula/ValidateFormula.py
@@ -39,6 +39,7 @@ from arelle.PluginManager import pluginClassMethods
 from arelle.PythonUtil import normalizeSpace
 from arelle.XmlValidate import validate as xml_validate
 from arelle.formula import XPathContext, XPathParser
+from arelle.formula.FactAspectsCache import FactAspectsMatchCache
 
 formulaIdWhitespacesSeparatedPattern = re.compile(r"(\w+\s)*(\w+)$")  # prenormalized IDs list
 
@@ -482,6 +483,7 @@ def validate(val, xpathContext=None, parametersOnly=False, statusMsg='', compile
 
     if xpathContext is None:
         xpathContext = XPathContext.create(val.modelXbrl)
+    xpathContext.factAspectsCache = FactAspectsMatchCache()
     xpathContext.parameterQnames = parameterQnames  # needed for formula filters to determine variable dependencies
     for paramQname in orderedParameters:
         modelParameter = val.modelXbrl.qnameParameters[paramQname]
@@ -932,6 +934,7 @@ def validate(val, xpathContext=None, parametersOnly=False, statusMsg='', compile
     for pluginXbrlMethod in pluginClassMethods("ValidateFormula.Finished"):
         pluginXbrlMethod(val)
 
+    del xpathContext.factAspectsCache
     instanceProducingVariableSets.clear()  # dereference
     parameterQnames.clear()
     instanceQnames.clear()

--- a/tests/unit_tests/arelle/formula/test_fact_aspects_cache.py
+++ b/tests/unit_tests/arelle/formula/test_fact_aspects_cache.py
@@ -1,0 +1,60 @@
+from arelle.formula.FactAspectsCache import FactAspectsMatchCache
+
+
+class TestFactAspectsMatchCache:
+    def test_match(self):
+        cache = FactAspectsMatchCache()
+        cache.cacheMatch("fact1", "fact2", "aspect")
+
+        fact1_evaluations = cache.evaluations("fact1", "fact2")
+        fact2_evaluations = cache.evaluations("fact2", "fact1")
+
+        assert all(evaluations == {"aspect": True} for evaluations in (fact1_evaluations, fact2_evaluations))
+
+    def test_non_match(self):
+        cache = FactAspectsMatchCache()
+        cache.cacheNotMatch("fact1", "fact2", "aspect")
+
+        fact1_evaluations = cache.evaluations("fact1", "fact2")
+        fact2_evaluations = cache.evaluations("fact2", "fact1")
+
+        assert all(evaluations == {"aspect": False} for evaluations in (fact1_evaluations, fact2_evaluations))
+
+    def test_mixed_evaluations(self):
+        cache = FactAspectsMatchCache()
+        cache.cacheMatch("fact1", "fact2", "aspect1")
+        cache.cacheNotMatch("fact1", "fact2", "aspect2")
+
+        evaluations = cache.evaluations("fact1", "fact2")
+
+        assert evaluations == {
+            "aspect1": True,
+            "aspect2": False,
+        }
+
+    def test_empty_cache(self):
+        cache = FactAspectsMatchCache()
+
+        evaluations = cache.evaluations("fact1", "fact2")
+
+        assert evaluations == {}
+
+    def test_additional_facts(self):
+        cache = FactAspectsMatchCache()
+
+        cache.cacheMatch("fact1", "fact2", "aspect1")
+        cache.cacheNotMatch("fact1", "fact2", "aspect2")
+        cache.cacheMatch("fact1", "fact2", "aspect3")
+
+        cache.cacheNotMatch("fact1", "fact3", "aspect1")
+        cache.cacheMatch("fact1", "fact3", "aspect2")
+
+        cache.cacheNotMatch("fact2", "fact3", "aspect1")
+
+        evaluations = cache.evaluations("fact1", "fact2")
+
+        assert evaluations == {
+            "aspect1": True,
+            "aspect2": False,
+            "aspect3": True,
+        }


### PR DESCRIPTION
#### Reason for change
Formula performance issues reported in #217 

#### Description of change
Improves formula performance by ~75% in the large doc provided in #217 by caching and avoiding reprocessing aspect comparisons.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
