### PR TITLE
Include ixbrl-viewer git history (tags) for version in build

### DIFF
--- a/.github/workflows/build-and-release-linux.yml
+++ b/.github/workflows/build-and-release-linux.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Checkout ixbrl-viewer
         uses: actions/checkout@v3.5.0
         with:
+          fetch-depth: 0
           repository: Workiva/ixbrl-viewer
           path: ixbrl-viewer
           ref: ${{ inputs.ixbrl_viewer_ref }}

--- a/.github/workflows/build-and-release-mac.yml
+++ b/.github/workflows/build-and-release-mac.yml
@@ -63,6 +63,7 @@ jobs:
           rm -rf tmp
       - uses: actions/checkout@v3.5.0
         with:
+          fetch-depth: 0
           repository: Workiva/ixbrl-viewer
           path: tmp/ixbrl-viewer
           ref: ${{ inputs.ixbrl_viewer_ref }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -103,6 +103,7 @@ jobs:
     - name: Checkout ixbrl-viewer
       uses: actions/checkout@v3.5.0
       with:
+        fetch-depth: 0
         repository: Workiva/ixbrl-viewer
         path: ixbrl-viewer
         ref: ${{ inputs.ixbrl_viewer_ref }}


### PR DESCRIPTION
#### Reason for change
The ixbrl-viewer build (`npm run prod`) requires the project git history (tags) in order to include the version.

#### Description of change
Checks out the ixbrl-viewer repo with its full history in our build workflows.

#### Steps to Test
* ci

**review**:
@Arelle/arelle
