### PR TITLE
SEC: expand JPEG header detection

### DIFF
--- a/arelle/ValidateFilingText.py
+++ b/arelle/ValidateFilingText.py
@@ -924,10 +924,8 @@ class TextBlockHandler(xml.sax.ContentHandler, xml.sax.ErrorHandler):
              error=err.getMessage(), line=err.getLineNumber(), column=err.getColumnNumber())
 '''
 
-def validateGraphicHeaderType(data):
-    # Support both JFIF APP0 (0xffe0 + 'JFIF') and APP1 Exif (0xffe1 + 'Exif') JPEG application segment types
-    if ((data[:4] == b'\xff\xd8\xff\xe0' and data[6:11] == b'JFIF\0') or
-        (data[:4] == b'\xff\xd8\xff\xe1' and data[6:11] == b'Exif\0')):
+def validateGraphicHeaderType(data: bytes) -> str:
+    if data[:2] == b"\xff\xd8":
         return "jpg"
     elif data[:3] == b"GIF" and data[3:6] in (b'89a', b'89b', b'87a'):
         return "gif"


### PR DESCRIPTION
#### Reason for change
This patch should be adopted by the SEC before we merge into master to make sure validations stay in sync with live filings.

#### Description of change
App0 and App1 are not the only valid JPEG application segments. The prior implementation is causing files saved in Photoshop to be flagged as invalid. 

#### Steps to Test
* Validate [filing_documents.zip](https://github.com/Arelle/Arelle/files/11116065/filing_documents.zip) and confirm `[EFM.5.02.05.graphicFileContent]` isn't logged for the embedded image.
* `python arelleCmdLine.py -f ./filing_documents.zip --validate --plugins=validate/EFM --disclosureSystem efm-pragmatic`

**review**:
@Arelle/arelle
