### PR TITLE
ESEF: expand JPEG header detection

### DIFF
--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -81,8 +81,7 @@ def checkImageContents(modelXbrl: ModelXbrl, imgElt: ModelObject, imgType: str, 
     else:
         if data[:3] == b"GIF" and data[3:6] in (b'89a', b'89b', b'87a'):
             headerType = "gif"
-        elif ((data[:4] == b'\xff\xd8\xff\xe0' and data[6:11] == b'JFIF\x00') or
-              (data[:4] == b'\xff\xd8\xff\xe1' and data[6:11] == b'Exif\x00')):
+        elif data[:2] == b"\xff\xd8":
             headerType = "jpg"
         elif data[:8] == b"\x89PNG\r\n\x1a\n":
             headerType = "png"

--- a/arelle/plugin/validate/ESEF_2022/Util.py
+++ b/arelle/plugin/validate/ESEF_2022/Util.py
@@ -89,8 +89,7 @@ def checkImageContents(modelXbrl: ModelXbrl, imgElt: ModelObject, imgType: str, 
     else:
         if data[:3] == b"GIF" and data[3:6] in (b'89a', b'89b', b'87a'):
             headerType = "gif"
-        elif ((data[:4] == b'\xff\xd8\xff\xe0' and data[6:11] == b'JFIF\x00') or
-              (data[:4] == b'\xff\xd8\xff\xe1' and data[6:11] == b'Exif\x00')):
+        elif data[:2] == b"\xff\xd8":
             headerType = "jpg"
         elif data[:8] == b"\x89PNG\r\n\x1a\n":
             headerType = "png"


### PR DESCRIPTION
#### Reason for change
Unlike #633 for the SEC this PR can be merged now. 

#### Description of change
App0 and App1 are no longer the only valid JPEG application segments. The prior implementation is causing files saved in Photoshop to be flagged as invalid.

#### Steps to Test
* ESEF CI

**review**:
@Arelle/arelle
