### PR TITLE
Update type casts to support Python 3.7 syntax

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -7,7 +7,7 @@ import os, sys, traceback, uuid
 import regex as re
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Type, TypeVar, cast, Optional
+from typing import Dict, TYPE_CHECKING, Any, Type, TypeVar, Union, cast, Optional
 import logging
 from decimal import Decimal
 from arelle import UrlUtil, XmlUtil, ModelValue, XbrlConst, XmlValidate
@@ -655,7 +655,7 @@ class ModelXbrl:
                         _("Create context for %(priItem)s, cannot determine valid context elements, no suitable hypercubes"),
                         modelObject=self, priItem=priItem)
                     # fp.context.qnameDims is actually of type Dict[QName, DimValuePrototype]
-                fpDims = cast('dict[int | QName, QName | DimValuePrototype]', fp.context.qnameDims)
+                fpDims = cast(Dict[Union[int, 'QName'], Union['QName', DimValuePrototype]], fp.context.qnameDims)
             else:
                 fpDims = dims # dims known to be valid (such as for inline extraction)
             for dimQname in sorted(fpDims.keys()):

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -3,7 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 import regex as re
-from typing import Any, Union, cast
+from typing import Any, List, Set, Union, cast
 from arelle import (XmlUtil, XbrlUtil, XbrlConst,
                 ValidateXbrlCalcs, ValidateXbrlDimensions, ValidateXbrlDTS, ValidateUtr)
 from arelle.formula import ValidateFormula
@@ -167,7 +167,7 @@ class ValidateXbrl:
                 noUndirected = cyclesAllowed == "none"
                 fromRelationships = relsSet.fromModelObjects()
                 for relFrom, rels in fromRelationships.items():
-                    cycleFound = cast(list[ModelRelationship], self.fwdCycle(relsSet, rels, noUndirected, {relFrom}))
+                    cycleFound = cast(List[ModelRelationship], self.fwdCycle(relsSet, rels, noUndirected, {relFrom}))
 
                     if cycleFound is not None:
                         pathEndsAt = len(cycleFound)  # consistently find start of path
@@ -446,7 +446,7 @@ class ValidateXbrl:
             self.factsWithDeprecatedIxNamespace = []
             factFootnoteRefs = set()
             undefinedFacts = []
-            for f in cast(set[ModelInlineFact], modelXbrl.factsInInstance):
+            for f in cast(Set[ModelInlineFact], modelXbrl.factsInInstance):
                 for footnoteID in f.footnoteRefs:
                     if footnoteID not in self.ixdsFootnotes:
                         modelXbrl.error(ixMsgCode("footnoteRef", f, name="footnote", sect="validation"),
@@ -816,7 +816,7 @@ class ValidateXbrl:
                         #            _("Fact %(fact)s value %(value)s context %(contextID)s rounding exception %(error)s"),
                         #            modelObject=f, fact=f.qname, value=f.value, contextID=f.contextID, error = err)
                     if self.validateEnum and concept.isEnumeration and getattr(f,"xValid", 0) == 4 and not f.isNil:
-                        _qnEnums = cast(Union[list[QName], QName], f.xValue)
+                        _qnEnums = cast(Union[List[QName], QName], f.xValue)
                         qnEnums = _qnEnums if isinstance(_qnEnums, list) else [_qnEnums]
                         if not all(ValidateXbrlDimensions.enumerationMemberUsable(self, concept, self.modelXbrl.qnameConcepts.get(qnEnum))
                                    for qnEnum in qnEnums):

--- a/arelle/plugin/validate/ESEF/Dimensions.py
+++ b/arelle/plugin/validate/ESEF/Dimensions.py
@@ -5,7 +5,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 from collections import defaultdict
-from typing import Any, cast
+from typing import Any, List, cast
 from arelle.ModelDtsObject import ModelConcept, ModelLink
 from arelle.ModelObject import ModelObject
 from arelle.PrototypeDtsObject import PrototypeObject
@@ -154,7 +154,7 @@ def checkFilingDimensions(val: ValidateXbrl) -> None:
                 modelObject=rels, anchoringDimensionalELR=ELR)
 
     # check base set dimension default overrides in extension taxonomies
-    for modelLink in cast(list[ModelLink], val.modelXbrl.baseSets[XbrlConst.dimensionDefault, None, None, None]):
+    for modelLink in cast(List[ModelLink], val.modelXbrl.baseSets[XbrlConst.dimensionDefault, None, None, None]):
         if isExtension(val, modelLink):
             for linkChild in modelLink:
                 if (isinstance(linkChild,(ModelObject,PrototypeObject)) and

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -13,7 +13,7 @@ from arelle.UrlUtil import scheme
 from arelle.ModelManager import ModelManager
 from arelle.ModelXbrl import ModelXbrl
 from arelle.ValidateXbrl import ValidateXbrl
-from typing import Any, Union, cast
+from typing import Any, Dict, List, Union, cast
 from arelle.ModelDocument import ModelDocument
 from arelle.typing import TypeGetText
 
@@ -121,4 +121,4 @@ def loadAuthorityValidations(modelXbrl: ModelXbrl) -> list[Any] | dict[Any, Any]
     _file = openFileStream(modelXbrl.modelManager.cntlr, resourcesFilePath(modelXbrl.modelManager, "authority-validations.json"), 'rt', encoding='utf-8')
     validations = json.load(_file) # {localName: date, ...}
     _file.close()
-    return cast(Union[dict[Any, Any], list[Any]], validations)
+    return cast(Union[Dict[Any, Any], List[Any]], validations)

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -78,7 +78,7 @@ from arelle.formula.XPathContext import XPathContext
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelInstanceObject import ModelInlineFootnote
 from arelle.ModelInstanceObject import ModelContext
-from typing import Any, cast
+from typing import Any, Dict, cast
 from collections.abc import Generator
 import zipfile
 
@@ -171,7 +171,7 @@ def validateXbrlStart(val: ValidateXbrl, parameters: dict[Any, Any] | None=None,
     authorityValidations = loadAuthorityValidations(val.modelXbrl)
     # loadAuthorityValidations returns either a list or a dict but in this context, we expect a dict.
     # By using cast, we let mypy know that a list is _not_ expected here.
-    authorityValidations = cast(dict[Any, Any], authorityValidations)
+    authorityValidations = cast(Dict[Any, Any], authorityValidations)
 
     val.authParam = authorityValidations["default"]
     val.authParam.update(authorityValidations.get(val.authority, {}))

--- a/arelle/plugin/validate/ESEF_2022/Dimensions.py
+++ b/arelle/plugin/validate/ESEF_2022/Dimensions.py
@@ -7,7 +7,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 from collections import defaultdict
-from typing import Any, cast
+from typing import Any, List, cast
 from arelle.ModelDtsObject import ModelConcept, ModelLink
 from arelle.ModelObject import ModelObject
 from arelle.PrototypeDtsObject import PrototypeObject
@@ -155,7 +155,7 @@ def checkFilingDimensions(val: ValidateXbrl) -> None:
                 modelObject=rels, anchoringDimensionalELR=ELR)
 
     # check base set dimension default overrides in extension taxonomies
-    for modelLink in cast(list[ModelLink], val.modelXbrl.baseSets[XbrlConst.dimensionDefault, None, None, None]):
+    for modelLink in cast(List[ModelLink], val.modelXbrl.baseSets[XbrlConst.dimensionDefault, None, None, None]):
         if isExtension(val, modelLink):
             for linkChild in modelLink:
                 if (isinstance(linkChild,(ModelObject,PrototypeObject)) and

--- a/arelle/plugin/validate/ESEF_2022/Util.py
+++ b/arelle/plugin/validate/ESEF_2022/Util.py
@@ -21,7 +21,7 @@ from arelle.UrlUtil import scheme
 from arelle.ModelManager import ModelManager
 from arelle.ModelXbrl import ModelXbrl
 from arelle.ValidateXbrl import ValidateXbrl
-from typing import Any, Union, cast
+from typing import Any, Dict, List, Union, cast
 from arelle.ModelDocument import ModelDocument
 from arelle.typing import TypeGetText
 from collections import defaultdict
@@ -129,7 +129,7 @@ def loadAuthorityValidations(modelXbrl: ModelXbrl) -> list[Any] | dict[Any, Any]
     _file = openFileStream(modelXbrl.modelManager.cntlr, resourcesFilePath(modelXbrl.modelManager, "authority-validations.json"), 'rt', encoding='utf-8')
     validations = json.load(_file) # {localName: date, ...}
     _file.close()
-    return cast(Union[dict[Any, Any], list[Any]], validations)
+    return cast(Union[Dict[Any, Any], List[Any]], validations)
 
 
 def checkForMultiLangDuplicates(modelXbrl: ModelXbrl) -> None:

--- a/arelle/plugin/validate/ESEF_2022/__init__.py
+++ b/arelle/plugin/validate/ESEF_2022/__init__.py
@@ -81,7 +81,7 @@ from arelle.formula.XPathContext import XPathContext
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelInstanceObject import ModelInlineFootnote
 from arelle.ModelInstanceObject import ModelContext
-from typing import Any, cast
+from typing import Any, Dict, cast
 from collections.abc import Generator
 from arelle.ModelValue import QName
 
@@ -186,7 +186,7 @@ def validateXbrlStart(val: ValidateXbrl, parameters: dict[Any, Any] | None=None,
     authorityValidations = loadAuthorityValidations(val.modelXbrl)
     # loadAuthorityValidations returns either a list or a dict but in this context, we expect a dict.
     # By using cast, we let mypy know that a list is _not_ expected here.
-    authorityValidations = cast(dict[Any, Any], authorityValidations)
+    authorityValidations = cast(Dict[Any, Any], authorityValidations)
 
     val.authParam = authorityValidations["default"]
     val.authParam.update(authorityValidations.get(val.authority, {}))

--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass, field
 

--- a/tests/integration_tests/validation/conformance_suite_configs.py
+++ b/tests/integration_tests/validation/conformance_suite_configs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig
 from tests.integration_tests.validation.conformance_suite_configurations.efm_current import config as efm_current
 from tests.integration_tests.validation.conformance_suite_configurations.esef_ixbrl_2021 import config as esef_ixbrl_2021

--- a/tests/integration_tests/validation/run_conformance_suites.py
+++ b/tests/integration_tests/validation/run_conformance_suites.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import sys
 from argparse import ArgumentParser, Namespace


### PR DESCRIPTION
#### Reason for change
#642 

#### Description of change
Unlike most other type declarations, parameters to the `cast(...)` function have to be parsed at runtime (the function itself is a noop). So we can't use the subscriptable collections (`list`, `dict`, `set`, `tuple`) that weren't available until 3.8.

#### Steps to Test
Run conformance suites with Python 3.7.

**review**:
@Arelle/arelle
