### PR TITLE
Remove undefined var

### DIFF
--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -702,7 +702,7 @@ def lxmlSchemaValidate(modelDocument: ModelDocument, extraSchema : str | None = 
                         cntlr.addToLog(_("XML schema validation error: %(error)s"),
                                        messageArgs={"error": str(err)},
                                        messageCode=msgCode,
-                                       file=(modelDocument.basename, _sl[i+1]),
+                                       file=modelDocument.basename,
                                        level=logging.INFO) # schemaLocation is just a hint
                         modelDocument.modelXbrl.errors.append(msgCode)
             if xsdTree is None:


### PR DESCRIPTION
#### Reason for change
Introduced in #630 
> File "/usr/local/lib/python3.11/site-packages/arelle/XhtmlValidate.py", line 78, in xhtmlValidate
XmlValidate.lxmlSchemaValidate(elt.modelDocument,
File "/usr/local/lib/python3.11/site-packages/arelle/XmlValidate.py", line 705, in lxmlSchemaValidate
file=(modelDocument.basename, _sl[i+1]),
^^^
UnboundLocalError: cannot access local variable '_sl' where it is not associated with a value

#### Description of change
Remove undefined var

#### Steps to Test
* CI

**review**:
@Arelle/arelle
