### PR TITLE
remove duplicate arguements from CntlrCmdLine.py

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -112,45 +112,37 @@ def parseAndRun(args):
                              "are individually so validated. "
                              "If formulae are present they will be validated and run unless --formula=none is specified. "
                              ))
-    parser.add_option("--noValidateTestcaseSchema", action="store_false", dest="validateTestcaseSchema", default=True,
+    parser.add_option("--noValidateTestcaseSchema", "--novalidatetestcaseschema", action="store_false", dest="validateTestcaseSchema", default=True,
                       help=_("Validate testcases against their schemas."))
-    parser.add_option("--novalidatetestcaseschema", action="store_false", dest="validateTestcaseSchema", default=True, help=SUPPRESS_HELP)
-    parser.add_option("--calcDecimals", action="store_true", dest="calcDecimals",
+    parser.add_option("--calcDecimals", "--calcdecimals", action="store_true", dest="calcDecimals",
                       help=_("Specify calculation linkbase validation inferring decimals."))
-    parser.add_option("--calcdecimals", action="store_true", dest="calcDecimals", help=SUPPRESS_HELP)
-    parser.add_option("--calcPrecision", action="store_true", dest="calcPrecision",
+    parser.add_option("--calcPrecision", "--calcprecision", action="store_true", dest="calcPrecision",
                       help=_("Specify calculation linkbase validation inferring precision."))
-    parser.add_option("--calcprecision", action="store_true", dest="calcPrecision", help=SUPPRESS_HELP)
-    parser.add_option("--calcDeduplicate", action="store_true", dest="calcDeduplicate",
+    parser.add_option("--calcDeduplicate", "--calcdeduplicate", action="store_true", dest="calcDeduplicate",
                       help=_("Specify de-duplication of consistent facts when performing calculation validation, chooses most accurate fact."))
-    parser.add_option("--calcdeduplicate", action="store_true", dest="calcDeduplicate", help=SUPPRESS_HELP)
     parser.add_option("--efm", action="store_true", dest="validateEFM",
                       help=_("Select Edgar Filer Manual (U.S. SEC) disclosure system validation (strict)."))
     parser.add_option("--efm-skip-calc-tree", action="store_false", default=True, dest="validateEFMCalcTree",
                       help=_("Skip walking of calculation tree during EFM validation."))
     parser.add_option("--gfm", action="store", dest="disclosureSystemName", help=SUPPRESS_HELP)
-    parser.add_option("--disclosureSystem", action="store", dest="disclosureSystemName",
+    parser.add_option("--disclosureSystem", "--disclosuresystem", action="store", dest="disclosureSystemName",
                       help=_("Specify a disclosure system name and"
                              " select disclosure system validation.  "
                              "Enter --disclosureSystem=help for list of names or help-verbose for list of names and descriptions. "))
-    parser.add_option("--disclosuresystem", action="store", dest="disclosureSystemName", help=SUPPRESS_HELP)
     parser.add_option("--hmrc", action="store_true", dest="validateHMRC",
                       help=_("Select U.K. HMRC disclosure system validation."))
     parser.add_option("--utr", action="store_true", dest="utrValidate",
                       help=_("Select validation with respect to Unit Type Registry."))
-    parser.add_option("--utrUrl", action="store", dest="utrUrl",
+    parser.add_option("--utrUrl", "--utrurl", action="store", dest="utrUrl",
                       help=_("Override disclosure systems Unit Type Registry location (URL or file path)."))
-    parser.add_option("--utrurl", action="store", dest="utrUrl", help=SUPPRESS_HELP)
     parser.add_option("--infoset", action="store_true", dest="infosetValidate",
                       help=_("Select validation with respect testcase infosets."))
-    parser.add_option("--labelLang", action="store", dest="labelLang",
+    parser.add_option("--labelLang", "--labellang", action="store", dest="labelLang",
                       help=_("Language for labels in following file options (override system settings)"))
-    parser.add_option("--labellang", action="store", dest="labelLang", help=SUPPRESS_HELP)
     parser.add_option("--disableRtl", action="store_true", dest="disableRtl", default=False,
                        help=_("Flag to disable reversing string read order for right to left languages, useful for some locale settings"))
-    parser.add_option("--labelRole", action="store", dest="labelRole",
+    parser.add_option("--labelRole", "--labelrole", action="store", dest="labelRole",
                       help=_("Label role for labels in following file options (instead of standard label)"))
-    parser.add_option("--labelrole", action="store", dest="labelRole", help=SUPPRESS_HELP)
     parser.add_option("--DTS", "--csvDTS", action="store", dest="DTSFile",
                       help=_("Write DTS tree into FILE (may be .csv or .html)"))
     parser.add_option("--facts", "--csvFacts", action="store", dest="factsFile",
@@ -175,164 +167,110 @@ def parseAndRun(args):
                       help=_("Write anchoring relationships (of definition) linkbase into FILE"))
     parser.add_option("--formulae", "--htmlFormulae", action="store", dest="formulaeFile",
                       help=_("Write formulae linkbase into FILE"))
-    parser.add_option("--viewArcrole", action="store", dest="viewArcrole",
+    parser.add_option("--viewArcrole", "--viewarcrole", action="store", dest="viewArcrole",
                       help=_("Write linkbase relationships for viewArcrole into viewFile"))
-    parser.add_option("--viewarcrole", action="store", dest="viewArcrole", help=SUPPRESS_HELP)
-    parser.add_option("--viewFile", action="store", dest="viewFile",
+    parser.add_option("--viewFile", "--viewfile", action="store", dest="viewFile",
                       help=_("Write linkbase relationships for viewArcrole into viewFile"))
-    parser.add_option("--relationshipCols", action="store", dest="relationshipCols",
+    parser.add_option("--relationshipCols", "--relationshipcols", action="store", dest="relationshipCols",
                       help=_("Extra columns for relationship file (comma or space separated: Name, Namespace, LocalName, Documentation and References)"))
-    parser.add_option("--relationshipcols", action="store", dest="relationshipCols", help=SUPPRESS_HELP)
-    parser.add_option("--viewfile", action="store", dest="viewFile", help=SUPPRESS_HELP)
-    parser.add_option("--roleTypes", action="store", dest="roleTypesFile",
+    parser.add_option("--roleTypes", "--roletypes", action="store", dest="roleTypesFile",
                       help=_("Write defined role types into FILE"))
-    parser.add_option("--roletypes", action="store", dest="roleTypesFile", help=SUPPRESS_HELP)
-    parser.add_option("--arcroleTypes", action="store", dest="arcroleTypesFile",
+    parser.add_option("--arcroleTypes", "--arcroletypes", action="store", dest="arcroleTypesFile",
                       help=_("Write defined arcrole types into FILE"))
-    parser.add_option("--arcroletypes", action="store", dest="arcroleTypesFile", help=SUPPRESS_HELP)
-    parser.add_option("--testReport", "--csvTestReport", action="store", dest="testReport",
+    parser.add_option("--testReport", "--csvTestReport", "--testreport", "--csvtestreport", action="store", dest="testReport",
                       help=_("Write test report of validation (of test cases) into FILE"))
-    parser.add_option("--testreport", "--csvtestreport", action="store", dest="testReport", help=SUPPRESS_HELP)
-    parser.add_option("--testReportCols", action="store", dest="testReportCols",
+    parser.add_option("--testReportCols", "--testreportcols", action="store", dest="testReportCols",
                       help=_("Columns for test report file"))
-    parser.add_option("--testreportcols", action="store", dest="testReportCols", help=SUPPRESS_HELP)
-    parser.add_option("--rssReport", action="store", dest="rssReport",
+    parser.add_option("--rssReport", "--rssreport", action="store", dest="rssReport",
                       help=_("Write RSS report into FILE"))
-    parser.add_option("--rssreport", action="store", dest="rssReport", help=SUPPRESS_HELP)
-    parser.add_option("--rssReportCols", action="store", dest="rssReportCols",
+    parser.add_option("--rssReportCols", "--rssreportcols", action="store", dest="rssReportCols",
                       help=_("Columns for RSS report file"))
-    parser.add_option("--rssreportcols", action="store", dest="rssReportCols", help=SUPPRESS_HELP)
-    parser.add_option("--skipDTS", action="store_true", dest="skipDTS",
+    parser.add_option("--skipDTS", "--skipdts", action="store_true", dest="skipDTS",
                       help=_("Skip DTS activities (loading, discovery, validation), useful when an instance needs only to be parsed."))
-    parser.add_option("--skipdts", action="store_true", dest="skipDTS", help=SUPPRESS_HELP)
-    parser.add_option("--skipLoading", action="store", dest="skipLoading",
+    parser.add_option("--skipLoading", "--skiploading", action="store", dest="skipLoading",
                       help=_("Skip loading discovered or schemaLocated files matching pattern (unix-style file name patterns separated by '|'), useful when not all linkbases are needed."))
-    parser.add_option("--skiploading", action="store", dest="skipLoading", help=SUPPRESS_HELP)
-    parser.add_option("--logFile", action="store", dest="logFile",
+    parser.add_option("--logFile", "--logfile", action="store", dest="logFile",
                       help=_("Write log messages into file, otherwise they go to standard output.  "
                              "If file ends in .xml it is xml-formatted, otherwise it is text. "))
-    parser.add_option("--logfile", action="store", dest="logFile", help=SUPPRESS_HELP)
-    parser.add_option("--logFormat", action="store", dest="logFormat",
+    parser.add_option("--logFormat", "--logformat", action="store", dest="logFormat",
                       help=_("Logging format for messages capture, otherwise default is \"[%(messageCode)s] %(message)s - %(file)s\"."))
-    parser.add_option("--logformat", action="store", dest="logFormat", help=SUPPRESS_HELP)
-    parser.add_option("--logLevel", action="store", dest="logLevel",
+    parser.add_option("--logLevel", "--loglevel", action="store", dest="logLevel",
                       help=_("Minimum level for messages capture, otherwise the message is ignored.  "
                              "Current order of levels are debug, info, info-semantic, warning, warning-semantic, warning, assertion-satisfied, inconsistency, error-semantic, assertion-not-satisfied, and error. "))
-    parser.add_option("--loglevel", action="store", dest="logLevel", help=SUPPRESS_HELP)
-    parser.add_option("--logLevelFilter", action="store", dest="logLevelFilter",
+    parser.add_option("--logLevelFilter", "--loglevelfilter", action="store", dest="logLevelFilter",
                       help=_("Regular expression filter for logLevel.  "
                              "(E.g., to not match *-semantic levels, logLevelFilter=(?!^.*-semantic$)(.+). "))
-    parser.add_option("--loglevelfilter", action="store", dest="logLevelFilter", help=SUPPRESS_HELP)
-    parser.add_option("--logCodeFilter", action="store", dest="logCodeFilter",
+    parser.add_option("--logCodeFilter", "--logcodefilter", action="store", dest="logCodeFilter",
                       help=_("Regular expression filter for log message code."))
-    parser.add_option("--logcodefilter", action="store", dest="logCodeFilter", help=SUPPRESS_HELP)
-    parser.add_option("--logTextMaxLength", action="store", dest="logTextMaxLength", type="int",
+    parser.add_option("--logTextMaxLength", "--logtextmaxlength", action="store", dest="logTextMaxLength", type="int",
                       help=_("Log file text field max length override."))
-    parser.add_option("--logtextmaxlength", action="store", dest="logTextMaxLength", type="int", help=SUPPRESS_HELP)
-    parser.add_option("--logRefObjectProperties", action="store_true", dest="logRefObjectProperties",
+    parser.add_option("--logRefObjectProperties", "--logrefobjectproperties", action="store_true", dest="logRefObjectProperties",
                       help=_("Log reference object properties (default)."), default=True)
-    parser.add_option("--logrefobjectproperties", action="store_true", dest="logRefObjectProperties", help=SUPPRESS_HELP)
-    parser.add_option("--logNoRefObjectProperties", action="store_false", dest="logRefObjectProperties",
+    parser.add_option("--logNoRefObjectProperties", "--lognorefobjectproperties", action="store_false", dest="logRefObjectProperties",
                       help=_("Do not log reference object properties."))
-    parser.add_option("--lognorefobjectproperties", action="store_false", dest="logRefObjectProperties", help=SUPPRESS_HELP)
     parser.add_option("--statusPipe", action="store", dest="statusPipe", help=SUPPRESS_HELP)
     parser.add_option("--monitorParentProcess", action="store", dest="monitorParentProcess", help=SUPPRESS_HELP)
-    parser.add_option("--outputAttribution", action="store", dest="outputAttribution", help=SUPPRESS_HELP)
-    parser.add_option("--outputattribution", action="store", dest="outputAttribution", help=SUPPRESS_HELP)
+    parser.add_option("--outputAttribution", "--outputattribution", action="store", dest="outputAttribution", help=SUPPRESS_HELP)
     parser.add_option("--showOptions", action="store_true", dest="showOptions", help=SUPPRESS_HELP)
     parser.add_option("--parameters", action="store", dest="parameters", help=_("Specify parameters for formula and validation (name=value[,name=value])."))
-    parser.add_option("--parameterSeparator", action="store", dest="parameterSeparator", help=_("Specify parameters separator string (if other than comma)."))
-    parser.add_option("--parameterseparator", action="store", dest="parameterSeparator", help=SUPPRESS_HELP)
+    parser.add_option("--parameterSeparator", "--parameterseparator", action="store", dest="parameterSeparator", help=_("Specify parameters separator string (if other than comma)."))
     parser.add_option("--formula", choices=("validate", "run", "none"), dest="formulaAction",
                       help=_("Specify formula action: "
                              "validate - validate only, without running, "
                              "run - validate and run, or "
                              "none - prevent formula validation or running when also specifying -v or --validate.  "
                              "if this option is not specified, -v or --validate will validate and run formulas if present"))
-    parser.add_option("--formulaParamExprResult", action="store_true", dest="formulaParamExprResult", help=_("Specify formula tracing."))
-    parser.add_option("--formulaparamexprresult", action="store_true", dest="formulaParamExprResult", help=SUPPRESS_HELP)
-    parser.add_option("--formulaParamInputValue", action="store_true", dest="formulaParamInputValue", help=_("Specify formula tracing."))
-    parser.add_option("--formulaparaminputvalue", action="store_true", dest="formulaParamInputValue", help=SUPPRESS_HELP)
-    parser.add_option("--formulaCallExprSource", action="store_true", dest="formulaCallExprSource", help=_("Specify formula tracing."))
-    parser.add_option("--formulacallexprsource", action="store_true", dest="formulaCallExprSource", help=SUPPRESS_HELP)
-    parser.add_option("--formulaCallExprCode", action="store_true", dest="formulaCallExprCode", help=_("Specify formula tracing."))
-    parser.add_option("--formulacallexprcode", action="store_true", dest="formulaCallExprCode", help=SUPPRESS_HELP)
-    parser.add_option("--formulaCallExprEval", action="store_true", dest="formulaCallExprEval", help=_("Specify formula tracing."))
-    parser.add_option("--formulacallexpreval", action="store_true", dest="formulaCallExprEval", help=SUPPRESS_HELP)
-    parser.add_option("--formulaCallExprResult", action="store_true", dest="formulaCallExprResult", help=_("Specify formula tracing."))
-    parser.add_option("--formulacallexprtesult", action="store_true", dest="formulaCallExprResult", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarSetExprEval", action="store_true", dest="formulaVarSetExprEval", help=_("Specify formula tracing."))
-    parser.add_option("--formulavarsetexpreval", action="store_true", dest="formulaVarSetExprEval", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarSetExprResult", action="store_true", dest="formulaVarSetExprResult", help=_("Specify formula tracing."))
-    parser.add_option("--formulavarsetexprresult", action="store_true", dest="formulaVarSetExprResult", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarSetTiming", action="store_true", dest="timeVariableSetEvaluation", help=_("Specify showing times of variable set evaluation."))
-    parser.add_option("--formulavarsettiming", action="store_true", dest="timeVariableSetEvaluation", help=SUPPRESS_HELP)
-    parser.add_option("--formulaAsserResultCounts", action="store_true", dest="formulaAsserResultCounts", help=_("Specify formula tracing."))
-    parser.add_option("--formulaasserresultcounts", action="store_true", dest="formulaAsserResultCounts", help=SUPPRESS_HELP)
-    parser.add_option("--formulaSatisfiedAsser", action="store_true", dest="formulaSatisfiedAsser", help=_("Specify formula tracing."))
-    parser.add_option("--formulasatisfiedasser", action="store_true", dest="formulaSatisfiedAsser", help=SUPPRESS_HELP)
-    parser.add_option("--formulaUnsatisfiedAsser", action="store_true", dest="formulaUnsatisfiedAsser", help=_("Specify formula tracing."))
-    parser.add_option("--formulaunsatisfiedasser", action="store_true", dest="formulaUnsatisfiedAsser", help=SUPPRESS_HELP)
-    parser.add_option("--formulaUnsatisfiedAsserError", action="store_true", dest="formulaUnsatisfiedAsserError", help=_("Specify formula tracing."))
-    parser.add_option("--formulaunsatisfiedassererror", action="store_true", dest="formulaUnsatisfiedAsserError", help=SUPPRESS_HELP)
-    parser.add_option("--formulaUnmessagedUnsatisfiedAsser", action="store_true", dest="formulaUnmessagedUnsatisfiedAsser", help=_("Specify trace messages for unsatisfied assertions with no formula messages."))
-    parser.add_option("--formulaunmessagedunsatisfiedasser", action="store_true", dest="formulaUnmessagedUnsatisfiedAsser", help=SUPPRESS_HELP)
-    parser.add_option("--formulaFormulaRules", action="store_true", dest="formulaFormulaRules", help=_("Specify formula tracing."))
-    parser.add_option("--formulaformularules", action="store_true", dest="formulaFormulaRules", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarsOrder", action="store_true", dest="formulaVarsOrder", help=_("Specify formula tracing."))
-    parser.add_option("--formulavarsorder", action="store_true", dest="formulaVarsOrder", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarExpressionSource", action="store_true", dest="formulaVarExpressionSource", help=_("Specify formula tracing."))
-    parser.add_option("--formulavarexpressionsource", action="store_true", dest="formulaVarExpressionSource", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarExpressionCode", action="store_true", dest="formulaVarExpressionCode", help=_("Specify formula tracing."))
-    parser.add_option("--formulavarexpressioncode", action="store_true", dest="formulaVarExpressionCode", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarExpressionEvaluation", action="store_true", dest="formulaVarExpressionEvaluation", help=_("Specify formula tracing."))
-    parser.add_option("--formulavarexpressionevaluation", action="store_true", dest="formulaVarExpressionEvaluation", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarExpressionResult", action="store_true", dest="formulaVarExpressionResult", help=_("Specify formula tracing."))
-    parser.add_option("--formulavarexpressionresult", action="store_true", dest="formulaVarExpressionResult", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarFilterWinnowing", action="store_true", dest="formulaVarFilterWinnowing", help=_("Specify formula tracing."))
-    parser.add_option("--formulavarfilterwinnowing", action="store_true", dest="formulaVarFilterWinnowing", help=SUPPRESS_HELP)
-    parser.add_option("--formulaVarFiltersResult", action="store_true", dest="formulaVarFiltersResult", help=_("Specify formula tracing."))
-    parser.add_option("--formulavarfiltersresult", action="store_true", dest="formulaVarFiltersResult", help=SUPPRESS_HELP)
-    parser.add_option("--testcaseResultsCaptureWarnings", action="store_true", dest="testcaseResultsCaptureWarnings",
+    parser.add_option("--formulaParamExprResult", "--formulaparamexprresult", action="store_true", dest="formulaParamExprResult", help=_("Specify formula tracing."))
+    parser.add_option("--formulaParamInputValue", "--formulaparaminputvalue", action="store_true", dest="formulaParamInputValue", help=_("Specify formula tracing."))
+    parser.add_option("--formulaCallExprSource", "--formulacallexprsource", action="store_true", dest="formulaCallExprSource", help=_("Specify formula tracing."))
+    parser.add_option("--formulaCallExprCode", "--formulacallexprcode", action="store_true", dest="formulaCallExprCode", help=_("Specify formula tracing."))
+    parser.add_option("--formulaCallExprEval", "--formulacallexpreval", action="store_true", dest="formulaCallExprEval", help=_("Specify formula tracing."))
+    parser.add_option("--formulaCallExprResult", "--formulacallexprtesult", action="store_true", dest="formulaCallExprResult", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarSetExprEval", "--formulavarsetexpreval", action="store_true", dest="formulaVarSetExprEval", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarSetExprResult", "--formulavarsetexprresult", action="store_true", dest="formulaVarSetExprResult", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarSetTiming", "--formulavarsettiming", action="store_true", dest="timeVariableSetEvaluation", help=_("Specify showing times of variable set evaluation."))
+    parser.add_option("--formulaAsserResultCounts", "--formulaasserresultcounts", action="store_true", dest="formulaAsserResultCounts", help=_("Specify formula tracing."))
+    parser.add_option("--formulaSatisfiedAsser", "--formulasatisfiedasser", action="store_true", dest="formulaSatisfiedAsser", help=_("Specify formula tracing."))
+    parser.add_option("--formulaUnsatisfiedAsser", "--formulaunsatisfiedasser", action="store_true", dest="formulaUnsatisfiedAsser", help=_("Specify formula tracing."))
+    parser.add_option("--formulaUnsatisfiedAsserError", "--formulaunsatisfiedassererror", action="store_true", dest="formulaUnsatisfiedAsserError", help=_("Specify formula tracing."))
+    parser.add_option("--formulaUnmessagedUnsatisfiedAsser", "--formulaunmessagedunsatisfiedasser", action="store_true", dest="formulaUnmessagedUnsatisfiedAsser", help=_("Specify trace messages for unsatisfied assertions with no formula messages."))
+    parser.add_option("--formulaFormulaRules", "--formulaformularules", action="store_true", dest="formulaFormulaRules", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarsOrder", "--formulavarsorder", action="store_true", dest="formulaVarsOrder", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarExpressionSource", "--formulavarexpressionsource", action="store_true", dest="formulaVarExpressionSource", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarExpressionCode", "--formulavarexpressioncode", action="store_true", dest="formulaVarExpressionCode", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarExpressionEvaluation", "--formulavarexpressionevaluation", action="store_true", dest="formulaVarExpressionEvaluation", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarExpressionResult", "--formulavarexpressionresult", action="store_true", dest="formulaVarExpressionResult", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarFilterWinnowing", "--formulavarfilterwinnowing", action="store_true", dest="formulaVarFilterWinnowing", help=_("Specify formula tracing."))
+    parser.add_option("--formulaVarFiltersResult", "--formulavarfiltersresult", action="store_true", dest="formulaVarFiltersResult", help=_("Specify formula tracing."))
+    parser.add_option("--testcaseResultsCaptureWarnings", "--testcaseresultscapturewarnings", action="store_true", dest="testcaseResultsCaptureWarnings",
                       help=_("For testcase variations capture warning results, default is inconsistency or warning if there is any warning expected result.  "))
-    parser.add_option("--testcaseresultscapturewarnings", action="store_true", dest="testcaseResultsCaptureWarnings", help=SUPPRESS_HELP)
     parser.add_option("--testcaseResultOptions", choices=("match-any", "match-all"), action="store", dest="testcaseResultOptions",
                       help=_("For testcase results, default is match any expected result, options to match any or match all expected result(s).  "))
-    parser.add_option("--formulaRunIDs", action="store", dest="formulaRunIDs", help=_("Specify formula/assertion IDs to run, separated by a '|' character, or a regex expression."))
-    parser.add_option("--formularunids", action="store", dest="formulaRunIDs", help=SUPPRESS_HELP)
-    parser.add_option("--formulaCompileOnly", action="store_true", dest="formulaCompileOnly", help=_("Specify formula are to be compiled but not executed."))
-    parser.add_option("--formulacompileonly", action="store_true", dest="formulaCompileOnly", help=SUPPRESS_HELP)
+    parser.add_option("--formulaRunIDs", "--formularunids", action="store", dest="formulaRunIDs", help=_("Specify formula/assertion IDs to run, separated by a '|' character, or a regex expression."))
+    parser.add_option("--formulaCompileOnly", "--formulacompileonly", action="store_true", dest="formulaCompileOnly", help=_("Specify formula are to be compiled but not executed."))
     parser.add_option("--formulaCacheSize", "--formulacachesize", action="store", dest="formulaCacheSize", help=_("Specify the number of fact aspect combinations to cache during formula evaluations. Negative numbers have no limit. (10_000_000 is default)"))
-    parser.add_option(UILANG_OPTION, action="store", dest="uiLang",
+    parser.add_option(UILANG_OPTION, UILANG_OPTION.lower(), action="store", dest="uiLang",
                       help=_("Language for user interface (override system settings, such as program messages).  Does not save setting.  Requires locale country code, e.g. en-GB or en-US."))
-    parser.add_option(UILANG_OPTION.lower(), action="store", dest="uiLang", help=SUPPRESS_HELP)
     parser.add_option("--proxy", action="store", dest="proxy",
                       help=_("Modify and re-save proxy settings configuration.  "
                              "Enter 'system' to use system proxy setting, 'none' to use no proxy, "
                              "'http://[user[:password]@]host[:port]' "
                              " (e.g., http://192.168.1.253, http://example.com:8080, http://joe:secret@example.com:8080), "
                              " or 'show' to show current setting, ." ))
-    parser.add_option("--internetConnectivity", choices=("online", "offline"), dest="internetConnectivity",
+    parser.add_option("--internetConnectivity", "--internetconnectivity", choices=("online", "offline"), dest="internetConnectivity",
                       help=_("Specify internet connectivity: online or offline"))
-    parser.add_option("--internetconnectivity", action="store", dest="internetConnectivity", help=SUPPRESS_HELP)
-    parser.add_option("--internetTimeout", type="int", dest="internetTimeout",
+    parser.add_option("--internetTimeout", "--internettimeout", type="int", dest="internetTimeout",
                       help=_("Specify internet connection timeout in seconds (0 means unlimited)."))
-    parser.add_option("--internettimeout", type="int", action="store", dest="internetTimeout", help=SUPPRESS_HELP)
-    parser.add_option("--internetRecheck", choices=("weekly", "daily", "never", "hourly", "quarter-hourly"), action="store", dest="internetRecheck",
+    parser.add_option("--internetRecheck", "--internetrecheck", choices=("weekly", "daily", "never", "hourly", "quarter-hourly"), action="store", dest="internetRecheck",
                       help=_("Specify rechecking for newer cache files 'daily', 'weekly', 'monthly' or 'never' ('weekly' is default)"))
-    parser.add_option("--internetrecheck", choices=("weekly", "daily", "never"), action="store", dest="internetRecheck", help=SUPPRESS_HELP)
-    parser.add_option("--internetLogDownloads", action="store_true", dest="internetLogDownloads",
+    parser.add_option("--internetLogDownloads", "--internetlogdownloads", action="store_true", dest="internetLogDownloads",
                       help=_("Log info message for downloads to web cache."))
-    parser.add_option("--internetlogdownloads", action="store_true", dest="internetLogDownloads", help=SUPPRESS_HELP)
-    parser.add_option("--noCertificateCheck", action="store_true", dest="noCertificateCheck",
+    parser.add_option("--noCertificateCheck", "--nocertificatecheck", action="store_true", dest="noCertificateCheck",
                       help=_("Specify no checking of internet secure connection certificate"))
-    parser.add_option("--nocertificatecheck", action="store_true", dest="noCertificateCheck", help=SUPPRESS_HELP)
-    parser.add_option("--httpsRedirectCache", action="store_true", dest="httpsRedirectCache",
+    parser.add_option("--httpsRedirectCache", "--httpsredirectcache", action="store_true", dest="httpsRedirectCache",
                       help=_("Treat http and https schemes interchangeably when looking up files from the webcache"))
-    parser.add_option("--httpsredirectcache", action="store_true", dest="httpsRedirectCache", help=SUPPRESS_HELP)
-    parser.add_option("--httpUserAgent", action="store", dest="httpUserAgent",
+    parser.add_option("--httpUserAgent", "--httpuseragent", action="store", dest="httpUserAgent",
                       help=_("Specify non-standard http header User-Agent value"))
-    parser.add_option("--httpuseragent", action="store", dest="httpUserAgent", help=SUPPRESS_HELP)
     parser.add_option("--xdgConfigHome", action="store", dest="xdgConfigHome",
                       help=_("Specify non-standard location for configuration and cache files (overrides environment parameter XDG_CONFIG_HOME)."))
     parser.add_option("--plugins", action="store", dest="plugins",
@@ -345,22 +283,20 @@ def parseAndRun(args):
                              "or ../examples/plugin/hello_dolly.py for relative use of examples directory) "
                              "Local python files do not require .py suffix, e.g., hello_dolly without .py is sufficient, "
                              "Packaged plug-in urls are their directory's url (e.g., --plugins EdgarRenderer or --plugins xbrlDB).  " ))
-    parser.add_option("--packages", action="store", dest="packages",
+    parser.add_option("--packages", "--package", action="store", dest="packages",
                       help=_("Specify taxonomy packages configuration.  "
                              "Enter 'show' to show current packages configuration.  "
                              "Commands show, and module urls are '|' separated: "
                              "url specifies a package by its url or filename, please use full paths. "
                              "(Package settings from GUI are no longer shared with cmd line operation. "
                              "Cmd line package settings are not persistent.)  " ))
-    parser.add_option("--package", action="store", dest="packages", help=SUPPRESS_HELP)
     parser.add_option("--packageManifestName", action="store", dest="packageManifestName",
                       help=_("Provide non-standard archive manifest file name pattern (e.g., *taxonomyPackage.xml).  "
                              "Uses unix file name pattern matching.  "
                              "Multiple manifest files are supported in archive (such as oasis catalogs).  "
                              "(Replaces search for either .taxonomyPackage.xml or catalog.xml).  " ))
     parser.add_option("--abortOnMajorError", action="store_true", dest="abortOnMajorError", help=_("Abort process on major error, such as when load is unable to find an entry or discovered file."))
-    parser.add_option("--showEnvironment", action="store_true", dest="showEnvironment", help=_("Show Arelle's config and cache directory and host OS environment parameters."))
-    parser.add_option("--showenvironment", action="store_true", dest="showEnvironment", help=SUPPRESS_HELP)
+    parser.add_option("--showEnvironment", "--showenvironment", action="store_true", dest="showEnvironment", help=_("Show Arelle's config and cache directory and host OS environment parameters."))
     parser.add_option("--collectProfileStats", action="store_true", dest="collectProfileStats", help=_("Collect profile statistics, such as timing of validation activities and formulae."))
     if hasWebServer:
         parser.add_option("--webserver", action="store", dest="webserver",


### PR DESCRIPTION
#### Reason for change
There were duplicate argument parser options for all lower case and camel case options. This addresses issue: #646

#### Description of change
It is recommended to rewrite the duplicate command line options in CntlrCmdLine.py to support multiple parameter names. By using the option parser's ability to accept multiple parameter names, we can eliminate the need for duplicate declarations, while ensuring that the same option can be invoked using different capitalization or spacing. This improves the usability and flexibility of the code for the end-users.

#### Steps to Test

**review**:
@Arelle/arelle
