### PR TITLE
Make sure XML comments are closed on write

### DIFF
--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -1174,7 +1174,8 @@ def writexml(
             else:
                 writexml(writer, child, indent=indent, xmlcharrefreplace=xmlcharrefreplace, parentNsmap={})
     elif isinstance(node,etree._Comment): # ok to use minidom implementation
-        writer.write(indent+"<!--" + node.text if isinstance(node.text, str) else '' + "-->\n")
+        commentText = node.text if isinstance(node.text, str) else ''
+        writer.write(indent + "<!--" + commentText + "-->\n")
     elif isinstance(node,etree._ProcessingInstruction): # ok to use minidom implementation
         writer.write(indent + str(node) + "\n")
     elif isinstance(node,etree._Element):


### PR DESCRIPTION
#### Reason for change
resolves #655 

#### Description of change
The conditional expression for ensuring a text value is inserted for comments also encapsulates the closing tag. For example, in the OIM plugin when an XML file is saved the `extracted from OIM` comment is written like:
`<!--extracted from OIM /Users/austinmatherne/Desktop/test.json`
instead of:
`<!--extracted from OIM /Users/austinmatherne/Desktop/test.json-->`

#### Steps to Test
1. Extract the JSON file from [test.json.zip](https://github.com/Arelle/Arelle/files/11227505/test.json.zip).
2. Enable the `Load From OIM` plugin in Arelle.
3. Restart Arelle.
4. Open the extracted JSON file (File -> Open File).
5. Give the output XBRL document a name and save.
6. Open the XBRL document in a text editor.
7. Confirm that the `extracted from OIM` comment on the second line is properly closed with `-->`.


**review**:
@Arelle/arelle
