### PR TITLE
ESEF: don't include SVG fragments in base64 data image decoding

### DIFF
--- a/arelle/UrlUtil.py
+++ b/arelle/UrlUtil.py
@@ -2,8 +2,9 @@
 See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
+
+import base64
 import os
-from typing import Any
 import regex as re
 from urllib.request import pathname2url
 from urllib.parse import urldefrag, unquote, quote, urljoin
@@ -385,3 +386,10 @@ def relativeUri(baseUri: str, relativeUri: str) -> str: # return uri relative to
     if mBaseUri and not mRelUri:
         baseUri = mBaseUri.group(1) # remove the zip part so relative URI is within zip
     return os.path.relpath(relativeUri, os.path.dirname(baseUri)).replace('\\','/')
+
+
+def decodeBase64DataImage(imageData: str | None) -> bytes | None:
+    if imageData is None:
+        return None
+    imageDataWithoutUriFragment = imageData.split("#", 1)[0]
+    return base64.b64decode(imageDataWithoutUriFragment)

--- a/arelle/ValidateFilingText.py
+++ b/arelle/ValidateFilingText.py
@@ -8,7 +8,7 @@ import regex as re
 from arelle.XbrlConst import ixbrlAll, xhtml
 from arelle.XmlUtil import setXmlns, xmlstring
 from arelle.ModelObject import ModelObject
-from arelle.UrlUtil import isHttpUrl, scheme
+from arelle.UrlUtil import decodeBase64DataImage, isHttpUrl, scheme
 
 XMLdeclaration = re.compile(r"<\?xml.*\?>", re.DOTALL)
 XMLpattern = re.compile(r".*(<|&lt;|&#x3C;|&#60;)[A-Za-z_]+[A-Za-z0-9_:]*[^>]*(/>|>|&gt;|/&gt;).*", re.DOTALL)
@@ -627,7 +627,7 @@ def validateTextBlockFacts(modelXbrl):
                                             if (not allowedImageTypes["data-scheme"] or
                                                 not m or not m.group(1) or not m.group(2)
                                                 or m.group(1)[1:] not in allowedImageTypes["mime-types"]
-                                                or m.group(1)[1:] != validateGraphicHeaderType(base64.b64decode(m.group(3)))):
+                                                or m.group(1)[1:] != validateGraphicHeaderType(decodeBase64DataImage(m.group(3)))):
                                                 modelXbrl.error(("EFM.6.05.16.graphicDataUrl", "FERC.6.05.16.graphicDataUrl"),
                                                     _("Fact %(fact)s of context %(contextID)s references a graphics data URL which isn't accepted or valid '%(attribute)s' for <%(element)s>"),
                                                     modelObject=f1, fact=f1.qname, contextID=f1.contextID,
@@ -769,7 +769,7 @@ def validateHtmlContent(modelXbrl, referenceElt, htmlEltTree, validatedObjectLab
                             if (not allowedImageTypes["data-scheme"] or
                                 not m or not m.group(1) or not m.group(2)
                                 or m.group(1)[1:] not in allowedImageTypes["mime-types"]
-                                or m.group(1)[1:] != validateGraphicHeaderType(base64.b64decode(m.group(3)))):
+                                or m.group(1)[1:] != validateGraphicHeaderType(decodeBase64DataImage(m.group(3)))):
                                 modelXbrl.error(messageCodePrefix + "graphicDataUrl",
                                     _("%(validatedObjectLabel)s references a graphics data URL which isn't accepted '%(attribute)s' for <%(element)s>"),
                                     modelObject=elt, validatedObjectLabel=validatedObjectLabel,

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -53,7 +53,7 @@ from arelle.ModelObject import ModelObject
 from arelle.ModelValue import QName, qname
 from arelle.PackageManager import validateTaxonomyPackage
 from arelle.PythonUtil import strTruncate
-from arelle.UrlUtil import isHttpUrl, scheme
+from arelle.UrlUtil import decodeBase64DataImage, isHttpUrl, scheme
 from arelle.Version import authorLabel, copyrightLabel
 from arelle.XmlValidate import VALID, lexicalPatterns
 
@@ -474,7 +474,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                             modelObject=elt, src=src[:128])
                                     # check for malicious image contents
                                     try: # allow embedded newlines
-                                        checkImageContents(modelXbrl, elt, m.group(1), False, base64.b64decode(m.group(3)))
+                                        checkImageContents(modelXbrl, elt, m.group(1), False, decodeBase64DataImage(m.group(3)))
                                         imgContents = None # deref, may be very large
                                     except base64.binascii.Error as err:
                                         modelXbrl.error("ESEF.2.5.1.embeddedImageNotUsingBase64Encoding",

--- a/arelle/plugin/validate/ESEF_2022/__init__.py
+++ b/arelle/plugin/validate/ESEF_2022/__init__.py
@@ -57,7 +57,7 @@ from arelle.ModelValue import qname
 from arelle.PackageManager import validateTaxonomyPackage
 from arelle.PythonUtil import strTruncate, normalizeSpace
 from arelle.Version import authorLabel, copyrightLabel
-from arelle.UrlUtil import isHttpUrl, scheme
+from arelle.UrlUtil import decodeBase64DataImage, isHttpUrl, scheme
 from arelle.XmlValidate import lexicalPatterns
 
 from arelle.ValidateXbrlCalcs import inferredDecimals, rangeValue
@@ -494,7 +494,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                             modelObject=elt, src=src[:128])
                                     # check for malicious image contents
                                     try: # allow embedded newlines
-                                        checkImageContents(modelXbrl, elt, m.group(1), False, base64.b64decode(m.group(3)))
+                                        checkImageContents(modelXbrl, elt, m.group(1), False, decodeBase64DataImage(m.group(3)))
                                         imgContents = None # deref, may be very large
                                     except base64.binascii.Error as err:
                                         modelXbrl.error("ESEF.2.5.1.embeddedImageNotUsingBase64Encoding",


### PR DESCRIPTION
#### Reason for change
SVG fragments at the end of embedded data:image URIs are currently being passed along as part of the base64 content. This causes the decoding process to fail, resulting in the data image being marked as invalid.

#### Description of change
Separate fragments from the base64 image during ESEF data image validation.

#### Steps to Test
Validate an ESEF doc with a data image SVG which uses SVG fragments.

**review**:
@Arelle/arelle
