### PR TITLE
Add automatic "fast" pytest mark to run only fast unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ xfail_strict = true
 empty_parameter_set_mark = "fail_at_collect"
 addopts = "--strict-markers"
 markers = [
+    "fast: mark automatically applied to tests which don't have the \"slow\" mark applied (deselect with '-m \"not fast\"')",
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 

--- a/tests/unit_tests/arelle/conftest.py
+++ b/tests/unit_tests/arelle/conftest.py
@@ -8,3 +8,9 @@ def mock_gettext(monkeypatch):
     monkeypatch.setitem(builtins.__dict__, "_", lambda s: s)
     yield
     monkeypatch.delitem(builtins.__dict__, "_")
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        test_marked_slow = item.get_closest_marker("slow")
+        if test_marked_slow is None:
+            item.add_marker(pytest.mark.fast)


### PR DESCRIPTION
#### Reason for change
https://github.com/Arelle/Arelle/pull/667#discussion_r1171558327

#### Description of change
Automatically applies `fast` mark for tests which don't have the `slow` mark applied

#### Steps to Test
* run `❯ pytest tests/unit_tests -m fast`
* run `❯ pytest tests/unit_tests -m slow`

**review**:
@Arelle/arelle
