### PR TITLE
GUI set internet connection timeout

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -468,7 +468,7 @@ class Cntlr:
         if self.hasFileSystem and not self.disablePersistentConfig:
             with io.open(self.configJsonFile, 'wt', encoding='utf-8') as f:
                 # might not be unicode in 2.7
-                jsonStr = str(json.dumps(self.config, ensure_ascii=False, indent=2))
+                jsonStr = str(json.dumps(self.config, ensure_ascii=False, indent=2, sort_keys=True))
                 f.write(jsonStr)  # 2.7 getss unicode this way
 
     # default non-threaded viewModelObject

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -1142,7 +1142,6 @@ class CntlrWinMain (Cntlr.Cntlr):
         if response is not None and response >= 0:
             self.webCache.timeout = response or None # set to None if zero - no timenout
             self.config["internetConnectionTimeout"] = self.webCache.timeout
-            
 
     def confirmClearWebCache(self):
         if tkinter.messagebox.askyesno(

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -223,10 +223,12 @@ class CntlrWinMain (Cntlr.Cntlr):
                     underline=0,
                     onvalue=_opt_val
              )
+        self.webCache.timeout = self.config.setdefault("internetConnectionTimeout", None)
 
         cacheMenu.add_command(label=_("Clear cache"), underline=0, command=self.confirmClearWebCache)
         cacheMenu.add_command(label=_("Manage cache"), underline=0, command=self.manageWebCache)
         cacheMenu.add_cascade(label=self._internetRecheckLabel, menu=internetCacheRecheckMenu, underline=0, state=_recheck_initial)
+        cacheMenu.add_command(label=_("Internet connection timeout"), underline=0, command=self.internetConnectionTimeout)
         cacheMenu.add_command(label=_("Proxy Server"), underline=0, command=self.setupProxy)
         cacheMenu.add_command(label=_("HTTP User Agent"), underline=0, command=self.setupUserAgent)
         self.webCache.httpUserAgent = self.config.get("httpUserAgent")
@@ -1130,6 +1132,17 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.webCache.noCertificateCheck = self.noCertificateCheck.get() # resets proxy handlers
         self.config["noCertificateCheck"] = self.webCache.noCertificateCheck
         self.saveConfig()
+
+    def internetConnectionTimeout(self):
+        response = tkinter.simpledialog.askinteger(
+                    _("arelle - Internet Connection Timeout"),
+                    _("Enter timeout in seconds or 0 for no timeout"),
+                    initialvalue=str(self.webCache.timeout or 0),
+                    parent=self.parent)
+        if response is not None and response >= 0:
+            self.webCache.timeout = response or None # set to None if zero - no timenout
+            self.config["internetConnectionTimeout"] = self.webCache.timeout
+            
 
     def confirmClearWebCache(self):
         if tkinter.messagebox.askyesno(


### PR DESCRIPTION
#### Reason for change
Cmd line has had an option to set internet connection timeout but GUI did not.
A timeout setting is useful if ipv6 connectivity is flakey or other trouble shooting.

#### Description of change
Add GUI option tools->internet->connection timeout setter.

(Also change config.json to store in sorted key order so it's easier to identify config changes.)

#### Steps to Test
Check for persistence of setting in config.json.  Test on flakey internet (my home on Spectrum trying ipv6 to www.xbrl.org, but every other site works fine on Spectrum ipv6).

**review**:
@Arelle/arelle
