### PR TITLE
XT-2898 Add 'beta' feature flag handling

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 osPrcs: Any = None
 LOG_TEXT_MAX_LENGTH = 32767
 cxFrozen = getattr(sys, 'frozen', False)
+# Add camelCaseOptionName
+BETA_FEATURES: list[str] = []
 
 
 def resourcesDir() -> str:
@@ -51,6 +53,7 @@ def resourcesDir() -> str:
        os.path.exists(os.path.join(os.path.dirname(_resourcesDir),"images")):
         _resourcesDir = os.path.dirname(_resourcesDir)
     return _resourcesDir
+
 
 class Cntlr:
     """
@@ -105,6 +108,7 @@ class Cntlr:
 
     """
     __version__ = "1.6.0"
+    betaFeatures: dict[str, bool]
     hasWin32gui: bool
     hasGui: bool
     hasFileSystem: bool
@@ -139,7 +143,14 @@ class Cntlr:
         logFormat: str | None = None,
         uiLang: str | None = None,
         disable_persistent_config: bool = False,
+        betaFeatures: dict[str, bool] | None =None
     ) -> None:
+        if betaFeatures is None:
+            betaFeatures = {}
+        self.betaFeatures = {
+            b: betaFeatures.get(b, False)
+            for b in BETA_FEATURES
+        }
         self.hasWin32gui = False
         self.hasGui = hasGui
         self.hasFileSystem = True # no file system on Google App Engine servers

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -7,13 +7,14 @@ See COPYRIGHT.md for copyright information.
 '''
 from arelle import PythonUtil # define 2.x or 3.x string types
 import gettext, time, datetime, os, shlex, sys, traceback, fnmatch, threading, json, logging, platform
-from optparse import OptionParser, SUPPRESS_HELP
+from optparse import OptionGroup, OptionParser, SUPPRESS_HELP
 import regex as re
 from arelle import (Cntlr, FileSource, ModelDocument, RenderingEvaluator, XmlUtil, XbrlConst, Version,
                     ViewFileDTS, ViewFileFactList, ViewFileFactTable, ViewFileConcepts,
                     ViewFileFormulae, ViewFileRelationshipSet, ViewFileTests, ViewFileRssFeed,
                     ViewFileRoleTypes,
                     ModelManager)
+from arelle.Cntlr import BETA_FEATURES
 from arelle.ModelValue import qname
 from arelle.Locale import format_string, setApplicationLocale, setDisableRTL
 from arelle.ModelFormulaObject import FormulaOptions
@@ -118,6 +119,12 @@ def parseAndRun(args):
                              ))
     parser.add_option("--noValidateTestcaseSchema", "--novalidatetestcaseschema", action="store_false", dest="validateTestcaseSchema", default=True,
                       help=_("Validate testcases against their schemas."))
+    betaGroup = OptionGroup(parser, "Beta Features",
+                        "Caution: these are beta features, use these options at your own risk.")
+    for b in BETA_FEATURES:
+        assert b.startswith('beta'), 'All beta options must start with "beta"'
+        betaGroup.add_option(f'--{b}', f'--{b.lower()}', action="store_true", default=False, help=f"Toggles on the beta {b} feature")
+    parser.add_option_group(betaGroup)
     parser.add_option("--calcDecimals", "--calcdecimals", action="store_true", dest="calcDecimals",
                       help=_("Specify calculation linkbase validation inferring decimals."))
     parser.add_option("--calcPrecision", "--calcprecision", action="store_true", dest="calcPrecision",
@@ -510,7 +517,8 @@ class CntlrCmdLine(Cntlr.Cntlr):
         :param options: OptionParser options from parse_args of main argv arguments (when called from command line) or corresponding arguments from web service (REST) request.
         :type options: optparse.Values
         """
-
+        for b in BETA_FEATURES:
+            self.betaFeatures[b] = getattr(options, b)
         if options.statusPipe or options.monitorParentProcess:
             try:
                 global win32file, win32api, win32process, pywintypes


### PR DESCRIPTION
#### Reason for change
We want the ability to work on some beta features without disrupting the general flow for normal arelle users

#### Description of change
Adds beta feature flags to a beta features option group.

```
python arelleCmdLine.py --help
...
  --diagnostics         output system diagnostics information

  Beta Features:
    Caution: these are beta features, use these options at your own risk.
```

### Note:
Empty is expected as there are no beta features at the moment

#### Steps to Test
1. Pull the branch
2. run `python arelleCmdLine.py --help`, verify that `Beta Features` are displayed at the bottom
3. Add `'betaExampleOption'`, `'betaExampleOption2'` to the `BETA_FEATURES` list added in this PR
  a. Run  `python arelleCmdLine.py --help` and verify that `"--betaExampleOption --betaExampleOption"` and `"--betaExampleOption2 --betaExampleOption2"` show up in the `Beta Features` at the bottom
  b. Add `print(self.betaExampleOption, self.betaExampleOption2)` after the options are stored on the cntrl
  c. Run `python arelleCmdLine.py <VALID OPTIONS> --betaExampleOption` verify that `True False` is printed

**review**:
@Arelle/arelle
