### PR TITLE
Don't write webcache and plugins to disk if persistent config is disabled

### DIFF
--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -101,7 +101,7 @@ def orderedPluginConfig():
 
 def save(cntlr: Cntlr) -> None:
     global pluginConfigChanged
-    if pluginConfigChanged and cntlr.hasFileSystem:
+    if pluginConfigChanged and cntlr.hasFileSystem and not cntlr.disablePersistentConfig:
         pluginJsonFile = cntlr.userAppDir + os.sep + "plugins.json"
         with io.open(pluginJsonFile, 'wt', encoding='utf-8') as f:
             jsonStr = str(json.dumps(orderedPluginConfig(), ensure_ascii=False, indent=2)) # might not be unicode in 2.7

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -169,10 +169,10 @@ class WebCache:
         self._logDownloads = _logDownloads
 
     def saveUrlCheckTimes(self) -> None:
-        if self.cachedUrlCheckTimesModified:
+        if self.cachedUrlCheckTimesModified and not self.cntlr.disablePersistentConfig:
             with io.open(self.urlCheckJsonFile, 'wt', encoding='utf-8') as f:
                 f.write(json.dumps(self.cachedUrlCheckTimes, ensure_ascii=False, indent=0))
-        self.cachedUrlCheckTimesModified = False
+            self.cachedUrlCheckTimesModified = False
 
     @property
     def noCertificateCheck(self):


### PR DESCRIPTION
#### Reason for change
The webcache url times and plugin config can still attempt disk writes even when the `--disablePersistentConfig` option is used.

#### Description of change
webcache and plugin manager no longer write to disk when `--disablePersistentConfig` is used

#### Steps to Test
* ci

**review**:
@Arelle/arelle
