### PR TITLE
Include tinycss2 lib in frozen builds

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -46,6 +46,7 @@ includeLibs = [
     "pymysql",
     "regex",
     "sqlite3",
+    "tinycss2",
     "zlib",
 ]
 options = {


### PR DESCRIPTION
#### Reason for change
tinycss2 is a new dependency for the ESEF 2022 plugin. We have to explicitly include it in the list of libraries for cx freeze to bundle it with the frozen builds

#### Description of change
Include tinycss2 in the frozen builds

#### Steps to Test
* Enabling the ESEF_2022 plugin doesn't cause Arelle to crash at startup (macOS [build available for this branch here](https://github.com/austinmatherne-wk/Arelle/actions/runs/4809121465))

**review**:
@Arelle/arelle
