### PR TITLE
Calculations 1.1 REC

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -125,12 +125,21 @@ def parseAndRun(args):
         assert b.startswith('beta'), 'All beta options must start with "beta"'
         betaGroup.add_option(f'--{b}', f'--{b.lower()}', action="store_true", default=False, help=f"Toggles on the beta {b} feature")
     parser.add_option_group(betaGroup)
+    parser.add_option("--calc", action="store", dest="calcs",
+                      help=_("Specify calculations validations: "
+                             "none - default, "
+                             #"xbrl21precision - pre-2010 xbrl v2.1 calculations linkbase inferring precision, "
+                             "c10 or xbrl21 - Calc 1.0 (XBRL 2.1) calculations, "
+                             "c10d or xbrl21-dedup - Calc 1.0 (XBRL 2.1) calculations with de-duplication, "
+                             "c11r or round-to-nearest - Calc 1.1 round-to-nearest mode, "
+                             "c11t or truncation - Calc 1.1 truncation mode"
+                             ))
     parser.add_option("--calcDecimals", "--calcdecimals", action="store_true", dest="calcDecimals",
-                      help=_("Specify calculation linkbase validation inferring decimals."))
+                      help=_("Deprecated - XBRL v2.1 calculation linkbase validation inferring decimals."))
     parser.add_option("--calcPrecision", "--calcprecision", action="store_true", dest="calcPrecision",
-                      help=_("Specify calculation linkbase validation inferring precision."))
+                      help=_("Deprecated - pre-2010 XBRL v2.1 calculation linkbase validation inferring precision."))
     parser.add_option("--calcDeduplicate", "--calcdeduplicate", action="store_true", dest="calcDeduplicate",
-                      help=_("Specify de-duplication of consistent facts when performing calculation validation, chooses most accurate fact."))
+                      help=_("Deprecaated -  de-duplication of consistent facts when performing calculation validation, chooses most accurate fact."))
     parser.add_option("--efm", action="store_true", dest="validateEFM",
                       help=_("Select Edgar Filer Manual (U.S. SEC) disclosure system validation (strict)."))
     parser.add_option("--efm-skip-calc-tree", action="store_false", default=True, dest="validateEFMCalcTree",
@@ -744,17 +753,33 @@ class CntlrCmdLine(Cntlr.Cntlr):
             self.setLogLevelFilter(options.logLevelFilter)
         if options.logCodeFilter:
             self.setLogCodeFilter(options.logCodeFilter)
+        from arelle.ValidateXbrlCalcs import ValidateCalcsMode as CalcsMode
         if options.calcDecimals:
             if options.calcPrecision:
                 self.addToLog(_("both --calcDecimals and --calcPrecision validation are requested, proceeding with --calcDecimals only"),
                               messageCode="info", file=options.entrypointFile)
-            self.modelManager.validateInferDecimals = True
-            self.modelManager.validateCalcLB = True
+            if options.calcs:
+                self.addToLog(_("both --calcDecimals and --calcs validation are requested, proceeding with --calcDecimals only"),
+                              messageCode="info", file=options.entrypointFile)
+            self.modelManager.validateCalcs = CalcsMode.XBRL_v2_1 + (options.calcDeduplicate or 0)
         elif options.calcPrecision:
-            self.modelManager.validateInferDecimals = False
-            self.modelManager.validateCalcLB = True
-        if options.calcDeduplicate:
-            self.modelManager.validateDedupCalcs = True
+            self.modelManager.validateCalcs = CalcsMode.XBRL_v2_1_INFER_PRECISION
+        else:
+            try:
+                self.modelManager.validateCalcs = {
+                     "xbrl21precision": CalcsMode.XBRL_v2_1_INFER_PRECISION,
+                     "xbrl21": CalcsMode.XBRL_v2_1,
+                     "c10": CalcsMode.XBRL_v2_1,
+                     "xbrl21-dedup": CalcsMode.XBRL_v2_1_DEDUPLICATE,
+                     "c10d": CalcsMode.XBRL_v2_1_DEDUPLICATE,
+                     "round-to-nearest": CalcsMode.ROUND_TO_NEAREST,
+                     "c11r": CalcsMode.ROUND_TO_NEAREST,
+                     "truncation": CalcsMode.TRUNCATION,
+                     "c11t": CalcsMode.TRUNCATION
+                    }.get(options.calcs)
+            except KEYERROR:
+                self.addToLog(_("--calcs value invalid, request ignored"),
+                              messageCode="info", file=options.entrypointFile)
         if options.utrValidate:
             self.modelManager.validateUtr = True
         if options.infosetValidate:

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -127,7 +127,7 @@ def parseAndRun(args):
     parser.add_option_group(betaGroup)
     parser.add_option("--calc", action="store", dest="calcs",
                       help=_("Specify calculations validations: "
-                             "none - default, "
+                             "none - no calculations validation, "
                              #"xbrl21precision - pre-2010 xbrl v2.1 calculations linkbase inferring precision, "
                              "c10 or xbrl21 - Calc 1.0 (XBRL 2.1) calculations, "
                              "c10d or xbrl21-dedup - Calc 1.0 (XBRL 2.1) calculations with de-duplication, "
@@ -767,6 +767,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
         else:
             try:
                 self.modelManager.validateCalcs = {
+                     "none": CalcsMode.NONE,
                      "xbrl21precision": CalcsMode.XBRL_v2_1_INFER_PRECISION,
                      "xbrl21": CalcsMode.XBRL_v2_1,
                      "c10": CalcsMode.XBRL_v2_1,
@@ -776,9 +777,9 @@ class CntlrCmdLine(Cntlr.Cntlr):
                      "c11r": CalcsMode.ROUND_TO_NEAREST,
                      "truncation": CalcsMode.TRUNCATION,
                      "c11t": CalcsMode.TRUNCATION
-                    }.get(options.calcs)
-            except KEYERROR:
-                self.addToLog(_("--calcs value invalid, request ignored"),
+                    }[options.calcs]
+            except KeyError:
+                self.addToLog(_("--calc parameter value invalid, parameter ignored"),
                               messageCode="info", file=options.entrypointFile)
         if options.utrValidate:
             self.modelManager.validateUtr = True

--- a/arelle/CntlrWebMain.py
+++ b/arelle/CntlrWebMain.py
@@ -604,9 +604,9 @@ or label linkbases.  Multiple file names are separated by a '|' character.</td><
 <code>c10</code> or <code>xbrl21</code>: Calc 1.0 (XBRL 2.1) calculations<br/>
 <code>c10d</code> or <code>xbrl21-dedup</code>: Calc 1.0 (XBRL 2.1) calculations<br/>
 <code>c11r</code> or <code>round-to-nearest</code>: Calc 1.1 round-to-nearest mode<br/>
-<code>c11t</code> or <code>truncation</code>: Calc 1.1 truncation mode</td></tr> 
-<tr><td style="text-indent: 1em;">calcDecimals</td><td>Deprecated - XBRL v2.1 calculation linkbase validation inferring decimals.</td></tr> 
-<tr><td style="text-indent: 1em;">calcPrecision</td><td>Deprecated - pre-2010 XBRL v2.1 calculation linkbase validation inferring precision.</td></tr> 
+<code>c11t</code> or <code>truncation</code>: Calc 1.1 truncation mode</td></tr>
+<tr><td style="text-indent: 1em;">calcDecimals</td><td>Deprecated - XBRL v2.1 calculation linkbase validation inferring decimals.</td></tr>
+<tr><td style="text-indent: 1em;">calcPrecision</td><td>Deprecated - pre-2010 XBRL v2.1 calculation linkbase validation inferring precision.</td></tr>
 <tr><td style="text-indent: 1em;">efm-*</td><td>Select Edgar Filer Manual (U.S. SEC) disclosure system validation. (Alternative to flavor parameter.):<br/>
 <code>efm-pragmatic</code>: SEC-required rules, currently-allowed years<br/>
 <code>efm-strict</code>: SEC-semantic additional rules, currently-allowed years<br/>

--- a/arelle/CntlrWebMain.py
+++ b/arelle/CntlrWebMain.py
@@ -600,8 +600,13 @@ or label linkbases.  Multiple file names are separated by a '|' character.</td><
 <tr><td style="text-indent: 1em;">labelLang</td><td>Label language to override system settings, e.g., <code>&labelLang=ja</code>.</td></tr>
 <tr><td style="text-indent: 1em;">labelRole</td><td>Label role instead of standard label, e.g., <code>&labelRole=http://www.xbrl.org/2003/role/verboseLabel</code>.  To use the concept QName instead of a label, specify <code>&labelRole=XBRL-concept-name</code>.</td></tr>
 <tr><td style="text-indent: 1em;">uiLang</td><td>User interface language to override system settings, e.g., <code>&uiLang=fr</code>.  Changes setting for current session (but not saved setting).</td></tr>
-<tr><td style="text-indent: 1em;">calcDecimals</td><td>Specify calculation linkbase validation inferring decimals.</td></tr>
-<tr><td style="text-indent: 1em;">calcPrecision</td><td>Specify calculation linkbase validation inferring precision.</td></tr>
+<tr><td style="text-indent: 1em;">calc</td><td>Specify calculation validation:<br/>
+<code>c10</code> or <code>xbrl21</code>: Calc 1.0 (XBRL 2.1) calculations<br/>
+<code>c10d</code> or <code>xbrl21-dedup</code>: Calc 1.0 (XBRL 2.1) calculations<br/>
+<code>c11r</code> or <code>round-to-nearest</code>: Calc 1.1 round-to-nearest mode<br/>
+<code>c11t</code> or <code>truncation</code>: Calc 1.1 truncation mode</td></tr> 
+<tr><td style="text-indent: 1em;">calcDecimals</td><td>Deprecated - XBRL v2.1 calculation linkbase validation inferring decimals.</td></tr> 
+<tr><td style="text-indent: 1em;">calcPrecision</td><td>Deprecated - pre-2010 XBRL v2.1 calculation linkbase validation inferring precision.</td></tr> 
 <tr><td style="text-indent: 1em;">efm-*</td><td>Select Edgar Filer Manual (U.S. SEC) disclosure system validation. (Alternative to flavor parameter.):<br/>
 <code>efm-pragmatic</code>: SEC-required rules, currently-allowed years<br/>
 <code>efm-strict</code>: SEC-semantic additional rules, currently-allowed years<br/>

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -917,7 +917,7 @@ class CntlrWinMain (Cntlr.Cntlr):
                 hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, XbrlConst.parentChild, lang=self.labelLang)
                 if hasView and topView is None: topView = modelXbrl.views[-1]
                 currentAction = "calculation linkbase view"
-                hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, 
+                hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt,
                                                                      XbrlConst.summationItem if self.modelManager.validateCalcs in (CalcsMode.XBRL_v2_1_INFER_PRECISION, CalcsMode.XBRL_v2_1, CalcsMode.XBRL_v2_1_DEDUPLICATE)
                                                                      else (XbrlConst.summationItem, XbrlConst.summationItem11) if self.modelManager.validateCalcs in (CalcsMode.ROUND_TO_NEAREST, CalcsMode.XBRL_v2_1_DEDUPLICATE)
                                                                      else (),

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -13,7 +13,7 @@ if sys.platform == 'win32' and getattr(sys, 'frozen', False):
     # need the .dll directory in path to be able to access Tk and Tcl DLLs efore importinng Tk, etc.
     os.environ['PATH'] = os.path.dirname(sys.executable) + ";" + os.environ['PATH']
 
-from tkinter import (Tk, Tcl, TclError, Toplevel, Menu, PhotoImage, StringVar, BooleanVar, N, S, E, W, EW,
+from tkinter import (Tk, Tcl, TclError, Toplevel, Menu, PhotoImage, StringVar, BooleanVar, IntVar, N, S, E, W, EW,
                      HORIZONTAL, VERTICAL, END, font as tkFont)
 try:
     from tkinter.ttk import Frame, Button, Label, Combobox, Separator, PanedWindow, Notebook
@@ -32,6 +32,7 @@ from arelle.CntlrWinTooltip import ToolTip
 from arelle import XbrlConst
 from arelle.PluginManager import pluginClassMethods
 from arelle.UrlUtil import isHttpUrl
+from arelle.ValidateXbrlCalcs import ValidateCalcsMode as CalcsMode
 from arelle.Version import copyrightLabel
 import logging
 
@@ -151,18 +152,16 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.validateDisclosureSystem.trace("w", self.setValidateDisclosureSystem)
         validateMenu.add_checkbutton(label=_("Disclosure system checks"), underline=0, variable=self.validateDisclosureSystem, onvalue=True, offvalue=False)
         validateMenu.add_command(label=_("Select disclosure system..."), underline=0, command=self.selectDisclosureSystem)
-        self.modelManager.validateCalcLB = self.config.setdefault("validateCalcLB",False)
-        self.validateCalcLB = BooleanVar(value=self.modelManager.validateCalcLB)
-        self.validateCalcLB.trace("w", self.setValidateCalcLB)
-        validateMenu.add_checkbutton(label=_("Calc Linkbase checks"), underline=0, variable=self.validateCalcLB, onvalue=True, offvalue=False)
-        self.modelManager.validateInferDecimals = self.config.setdefault("validateInferDecimals",True)
-        self.validateInferDecimals = BooleanVar(value=self.modelManager.validateInferDecimals)
-        self.validateInferDecimals.trace("w", self.setValidateInferDecimals)
-        validateMenu.add_checkbutton(label=_("Infer Decimals in calculations"), underline=0, variable=self.validateInferDecimals, onvalue=True, offvalue=False)
-        self.modelManager.validateDedupCalcs = self.config.setdefault("validateDedupCalcs",False)
-        self.validateDedupCalcs = BooleanVar(value=self.modelManager.validateDedupCalcs)
-        self.validateDedupCalcs.trace("w", self.setValidateDedupCalcs)
-        validateMenu.add_checkbutton(label=_("De-duplicate calculations"), underline=0, variable=self.validateDedupCalcs, onvalue=True, offvalue=False)
+        calcMenu = Menu(self.menubar, tearoff=0)
+        self.modelManager.validateCalcs = self.config.setdefault("validateCalcsEnum", CalcsMode.NONE)
+        self.calcChoiceEnumVar = IntVar(self.parent, value=self.modelManager.validateCalcs)
+        self.calcChoiceEnumVar.trace("w", self.setCalcChoiceEnumVar)
+        calcMenu.add_radiobutton(label=_('No calculation checks'), underline=0, var=self.calcChoiceEnumVar, value=CalcsMode.NONE)
+        calcMenu.add_radiobutton(label=_('Calc 1.0 calculations'), underline=0, var=self.calcChoiceEnumVar, value=CalcsMode.XBRL_v2_1)
+        calcMenu.add_radiobutton(label=_('Calc 1.0 with de-duplication'), underline=0, var=self.calcChoiceEnumVar, value=CalcsMode.XBRL_v2_1_DEDUPLICATE)
+        calcMenu.add_radiobutton(label=_('Calc 1.1 round-to-nearest mode'), underline=0, var=self.calcChoiceEnumVar, value=CalcsMode.ROUND_TO_NEAREST)
+        calcMenu.add_radiobutton(label=_('Calc 1.1 truncation mode'), underline=0, var=self.calcChoiceEnumVar, value=CalcsMode.TRUNCATION)
+        toolsMenu.add_cascade(label=_("Calc linkbase"), menu=calcMenu, underline=0)
         self.modelManager.validateUtr = self.config.setdefault("validateUtr",True)
         self.validateUtr = BooleanVar(value=self.modelManager.validateUtr)
         self.validateUtr.trace("w", self.setValidateUtr)
@@ -918,7 +917,11 @@ class CntlrWinMain (Cntlr.Cntlr):
                 hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, XbrlConst.parentChild, lang=self.labelLang)
                 if hasView and topView is None: topView = modelXbrl.views[-1]
                 currentAction = "calculation linkbase view"
-                hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, XbrlConst.summationItem, lang=self.labelLang)
+                hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, 
+                                                                     XbrlConst.summationItem if self.modelManager.validateCalcs in (CalcsMode.XBRL_v2_1_INFER_PRECISION, CalcsMode.XBRL_v2_1, CalcsMode.XBRL_v2_1_DEDUPLICATE)
+                                                                     else (XbrlConst.summationItem, XbrlConst.summationItem11) if self.modelManager.validateCalcs in (CalcsMode.ROUND_TO_NEAREST, CalcsMode.XBRL_v2_1_DEDUPLICATE)
+                                                                     else (),
+                                                                     lang=self.labelLang)
                 if hasView and topView is None: topView = modelXbrl.views[-1]
                 currentAction = "dimensions relationships view"
                 hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, "XBRL-dimensions", lang=self.labelLang)
@@ -1278,15 +1281,7 @@ class CntlrWinMain (Cntlr.Cntlr):
             if valType == ModelDocument.Type.VERSIONINGREPORT:
                 v = _("Validate versioning report")
             else:
-                if self.modelManager.validateCalcLB:
-                    if self.modelManager.validateInferDecimals:
-                        c = _("\nCheck calculations (infer decimals)")
-                    else:
-                        c = _("\nCheck calculations (infer precision)")
-                    if self.modelManager.validateDedupCalcs:
-                        c += _("\nDeduplicate calculations")
-                else:
-                    c = ""
+                c = "\n" + CalcsMode.label[self.modelManager.validateCalcs]
                 if self.modelManager.validateUtr:
                     u = _("\nCheck unit type registry")
                 else:
@@ -1300,21 +1295,9 @@ class CntlrWinMain (Cntlr.Cntlr):
             v = _("Validate")
         self.validateTooltipText.set(v)
 
-    def setValidateCalcLB(self, *args):
-        self.modelManager.validateCalcLB = self.validateCalcLB.get()
-        self.config["validateCalcLB"] = self.modelManager.validateCalcLB
-        self.saveConfig()
-        self.setValidateTooltipText()
-
-    def setValidateInferDecimals(self, *args):
-        self.modelManager.validateInferDecimals = self.validateInferDecimals.get()
-        self.config["validateInferDecimals"] = self.modelManager.validateInferDecimals
-        self.saveConfig()
-        self.setValidateTooltipText()
-
-    def setValidateDedupCalcs(self, *args):
-        self.modelManager.validateDedupCalcs = self.validateDedupCalcs.get()
-        self.config["validateDedupCalcs"] = self.modelManager.validateDedupCalcs
+    def setCalcChoiceEnumVar(self, *args):
+        self.modelManager.validateCalcs = self.calcChoiceEnumVar.get()
+        self.config["validateCalcsEnum"] = self.modelManager.validateCalcs
         self.saveConfig()
         self.setValidateTooltipText()
 

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -917,11 +917,7 @@ class CntlrWinMain (Cntlr.Cntlr):
                 hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, XbrlConst.parentChild, lang=self.labelLang)
                 if hasView and topView is None: topView = modelXbrl.views[-1]
                 currentAction = "calculation linkbase view"
-                hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt,
-                                                                     XbrlConst.summationItem if self.modelManager.validateCalcs in (CalcsMode.XBRL_v2_1_INFER_PRECISION, CalcsMode.XBRL_v2_1, CalcsMode.XBRL_v2_1_DEDUPLICATE)
-                                                                     else (XbrlConst.summationItem, XbrlConst.summationItem11) if self.modelManager.validateCalcs in (CalcsMode.ROUND_TO_NEAREST, CalcsMode.XBRL_v2_1_DEDUPLICATE)
-                                                                     else (),
-                                                                     lang=self.labelLang)
+                hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, ("Calculation",(XbrlConst.summationItem, XbrlConst.summationItem11)), lang=self.labelLang)
                 if hasView and topView is None: topView = modelXbrl.views[-1]
                 currentAction = "dimensions relationships view"
                 hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, "XBRL-dimensions", lang=self.labelLang)

--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -450,8 +450,8 @@ class ModelFact(ModelObject):
                     return False
 
                 if numericIntervalConsistency: # values consistent with being rounded from same number
-                    (a1,b1) = rangeValue(self.value, inferredDecimals(self))
-                    (a2,b2) = rangeValue(other.value, inferredDecimals(other))
+                    (a1,b1,_ia1,_ib2) = rangeValue(self.value, inferredDecimals(self))
+                    (a2,b2,_ia2,_ib2) = rangeValue(other.value, inferredDecimals(other))
                     return not (b1 < a2 or b2 < a1)
 
                 if self.modelXbrl.modelManager.validateInferDecimals:

--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -37,7 +37,7 @@ from typing import Any
 from lxml import etree
 from arelle import XmlUtil, XbrlConst, XbrlUtil, UrlUtil, Locale, ModelValue
 from arelle.Aspect import Aspect
-from arelle.ValidateXbrlCalcs import inferredPrecision, inferredDecimals, roundValue, rangeValue
+from arelle.ValidateXbrlCalcs import inferredPrecision, inferredDecimals, roundValue, rangeValue, ValidateCalcsMode
 from arelle.XmlValidate import UNVALIDATED, INVALID, VALID, validate as xmlValidate
 from arelle.PrototypeInstanceObject import DimValuePrototype
 from math import isnan, isinf
@@ -454,14 +454,14 @@ class ModelFact(ModelObject):
                     (a2,b2,_ia2,_ib2) = rangeValue(other.value, inferredDecimals(other))
                     return not (b1 < a2 or b2 < a1)
 
-                if self.modelXbrl.modelManager.validateInferDecimals:
+                if self.modelXbrl.modelManager.validateCalcs != ValidateCalcsMode.XBRL_v2_1_INFER_PRECISION:
                     d = min((inferredDecimals(self), inferredDecimals(other))); p = None
                     if isnan(d):
                         if deemP0Equal:
                             return True
                         elif deemP0inf: # for test cases deem P0 as INF comparison
                             return self.xValue == other.xValue
-                else:
+                else: # pre-2010 XBRL 2.1 inferred precision
                     d = None; p = min((inferredPrecision(self), inferredPrecision(other)))
                     if p == 0:
                         if deemP0Equal:

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -36,17 +36,9 @@ class ModelManager:
 
         Disclosure system object.  To select the disclosure system, e.g., 'gfm', moduleManager.disclosureSystem.select('gfm').
 
-        .. attribute:: validateCalcLB
+        .. attribute:: validateCalcs
 
-        True for calculation linkbase validation.
-
-        .. attribute:: validateInferDecimals
-
-        True for calculation linkbase validation to infer decimals (instead of precision)
-
-        .. attribute:: validateDedupCalcs
-
-        True for calculation linkbase validation de-duplicate calculations
+        ValidateXbrlCalcs.ValidateCalcsMode
 
         .. attribute:: validateUTR
 
@@ -64,9 +56,7 @@ class ModelManager:
         self.cntlr = cntlr
         self.validateDisclosureSystem = False
         self.disclosureSystem = DisclosureSystem.DisclosureSystem(self)
-        self.validateCalcLB = False
-        self.validateInferDecimals = True
-        self.validateDedupCalcs = False
+        self.validateCalcs = 0 # ValidateXbrlCalcs.ValidateCalcsMode
         self.validateInfoset = False
         self.validateUtr = False
         self.validateTestcaseSchema = True

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 import gc, sys, traceback, logging
-from arelle import ModelXbrl, Validate, DisclosureSystem, PackageManager
+from arelle import ModelXbrl, Validate, DisclosureSystem, PackageManager, ValidateXbrlCalcs
 from arelle.ModelFormulaObject import FormulaOptions
 from arelle.PluginManager import pluginClassMethods
 from arelle.typing import LocaleDict
@@ -68,6 +68,7 @@ class ModelManager:
         self.customTransforms: dict[QName, Callable[[str], str]] | None = None
         self.isLocaleSet = False
         self.setLocale()
+        ValidateXbrlCalcs.init() # required due to circular dependencies in module
 
     def shutdown(self):
         self.status = "shutdown"

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -108,9 +108,7 @@ class ValidateXbrl:
         self.validateSBRNL = self.validateDisclosureSystem and self.disclosureSystem.SBRNL
         self.validateEFMorGFMorSBRNL = self.validateEFMorGFM or self.validateSBRNL
         self.validateXmlLang = self.validateDisclosureSystem and self.disclosureSystem.xmlLangPattern
-        self.validateCalcLB = modelXbrl.modelManager.validateCalcLB
-        self.validateInferDecimals = modelXbrl.modelManager.validateInferDecimals
-        self.validateDedupCalcs = modelXbrl.modelManager.validateDedupCalcs
+        self.validateCalcs = modelXbrl.modelManager.validateCalcs
         self.validateUTR = (modelXbrl.modelManager.validateUtr or
                             (self.parameters and self.parameters.get(qname("forceUtrValidation",noPrefixIsNoNamespace=True),(None,"false"))[1] == "true") or
                             (self.validateEFM and
@@ -417,11 +415,9 @@ class ValidateXbrl:
             validateUniqueParticleAttribution(modelXbrl, modelType.particlesList, modelType)
         modelXbrl.profileStat(_("validateDTS"))
 
-        if self.validateCalcLB:
+        if self.validateCalcs:
             modelXbrl.modelManager.showStatus(_("Validating instance calculations"))
-            ValidateXbrlCalcs.validate(modelXbrl,
-                                       inferDecimals=self.validateInferDecimals,
-                                       deDuplicate=self.validateDedupCalcs)
+            ValidateXbrlCalcs.validate(modelXbrl, self.validateCalcs)
             modelXbrl.profileStat(_("validateCalculations"))
 
         if self.validateUTR:

--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -25,7 +25,7 @@ class ValidateCalcsMode:
     XBRL_v2_1_DEDUPLICATE = 3       # post-2010 spec v2.1 with deduplication
     ROUND_TO_NEAREST = 4            # calculations 1.1 round-to-nearest mode
     TRUNCATION = 5                  # calculations 1.1 truncation mode
-    
+
     label = {
         NONE: "No calculations linkbase checks",
         XBRL_v2_1_INFER_PRECISION: "Pre-2010 XBRL 2.1 calculations validation inferring precision",
@@ -34,7 +34,7 @@ class ValidateCalcsMode:
         ROUND_TO_NEAREST: "Calculations 1.1 round-to-nearest mode",
         TRUNCATION: "Calculations 1.1 truncation mode"
         }
-    
+
 oimErrorCodePattern = re_compile("xbrl[cjx]e:|oimc?e:")
 numberPattern = re_compile("[-+]?[0]*([1-9]?[0-9]*)([.])?(0*)([1-9]?[0-9]*)?([eE])?([-+]?[0-9]*)?")
 ZERO = decimal.Decimal(0)
@@ -90,7 +90,7 @@ class ValidateXbrlCalcs:
         calc11 = self.calc11 # round or truncate
         calc11t = self.calc11t # truncate
         sumConceptItemRels = defaultdict(dict) # for calc11 dup sum-item detection
-          
+
         if xbrl21:
             if not self.modelXbrl.contexts and not self.modelXbrl.facts:
                 return # skip if no contexts or facts (note that in calc11 mode the dup relationships test is nonetheless required)
@@ -100,7 +100,7 @@ class ValidateXbrlCalcs:
             oimErrs = set()
             for i in range(len(modelXbrl.errors) - 1, -1, -1):
                 e = modelXbrl.errors[i]
-                if oimErrorCodePattern.match(e):                    
+                if oimErrorCodePattern.match(e):
                     del modelXbrl.errors[i] # remove the oim errors from modelXbrl.errors
                 oimErrs.add(e)
             if len(oimErrs) == 1 and "xbrlxe:unsupportedTuple" in oimErrs:
@@ -109,7 +109,7 @@ class ValidateXbrlCalcs:
             elif len(oimErrs) > 0:
                 modelXbrl.warning("calc11e:oimIncompatibleReportWarning","Validating of calculations is skipped due to OIM errors.")
                 return;
-            
+
         # identify equal contexts
         modelXbrl.profileActivity()
         uniqueContextHashes = {}
@@ -230,7 +230,7 @@ class ValidateXbrlCalcs:
                                             if not fact.isNil:
                                                 if fact in self.duplicatedFacts:
                                                     dupBindingKeys.add(sumBindKey)
-                                                elif (sumBindKey in boundSums and sumBindKey not in dupBindingKeys 
+                                                elif (sumBindKey in boundSums and sumBindKey not in dupBindingKeys
                                                       and fact not in self.consistentDupFacts
                                                       and not (len(sumFacts) > 1 and not self.deDuplicate)): # don't bind if sum duplicated without dedup option
                                                     roundedSum = roundFact(fact, self.inferDecimals)
@@ -242,16 +242,16 @@ class ValidateXbrlCalcs:
                                                         unreportedContribingItemQnames = [] # list the missing/unreported contributors in relationship order
                                                         for modelRel in modelRels:
                                                             itemConcept = modelRel.toModelObject
-                                                            if (itemConcept is not None and 
+                                                            if (itemConcept is not None and
                                                                 (itemConcept, ancestor, contextHash, unit) not in self.itemFacts):
                                                                 unreportedContribingItemQnames.append(str(itemConcept.qname))
                                                         modelXbrl.log('INCONSISTENCY', "xbrl.5.2.5.2:calcInconsistency",
                                                             _("Calculation inconsistent from %(concept)s in link role %(linkrole)s reported sum %(reportedSum)s computed sum %(computedSum)s context %(contextID)s unit %(unitID)s unreportedContributingItems %(unreportedContributors)s"),
                                                             modelObject=wrappedSummationAndItems(fact, roundedSum, _boundSummationItems),
-                                                            concept=sumConcept.qname, linkrole=ELR, 
+                                                            concept=sumConcept.qname, linkrole=ELR,
                                                             linkroleDefinition=modelXbrl.roleTypeDefinition(ELR),
                                                             reportedSum=Locale.format_decimal(modelXbrl.locale, roundedSum, 1, max(d,0)),
-                                                            computedSum=Locale.format_decimal(modelXbrl.locale, roundedItemsSum, 1, max(d,0)), 
+                                                            computedSum=Locale.format_decimal(modelXbrl.locale, roundedItemsSum, 1, max(d,0)),
                                                             contextID=fact.context.id, unitID=fact.unit.id,
                                                             unreportedContributors=", ".join(unreportedContribingItemQnames) or "none")
                                                         del unreportedContribingItemQnames[:]
@@ -267,10 +267,10 @@ class ValidateXbrlCalcs:
                                                 modelXbrl.error("calc11e:inconsistentCalculationUsing" + self.calc11suffix,
                                                     _("Calculation inconsistent from %(concept)s in link role %(linkrole)s reported sum %(reportedSum)s computed sum %(computedSum)s context %(contextID)s unit %(unitID)s"),
                                                     modelObject=sumFacts + boundIntervalItems[sumBindKey],
-                                                    concept=sumConcept.qname, linkrole=ELR, 
+                                                    concept=sumConcept.qname, linkrole=ELR,
                                                     linkroleDefinition=modelXbrl.roleTypeDefinition(ELR),
                                                     reportedSum=rangeToStr(s1,s2,incls1,incls2),
-                                                    computedSum=rangeToStr(x1,s2,inclx1,inclx2), 
+                                                    computedSum=rangeToStr(x1,s2,inclx1,inclx2),
                                                     contextID=sumFacts[0].context.id, unitID=sumFacts[0].unit.id)
                             boundSummationItems.clear() # dereference facts in list
                             boundIntervalItems.clear()
@@ -392,7 +392,7 @@ class ValidateXbrlCalcs:
         if any(f.isNil for f in fList):
             if all(f.isNil for f in fList):
                 return (NIL_FACT_SET,NIL_FACT_SET,True,True)
-            _inConsistent = True # provide error message 
+            _inConsistent = True # provide error message
         else: # not all have same decimals
             a = b = None
             inclA = inclB = _inConsistent = False
@@ -411,26 +411,26 @@ class ValidateXbrlCalcs:
                 else:
                     decVals[_d] = _v
                     _a, _b, _inclA, _inclB = rangeValue(_v, _d, truncate=truncate)
-                    if a is None or _a >= a: 
+                    if a is None or _a >= a:
                         a = _a
                         inclA |= _inclA
-                    if b is None or _b <= b: 
+                    if b is None or _b <= b:
                         b = _b
-                        inclB |= _inclB 
+                        inclB |= _inclB
             _inConsistent = (a == b and not(inclA and inclB)) or (a > b)
         if _excessDigitFacts:
             self.modelXbrl.error("calc11e:excessDigits",
                 "Calculations check stopped for excess digits in fact values %(element)s: %(values)s, %(contextIDs)s.",
-                modelObject=fList, element=_excessDigitFacts[0].qname, 
-                contextIDs=", ".join(sorted(set(f.contextID for f in _excessDigitFacts))), 
+                modelObject=fList, element=_excessDigitFacts[0].qname,
+                contextIDs=", ".join(sorted(set(f.contextID for f in _excessDigitFacts))),
                 values=", ".join(strTruncate(f.value,64) for f in _excessDigitFacts))
             return (INCONSISTENT, INCONSISTENT,True,True)
         if _inConsistent:
             self.modelXbrl.error(
                 "calc11e:disallowedDuplicateFactsUsingTruncation" if self.calc11t else "oime:disallowedDuplicateFacts",
                 "Calculations check stopped for duplicate fact values %(element)s: %(values)s, %(contextIDs)s.",
-                modelObject=fList, element=fList[0].qname, 
-                contextIDs=", ".join(sorted(set(f.contextID for f in fList))), 
+                modelObject=fList, element=fList[0].qname,
+                contextIDs=", ".join(sorted(set(f.contextID for f in fList))),
                 values=", ".join(strTruncate(f.value,64) for f in fList))
             return (INCONSISTENT, INCONSISTENT,True,True)
         return (a, b, inclA, inclB)

--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -40,7 +40,19 @@ class ValidateCalcsMode:
         TRUNCATION: "Calculations 1.1 truncation mode"
         }
 
-oimErrorCodePattern = re_compile("xbrl[cjx]e:|oimc?e:")
+oimXbrlxeBlockingErrorCodes = {
+        "xbrlxe:nonDimensionalSegmentScenarioContent",
+        "xbrlxe:nonStandardFootnoteResourceRole",
+        "xbrlxe:unsupportedTuple",
+        "xbrlxe:unexpectedContextContent",
+        "xbrlxe:unlinkedFootnoteResource",
+        "xbrlxe:unsupportedComplexTypedDimension",
+        "xbrlxe:unsupportedExternalRoleRef",
+        "xbrlxe:unsupportedFraction",
+        "xbrlxe:unsupportedLinkbaseReference",
+        "xbrlxe:unsupportedXmlBase",
+        "xbrlxe:unsupportedZeroPrecisionFact"
+        }
 numberPattern = re_compile("[-+]?[0]*([1-9]?[0-9]*)([.])?(0*)([1-9]?[0-9]*)?([eE])?([-+]?[0-9]*)?")
 ZERO = decimal.Decimal(0)
 ONE = decimal.Decimal(1)
@@ -102,13 +114,13 @@ class ValidateXbrlCalcs:
             oimErrs = set()
             for i in range(len(modelXbrl.errors) - 1, -1, -1):
                 e = modelXbrl.errors[i]
-                if oimErrorCodePattern.match(e):
+                if e in oimXbrlxeBlockingErrorCodes:
                     del modelXbrl.errors[i] # remove the oim errors from modelXbrl.errors
                 oimErrs.add(e)
-            if len(oimErrs) == 1 and "xbrlxe:unsupportedTuple" in oimErrs:
+            if any(e == "xbrlxe:unsupportedTuple" for e in oimErrs):
                 # ignore this error and change to warning
                 modelXbrl.warning("calc11e:tuplesInReportWarning","Validating of calculations ignores tuples.")
-            elif len(oimErrs) > 0:
+            if any(e in oimXbrlxeBlockingErrorCodes for e in oimErrs if e != "xbrlxe:unsupportedTuple"):
                 modelXbrl.warning("calc11e:oimIncompatibleReportWarning","Validating of calculations is skipped due to OIM errors.")
                 return;
 

--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -16,7 +16,12 @@ from arelle.XmlValidate import UNVALIDATED, VALID
 if TYPE_CHECKING:
     from arelle.ModelInstanceObject import ModelFact
 else:
-    ModelFact = None
+    ModelFact = None # circular import with ModelInstanceObject
+
+def init(): # prevent circular imports
+    global ModelFact
+    if ModelFact is None:
+        from arelle.ModelInstanceObject import ModelFact
 
 class ValidateCalcsMode:
     NONE = 0                        # no calculations linkbase validation
@@ -53,9 +58,6 @@ def rangeToStr(a, b, inclA, inclB) -> str:
     return {True:"[", False: "("}[inclA] + f"{a}, {b}" + {True:"]", False: ")"}[inclB]
 
 def validate(modelXbrl, validateCalcs) -> None:
-    global ModelFact
-    if ModelFact is None:
-        from arelle.ModelInstanceObject import ModelFact
     ValidateXbrlCalcs(modelXbrl, validateCalcs).validate()
 
 class ValidateXbrlCalcs:

--- a/arelle/ViewUtil.py
+++ b/arelle/ViewUtil.py
@@ -39,6 +39,8 @@ def groupRelationshipSet(modelXbrl, arcrole, linkrole, linkqname, arcqname):
 
 def groupRelationshipLabel(arcrole):
     if isinstance(arcrole, (list,tuple)): # (group-name, [arcroles])
+        if len(set(XbrlConst.baseSetArcroleLabel(a) for a in arcrole)) == 1: # calc arcroles are all same group
+            return groupRelationshipLabel(arcrole[0])
         arcroleName = arcrole[0]
     else:
         arcroleName = XbrlConst.baseSetArcroleLabel(arcrole)[1:]

--- a/arelle/ViewUtil.py
+++ b/arelle/ViewUtil.py
@@ -39,8 +39,6 @@ def groupRelationshipSet(modelXbrl, arcrole, linkrole, linkqname, arcqname):
 
 def groupRelationshipLabel(arcrole):
     if isinstance(arcrole, (list,tuple)): # (group-name, [arcroles])
-        if len(set(XbrlConst.baseSetArcroleLabel(a) for a in arcrole)) == 1: # calc arcroles are all same group
-            return groupRelationshipLabel(arcrole[0])
         arcroleName = arcrole[0]
     else:
         arcroleName = XbrlConst.baseSetArcroleLabel(arcrole)[1:]

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -156,6 +156,7 @@ factFootnote = "http://www.xbrl.org/2003/arcrole/fact-footnote"
 factExplanatoryFact = "http://www.xbrl.org/2009/arcrole/fact-explanatoryFact"
 parentChild = "http://www.xbrl.org/2003/arcrole/parent-child"
 summationItem = "http://www.xbrl.org/2003/arcrole/summation-item"
+summationItem11 = "https://xbrl.org/2023/arcrole/summation-item"
 essenceAlias = "http://www.xbrl.org/2003/arcrole/essence-alias"
 similarTuples = "http://www.xbrl.org/2003/arcrole/similar-tuples"
 requiresElement = "http://www.xbrl.org/2003/arcrole/requires-element"
@@ -688,7 +689,7 @@ def baseSetArcroleLabel(arcrole: str) -> str:  # with sort char in first positio
         return _("1Rendering")
     if arcrole == parentChild:
         return _("1Presentation")
-    if arcrole == summationItem:
+    if arcrole in (summationItem, summationItem11):
         return _("1Calculation")
     if arcrole == widerNarrower:
         return "1Anchoring"

--- a/arelle/examples/CustomLogger.py
+++ b/arelle/examples/CustomLogger.py
@@ -5,6 +5,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import print_function
 from arelle import Cntlr
+from arelle.ValidateXbrlCalcs import ValidateCalcsMode
 
 class CntlrCustomLoggingExample(Cntlr.Cntlr):
 
@@ -18,8 +19,7 @@ class CntlrCustomLoggingExample(Cntlr.Cntlr):
 
         modelXbrl = self.modelManager.load("c:\\temp\\test.xbrl")
 
-        self.modelManager.validateInferDecimals = True
-        self.modelManager.validateCalcLB = True
+        self.modelManager.validateCalcs = ValidateCalcsMode.XBRL_v2_1
 
         self.modelManager.validate()
 

--- a/arelle/examples/LoadEFMvalidate.py
+++ b/arelle/examples/LoadEFMvalidate.py
@@ -4,6 +4,7 @@ This module is an example Arelle controller in non-interactive mode
 See COPYRIGHT.md for copyright information.
 '''
 from arelle import Cntlr
+from arelle.ValidateXbrlCalcs import ValidateCalcsMode
 
 class CntlrEfmValidateExample(Cntlr.Cntlr):
 
@@ -17,8 +18,7 @@ class CntlrEfmValidateExample(Cntlr.Cntlr):
 
         modelXbrl = self.modelManager.load("c:\\temp\\test.xbrl")
 
-        self.modelManager.validateInferDecimals = True
-        self.modelManager.validateCalcLB = True
+        self.modelManager.validateCalcs = ValidateCalcsMode.XBRL_v2_1
 
         # perfrom XBRL 2.1, dimensions, calculation and SEC EFM validation
         self.modelManager.validate()

--- a/arelle/examples/LoadValidate.py
+++ b/arelle/examples/LoadValidate.py
@@ -4,6 +4,7 @@ This module is an example Arelle controller in non-interactive mode
 See COPYRIGHT.md for copyright information.
 '''
 from arelle import Cntlr
+from arelle.ValidateXbrlCalcs import ValidateCalcsMode
 
 # this is the controller class
 class CntlrValidateExample(Cntlr.Cntlr):
@@ -18,8 +19,7 @@ class CntlrValidateExample(Cntlr.Cntlr):
         modelXbrl = self.modelManager.load("c:\\temp\\test.xbrl")
 
         # select validation of calculation linkbase using infer decimals option
-        self.modelManager.validateInferDecimals = True
-        self.modelManager.validateCalcLB = True
+        self.modelManager.validateCalcs = ValidateCalcsMode.XBRL_v2_1
 
         # perfrom XBRL 2.1, dimensions, calculation
         self.modelManager.validate()

--- a/arelle/examples/plugin/testcaseCalc11ValidateSetup.py
+++ b/arelle/examples/plugin/testcaseCalc11ValidateSetup.py
@@ -1,0 +1,32 @@
+'''
+This plug-in removes xmlns="http://www.w3.org/1999/xhtml" from 
+escaped html in text content of expected instance facts for inline XBRL text facts
+
+(c) Copyright 2019 Mark V Systems Limited, All rights reserved.
+'''
+try:
+    import regex as re
+except ImportError:
+    import re
+from arelle.XhtmlValidate import htmlEltUriAttrs, resolveHtmlUri
+from arelle.ValidateXbrlCalcs import ValidateCalcsMode as CalcsMode
+
+def testcaseVariationLoaded(testInstance, testcaseInstance, modelTestcaseVariation):
+    for result in modelTestcaseVariation.iter("{*}result"):
+        for n, v in result.attrib.items():
+            if n.endswith("mode"):
+                if v == "round-to-nearest":
+                    testInstance.modelManager.validateCalcs = CalcsMode.ROUND_TO_NEAREST
+                elif v == "truncate":
+                    testInstance.modelManager.validateCalcs = CalcsMode.TRUNCATION
+                
+__pluginInfo__ = {
+    'name': 'Testcase obtain expected calc 11 mode from variation/result@mode',
+    'version': '0.9',
+    'description': "This plug-in removes xxx.  ",
+    'license': 'Apache-2',
+    'author': 'Mark V Systems Limited',
+    'copyright': '(c) Copyright 2019 Mark V Systems Limited, All rights reserved.',
+    # classes of mount points (required)
+    'TestcaseVariation.Xbrl.Loaded': testcaseVariationLoaded,
+}

--- a/arelle/examples/plugin/testcaseCalc11ValidateSetup.py
+++ b/arelle/examples/plugin/testcaseCalc11ValidateSetup.py
@@ -1,5 +1,5 @@
 '''
-This plug-in removes xmlns="http://www.w3.org/1999/xhtml" from 
+This plug-in removes xmlns="http://www.w3.org/1999/xhtml" from
 escaped html in text content of expected instance facts for inline XBRL text facts
 
 (c) Copyright 2019 Mark V Systems Limited, All rights reserved.
@@ -19,7 +19,7 @@ def testcaseVariationLoaded(testInstance, testcaseInstance, modelTestcaseVariati
                     testInstance.modelManager.validateCalcs = CalcsMode.ROUND_TO_NEAREST
                 elif v == "truncate":
                     testInstance.modelManager.validateCalcs = CalcsMode.TRUNCATION
-                
+
 __pluginInfo__ = {
     'name': 'Testcase obtain expected calc 11 mode from variation/result@mode',
     'version': '0.9',

--- a/arelle/plugin/instanceInfo.py
+++ b/arelle/plugin/instanceInfo.py
@@ -182,7 +182,7 @@ def showInfo(cntlr, options, modelXbrl, _entrypoint, *args, **kwargs):
                         _v = f0.xValue
                         _inConsistent = isnan(_v) # NaN is incomparable, always makes dups inconsistent
                         decVals[_d] = _v
-                        aMax, bMin = rangeValue(_v, _d)
+                        aMax, bMin, _inclA, _inclB = rangeValue(_v, _d)
                         for f in fList[1:]:
                             _d = inferredDecimals(f)
                             _v = f.xValue
@@ -193,7 +193,7 @@ def showInfo(cntlr, options, modelXbrl, _entrypoint, *args, **kwargs):
                                 _inConsistent |= _v != decVals[_d]
                             else:
                                 decVals[_d] = _v
-                            a, b = rangeValue(_v, _d)
+                            a, b, _inclA, _inclB = rangeValue(_v, _d)
                             if a > aMax: aMax = a
                             if b < bMin: bMin = b
                         if not _inConsistent:

--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -687,7 +687,7 @@ def checkForDuplicates(modelXbrl, allowedDups, footnoteIDs):
                                     _v = f0.xValue
                                     _inConsistent = isnan(_v) # NaN is incomparable, always makes dups inconsistent
                                     decVals[_d] = _v
-                                    aMax, bMin = rangeValue(_v, _d)
+                                    aMax, bMin, _inclA, _inclB = rangeValue(_v, _d)
                                     for f in fList[1:]:
                                         _d = inferredDecimals(f)
                                         _v = f.xValue
@@ -698,7 +698,7 @@ def checkForDuplicates(modelXbrl, allowedDups, footnoteIDs):
                                             _inConsistent |= _v != decVals[_d]
                                         else:
                                             decVals[_d] = _v
-                                        a, b = rangeValue(_v, _d)
+                                        a, b, _inclA, _inclB = rangeValue(_v, _d)
                                         if a > aMax: aMax = a
                                         if b < bMin: bMin = b
                                     if not _inConsistent:

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -831,7 +831,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                             _v = f0.xValue
                             _inConsistent = isnan(_v) # NaN is incomparable, always makes dups inconsistent
                             decVals[_d] = _v
-                            aMax, bMin = rangeValue(_v, _d)
+                            aMax, bMin, _inclA, _inclB = rangeValue(_v, _d)
                             for f in fList[1:]:
                                 _d = inferredDecimals(f)
                                 _v = f.xValue
@@ -842,7 +842,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                                     _inConsistent |= _v != decVals[_d]
                                 else:
                                     decVals[_d] = _v
-                                a, b = rangeValue(_v, _d)
+                                a, b, _inclA, _inclB = rangeValue(_v, _d)
                                 if a > aMax: aMax = a
                                 if b < bMin: bMin = b
                             if not _inConsistent:

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -792,7 +792,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     _v = cast(float, f0.xValue)
                     _inConsistent = isnan(_v) # NaN is incomparable, always makes dups inconsistent
                     decVals[_d] = _v
-                    aMax, bMin = rangeValue(_v, _d)
+                    aMax, bMin, _inclA, _inclB = rangeValue(_v, _d)
                     for f in fList[1:]:
                         _d = inferredDecimals(f)
                         _v = cast(float, f.xValue)
@@ -803,7 +803,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                             _inConsistent |= _v != decVals[_d]
                         else:
                             decVals[_d] = _v
-                        a, b = rangeValue(_v, _d)
+                        a, b, _inclA, _inclB = rangeValue(_v, _d)
                         if a > aMax: aMax = a
                         if b < bMin: bMin = b
                     if not _inConsistent:

--- a/arelle/plugin/validate/ESEF_2022/__init__.py
+++ b/arelle/plugin/validate/ESEF_2022/__init__.py
@@ -871,7 +871,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                         continue
                     _inConsistent = isnan(_v) # NaN is incomparable, always makes dups inconsistent
                     decVals[_d] = _v
-                    aMax, bMin = rangeValue(_v, _d)
+                    aMax, bMin, _inclA, _inclB = rangeValue(_v, _d)
                     for f in fList[1:]:
                         _d = inferredDecimals(f)
                         _v = cast(float, f.xValue)
@@ -882,7 +882,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                             _inConsistent |= _v != decVals[_d]
                         else:
                             decVals[_d] = _v
-                        a, b = rangeValue(_v, _d)
+                        a, b, _inclA, _inclB = rangeValue(_v, _d)
                         if a > aMax: aMax = a
                         if b < bMin: bMin = b
                     if not _inConsistent:

--- a/arelle/plugin/validate/HMRC/__init__.py
+++ b/arelle/plugin/validate/HMRC/__init__.py
@@ -395,7 +395,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                                     _v = f0.xValue
                                     _inConsistent = isnan(_v) # NaN is incomparable, always makes dups inconsistent
                                     decVals[_d] = _v
-                                    aMax, bMin = rangeValue(_v, _d)
+                                    aMax, bMin, _inclA, _inclB = rangeValue(_v, _d)
                                     for f in fList[1:]:
                                         _d = inferredDecimals(f)
                                         _v = f.xValue
@@ -406,7 +406,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                                             _inConsistent |= _v != decVals[_d]
                                         else:
                                             decVals[_d] = _v
-                                        a, b = rangeValue(_v, _d)
+                                        a, b, _inclA, _inclB = rangeValue(_v, _d)
                                         if a > aMax: aMax = a
                                         if b < bMin: bMin = b
                                     if not _inConsistent:

--- a/arelle/plugin/validate/ROS/__init__.py
+++ b/arelle/plugin/validate/ROS/__init__.py
@@ -323,7 +323,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                                     _v = f0.xValue
                                     _inConsistent = isnan(_v) # NaN is incomparable, always makes dups inconsistent
                                     decVals[_d] = _v
-                                    aMax, bMin = rangeValue(_v, _d)
+                                    aMax, bMin, _inclA, _inclB = rangeValue(_v, _d)
                                     for f in fList[1:]:
                                         _d = inferredDecimals(f)
                                         _v = f.xValue
@@ -334,7 +334,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                                             _inConsistent |= _v != decVals[_d]
                                         else:
                                             decVals[_d] = _v
-                                        a, b = rangeValue(_v, _d)
+                                        a, b, _inclA, _inclB = rangeValue(_v, _d)
                                         if a > aMax: aMax = a
                                         if b < bMin: bMin = b
                                     if not _inConsistent:

--- a/arelle/plugin/validate/calc2.py
+++ b/arelle/plugin/validate/calc2.py
@@ -79,10 +79,6 @@ class ValidateXbrlCalc2:
         if not modelXbrl.contexts or not modelXbrl.facts:
             return # skip if no contexts or facts
 
-        if not self.val.validateInferDecimals: # infering precision is now contrary to XBRL REC section 5.2.5.2
-            modelXbrl.error("calc2e:inferringPrecision","Calc2 requires inferring decimals.")
-            return
-
         startedAt = time.time()
 
         # check balance attributes and weights, same as XBRL 2.1

--- a/arelle/plugin/validate/calc2.py
+++ b/arelle/plugin/validate/calc2.py
@@ -41,7 +41,7 @@ def intervalValue(fact, dec=None): # value in decimals
     return rangeValue(fact.value, dec)
 
 def addInterval(boundValues, key, intervalValue, weight=None):
-    a, b = intervalValue
+    a, b, _inclA, _inclB = intervalValue
     if a is NIL:
         result = NILinterval
     else:
@@ -203,10 +203,10 @@ class ValidateXbrlCalc2:
                         _inConsistent = not all(intervalValue(f) == v0 for f in fList[1:])
                     else: # not all have same decimals
                         d0 = inferredDecimals(f0)
-                        aMax, bMin = intervalValue(f0, d0)
+                        aMax, bMin, _inclA, _inclB = intervalValue(f0, d0)
                         for f in fList[1:]:
                             df = inferredDecimals(f0)
-                            a, b = intervalValue(f, df)
+                            a, b, _inclA, _inclB = intervalValue(f, df)
                             if a > aMax: aMax = a
                             if b < bMin: bMin = b
                             if df > d0: # take most accurate fact in section
@@ -321,7 +321,7 @@ class ValidateXbrlCalc2:
                             dimMemKey = (hCntx, unit, dimQN, memQN)
                             if dimMemKey in self.aggBoundFacts:
                                 for f in self.aggBoundFacts[dimMemKey]:
-                                    a, b = intervalValue(f)
+                                    a, b, _inclA, _inclB = intervalValue(f)
                                     factDomKey = (f.concept, hCntx, unit, dimQN, domQN)
                                     addInterval(boundAggs, factDomKey, intervalValue(f))
                                     boundAggItems[aggKey].append(f)
@@ -338,7 +338,7 @@ class ValidateXbrlCalc2:
                 if factKey in self.sumBoundFacts:
                     for f in self.sumBoundFacts[factKey]:
                         d = inferredDecimals(f)
-                        sa, sb = intervalValue(f, d)
+                        sa, sb, _inclA, _inclB = intervalValue(f, d)
                         if ((ia is NIL) ^ (sa is NIL)) or ((ia is not NIL) and (sb < ia or sa > ib)):
                             self.modelXbrl.log('INCONSISTENCY', "calc2e:summationInconsistency",
                                 _("Summation inconsistent from %(concept)s in section %(section)s reported sum %(reportedSum)s, computed sum %(computedSum)s context %(contextID)s unit %(unitID)s unreported contributing items %(unreportedContributors)s"),
@@ -367,7 +367,7 @@ class ValidateXbrlCalc2:
                             d = 0
                             break
                         d = inferredDecimals(f)
-                        a, b = intervalValue(f,d)
+                        a, b, _inclA, _inclB = intervalValue(f,d)
                         endBalA += a
                         endBalB += b
                     foundStartingFact = (endBalA is NIL)
@@ -379,7 +379,7 @@ class ValidateXbrlCalc2:
                                     endBalA = endBalB = NIL
                                     foundStartingFact = True
                                     break
-                                a, b = intervalValue(f)
+                                a, b, _inclA, _inclB = intervalValue(f)
                                 endBalA -= a
                                 endBalB -= b
                                 foundStartingFact = True
@@ -424,7 +424,7 @@ class ValidateXbrlCalc2:
                     if factDomKey in self.aggBoundConceptFacts:
                         for f in self.aggBoundConceptFacts[factDomKey]:
                             d = inferredDecimals(f)
-                            sa, sb = intervalValue(f, d)
+                            sa, sb, _inclA, _inclB = intervalValue(f, d)
                             if ((ia is NIL) ^ (sa is NIL)) or ((ia is not NIL) and (sb < ia or sa > ib)):
                                 self.modelXbrl.log('INCONSISTENCY', "calc2e:aggregationInconsistency",
                                     _("Aggregation inconsistent for %(concept)s, domain %(domain)s in section %(section)s reported sum %(reportedSum)s, computed sum %(computedSum)s context %(contextID)s unit %(unitID)s unreported contributing members %(unreportedContributors)s"),


### PR DESCRIPTION
#### Reason for change
Implementation of Calculations 1.1 spec (REC)

#### Description of change
Replaces [#135](https://github.com/Arelle/Arelle/pull/135) (initial implementation, pre-REC)

#### Steps to Test
[Calculations 1.1 conformance suite](https://base-spec.ci.xbrl.org/calculations/1-1-0-rec-calc11-2023-02-22/conformance/calculation-1.1-conformance-2023-02-22.zip)
Check GUI and CmdLine calc options (various modes of calc 1.0 and calc 1.1).

**review**:
@Arelle/arelle
