### PR TITLE
Add calc 1.1 conformance suite to test runner

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_configs.py
+++ b/tests/integration_tests/validation/conformance_suite_configs.py
@@ -7,6 +7,7 @@ from tests.integration_tests.validation.conformance_suite_configurations.esef_ix
 from tests.integration_tests.validation.conformance_suite_configurations.esef_xhtml_2021 import config as esef_xhtml_2021
 from tests.integration_tests.validation.conformance_suite_configurations.esef_xhtml_2022 import config as esef_xhtml_2022
 from tests.integration_tests.validation.conformance_suite_configurations.xbrl_2_1 import config as xbrl_2_1
+from tests.integration_tests.validation.conformance_suite_configurations.xbrl_calculations_1_1 import config as xbrl_calculations_1_1
 from tests.integration_tests.validation.conformance_suite_configurations.xbrl_dimensions_1_0 import config as xbrl_dimensions_1_0
 from tests.integration_tests.validation.conformance_suite_configurations.xbrl_extensible_enumerations_1_0 import config as xbrl_extensible_enumerations_1_0
 from tests.integration_tests.validation.conformance_suite_configurations.xbrl_extensible_enumerations_2_0 import config as xbrl_extensible_enumerations_2_0
@@ -33,6 +34,7 @@ ALL_CONFORMANCE_SUITE_CONFIGS: tuple[ConformanceSuiteConfig, ...] = (
     esef_xhtml_2021,
     esef_xhtml_2022,
     xbrl_2_1,
+    xbrl_calculations_1_1,
     xbrl_dimensions_1_0,
     xbrl_extensible_enumerations_1_0,
     xbrl_extensible_enumerations_2_0,

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_calculations_1_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_calculations_1_1.py
@@ -1,0 +1,40 @@
+from pathlib import PurePath
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig
+
+config = ConformanceSuiteConfig(
+    args=[
+        '--plugin', 'loadFromOIM',
+        '--plugin', '../../arelle/examples/plugin/testcaseCalc11ValidateSetup.py',
+    ],
+    expected_failure_ids=frozenset([
+        # The loadFromOIM plugin is required to load the conformance suite json
+        # files. However, OIM validation raises xbrlxe:unsupportedTuple for
+        # tuples which then raises calc11e:tuplesInReportWarning in calc 1.1.
+        # This isn't modeled in the conformance suite, but expected if both
+        # calc 1.1 and OIM validation are performed together.
+        # https://www.xbrl.org/Specification/xbrl-xml/REC-2021-10-13/xbrl-xml-REC-2021-10-13.html#unsupportedTuple
+        # https://www.xbrl.org/Specification/calculation-1.1/REC-2023-02-22/calculation-1.1-REC-2023-02-22.html#error-calc11e-tuplesinreportwarning
+        'calculation-1.1-conformance-2023-02-22/calc11/oim-tuple-consistent-round',
+        'calculation-1.1-conformance-2023-02-22/calc11/oim-tuple-consistent-truncate',
+        'calculation-1.1-conformance-2023-02-22/calc11/oim-tuple-ignored-calculation-round',
+        'calculation-1.1-conformance-2023-02-22/calc11/oim-tuple-ignored-calculation-truncate',
+        'calculation-1.1-conformance-2023-02-22/xbrl21/oim-tuple-consistent-round',
+        'calculation-1.1-conformance-2023-02-22/xbrl21/oim-tuple-consistent-truncate',
+        'calculation-1.1-conformance-2023-02-22/xbrl21/oim-tuple-ignored-calculation-round',
+        'calculation-1.1-conformance-2023-02-22/xbrl21/oim-tuple-ignored-calculation-truncate',
+
+        # Similar to the above, validation errors other than
+        # xbrlxe:unsupportedTuple are expected to raise
+        # calc11e:oimIncompatibleReportWarning during calc 1.1 validation.
+        # https://www.xbrl.org/Specification/calculation-1.1/REC-2023-02-22/calculation-1.1-REC-2023-02-22.html#error-calc11e-oimincompatiblereportwarning
+        'calculation-1.1-conformance-2023-02-22/calc11/oim-illegal-fraction-item-round',
+        'calculation-1.1-conformance-2023-02-22/calc11/oim-illegal-fraction-item-truncate',
+        'calculation-1.1-conformance-2023-02-22/xbrl21/oim-illegal-fraction-item-round',
+        'calculation-1.1-conformance-2023-02-22/xbrl21/oim-illegal-fraction-item-truncate',
+    ]),
+    file='calculation-1.1-conformance-2023-02-22/index.xml',
+    info_url='https://specifications.xbrl.org/work-product-index-calculations-2-calculations-1-1.html',
+    local_filepath='calculation-1.1-conformance-2023-02-22.zip',
+    membership_url='https://www.xbrl.org/join',
+    name=PurePath(__file__).stem,
+)


### PR DESCRIPTION
#### Reason for change
#680 added support for calc 1.1, but we still need to include the conformance suite within our test runner.

#### Description of change
Add calc 1.1 conformance suite to test runner and CI

#### Steps to Test
* ci

**review**:
@Arelle/arelle
