### PR TITLE
Update to latest OIM conformance suite (2023-04-19)

### DIFF
--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -1196,7 +1196,7 @@ def loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                 for extendedFile in documentInfo["extends"]:
                     try:
                         extendedOimObject = loadOimObject(extendedFile, mappedUrl, visitedFiles, extensionChain)
-                    except FileNotFoundError:
+                    except IOError:
                         error("{}:unresolvableBaseMetadataFile".format(errPrefix),
                               _("Extending document file not found: %(extendingFile)s, referenced from %(extendedFile)s"),
                               extendingFile=extendedFile, extendedFile=oimFile)

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_oim_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_oim_1_0.py
@@ -7,9 +7,9 @@ config = ConformanceSuiteConfig(
         '--httpsRedirectCache',
         '--plugins', 'loadFromOIM',
     ],
-    file='oim-index.xml',
+    file='oim-conformance-2023-04-19/oim-index.xml',
     info_url='https://specifications.xbrl.org/work-product-index-open-information-model-open-information-model.html',
-    local_filepath='oim-conf-2021-10-13.zip',
+    local_filepath='oim-conformance-2023-04-19.zip',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
 )


### PR DESCRIPTION
#### Reason for change
A new OIM conformance suite was released by XII. Running the new suite exposed a gap in metadata loading exception handling.

#### Description of change
Updates OIM conformance suite in test runner and loadFromOIM plugin to pass all tests.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
