### PR TITLE
Stop type errors from occurring in isnan check

### DIFF
--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -412,13 +412,13 @@ class ValidateXbrlCalcs:
             inclA = inclB = _inConsistent = False
             decVals = {}
             for f in fList:
-                _d = inferredDecimals(f)
-                _v = f.xValue
-                if isnan(_v):
+                if f.xValid < VALID or isnan(f.xValue):
                     if len(fList) > 1:
                         _inConsistent = True
                     break
-                elif insignificantDigits(_v, decimals=_d):
+                _d = inferredDecimals(f)
+                _v = f.xValue
+                if insignificantDigits(_v, decimals=_d):
                     _excessDigitFacts.append(f)
                 elif _d in decVals:
                     _inConsistent |= _v != decVals[_d]


### PR DESCRIPTION
#### Reason for change
It was possible to cause a Type error in the new Calc 1.1 code with invalid values.

#### Description of change
Added a valid check prior to the isnan check

#### Steps to Test
Run validation on the following document. 
[gaap-2022.zip](https://github.com/Arelle/Arelle/files/11482572/gaap-2022.zip)
It should not produce a TypeError.

**review**:
@Arelle/arelle
