### PR TITLE
Handle calc11 nil fact set and invalid facts

### DIFF
--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -271,7 +271,7 @@ class ValidateXbrlCalcs:
                                                         del unreportedContribingItemQnames[:]
                                     if calc11:
                                         s1, s2, incls1, incls2 = self.consistentFactValueInterval(sumFacts, calc11t)
-                                        if s1 is not INCONSISTENT and sumBindKey not in blockedIntervals and sumBindKey in boundIntervals:
+                                        if s1 is not INCONSISTENT and s1 is not NIL_FACT_SET and sumBindKey not in blockedIntervals and sumBindKey in boundIntervals:
                                             x1, x2, inclx1, inclx2 = boundIntervals[sumBindKey]
                                             a = max(s1, x1)
                                             b = min(s2, x2)
@@ -337,7 +337,7 @@ class ValidateXbrlCalcs:
     def bindFacts(self, facts, ancestors):
         for f in facts:
             concept = f.concept
-            if concept is not None:
+            if concept is not None and f.xValid >= VALID:
                 # index facts by their calc relationship set
                 if concept.isNumeric:
                     for ancestor in ancestors:
@@ -412,7 +412,7 @@ class ValidateXbrlCalcs:
             inclA = inclB = _inConsistent = False
             decVals = {}
             for f in fList:
-                if f.xValid < VALID or isnan(f.xValue):
+                if isnan(f.xValue):
                     if len(fList) > 1:
                         _inConsistent = True
                     break


### PR DESCRIPTION
#### Reason for change
Calc 1.1 in calc-11 mode wasn't behaving with nil fact sets
Invalid facts were leaking into bound facts list

#### Description of change
Add nil fact set condition to calc 1.1 mode if statement
Move fact VALID test up to bindFacts method

#### Steps to Test
calc 1.1 test suite
workiva test "gaap-2018.zip" with facts having invalid concepts.

**review**:
@Arelle/arelle
