### PR TITLE
Include lazy loaded holidays imports

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -31,6 +31,8 @@ includeLibs = [
     "graphviz",
     "gzip",
     "holidays",
+    "holidays.countries",
+    "holidays.financial",
     "isodate",
     "lxml._elementpath",
     "lxml.etree",


### PR DESCRIPTION
#### Reason for change
These submodules are lazy loaded in the latest holidays release (0.25) and therefore no longer automatically detected and included by cx_Freeze.

https://github.com/dr-prodigy/python-holidays/pull/1087

#### Description of change
Explicitly include the countries and financial imports for holidays in the frozen builds

#### Steps to Test
CI

**review**:
@Arelle/arelle
