### PR TITLE
Updating ESEF jpg detection

### DIFF
--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -86,7 +86,7 @@ def checkImageContents(modelXbrl: ModelXbrl, imgElt: ModelObject, imgType: str, 
         else:
             headerType = "unrecognized"
         if (("gif" not in imgType and headerType == "gif") or
-            ("jpeg" not in imgType and headerType == "jpg") or
+            ("jpeg" not in imgType and "jpg" not in imgType and headerType == "jpg") or
             ("png" not in imgType and headerType == "png")):
             imageDoesNotMatchItsFileExtension = f"ESEF.{guidance}.imageDoesNotMatchItsFileExtension"
             incorrectMIMETypeSpecified = f"ESEF.{guidance}.incorrectMIMETypeSpecified"

--- a/arelle/plugin/validate/ESEF_2022/Util.py
+++ b/arelle/plugin/validate/ESEF_2022/Util.py
@@ -164,7 +164,7 @@ def checkImageContents(baseURI: Optional[str], modelXbrl: ModelXbrl, imgElt: _El
         else:
             headerType = "unrecognized"
         if (("gif" not in imgType and headerType == "gif") or
-            ("jpeg" not in imgType and headerType == "jpg") or
+            ("jpeg" not in imgType and "jpg" not in imgType and headerType == "jpg") or
             ("png" not in imgType and headerType == "png")):
             imageDoesNotMatchItsFileExtension = f"{guidance}.imageDoesNotMatchItsFileExtension"
             incorrectMIMETypeSpecified = f"{guidance}.incorrectMIMETypeSpecified"


### PR DESCRIPTION
#### Reason for change

.jpg files were not being detected as jpg/jpeg files.

#### Description of change

Added .jpg to ESEF and ESEF_2022 checkImageContents.

#### Steps to Test

Validate filing in issue: https://github.com/Arelle/Arelle/issues/714

**review**:
@Arelle/arelle
