### PR TITLE
calc 1.1, fix spurious EFM.6.5.57 msg

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -15,6 +15,7 @@ from arelle.ModelValue import qname
 from arelle.ModelDtsObject import ModelLink
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelObjectFactory import parser
+from arelle.ModelRelationshipSet import baseSetSortkey
 from arelle.PrototypeDtsObject import LinkPrototype, LocPrototype, ArcPrototype, DocumentPrototype, PrototypeElementTree
 from arelle.PluginManager import pluginClassMethods
 from arelle.PythonUtil import OrderedDefaultDict, normalizeSpace
@@ -370,7 +371,7 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
             # re-order base set keys for entry point or supplemental linkbase addition
             modelXbrl.baseSets = OrderedDefaultDict( # order by linkRole, arcRole of key
                 modelXbrl.baseSets.default_factory,
-                sorted(modelXbrl.baseSets.items(), key=lambda i: (i[0][0] or "",i[0][1] or "")))
+                sorted(modelXbrl.baseSets.items(), key=lambda i: baseSetSortkey(i[0])))
 
     return modelDocument
 

--- a/arelle/ModelRelationshipSet.py
+++ b/arelle/ModelRelationshipSet.py
@@ -98,6 +98,12 @@ def baseSetRelationship(arcElement):
             return rel
     return None
 
+def baseSetSortkey(baseSetKey): # for base set sorting functions
+    arcrole, linkrole, _linkqname, _arcqname = baseSetKey
+    # arcrole may be a string or tuple of strings.
+    return (",".join(arcrole) if isinstance(arcrole, (tuple,list)) else arcrole or "",
+            linkrole or "")
+
 class ModelRelationshipSet:
     __slots__ = ("isChanged", "modelXbrl", "arcrole", "linkrole", "linkqname", "arcqname",
                  "modelRelationshipsFrom", "modelRelationshipsTo", "modelConceptRoots", "modellinkRoleUris",

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -157,6 +157,7 @@ factExplanatoryFact = "http://www.xbrl.org/2009/arcrole/fact-explanatoryFact"
 parentChild = "http://www.xbrl.org/2003/arcrole/parent-child"
 summationItem = "http://www.xbrl.org/2003/arcrole/summation-item"
 summationItem11 = "https://xbrl.org/2023/arcrole/summation-item"
+summationItems: Tuple[str, str] = (summationItem, summationItem11)
 essenceAlias = "http://www.xbrl.org/2003/arcrole/essence-alias"
 similarTuples = "http://www.xbrl.org/2003/arcrole/similar-tuples"
 requiresElement = "http://www.xbrl.org/2003/arcrole/requires-element"

--- a/arelle/plugin/validate/EFM/resources/dei-validations.json
+++ b/arelle/plugin/validate/EFM/resources/dei-validations.json
@@ -2802,7 +2802,7 @@
             "message": "dq-{efmSection}-{tag}-Unexpected"
         },
         "oef:class": {
-            "axes": ["oef:ClassAxis"],
+            "axes": ["!std!:ClassAxis"],
             "axes-operator": "all",
             "cubes": ["http://xbrl.sec.gov/oef/role/ClassOnly"],
             "required-context-period": true,

--- a/arelle/plugin/validate/EFM/resources/edgartaxonomies/edgartaxonomies-23-2.xml
+++ b/arelle/plugin/validate/EFM/resources/edgartaxonomies/edgartaxonomies-23-2.xml
@@ -3,6 +3,15 @@
 <Erxl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="66" xsi:noNamespaceSchemaLocation="erxl.xsd">
     <Loc>
         <Family>BASE</Family>
+        <Version>2023</Version>
+        <Href>https://www.xbrl.org/2023/calculation-1.1.xsd</Href>
+        <AttType>SCH</AttType>
+        <FileTypeName>Schema</FileTypeName>
+        <Elements>0</Elements>
+        <Namespace>https://xbrl.org/2023/calculation-1.1</Namespace>
+    </Loc>
+    <Loc>
+        <Family>BASE</Family>
         <Version>2014</Version>
         <Href>http://www.xbrl.org/2014/extensible-enumerations.xsd</Href>
         <AttType>SCH</AttType>

--- a/arelle/plugin/validate/EFM/resources/edgartaxonomies/edgartaxonomies-all-years.xml
+++ b/arelle/plugin/validate/EFM/resources/edgartaxonomies/edgartaxonomies-all-years.xml
@@ -7,6 +7,15 @@ are not subject to domestic copyright protection. 17 U.S.C. 105.
 -->
     <Loc>
         <Family>BASE</Family>
+        <Version>2023</Version>
+        <Href>https://www.xbrl.org/2023/calculation-1.1.xsd</Href>
+        <AttType>SCH</AttType>
+        <FileTypeName>Schema</FileTypeName>
+        <Elements>0</Elements>
+        <Namespace>https://xbrl.org/2023/calculation-1.1</Namespace>
+    </Loc>
+    <Loc>
+        <Family>BASE</Family>
         <Version>2014</Version>
         <Href>http://www.xbrl.org/2014/extensible-enumerations.xsd</Href>
         <AttType>SCH</AttType>


### PR DESCRIPTION
#### Reason for change
For EDGAR update 23.2.u2

#### Description of change
Fixes calc 1.1 and spurious efm 6.5.57 msg

#### Steps to Test
* test with attached calc 1.1 version of EFM test suite and regression tests

[614-calc1.1-syntax.zip](https://github.com/Arelle/Arelle/files/11869222/614-calc1.1-syntax.zip)

**review**:
@Arelle/arelle
