### PR TITLE
Only download Python artifacts in PyPI publish job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,16 +60,22 @@ jobs:
     steps:
       - name: Install twine
         run: pip install -U twine
-      - name: Download artifacts
+      - name: Download tar artifact
         uses: actions/download-artifact@v3.0.2
+        with:
+          name: arelle.tar.gz
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: arelle.whl
       - name: Publish package on release
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
           TWINE_REPOSITORY: ${{ github.repository == 'Arelle/Arelle' && 'pypi' || 'testpypi' }}
-        run: twine upload */*
+        run: twine upload ./*
       - name: Upload release artifact
         uses: softprops/action-gh-release@v0.1.15
         with:
           fail_on_unmatched_files: true
-          files: '*/*'
+          files: './*'


### PR DESCRIPTION
#### Reason for change
This addresses a race condition present in the release workflow.

If the Python publish workflow starts after one of the frozen build jobs completes, it downloads all artifacts, which include both the Python and frozen build artifacts. This causes a failure during the twine upload step.

#### Description of change
Don't download frozen build artifacts from within the Python publish job.

#### Steps to Test
* CI (tested [here](https://github.com/austinmatherne-wk/Arelle/actions/runs/5416771221) with race condition)

**review**:
@Arelle/arelle
