### PR TITLE
Remove xbrlxe:unexpectedContextContent

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_oim_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_oim_1_0.py
@@ -7,6 +7,10 @@ config = ConformanceSuiteConfig(
         '--httpsRedirectCache',
         '--plugins', 'loadFromOIM',
     ],
+    expected_failure_ids=frozenset([
+        '600-xml/index-xbrl-xml.xml/V-05',
+        '600-xml/index-xbrl-xml.xml/V-06',
+    ]),
     file='oim-conformance-2023-04-19/oim-index.xml',
     info_url='https://specifications.xbrl.org/work-product-index-open-information-model-open-information-model.html',
     local_filepath='oim-conformance-2023-04-19.zip',


### PR DESCRIPTION
#### Reason for change
The OIM WG agreed to remove xbrlxe:unexpectedContextContent from xBRL-xml which was not testable due to OIM issue [#419](https://gitlab.xbrl.org/oim/oim/-/issues/419)

#### Description of change
Update impl to align with [updated test suite](https://gitlab.xbrl.org/oim/oim/-/merge_requests/440/diffs) (expected failure IDs are needed until the new suite is published)

#### Steps to Test
* CI

**review**:
@Arelle/arelle
