### PR TITLE
edgr23.2 update 3

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -15,7 +15,6 @@ from arelle.ModelValue import qname
 from arelle.ModelDtsObject import ModelLink
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelObjectFactory import parser
-from arelle.ModelRelationshipSet import baseSetSortkey
 from arelle.PrototypeDtsObject import LinkPrototype, LocPrototype, ArcPrototype, DocumentPrototype, PrototypeElementTree
 from arelle.PluginManager import pluginClassMethods
 from arelle.PythonUtil import OrderedDefaultDict, normalizeSpace
@@ -371,7 +370,7 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
             # re-order base set keys for entry point or supplemental linkbase addition
             modelXbrl.baseSets = OrderedDefaultDict( # order by linkRole, arcRole of key
                 modelXbrl.baseSets.default_factory,
-                sorted(modelXbrl.baseSets.items(), key=lambda i: baseSetSortkey(i[0])))
+                sorted(modelXbrl.baseSets.items(), key=lambda i: (i[0][0] or "",i[0][1] or "")))
 
     return modelDocument
 

--- a/arelle/ModelRelationshipSet.py
+++ b/arelle/ModelRelationshipSet.py
@@ -98,12 +98,6 @@ def baseSetRelationship(arcElement):
             return rel
     return None
 
-def baseSetSortkey(baseSetKey): # for base set sorting functions
-    arcrole, linkrole, _linkqname, _arcqname = baseSetKey
-    # arcrole may be a string or tuple of strings.
-    return (",".join(arcrole) if isinstance(arcrole, (tuple,list)) else arcrole or "",
-            linkrole or "")
-
 class ModelRelationshipSet:
     __slots__ = ("isChanged", "modelXbrl", "arcrole", "linkrole", "linkqname", "arcqname",
                  "modelRelationshipsFrom", "modelRelationshipsTo", "modelConceptRoots", "modellinkRoleUris",
@@ -113,8 +107,8 @@ class ModelRelationshipSet:
     def __init__(self, modelXbrl, arcrole, linkrole=None, linkqname=None, arcqname=None, includeProhibits=False):
         self.isChanged = False
         self.modelXbrl = modelXbrl
-        self.arcrole = arcrole # may be str, tuple or frozenset
-        self.linkrole = linkrole # may be str, tuple or frozenset
+        self.arcrole = arcrole # may be str, None, tuple or frozenset
+        self.linkrole = linkrole # may be str, None, tuple or frozenset
         self.linkqname = linkqname
         self.arcqname = arcqname
 

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -316,7 +316,7 @@ class ModelXbrl:
         self.errorCaptureLevel: str = (errorCaptureLevel or logging._checkLevel("INCONSISTENCY"))  # type: ignore[attr-defined]
         self.errors: list[str | None] = []
         self.logCount: dict[str, int] = {}
-        self.arcroleTypes: defaultdict[str | tuple[str, ...], list[ModelRoleType]] = defaultdict(list)
+        self.arcroleTypes: defaultdict[str, list[ModelRoleType]] = defaultdict(list)
         self.roleTypes: defaultdict[str, list[ModelRoleType]] = defaultdict(list)
         self.qnameConcepts: dict[QName, ModelConcept] = {}  # indexed by qname of element
         self.nameConcepts: defaultdict[str, list[ModelConcept]] = defaultdict(list)  # contains ModelConcepts by name
@@ -324,8 +324,8 @@ class ModelXbrl:
         self.qnameAttributeGroups: dict[QName, Any] = {}
         self.qnameGroupDefinitions: dict[QName, Any] = {}
         self.qnameTypes: dict[QName, ModelType] = {}  # contains ModelTypes by qname key of type
-        self.baseSets: defaultdict[tuple[str | tuple[str, ...], str | None, QName | None, QName | None], list[ModelObject | LinkPrototype]] = defaultdict(list)  # contains ModelLinks for keys arcrole, arcrole#linkrole
-        self.relationshipSets: dict[tuple[str] | tuple[str | tuple[str, ...], tuple[str, ...] | str | None, QName | None, QName | None, bool], ModelRelationshipSetClass] = {}  # contains ModelRelationshipSets by bas set keys
+        self.baseSets: defaultdict[tuple[str, str | None, QName | None, QName | None], list[ModelObject | LinkPrototype]] = defaultdict(list)  # contains ModelLinks for keys arcrole, arcrole#linkrole
+        self.relationshipSets: dict[tuple[str] | tuple[str, tuple[str, ...] | str | None, QName | None, QName | None, bool], ModelRelationshipSetClass] = {}  # contains ModelRelationshipSets by bas set keys
         self.qnameDimensionDefaults: dict[QName, QName] = {}  # contains qname of dimension (index) and default member(value)
         self.facts: list[ModelFact] = []
         self.factsInInstance: set[ModelFact] = set()
@@ -414,7 +414,7 @@ class ModelXbrl:
         else:
             return self.fileSource.url
 
-    def relationshipSet(self, arcrole: str | tuple[str, ...], linkrole: tuple[str, ...] | str | None = None, linkqname: QName | None = None, arcqname: QName | None = None, includeProhibits: bool = False) -> ModelRelationshipSetClass:
+    def relationshipSet(self, arcrole: str, linkrole: tuple[str, ...] | str | None = None, linkqname: QName | None = None, arcqname: QName | None = None, includeProhibits: bool = False) -> ModelRelationshipSetClass:
         """Returns a relationship set matching specified parameters (only arcrole is required).
 
         Resolve and determine relationship set.  If a relationship set of the same parameters was previously resolved, it is returned from a cache.

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -139,12 +139,10 @@ class ValidateXbrl:
         modelXbrl.modelManager.showStatus(_("validating relationship sets"))
         for baseSetKey in modelXbrl.baseSets.keys():
             arcrole, ELR, linkqname, arcqname = baseSetKey
-            if isinstance(arcrole, str) and arcrole.startswith("XBRL-") \
-                    or ELR is None \
-                    or linkqname is None \
-                    or arcqname is None:
+            if arcrole.startswith("XBRL-") or ELR is None or \
+                linkqname is None or arcqname is None:
                 continue
-            elif isinstance(arcrole, str) and arcrole in XbrlConst.standardArcroleCyclesAllowed:
+            elif arcrole in XbrlConst.standardArcroleCyclesAllowed:
                 # TODO: table should be in this module, where it is used
                 cyclesAllowed, specSect = XbrlConst.standardArcroleCyclesAllowed[arcrole]
             elif arcrole in self.modelXbrl.arcroleTypes and len(self.modelXbrl.arcroleTypes[arcrole]) > 0:
@@ -158,8 +156,8 @@ class ValidateXbrl:
                 specSect = None
             if cyclesAllowed != "any" or arcrole in (XbrlConst.summationItem,) \
                                       or arcrole in self.genericArcArcroles  \
-                                      or isinstance(arcrole, str) and arcrole.startswith(XbrlConst.formulaStartsWith) \
-                                      or (modelXbrl.hasXDT and isinstance(arcrole, str) and arcrole.startswith(XbrlConst.dimStartsWith)):
+                                      or arcrole.startswith(XbrlConst.formulaStartsWith) \
+                                      or (modelXbrl.hasXDT and arcrole.startswith(XbrlConst.dimStartsWith)):
                 relsSet = modelXbrl.relationshipSet(arcrole,ELR,linkqname,arcqname)
             if cyclesAllowed != "any" and \
                    ((XbrlConst.isStandardExtLinkQname(linkqname) and XbrlConst.isStandardArcQname(arcqname)) \
@@ -262,7 +260,7 @@ class ValidateXbrl:
                                     _("Essence-alias relationship from %(source)s to %(target)s in link role %(linkrole)s has different balances")).format(
                                     modelObject=modelRel,
                                     source=fromConcept.qname, target=toConcept.qname, linkrole=ELR)
-            elif modelXbrl.hasXDT and isinstance(arcrole, str) and arcrole.startswith(XbrlConst.dimStartsWith):
+            elif modelXbrl.hasXDT and arcrole.startswith(XbrlConst.dimStartsWith):
                 ValidateXbrlDimensions.checkBaseSet(self, arcrole, ELR, relsSet)
             elif arcrole in ValidateFormula.arcroleChecks:
                 ValidateFormula.checkBaseSet(self, arcrole, ELR, relsSet)

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -3373,7 +3373,8 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                 if sumLn in modelXbrl.nameConcepts and "calc-items" in rule: # (dqc_us_rules/pull/544)
                     sumConcept = modelXbrl.nameConcepts[sumLn][0]
                     linkroleURIs = OrderedSet(modelLink.role
-                                              for modelLink in val.modelXbrl.baseSets[(XbrlConst.summationItems,None,None,None)]
+                                              for arcRole in XbrlConst.summationItems
+                                              for modelLink in val.modelXbrl.baseSets[(arcRole,None,None,None)]
                                               if modelXbrl.relationshipSet(XbrlConst.summationItems, modelLink.role , None, None).fromModelObject(sumConcept))
 
                 for linkroleUri in linkroleURIs: # evaluate by network where applicable to ID
@@ -3698,7 +3699,9 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                 elif calcCashFlowLinkRolesMissingRoots == calcCashFlowLinkRoles: # every calc is missing the roots
                     for linkRole in calcCashFlowLinkRolesMissingRoots:
                         modelXbrl.warning(f"{dqcRuleName}.{id}", _(logMsg(msg)),
-                            modelObject=val.modelXbrl.baseSets[(XbrlConst.summationItems,linkroleUri,None,None)] or modelXbrl, # may be no base sets, in which case just show the instance
+                            modelObject=val.modelXbrl.baseSets[(XbrlConst.summationItem,linkroleUri,None,None)]
+                                        or val.modelXbrl.baseSets[(XbrlConst.summationItem11,linkroleUri,None,None)]
+                                        or modelXbrl, # may be no base sets, in which case just show the instance
                             linkRole=linkroleUri, linkroleDefinition=definition,
                             rootNames=(", ".join(r.name for r in calcRoots) or "(none)"),
                             edgarCode=edgarCode, ruleElementId=id)


### PR DESCRIPTION
#### Reason for change
Edgar update

#### Description of change
Herm:
> Base set key sorting led to uncovering that base set can never have more than one arcrole, caused by a get with tuple arcrole, because it's an ordered default dictionary.  Not sure whether this will go into SEC in 23.2.2 or earlier but it's a bug causing an exception in successive validation that gets into DEI check code.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
