### PR TITLE
Manage dockerfile python image version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,13 @@ updates:
           - ">=6"
       - dependency-name: "cx_Freeze"
       - dependency-name: "packaging"
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-name: "python"
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    groups:
+      dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "RDFLib"
         versions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11.4
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
#### Reason for change
Dependabot now supports grouping updates into a single PR

#### Description of change
* Add Python docker image to dependabot
* Group Python dependencies into a single PR

#### Steps to Test
* CI

**review**:
@Arelle/arelle
