### PR TITLE
Build ixbrl-viewer with Node.js 20

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
       node_version:
-        default: '19'
+        default: '20'
         description: 'Node.js version to use'
         required: false
         type: string
@@ -53,7 +53,7 @@ on:
         required: true
         type: string
       node_version:
-        default: '19'
+        default: '20'
         description: 'Node.js version to use'
         required: true
         type: string

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       node_version:
-        default: '19'
+        default: '20'
         description: 'Node.js version to use'
         required: false
         type: string
@@ -43,7 +43,7 @@ on:
         required: false
         type: string
       node_version:
-        default: '19'
+        default: '20'
         description: 'Node.js version to use'
         required: true
         type: string

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       node_version:
-        default: '19'
+        default: '20'
         description: 'Node.js version to use'
         required: false
         type: string
@@ -49,7 +49,7 @@ on:
         required: false
         type: string
       node_version:
-        default: '19'
+        default: '20'
         description: 'Node.js version to use'
         required: true
         type: string

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       node_version:
-        default: '19'
+        default: '20'
         description: 'Node.js version to use'
         required: false
         type: string


### PR DESCRIPTION
#### Reason for change
Node.js 19 is EOL and ixbrl-viewer is [now built with Node.js 20](https://github.com/Workiva/ixbrl-viewer/blob/f884d9232adcd52b7d7114b9b0e6c7c662d8b489/Dockerfile#L1)

#### Description of change
Build ixbrl-viewer with Node.js 20

#### Steps to Test
* CI

**review**:
@Arelle/arelle
