### PR TITLE
Suffix release draft labels with "-release" not to conflict with Dependabot

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,11 +11,11 @@ template: |
 version-resolver:
   major:
     labels:
-      - 'major'
+      - 'major-release'
   minor:
     labels:
-      - 'minor'
+      - 'minor-release'
   patch:
     labels:
-      - 'patch'
+      - 'patch-release'
   default: patch


### PR DESCRIPTION
#### Reason for change
The `major`, `minor`, and `patch` labels are used and applied by Dependabot for dependency updates in those categories.

#### Description of change
Change the labels used for triggering release types not to conflict with dependabot.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
