### PR TITLE
Downgrade pyparsing to version compatible with matplotlib

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
           - ">=6"
       - dependency-name: "cx_Freeze"
       - dependency-name: "packaging"
+      - dependency-name: "pyparsing"
+        versions:
+          - "3.1.0"
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 certifi==2023.5.7
 lxml==4.9.2
 OpenPyXL==3.1.2
-pyparsing==3.1.0
+pyparsing==3.0.9
 regex==2023.6.3
 isodate==0.6.1
 aniso8601==9.0.1


### PR DESCRIPTION
#### Reason for change
3.1.0 causes issue with matplotlib error messages (https://github.com/matplotlib/matplotlib/issues/26152). Will hopefully be fixed in the next release.

#### Description of change
Rollback pyparsing version to enable matplotlib updates.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
