### PR TITLE
Warn offline mode

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -278,7 +278,7 @@ def parseAndRun(args):
                              "'http://[user[:password]@]host[:port]' "
                              " (e.g., http://192.168.1.253, http://example.com:8080, http://joe:secret@example.com:8080), "
                              " or 'show' to show current setting, ." ))
-    parser.add_option("--" + INTERNET_CONNECTIVITY, "--" + INTERNET_CONNECTIVITY.lower(), choices=("online", OFFLINE), dest="internetConnectivity",
+    parser.add_option(f"--{INTERNET_CONNECTIVITY}", f"--{INTERNET_CONNECTIVITY.lower()}", choices=("online", OFFLINE), dest="internetConnectivity",
                       help=_("Specify internet connectivity: online or offline"))
     parser.add_option("--internetTimeout", "--internettimeout", type="int", dest="internetTimeout",
                       help=_("Specify internet connection timeout in seconds (0 means unlimited)."))

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -20,6 +20,7 @@ from arelle.Locale import format_string, setApplicationLocale, setDisableRTL
 from arelle.ModelFormulaObject import FormulaOptions
 from arelle import PluginManager
 from arelle.PluginManager import pluginClassMethods
+from arelle.SocketUtils import INTERNET_CONNECTIVITY, OFFLINE
 from arelle.UrlUtil import isHttpUrl
 from arelle.Version import copyrightLabel
 from arelle.WebCache import proxyTuple
@@ -277,7 +278,7 @@ def parseAndRun(args):
                              "'http://[user[:password]@]host[:port]' "
                              " (e.g., http://192.168.1.253, http://example.com:8080, http://joe:secret@example.com:8080), "
                              " or 'show' to show current setting, ." ))
-    parser.add_option("--internetConnectivity", "--internetconnectivity", choices=("online", "offline"), dest="internetConnectivity",
+    parser.add_option("--" + INTERNET_CONNECTIVITY, "--" + INTERNET_CONNECTIVITY.lower(), choices=("online", OFFLINE), dest="internetConnectivity",
                       help=_("Specify internet connectivity: online or offline"))
     parser.add_option("--internetTimeout", "--internettimeout", type="int", dest="internetTimeout",
                       help=_("Specify internet connection timeout in seconds (0 means unlimited)."))

--- a/arelle/SocketUtils.py
+++ b/arelle/SocketUtils.py
@@ -1,0 +1,17 @@
+import socket
+
+INTERNET_CONNECTIVITY = 'internetConnectivity'
+OFFLINE = 'offline'
+
+
+class WarnSocket(socket.socket):
+    """
+    This is a simple wrapper around the socket to print a warning if Arelle attempts to download somthing while running in offline mode.
+    """
+    def __init__(self, family=-1, type=-1, proto=-1, fileno=None):
+        print(f"Arelle is running in offline mode but is attempting a download.")
+        super().__init__(family, type, proto, fileno)
+
+
+def warnSocket():
+    socket.socket = WarnSocket

--- a/arelle/SocketUtils.py
+++ b/arelle/SocketUtils.py
@@ -7,7 +7,7 @@ OFFLINE = 'offline'
 
 class WarnSocket(socket.socket):
     """
-    This is a simple wrapper around the socket to print a warning if Arelle attempts to download somthing while running in offline mode.
+    This is a simple wrapper around the socket to print a warning if Arelle attempts to download something while running in offline mode.
     """
     def __init__(self, family: int = -1, type: int = -1, proto: int = -1, fileno: int | None = None):
         print("Arelle is running in offline mode but is attempting a download.")

--- a/arelle/SocketUtils.py
+++ b/arelle/SocketUtils.py
@@ -8,10 +8,10 @@ class WarnSocket(socket.socket):
     """
     This is a simple wrapper around the socket to print a warning if Arelle attempts to download somthing while running in offline mode.
     """
-    def __init__(self, family=-1, type=-1, proto=-1, fileno=None):
-        print(f"Arelle is running in offline mode but is attempting a download.")
+    def __init__(self, family: int = -1, type: int = -1, proto: int = -1, fileno: int | None = None):
+        print("Arelle is running in offline mode but is attempting a download.")
         super().__init__(family, type, proto, fileno)
 
 
-def warnSocket():
-    socket.socket = WarnSocket
+def warnSocket() -> None:
+    socket.socket = WarnSocket  # type: ignore [misc]

--- a/arelle/SocketUtils.py
+++ b/arelle/SocketUtils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import socket
 
 INTERNET_CONNECTIVITY = 'internetConnectivity'

--- a/arelleCmdLine.py
+++ b/arelleCmdLine.py
@@ -4,7 +4,6 @@ Use this module to start Arelle in command line modes
 
 See COPYRIGHT.md for copyright information.
 '''
-import itertools
 import os
 import sys
 import regex as re
@@ -15,17 +14,18 @@ if sys.platform == "darwin" and getattr(sys, 'frozen', False):
 
 from arelle.SocketUtils import INTERNET_CONNECTIVITY, OFFLINE, warnSocket
 
-conn_regex = rf'(\s|^)--({INTERNET_CONNECTIVITY}|{INTERNET_CONNECTIVITY.lower()})'
-offline_regex = rf'{OFFLINE}(\s|$)'
-comp_eq = re.compile(conn_regex + '=' + offline_regex)
-comp_conn = re.compile(conn_regex)
-comp_offline = re.compile(offline_regex)
-for arg in sys.argv:
-    if re.match(comp_eq, arg):
+internetConnectivityArgPattern = rf'--({INTERNET_CONNECTIVITY}|{INTERNET_CONNECTIVITY.lower()})'
+internetConnectivityArgRegex = re.compile(internetConnectivityArgPattern)
+internetConnectivityOfflineEqualsRegex = re.compile(f"{internetConnectivityArgPattern}={OFFLINE}")
+prevArg = ''
+for arg in sys.argv[1:]:
+    if (
+            internetConnectivityOfflineEqualsRegex.fullmatch(arg)
+            or (internetConnectivityArgRegex.fullmatch(prevArg) and arg == OFFLINE)
+    ):
         warnSocket()
-for arg1, arg2 in itertools.pairwise(sys.argv):
-    if re.match(comp_conn, arg1) and re.match(comp_offline, arg2):
-        warnSocket()
+        break
+    prevArg = arg
 
 from arelle.BetaFeatures import BETA_OBJECT_MODEL_FEATURE, enableNewObjectModel
 

--- a/arelleCmdLine.py
+++ b/arelleCmdLine.py
@@ -4,20 +4,28 @@ Use this module to start Arelle in command line modes
 
 See COPYRIGHT.md for copyright information.
 '''
+import itertools
 import os
 import sys
-import re
-from arelle.SocketUtils import INTERNET_CONNECTIVITY, OFFLINE
-
+import regex as re
 
 if sys.platform == "darwin" and getattr(sys, 'frozen', False):
     for i in range(len(sys.path)):  # signed code can't contain python modules
         sys.path.append(sys.path[i].replace("MacOS", "Resources"))
 
-if re.compile(rf"(\s|^)--({INTERNET_CONNECTIVITY}|{INTERNET_CONNECTIVITY.lower()})(\s+|=){OFFLINE}(\s|$)") in sys.argv:
-    from arelle.SocketUtils import warnSocket
-    warnSocket()
+from arelle.SocketUtils import INTERNET_CONNECTIVITY, OFFLINE, warnSocket
 
+conn_regex = rf'(\s|^)--({INTERNET_CONNECTIVITY}|{INTERNET_CONNECTIVITY.lower()})'
+offline_regex = rf'{OFFLINE}(\s|$)'
+comp_eq = re.compile(conn_regex + '=' + offline_regex)
+comp_conn = re.compile(conn_regex)
+comp_offline = re.compile(offline_regex)
+for arg in sys.argv:
+    if re.match(comp_eq, arg):
+        warnSocket()
+for arg1, arg2 in itertools.pairwise(sys.argv):
+    if re.match(comp_conn, arg1) and re.match(comp_offline, arg2):
+        warnSocket()
 
 from arelle.BetaFeatures import BETA_OBJECT_MODEL_FEATURE, enableNewObjectModel
 

--- a/arelleCmdLine.py
+++ b/arelleCmdLine.py
@@ -6,11 +6,17 @@ See COPYRIGHT.md for copyright information.
 '''
 import os
 import sys
+import re
+from arelle.SocketUtils import INTERNET_CONNECTIVITY, OFFLINE
 
 
 if sys.platform == "darwin" and getattr(sys, 'frozen', False):
     for i in range(len(sys.path)):  # signed code can't contain python modules
         sys.path.append(sys.path[i].replace("MacOS", "Resources"))
+
+if re.compile(rf"(\s|^)--({INTERNET_CONNECTIVITY}|{INTERNET_CONNECTIVITY.lower()})(\s+|=){OFFLINE}(\s|$)") in sys.argv:
+    from arelle.SocketUtils import warnSocket
+    warnSocket()
 
 
 from arelle.BetaFeatures import BETA_OBJECT_MODEL_FEATURE, enableNewObjectModel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ module = [
     'arelle.ModelObjectFactory',
     'arelle.ModelValue',
     'arelle.ModelXbrl',
+    'arelle.SocketUtils',
     'arelle.SystemInfo',
     'arelle.Updater',
     'arelle.UrlUtil',


### PR DESCRIPTION
#### Reason for change

On occasion Arelle will silently download files it might need.  Now if that happens in offline mode a warning will be printed to the command line.

This is in response to [issue 684](https://github.com/Arelle/Arelle/issues/684) 
and is a step toward addressing [issue 711](https://github.com/Arelle/Arelle/issues/711). 

#### Description of change

Added a warning when Arelle downloads something in offline mode.

#### Steps to Test

1. Delete the files in the Arelle cache (~/Library/Caches/Arelle/http/www.xbrl.org/2016/taxonomy-package*)
2. Download the esef_taxonomy.zip file from [here](https://github.com/Arelle/Arelle/issues/684).
3. run "python arelleCmdLine.py -f https://filings.xbrl.org/5299004SWFL5JAN4W830/2022-06-30/ESEF/DK/0/5299004SWFL5JAN4W830-2022-06-30-en.zip --plugins validate/ESEF_2022 --disclosureSystem ESEF --internetConnectivity=offline --packages ~/Downloads/esef_taxonomy_2022.zip"
4. Verify warnings printed.

**review**:
@Arelle/arelle
