### PR TITLE
Validate ESEF IXDS docs not contained within a report package

### DIFF
--- a/arelle/plugin/validate/ESEF_2022/__init__.py
+++ b/arelle/plugin/validate/ESEF_2022/__init__.py
@@ -175,7 +175,12 @@ def modelXbrlLoadComplete(modelXbrl: ModelXbrl) -> None:
                     validateEntity(modelXbrl, filename, modelXbrl.fileSource)
         else:
             if isinstance(modelXbrl.fileSource.url, str):
-                validateEntity(modelXbrl, modelXbrl.fileSource.url, modelXbrl.fileSource)
+                ixdsDocUrls = getattr(modelXbrl, "ixdsDocUrls", None)
+                if ixdsDocUrls:
+                    for url in ixdsDocUrls:
+                        validateEntity(modelXbrl, url, modelXbrl.fileSource)
+                else:
+                    validateEntity(modelXbrl, modelXbrl.fileSource.url, modelXbrl.fileSource)
             elif isinstance(modelXbrl.fileSource.url, list):
                 for filename in modelXbrl.fileSource.url:
                     validateEntity(modelXbrl, filename, modelXbrl.fileSource)


### PR DESCRIPTION
#### Reason for change
The ESEF reporting manual requires that `ESEF.2.6.1.reportIncorrectlyPlacedInPackage` is raised if the report is not contained with a report package zip, but currently the ESEF 2022 plugin (the older ESEF plugin is fine) raises an exception instead.

#### Description of change
Validate the IXDS urls instead of the fake IXDS filesource url

#### Steps to Test
* copy and unzip (you'll need both the zip to use as a taxonomy package and the unpacked files to trigger the error): [abc.zip](https://github.com/Arelle/Arelle/files/12165440/abc.zip)
* run (use the paths on your system) `python arelleCmdLine.py --file "[{\"ixds\":[{\"file\":\"/Users/austinmatherne/Downloads/abc/reports/abc2019/abc-2019-12-31.xhtml\"},{\"file\":\"/Users/austinmatherne/Downloads/abc/reports/abc2019/PFSs.xhtml\"}]}]" --validate --plugin validate/ESEF_2022 --packages ~/Downloads/abc.zip --disclosureSystem esef`

With master you should get an exception `[Exception] Entry point loading Failed to complete request`.
With this branch you should get two `ESEF.2.6.1.reportIncorrectlyPlacedInPackage` errors.

**review**:
@Arelle/arelle
