### PR TITLE
Fix "string index out of range" if remapping exactly matches entry po…

### DIFF
--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -253,7 +253,7 @@ def parsePackage(cntlr, filesource, metadataFile, fileBase, errors=[]):
                     prefixLength = len(mapFrom)
                     if prefixLength > longestPrefix:
                         _remappedUrl = remappedUrl[prefixLength:]
-                        if not (_remappedUrl[0] in (os.sep, '/') or mapTo[-1] in (os.sep, '/')):
+                        if len(_remappedUrl) > 0 and (not (_remappedUrl[0] in (os.sep, '/') or mapTo[-1] in (os.sep, '/'))):
                             _remappedUrl = mapTo + os.sep + _remappedUrl
                         else:
                             _remappedUrl = mapTo + _remappedUrl

--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -253,7 +253,7 @@ def parsePackage(cntlr, filesource, metadataFile, fileBase, errors=[]):
                     prefixLength = len(mapFrom)
                     if prefixLength > longestPrefix:
                         _remappedUrl = remappedUrl[prefixLength:]
-                        if len(_remappedUrl) > 0 and (not (_remappedUrl[0] in (os.sep, '/') or mapTo[-1] in (os.sep, '/'))):
+                        if len(_remappedUrl) > 0 and not _remappedUrl.startswith((os.sep, '/')) and not mapTo.endswith((os.sep, '/')):
                             _remappedUrl = mapTo + os.sep + _remappedUrl
                         else:
                             _remappedUrl = mapTo + _remappedUrl


### PR DESCRIPTION
#### Reason for change

If a taxonomy package has a remapping in `catalog.xml` that is the same as an entry point URL in `taxonomyPackage.xml` you get the following error:

```
arelle --packages build/codelist-common-WGWD-YYYY-MM-DD.zip -v -f build/currency-current-WGWD-YYYY-MM-DD/currency-en.xsd 
Traceback (most recent call last):
  File "/home/pdw/Arelle/arelleCmdLine.py", line 43, in <module>
    CntlrCmdLine.main()
  File "/home/pdw/Arelle/arelle/CntlrCmdLine.py", line 52, in main
    parseAndRun(args)
  File "/home/pdw/Arelle/arelle/CntlrCmdLine.py", line 456, in parseAndRun
    cntlr.run(options)
  File "/home/pdw/Arelle/arelle/CntlrCmdLine.py", line 692, in run
    packageInfo = PackageManager.addPackage(self, cmd, options.packageManifestName)
  File "/home/pdw/Arelle/arelle/PackageManager.py", line 605, in addPackage
    newPackageInfo = packageInfo(cntlr, url, packageManifestName=packageManifestName)
  File "/home/pdw/Arelle/arelle/PackageManager.py", line 511, in packageInfo
    parsedPackage = parsePackage(_cntlr, filesource, packageFileUrl, packageFilePrefix, errors)
  File "/home/pdw/Arelle/arelle/PackageManager.py", line 256, in parsePackage
    if not (_remappedUrl[0] in (os.sep, '/') or mapTo[-1] in (os.sep, '/')):
IndexError: string index out of range
```
`_remappedURL` is the remainder of the URL that isn't covered by the remapping, so in this case it's a zero length string.

#### Description of change

Check the length of `_remappedURL` before access.

#### Steps to Test

Attempt to add a taxonomy package with a remapping that exactly matches an entry point URL.  

[codelist-common-WGWD-YYYY-MM-DD.zip](https://github.com/Arelle/Arelle/files/12242325/codelist-common-WGWD-YYYY-MM-DD.zip)


**review**:
@Arelle/arelle

