### PR TITLE
Save raw invalid value instead of `(ixTransformValueError)` in extraction jobs

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -620,6 +620,17 @@ class ModelInlineValueObject:
         self.xValue = None
 
     @property
+    def rawValue(self):
+        ixEscape = self.get("escape") in ("true", "1")
+        return XmlUtil.innerText(
+            self,
+            ixExclude="tuple" if self.elementQname == XbrlConst.qnIXbrl11Tuple else "html",
+            ixEscape=ixEscape,
+            ixContinuation=(self.elementQname == XbrlConst.qnIXbrl11NonNumeric),
+            ixResolveUris=ixEscape,
+            strip=(self.format is not None))  # transforms are whitespace-collapse, otherwise it is preserved.
+
+    @property
     def value(self):
         """(str) -- Overrides and corresponds to value property of ModelFact,
         for relevant inner text nodes aggregated and transformed as needed."""
@@ -629,13 +640,7 @@ class ModelInlineValueObject:
             self.xValid = UNVALIDATED # may not be initialized otherwise
             self.xValue = None
             f = self.format
-            ixEscape = self.get("escape") in ("true","1")
-            v = XmlUtil.innerText(self,
-                                  ixExclude="tuple" if self.elementQname == XbrlConst.qnIXbrl11Tuple else "html",
-                                  ixEscape=ixEscape,
-                                  ixContinuation=(self.elementQname == XbrlConst.qnIXbrl11NonNumeric),
-                                  ixResolveUris=ixEscape,
-                                  strip=(f is not None)) # transforms are whitespace-collapse, otherwise it is preserved.
+            v = self.rawValue
             if self.isNil:
                 self._ixValue = v
             else:

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -60,7 +60,7 @@ from arelle.FileSource import archiveFilenameParts, archiveFilenameSuffixes
 from arelle.ModelInstanceObject import ModelInlineFootnote
 from arelle.ModelObject import ModelObject
 from arelle.ModelDocument import ModelDocument, ModelDocumentReference, Type, load, create, inlineIxdsDiscover
-from arelle.ModelValue import qname
+from arelle.ModelValue import INVALIDixVALUE, qname
 from arelle.PluginManager import pluginClassMethods
 from arelle.PythonUtil import attrdict
 from arelle.UrlUtil import isHttpUrl
@@ -247,10 +247,10 @@ def createTargetInstance(modelXbrl, targetUrl, targetDocumentSchemaRefs, filingF
                     text = None
                 elif ( not(modelConcept.baseXsdType == "token" and modelConcept.isEnumeration)
                        and fact.xValid ):
-                    text = fact.xValue
+                    text = fact.rawValue if fact.xValue == INVALIDixVALUE else fact.xValue
                 # may need a special case for QNames (especially if prefixes defined below root)
                 else:
-                    text = fact.textValue
+                    text = fact.rawValue if fact.textValue == INVALIDixVALUE else fact.textValue
                 for attrName, attrValue in fact.items():
                     if attrName.startswith("{"):
                         attrs[qname(attrName,fact.nsmap)] = attrValue # using qname allows setting prefix in extracted instance


### PR DESCRIPTION
#### Reason for change
Values which fail transformation log an error, but are replaced with `(ixTransformValueError)`.

#### Description of change
If values can't be properly transformed they are passed through to the extracted instance without formatting and a validation error is logged.

#### Steps to Test
* use [wk-20230810.htm.zip](https://github.com/Arelle/Arelle/files/12317337/wk-20230810.htm.zip) (extracted).
* `python arelleCmdLine.py --file wk-20230810.htm --plugin inlineXbrlDocumentSet --saveInstance`
* Verify `[xmlSchema:valueError] Element ix:nonFraction fact us-gaap:Cash error Invalid value for nonFraction number` is logged.
* Verify that in the saved instance (wk-20230810_extracted.xbrl) the fact value for the cash concept (`invalid value`) is preserved.

**review**:
@Arelle/arelle
