### PR TITLE
Use delimitedList import which works with both pyparsing 3.0 and 3.1

### DIFF
--- a/arelle/formula/XPathParser.py
+++ b/arelle/formula/XPathParser.py
@@ -14,7 +14,6 @@ from xml.dom import minidom
 from pyparsing import (
     CaselessLiteral,
     Combine,
-    DelimitedList,
     Forward,
     Group,
     Keyword,
@@ -32,6 +31,7 @@ from pyparsing import (
     ZeroOrMore,
     alphanums,
     alphas,
+    delimitedList as DelimitedList,
     nums,
     quoted_string,
 )

--- a/arelle/plugin/formulaLoader.py
+++ b/arelle/plugin/formulaLoader.py
@@ -1299,7 +1299,7 @@ def compileXfsGrammar( cntlr, debugParsing ):
                  Literal, CaselessLiteral,
                  Combine, Opt, nums, Or, Forward, Group, ZeroOrMore, OneOrMore, StringEnd, alphanums,
                  ParserElement, quoted_string, dbl_quoted_string, sgl_quoted_string, QuotedString,
-                 DelimitedList, Suppress, Regex, FollowedBy,
+                 delimitedList as DelimitedList, Suppress, Regex, FollowedBy,
                  lineno, line, col)
 
     ParserElement.enable_packrat()

--- a/arelle/plugin/sphinx/SphinxParser.py
+++ b/arelle/plugin/sphinx/SphinxParser.py
@@ -773,7 +773,8 @@ def compileSphinxGrammar( cntlr ):
     cntlr.showStatus(_("Compiling Sphinx Grammar"))
     from pyparsing import (
         Word, Keyword, Literal, CaselessLiteral, Combine, Opt, nums, Forward, ZeroOrMore,
-        StringEnd, ParserElement, quoted_string, DelimitedList, Suppress, Regex, lineno
+        StringEnd, ParserElement, quoted_string, delimitedList as DelimitedList, Suppress,
+        Regex, lineno
     )
 
     ParserElement.enable_packrat()


### PR DESCRIPTION
#### Reason for change
`delimitedList` is deprecated in 3.1 (it's an alias for `DelimitedList`) and will be removed in 4.0, but `DelimitedList` doesn't exist in 3.0.

#### Description of change
Use deprecated import, but alias to match new API.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
