### PR TITLE
Fix saveLoadableExcel CLI

### DIFF
--- a/arelle/plugin/saveLoadableExcel.py
+++ b/arelle/plugin/saveLoadableExcel.py
@@ -434,7 +434,6 @@ def saveLoadableExcelMenuCommand(cntlr):
 def saveLoadableExcelCommandLineOptionExtender(parser, *args, **kwargs):
     # extend command line options with a save DTS option
     parser.add_option("--save-loadable-excel",
-                      action="store_true",
                       dest="saveLoadableExcel",
                       help=_("Save Loadable Excel file"))
 

--- a/arelle/plugin/saveLoadableExcel.py
+++ b/arelle/plugin/saveLoadableExcel.py
@@ -390,10 +390,11 @@ def saveLoadableExcel(dts, excelFile):
                     conceptsRow += 1
 
     try:
-        workbook.save(excelFile)
+        excelFilename = excelFile if excelFile.lower().endswith(".xlsx") else excelFile + ".xlsx"
+        workbook.save(excelFilename)
         dts.info("info:saveLoadableExcel",
             _("Saved Excel file: %(excelFile)s"),
-            excelFile=os.path.basename(excelFile),
+            excelFile=os.path.basename(excelFilename),
             modelXbrl=dts)
     except Exception as ex:
         dts.error("exception:saveLoadableExcel",


### PR DESCRIPTION
#### Reason for change
saveLoadableExcel plugin option `--save-loadable-excel` is a boolean, but needs to be a string (it's the file name of the saved excel file).

#### Description of change
* Change `--save-loadable-excel` CLI option type from boolean to string to match GUI operation
* Make sure file name ends in .xlsx

#### Steps to Test
`python arelleCmdLine.py --file https://www.sec.gov/Archives/edgar/data/1445305/000144530523000098/0001445305-23-000098-xbrl.zip/wk-20230331.xsd --plugin saveLoadableExcel --save-loadable-excel example.xlsx`

**review**:
@Arelle/arelle
