### PR TITLE
Use xbrli namespace prefix in newly created xbrl documents

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -420,7 +420,7 @@ def create(modelXbrl, type, uri, schemaRefs=None, isEntry=False, initialXml=None
     elif type == Type.INSTANCE:
         # modelXbrl.uriDir = os.path.dirname(normalizedUri)
         Xml = ('<nsmap>{}'
-               '<xbrl xmlns="http://www.xbrl.org/2003/instance"'
+               '<xbrli:xbrl xmlns:xbrli="http://www.xbrl.org/2003/instance"'
                ' xmlns:link="http://www.xbrl.org/2003/linkbase"'
                ' xmlns:xlink="http://www.w3.org/1999/xlink">').format(initialComment)
         if schemaRefs:

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -883,8 +883,7 @@ def addQnameValue(modelDocument: ModelDocument, qnameValue: QName | str) -> str:
         prefix = "{0}_{1}".format(qnameValue.prefix if qnameValue.prefix else '', dupNum)
         dupNum += 1
     setXmlns(modelDocument, prefix, ns)
-    assert isinstance(prefix, str)
-    return qnameValue.localName if len(prefix) == 0 else prefix + ':' + qnameValue.localName  # ModelValue type hints
+    return f'{prefix}:{qnameValue.localName}' if prefix else qnameValue.localName
 
 
 def setXmlns(modelDocument: etree._ElementTree | ModelDocument, prefix: str | None, namespaceURI: str) -> None:


### PR DESCRIPTION
#### Reason for change
When the `saveTargetDocument` code of InlineXBRLDocumentSet is triggered, this code creates a new xbrl instance model. During which ModelDocument creates new xml under the covers. However, the xml is missing a namespace prefix and thus all newly created xml documents use the default namespace.

This change updates the default namespace to be `xbrli` in the under the cover xml generation. 


#### Steps to Test
Take and ixbrl file and run it through the `saveTargetDocument` code in InlineXBRLDocumentSet. With out the fix, all xbrl elements will be written under a generic `<xbrl>` tag. All the tags for contexts including context, entity, etc. will also just be there generic forms. 

With the fix in place the initial '<xbrl>' tag now looks like `<xbrli:xbrl>` and Context tags will also be prefixed correctly with `xbrli`.


**review**:
@Arelle/arelle
