### PR TITLE
Fall back to rawValue if xValue or textValue are None

### DIFF
--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -249,8 +249,8 @@ def createTargetInstance(modelXbrl, targetUrl, targetDocumentSchemaRefs, filingF
                     attrs[XbrlConst.qnXsiNil] = "true"
                     text = None
                 elif ( not(modelConcept.baseXsdType == "token" and modelConcept.isEnumeration)
-                       and fact.xValid ):
-                    text = fact.rawValue if fact.xValue == INVALIDixVALUE else fact.xValue
+                       and fact.xValid >= VALID ):
+                    text = fact.xValue
                 # may need a special case for QNames (especially if prefixes defined below root)
                 else:
                     text = fact.rawValue if fact.textValue == INVALIDixVALUE else fact.textValue


### PR DESCRIPTION
#### Reason for change
Austin made a slight adjustment to this a few weeks ago for transformation errors. But now we are getting issues where non-numeric fact values are not being added to the new xml model because the code is looking for an xValue rather than textValue or rawValue. We need to tweak this code to make sure that this scenario also flows a fact value through when xValue does not exist.

#### Description of change
Make sure that if there is not a xValue or a textValue that we fall back to rawValue.

#### Steps to Test
CI

**review**:
@Arelle/arelle
