### PR TITLE
update calc1.1 for XII Calc MR 33 and test suite update

### DIFF
--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -469,6 +469,15 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
             return self._isNumeric
 
     @property
+    def isDecimal(self):
+        """(bool) -- True for a decimal xsd base type (not including xbrl fractions, float or double)"""
+        try:
+            return self._isDecimal
+        except AttributeError:
+            self._isDecimal = XbrlConst.isDecimalXsdType(self.baseXsdType)
+            return self._isDecimal
+
+    @property
     def isInteger(self):
         """(bool) -- True for elements of, or derived from, integer base type (not including fractionItemType)"""
         try:

--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -136,10 +136,10 @@ class ValidateXbrlCalcs:
                     del modelXbrl.errors[i] # remove the oim errors from modelXbrl.errors
                 oimErrs.add(e)
             if any(e == "xbrlxe:unsupportedTuple" for e in oimErrs):
-                # ignore this error and change to INCONSISTENCY
-                modelXbrl.log('INCONSISTENCY', "calc11e:tuplesInReportWarning","Validating of calculations ignores tuples.")
+                # ignore this error and change to warning
+                modelXbrl.warning("calc11e:tuplesInReportWarning","Validating of calculations ignores tuples.")
             if any(e in oimXbrlxeBlockingErrorCodes for e in oimErrs if e != "xbrlxe:unsupportedTuple"):
-                modelXbrl.log('INCONSISTENCY', "calc11e:oimIncompatibleReportWarning","Validating of calculations is skipped due to OIM errors.")
+                modelXbrl.warning("calc11e:oimIncompatibleReportWarning","Validating of calculations is skipped due to OIM errors.")
                 return;
 
         # identify equal contexts

--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -224,7 +224,7 @@ class ValidateXbrlCalcs:
                                                 _("The source and target of a Calculations v1.1 relationship MUST both be decimal concepts: %(sumConcept)s, %(itemConcept)s, link role %(linkrole)s"),
                                                 modelObject=(sumConcept, itemConcept, modelRel), linkrole=modelRel.linkrole,
                                                 sumConcept=sumConcept.qname, itemConcept=itemConcept.qname)
-                                            
+
                             # add up rounded items
                             boundSums = defaultdict(decimal.Decimal) # sum of facts meeting factKey
                             boundIntervals = {} # interval sum of facts meeting factKey

--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -221,7 +221,7 @@ class ValidateXbrlCalcs:
                                         siRels[itemConcept] = modelRel
                                         if not sumConcept.isDecimal or not itemConcept.isDecimal:
                                             modelXbrl.error("calc11e:nonDecimalItemNode",
-                                                _("The source and target of a Calculations v1.1 relationship MUST both be a decimal concepts: %(sumConcept)s, %(itemConcept)s, link role %(linkrole)s"),
+                                                _("The source and target of a Calculations v1.1 relationship MUST both be decimal concepts: %(sumConcept)s, %(itemConcept)s, link role %(linkrole)s"),
                                                 modelObject=(sumConcept, itemConcept, modelRel), linkrole=modelRel.linkrole,
                                                 sumConcept=sumConcept.qname, itemConcept=itemConcept.qname)
                                             

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -746,6 +746,25 @@ def isNumericXsdType(xsdType: str) -> bool:
     }
 
 
+def isDecimalXsdType(xsdType: str) -> bool:
+    return xsdType in {
+        "integer",
+        "positiveInteger",
+        "negativeInteger",
+        "nonNegativeInteger",
+        "nonPositiveInteger",
+        "long",
+        "unsignedLong",
+        "int",
+        "unsignedInt",
+        "short",
+        "unsignedShort",
+        "byte",
+        "unsignedByte",
+        "decimal",
+    }
+
+
 def isIntegerXsdType(xsdType: str) -> bool:
     return xsdType in {
         "integer",

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_calculations_1_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_calculations_1_1.py
@@ -2,35 +2,9 @@ from pathlib import PurePath
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig
 
 config = ConformanceSuiteConfig(
-    expected_failure_ids=frozenset(f'calculation-1.1-conformance-2023-02-22/{s}' for s in [
-        # The loadFromOIM plugin is required to load the conformance suite json
-        # files. However, OIM validation raises xbrlxe:unsupportedTuple for
-        # tuples which then raises calc11e:tuplesInReportWarning in calc 1.1.
-        # This isn't modeled in the conformance suite, but expected if both
-        # calc 1.1 and OIM validation are performed together.
-        # https://www.xbrl.org/Specification/xbrl-xml/REC-2021-10-13/xbrl-xml-REC-2021-10-13.html#unsupportedTuple
-        # https://www.xbrl.org/Specification/calculation-1.1/REC-2023-02-22/calculation-1.1-REC-2023-02-22.html#error-calc11e-tuplesinreportwarning
-        'calc11/index.xml:oim-tuple-consistent-round',
-        'calc11/index.xml:oim-tuple-consistent-truncate',
-        'calc11/index.xml:oim-tuple-ignored-calculation-round',
-        'calc11/index.xml:oim-tuple-ignored-calculation-truncate',
-        'xbrl21/index.xml:oim-tuple-consistent-round',
-        'xbrl21/index.xml:oim-tuple-consistent-truncate',
-        'xbrl21/index.xml:oim-tuple-ignored-calculation-round',
-        'xbrl21/index.xml:oim-tuple-ignored-calculation-truncate',
-
-        # Similar to the above, validation errors other than
-        # xbrlxe:unsupportedTuple are expected to raise
-        # calc11e:oimIncompatibleReportWarning during calc 1.1 validation.
-        # https://www.xbrl.org/Specification/calculation-1.1/REC-2023-02-22/calculation-1.1-REC-2023-02-22.html#error-calc11e-oimincompatiblereportwarning
-        'calc11/index.xml:oim-illegal-fraction-item-round',
-        'calc11/index.xml:oim-illegal-fraction-item-truncate',
-        'xbrl21/index.xml:oim-illegal-fraction-item-round',
-        'xbrl21/index.xml:oim-illegal-fraction-item-truncate',
-    ]),
-    file='calculation-1.1-conformance-2023-02-22/index.xml',
+    file='calculation-1.1-conformance-2023-12-20/index.xml',
     info_url='https://specifications.xbrl.org/work-product-index-calculations-2-calculations-1-1.html',
-    local_filepath='calculation-1.1-conformance-2023-02-22.zip',
+    local_filepath='calculation-1.1-conformance-2023-12-20.zip',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
     network_or_cache_required=False,

--- a/tests/plugin/testcaseCalc11ValidateSetup.py
+++ b/tests/plugin/testcaseCalc11ValidateSetup.py
@@ -12,6 +12,7 @@ from arelle.XhtmlValidate import htmlEltUriAttrs, resolveHtmlUri
 from arelle.ValidateXbrlCalcs import ValidateCalcsMode as CalcsMode
 
 def testcaseVariationLoaded(testInstance, testcaseInstance, modelTestcaseVariation):
+    testInstance.modelManager.formulaOptions.testcaseResultsCaptureWarnings = False
     for result in modelTestcaseVariation.iter("{*}result"):
         for n, v in result.attrib.items():
             if n.endswith("mode"):
@@ -19,6 +20,12 @@ def testcaseVariationLoaded(testInstance, testcaseInstance, modelTestcaseVariati
                     testInstance.modelManager.validateCalcs = CalcsMode.ROUND_TO_NEAREST
                 elif v == "truncate":
                     testInstance.modelManager.validateCalcs = CalcsMode.TRUNCATION
+        if result.tag.endswith("warning"):
+            testInstance.modelManager.formulaOptions.testcaseResultsCaptureWarnings = True
+                    
+def testcaseVariationExpectedResult(modelTestcaseVariation):
+    for result in modelTestcaseVariation.iter("{*}warning"):
+        return result.text
 
 __pluginInfo__ = {
     'name': 'Testcase obtain expected calc 11 mode from variation/result@mode',
@@ -29,4 +36,5 @@ __pluginInfo__ = {
     'copyright': '(c) Copyright 2019 Mark V Systems Limited, All rights reserved.',
     # classes of mount points (required)
     'TestcaseVariation.Xbrl.Loaded': testcaseVariationLoaded,
+    'ModelTestcaseVariation.ExpectedResult': testcaseVariationExpectedResult
 }

--- a/tests/plugin/testcaseCalc11ValidateSetup.py
+++ b/tests/plugin/testcaseCalc11ValidateSetup.py
@@ -1,18 +1,11 @@
-'''
-This plug-in removes xmlns="http://www.w3.org/1999/xhtml" from
-escaped html in text content of expected instance facts for inline XBRL text facts
-
-(c) Copyright 2019 Mark V Systems Limited, All rights reserved.
-'''
-try:
-    import regex as re
-except ImportError:
-    import re
-from arelle.XhtmlValidate import htmlEltUriAttrs, resolveHtmlUri
+"""
+See COPYRIGHT.md for copyright information.
+"""
 from arelle.ValidateXbrlCalcs import ValidateCalcsMode as CalcsMode
+from arelle.Version import authorLabel, copyrightLabel
+
 
 def testcaseVariationLoaded(testInstance, testcaseInstance, modelTestcaseVariation):
-    testInstance.modelManager.formulaOptions.testcaseResultsCaptureWarnings = False
     for result in modelTestcaseVariation.iter("{*}result"):
         for n, v in result.attrib.items():
             if n.endswith("mode"):
@@ -20,20 +13,20 @@ def testcaseVariationLoaded(testInstance, testcaseInstance, modelTestcaseVariati
                     testInstance.modelManager.validateCalcs = CalcsMode.ROUND_TO_NEAREST
                 elif v == "truncate":
                     testInstance.modelManager.validateCalcs = CalcsMode.TRUNCATION
-        if result.tag.endswith("warning"):
-            testInstance.modelManager.formulaOptions.testcaseResultsCaptureWarnings = True
-                    
+
+
 def testcaseVariationExpectedResult(modelTestcaseVariation):
     for result in modelTestcaseVariation.iter("{*}warning"):
         return result.text
+
 
 __pluginInfo__ = {
     'name': 'Testcase obtain expected calc 11 mode from variation/result@mode',
     'version': '0.9',
     'description': "This plug-in removes xxx.  ",
-    'license': 'Apache-2',
-    'author': 'Mark V Systems Limited',
-    'copyright': '(c) Copyright 2019 Mark V Systems Limited, All rights reserved.',
+    'license': "Apache-2",
+    'author': authorLabel,
+    'copyright': copyrightLabel,
     # classes of mount points (required)
     'TestcaseVariation.Xbrl.Loaded': testcaseVariationLoaded,
     'ModelTestcaseVariation.ExpectedResult': testcaseVariationExpectedResult


### PR DESCRIPTION
#### Reason for change
XII WG Calc WG !33 clarified spec para 3.1 to mean that specified error codes are at Arelle's INCONSISTENT severity instead of error.

Also new check for non-decimal calc arc nodes was introduced

Incorporate fix for Calc WG !35.

#### Description of change
See reason above.

#### Steps to Test
Use Calc WG DRAFT test suite from XII WG Calc !35, changing the DRAFT-YYYY-MM-DD to 2023 within calc1.1 test cases so it has production barcarole and schemaRef.

**review**:
@Arelle/arelle
