### PR TITLE
Update Python to latest patch release (3.11.5)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,7 +22,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.11.4'
+        default: '3.11.5'
         description: 'Python version to use'
         required: false
         type: string
@@ -58,7 +58,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.11.4'
+        default: '3.11.5'
         description: 'Python version to use'
         required: true
         type: string

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,9 @@ Here's how to set up your environment:
 2. Clone your fork: `git clone git@github.com:<your-github-username>/Arelle.git`
 3. Install [pyenv][pyenv-install]
 4. Install a supported version of Python.
-   For example, `pyenv install 3.11.4`
+   For example, `pyenv install 3.11.5`
 5. Create a virtual env using the Python version you just installed.
-   For example, `PYENV_VERSION=3.11.4 pyenv exec python -m venv venv`
+   For example, `PYENV_VERSION=3.11.5 pyenv exec python -m venv venv`
 6. Activate your environment: `source venv/bin/activate`
 7. Install dependencies: `pip install -r requirements-dev.txt`
 8. Verify you can run the app


### PR DESCRIPTION
#### Reason for change
Python 3.11.5 was released on Thursday. Dependabot isn't able to update the Python version for our Linux builds or docs.

#### Description of change
* Update default Python version for Linux build.
* Update suggested Python version in docs.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
