### PR TITLE
Defer JP FSA schema ref collection until after IXDS has been fully discovered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ arelle/plugin/validate/DQC_US_Rules
 arelle/plugin/validate/DQC.py
 arelle/plugin/validate/eforms.py
 arelle/plugin/validate/ESEF-DQC.py
+arelle/plugin/xendr
 arelle/plugin/Xince.py
 arelle/plugin/xule
 Arelle.egg-info

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -682,6 +682,7 @@ class ModelDocument:
         self.hrefObjects = []
         self.schemaLocationElements = set()
         self.referencedNamespaces = set()
+        self.targetDocumentSchemaRefs = set()
         self.inDTS = False
         self.definesUTR = False
         self.isModified = False

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -366,6 +366,10 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
                 XmlValidateSchema.validate(doc, doc.xmlRootElement, doc.targetNamespace) # validate schema elements
             if hasattr(modelXbrl, "ixdsHtmlElements"):
                 inlineIxdsDiscover(modelXbrl, modelDocument) # compile cross-document IXDS references
+                for doc in modelDocument.referencesDocument.keys():
+                    for referencedDoc in doc.referencesDocument.keys():
+                        if referencedDoc.type == Type.SCHEMA:
+                            modelDocument.targetDocumentSchemaRefs.add(doc.relativeUri(referencedDoc.uri))
 
         if isEntry or isSupplemental:
             # re-order base set keys for entry point or supplemental linkbase addition

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -102,9 +102,6 @@ class ModelInlineXbrlDocumentSet(ModelDocument):
                         referencedDocument.targetId = targetId
                         self.referencesDocument[doc] = referencedDocument
                         self.ixNS = doc.ixNS
-                        for referencedDoc in doc.referencesDocument.keys():
-                            if referencedDoc.type == Type.SCHEMA:
-                                self.targetDocumentSchemaRefs.add(doc.relativeUri(referencedDoc.uri))
         return True
 
 # this loader is used for test cases of multi-ix doc sets

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -91,7 +91,6 @@ class ModelInlineXbrlDocumentSet(ModelDocument):
             targetId = instanceElt.id
             self.targetDocumentId = targetId
             self.targetDocumentPreferredFilename = instanceElt.get('preferredFilename')
-            self.targetDocumentSchemaRefs = set()  # union all the instance schemaRefs
             for ixbrlElt in instanceElt.iter(tag="{http://disclosure.edinet-fsa.go.jp/2013/manifest}ixbrl"):
                 uri = ixbrlElt.textValue.strip()
                 if uri:
@@ -143,7 +142,6 @@ def inlineXbrlDocumentSetLoader(modelXbrl, normalizedUri, filepath, isEntry=Fals
         xml.append("</instances>\n")
         ixdocset = create(modelXbrl, Type.INLINEXBRLDOCUMENTSET, docsetUrl, isEntry=True, initialXml="".join(xml))
         ixdocset.type = Type.INLINEXBRLDOCUMENTSET
-        ixdocset.targetDocumentSchemaRefs = set()  # union all the instance schemaRefs
         _firstdoc = True
         for elt in ixdocset.xmlRootElement.iter(tag="instance"):
             # load ix document

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -102,6 +102,7 @@ class ModelInlineXbrlDocumentSet(ModelDocument):
                         referencedDocument = ModelDocumentReference("inlineDocument", instanceElt)
                         referencedDocument.targetId = targetId
                         self.referencesDocument[doc] = referencedDocument
+                        self.ixNS = doc.ixNS
                         for referencedDoc in doc.referencesDocument.keys():
                             if referencedDoc.type == Type.SCHEMA:
                                 self.targetDocumentSchemaRefs.add(doc.relativeUri(referencedDoc.uri))


### PR DESCRIPTION
#### Reason for change
resolves #841 

#### Description of change
The code path for the JP FSA inline document manifest wasn't updated along with the other IXDS code in #671. This PR defers schema ref handling until after the document set has been fully evaluated.

#### Steps to Test
1. Download report:
  `curl -LO https://github.com/Arelle/Arelle/files/12428902/JapaneseXBRLReport.zip`
2. unzip report:
  `unzip -d JapaneseXBRLReport JapaneseXBRLReport.zip`
3. extract instance:
  `python arelleCmdLine.py --plugin inlineXbrlDocumentSet --saveInstance --file JapaneseXBRLReport/manifest.xml`
4. verify no `schemaImportMissing` errors in extracted doc:
  `python arelleCmdLine.py --validate --file JapaneseXBRLReport/tse-acedjpfr-19990-2023-06-30-01-2023-08-18_extracted.xbrl`

**review**:
@Arelle/arelle
