### PR TITLE
Add defaultNamespace as an option from the command line

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -391,7 +391,7 @@ def loadSchemalocatedSchema(modelXbrl, element, relativeUrl, namespace, baseUrl)
             doc.inDTS = False
     return doc
 
-def create(modelXbrl, type, uri, schemaRefs=None, isEntry=False, initialXml=None, initialComment=None, base=None, discover=True, documentEncoding="utf-8") -> ModelDocument:
+def create(modelXbrl, type, uri, schemaRefs=None, isEntry=False, initialXml=None, initialComment=None, base=None, discover=True, documentEncoding="utf-8", xbrliNamespacePrefix=None) -> ModelDocument:
     """Returns a new modelDocument, created from scratch, with any necessary header elements
 
     (such as the schema, instance, or RSS feed top level elements)
@@ -419,14 +419,21 @@ def create(modelXbrl, type, uri, schemaRefs=None, isEntry=False, initialXml=None
         Xml = '<nsmap>{}{}</nsmap>'.format(initialComment or '', initialXml or '')
     elif type == Type.INSTANCE:
         # modelXbrl.uriDir = os.path.dirname(normalizedUri)
+        if xbrliNamespacePrefix is not None:
+            xbrli_instance_namespace = f'<{xbrliNamespacePrefix}:xbrl xmlns:{xbrliNamespacePrefix}="http://www.xbrl.org/2003/instance"'
+        else:
+            xbrli_instance_namespace = '<xbrl xmlns="http://www.xbrl.org/2003/instance"'
         Xml = ('<nsmap>{}'
-               '<xbrli:xbrl xmlns:xbrli="http://www.xbrl.org/2003/instance"'
+               '{}'
                ' xmlns:link="http://www.xbrl.org/2003/linkbase"'
-               ' xmlns:xlink="http://www.w3.org/1999/xlink">').format(initialComment)
+               ' xmlns:xlink="http://www.w3.org/1999/xlink">').format(initialComment, xbrli_instance_namespace)
         if schemaRefs:
             for schemaRef in schemaRefs:
                 Xml += '<link:schemaRef xlink:type="simple" xlink:href="{0}"/>'.format(schemaRef.replace("\\","/"))
-        Xml += '</xbrl></nsmap>'
+        if xbrliNamespacePrefix is not None:
+            Xml += f'</{xbrliNamespacePrefix}:xbrl></nsmap>'
+        else:
+            Xml += '</xbrl></nsmap>'
     elif type == Type.SCHEMA:
         Xml = ('<nsmap>{}<schema xmlns="http://www.w3.org/2001/XMLSchema" /></nsmap>').format(initialComment)
     elif type == Type.RSSFEED:

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -103,7 +103,7 @@ def load(modelManager: ModelManager, url: str | FileSourceClass, nextaction: str
 
 def create(
         modelManager: ModelManager, newDocumentType: int | None = None, url: str | None = None, schemaRefs: str|None = None, createModelDocument: bool = True, isEntry: bool = False,
-        errorCaptureLevel: str | None = None, initialXml: str | None = None, initialComment: str | None = None, base: str | None = None, discover: bool = True
+        errorCaptureLevel: str | None = None, initialXml: str | None = None, initialComment: str | None = None, base: str | None = None, discover: bool = True, xbrliNamespacePrefix: str | None = None
 ) -> ModelXbrl:
     from arelle import (ModelDocument, FileSource)
     modelXbrl = ModelXbrl(modelManager, errorCaptureLevel=errorCaptureLevel)
@@ -112,7 +112,7 @@ def create(
         modelXbrl.fileSource = FileSource.FileSource(cast(str, url), modelManager.cntlr)  # url may be an open file handle, use str(url) below
         modelXbrl.closeFileSource= True
         if createModelDocument:
-            modelXbrl.modelDocument = ModelDocument.create(modelXbrl, newDocumentType, str(url), schemaRefs=schemaRefs, isEntry=isEntry, initialXml=initialXml, initialComment=initialComment, base=base, discover=discover)
+            modelXbrl.modelDocument = ModelDocument.create(modelXbrl, newDocumentType, str(url), schemaRefs=schemaRefs, isEntry=isEntry, initialXml=initialXml, initialComment=initialComment, base=base, discover=discover, xbrliNamespacePrefix=xbrliNamespacePrefix)
             if isEntry:
                 del modelXbrl.entryLoadingUrl
                 loadSchemalocatedSchemas(modelXbrl)


### PR DESCRIPTION
#### Reason for change
Automatically defaulting to using `xbrli` as the default namespace broke other plugins. So instead add a command line option to InlineXbrlDocumentSet plugin that allows users to set a namespace if they so desire, otherwise default to the default namespace. 

#### Steps to Test
Use any ixbrl document to test the following:
1. run `python -m arelleCmdLine --plugin 'inlineXbrlDocumentSet' -f '[{"ixds":[{"file":"<directory to unzipped ixbrl filing>"}]}]' --saveInstance`
     - This should produce an extracted instance document in the defined directory that uses the default namespace: `<xbrl>`
 2. run 'python -m arelleCmdLine --plugin 'inlineXbrlDocumentSet' -f '[{"ixds":[{"file":"/Users/derekgengenbacher/workspaces/wf/arelle/workiva-2021-2Q-10K"}]}]' --saveInstance --defaultNamespace xbrli'
      - This should produce an extracted instance document in the defined directory that uses the xbrli namespace: `<xbrli:xbrl>`
 3. run `python -m arelleCmdLine --plugin 'inlineXbrlDocumentSet' -f '[{"ixds":[{"file":"/Users/derekgengenbacher/workspaces/wf/arelle/workiva-2021-2Q-10K"}]}]' --saveInstance --defaultNamespace i`
      - This should produce an extracted instance document in the defined directory that uses the i namespace: `<i:xbrl>`

**review**:
@Arelle/arelle
