### PR TITLE
Optimise the XpathParser (time and recusion). 

### DIFF
--- a/arelle/formula/XPathParser.py
+++ b/arelle/formula/XPathParser.py
@@ -490,7 +490,6 @@ def pushExpr(sourceStr: str, loc: int, toks: ParseResults) -> Expr:
     return expr
 
 
-ParserElement.enable_packrat()
 # define grammar
 variableRef = Regex(
     "[$]"  # variable prefix
@@ -526,25 +525,40 @@ qName = Regex(
 ncName = Word(alphas + '_', alphanums + '_-.')
 prefixOp = Literal(":")
 
+exponentLiteralStr = r"[eE]"
+plusorminusLiteralStr = r"[+-]"
+digitsStr = r"\d+"
+optionalDigitsStr = r"\d*"
+decimalPointStr = r"\."
+nanLiteralStr = r"NaN"
+integerLiteralStr = plusorminusLiteralStr + r"?" + digitsStr
+decimalFractionLiteralStr = plusorminusLiteralStr + "?" + decimalPointStr + digitsStr
+infLiteralStr = plusorminusLiteralStr + r"?INF"
+
 decimalPoint = Literal('.')
-exponentLiteral = CaselessLiteral('e')
+exponentLiteral = Regex(exponentLiteralStr)
 plusorminusLiteral = Literal('+') | Literal('-')
 digits = Word(nums)
-integerLiteral = Combine(Opt(plusorminusLiteral) + digits)
-decimalFractionLiteral = Combine(Opt(plusorminusLiteral) + decimalPoint + digits)
-infLiteral = Combine(Opt(plusorminusLiteral) + Literal("INF"))
-nanLiteral = Literal("NaN")
-floatLiteral = (
-    Combine(
-        integerLiteral
-        + ((decimalPoint + Opt(digits) + exponentLiteral + integerLiteral) | (exponentLiteral + integerLiteral))
-    )
-    | Combine(decimalFractionLiteral + exponentLiteral + integerLiteral)
-    | infLiteral
-    | nanLiteral
+integerLiteral = Regex(integerLiteralStr)
+decimalFractionLiteral = Regex(decimalFractionLiteralStr)
+infLiteral = Regex(infLiteralStr)
+nanLiteral = Regex(nanLiteralStr)
+floatLiteral = Regex(
+    integerLiteralStr
+    + r"(" + decimalPointStr + optionalDigitsStr + ")?"
+    + exponentLiteralStr + integerLiteralStr
+    + r"|"
+    + decimalFractionLiteralStr + exponentLiteralStr + integerLiteralStr
+    + r"|"
+    + infLiteralStr
+    + r"|"
+    + nanLiteralStr
 )
-decimalLiteral = Combine(integerLiteral + decimalPoint + Opt(digits)) | decimalFractionLiteral
-
+decimalLiteral = Regex(
+    integerLiteralStr + decimalPointStr + optionalDigitsStr
+    + r"|"
+    + decimalFractionLiteralStr
+)
 
 # emptySequence = Literal( "(" ) + Literal( ")" )
 lParen = Literal("(")


### PR DESCRIPTION
#### Reason for change
When validating (and compiling) the [Solvency 2.8](https://dev.eiopa.europa.eu/Taxonomy/Full/2.8.0/S2/EIOPA_SolvencyII_XBRL_Taxonomy_2.8.0.zip) ARS or QRS report, a RecursionError is raise for a few formulas.

Ids of the formulas
QRS: `s2md_BV1434`
ARS: `s2md_BV311_1-1-1`, `s2md_BV311_1-1-2`, `s2md_BV311_1-1-3`, `s2md_BV311_1-1-4`, `s2md_BV311_2-10`, `s2md_BV311_2-11`, `s2md_BV311_2-12`, `s2md_BV311_2-13`, `s2md_BV439-1`, `s2md_BV442-1`, `s2md_BV442-1`

Those formulas look like this (example id: `s2md_BV311_1-1-1`):
```
iaf:numeric-equal($v1,iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add(iaf:numeric-add($v2,$v3),$v4),$v5),$v6),$v7),$v8),$v9),$v10),$v11),$v12),$v13),$v14),$v15),$v16),$v17),$v18),$v19),$v20),$v21),$v22),$v23),$v24),$v25),$v26),$v27),$v28),$v29),$v30),$v31),$v32),iaf:sum($v33)))
```

#### Description of change
The changes are based on a discussion (summarized in the current issue) with the pyparsing author: see https://github.com/pyparsing/pyparsing/issues/509

##### Removal of the enable_packrat().

This parameter adds a cache, which is mostly useful for `infix_notation` (see [comment](https://github.com/pyparsing/pyparsing/issues/509#issuecomment-1697453660) in the pyparsing issue) which isn't used here. 
However, it's using time to store and look in the cache, and also adding unnecessary frames in the stack, which causes the Recursion error at the end for formulas described above. 

*This is the needed change to be able to validate the 2.8 ARS/QRS reports*

##### Change the syntax definition with Regex

As advised by the pyparsing author, the terminal items were changes to some Regex, allowing faster compile times (a probably also fewer frame in the stack used)

##### Timing improvement
Here is some timing for the formulas compile times of an ARS report, which contains ~2 000 formulas (only ran one time, but the time change seems big enough to not need a real timing measures):
  | With enablePackrat (before, compilation fails) | Without enablePackrat (after)
-- | -- | --
Before Regex | ~108s | ~67s
After Regex | ~83s | ~57s

**Caveats**: Those changes only reduce the stack, the same problem might still happen in the future if the eiopa still add more nested function. 

#### Steps to Test
Open a [Solvency 2.8](https://dev.eiopa.europa.eu/Taxonomy/Full/2.8.0/S2/EIOPA_SolvencyII_XBRL_Taxonomy_2.8.0.zip) ARS/QRS report (even empty) and try to validate it. 

**review**:
@Arelle/arelle
