### PR TITLE
Fix error in computed bounds in calc 1.1 error message

### DIFF
--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -284,7 +284,7 @@ class ValidateXbrlCalcs:
                                                     concept=sumConcept.qname, linkrole=ELR,
                                                     linkroleDefinition=modelXbrl.roleTypeDefinition(ELR),
                                                     reportedSum=rangeToStr(s1,s2,incls1,incls2),
-                                                    computedSum=rangeToStr(x1,s2,inclx1,inclx2),
+                                                    computedSum=rangeToStr(x1,x2,inclx1,inclx2),
                                                     contextID=sumFacts[0].context.id, unitID=sumFacts[0].unit.id)
                             boundSummationItems.clear() # dereference facts in list
                             boundIntervalItems.clear()


### PR DESCRIPTION
#### Reason for change

The computed bounds in a Calculations 1.1 error message are incorrect.  The error message incorrectly uses the reported upper bound, not the calculated upper bound.

#### Description of change

```diff
  reportedSum=rangeToStr(s1,s2,incls1,incls2),
- computedSum=rangeToStr(x1,s2,inclx1,inclx2),
+ computedSum=rangeToStr(x1,x2,inclx1,inclx2),
```

`[s1,s2]` is the reported interval
`[x1,x2]` is the computed interval

#### Steps to Test

Validate any report with calc 1.1 inconsistencies (e.g. [Calc 1.1 conf suite](https://base-spec.ci.xbrl.org/calculations/1-1-0-rec-calc11-2023-02-22/conformance/calculation-1.1-conformance-2023-02-22.zip) ) and check computed interval bounds.

**review**:
@Arelle/arelle
