### PR TITLE
Use make command to build ixbrl-viewer

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -109,7 +109,7 @@ jobs:
       - run: |
           cd tmp/ixbrl-viewer
           npm install
-          npm run prod
+          make prod
           cd ../..
           mv tmp/ixbrl-viewer/iXBRLViewerPlugin arelle/plugin/
           rm -rf tmp

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -117,7 +117,7 @@ jobs:
       working-directory: ixbrl-viewer
       run: |
         npm install
-        npm run prod
+        make prod
     - shell: cmd
       run: move ixbrl-viewer\iXBRLViewerPlugin arelle\plugin\iXBRLViewerPlugin && rmdir /s /q ixbrl-viewer
     - name: Set up Python ${{ inputs.python_version }}


### PR DESCRIPTION
#### Reason for change
Arelle/ixbrl-viewer/pull/557 is adding an additional required npm command for building the ixbrl-viewer. `make prod` will be updated to run both npm commands.

#### Description of change
To support both old and new versions of the plugin this updates our pipelines to use `make prod` instead of `npm run prod` (the Linux workflow already does this).

#### Steps to Test
* CI
* Builds with this PR and updated ixbrl-viewer
  * [Linux](https://github.com/Arelle/Arelle/actions/runs/6102220897)
  * [macOS](https://github.com/Arelle/Arelle/actions/runs/6102222044)
  * [Windows](https://github.com/Arelle/Arelle/actions/runs/6102222889)

**review**:
@Arelle/arelle
