### PR TITLE
Fix noDecimalsMonetaryItemType error message

### DIFF
--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -780,8 +780,11 @@ class ValidateXbrl:
                                     _("Fact %(fact)s context %(contextID)s is a numeric concept and must have either precision or decimals"),
                                     modelObject=f, fact=f.qname, contextID=f.contextID)
                             elif f.concept.instanceOfType(dtrNoDecimalsItemTypes) and inferredDecimals(f) > 0:
-                                self.modelXbrl.error("dtre:noDecimalsItemType",
-                                    _("Fact %(fact)s context %(contextID)s is a may not have inferred decimals value > 0: %(inferredDecimals)s"),
+                                if hasDecimals:
+                                    message = _("Fact %(fact)s context %(contextID)s must not have decimals value > 0: %(inferredDecimals)s")
+                                else:
+                                    message = _("Fact %(fact)s context %(contextID)s must not have inferred decimals value > 0: %(inferredDecimals)s")
+                                self.modelXbrl.error("dtre:noDecimalsItemType", message,
                                     modelObject=f, fact=f.qname, contextID=f.contextID, inferredDecimals=inferredDecimals(f))
                         else:
                             if hasPrecision or hasDecimals:


### PR DESCRIPTION
#### Reason for change
1. "is a may not" is nonsensical.
2. "inferred" is confusing if the fact has an explicit `decimals` attribute

#### Description of change

#### Steps to Test
[This zip](https://github.com/Arelle/Arelle/files/12674639/test.zip) has three facts.  The first should produce no error, the second should mention "decimals", and the last should mention "inferred decimals".

**review**:
@Arelle/arelle
