### PR TITLE
Prevent package manager from loading schemas in offline mode

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -604,6 +604,23 @@ class Cntlr:
             pass
         return 0
 
+    def workingOnlineOrInCache(self, url: str) -> bool:
+        """
+        Determines if the given URL should be requested based on the web cache's internet connectivity status
+        and whether the URL already exists in the cache.
+        :param url: Web URL
+        :return: True if the URL should be requested, False if not
+        """
+        if not self.webCache.workOffline:
+            # Working online, can proceed regardless of presence in cache
+            return True
+        cacheFilepath = self.webCache.urlToCacheFilepath(url)
+        if os.path.exists(cacheFilepath):
+            # The file exists in cache, we can proceed despite working offline
+            return True
+        return False
+
+
 def logRefsFileLines(refs: list[dict[str, Any]]) -> str:
     fileLines: defaultdict[Any, set[str]] = defaultdict(set)
     for ref in refs:

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -709,57 +709,9 @@ class CntlrCmdLine(Cntlr.Cntlr):
                                   moduleItem[0], moduleInfo.get("author"), moduleInfo.get("version"), moduleInfo.get("status"),
                                   moduleInfo.get("fileDate"), moduleInfo.get("description"), moduleInfo.get("license")),
                                   messageCode="info", file=moduleInfo.get("moduleURL"))
+
         if options.packages:
-            from arelle import PackageManager
-            savePackagesChanges = True
-            showPackages = False
-            for packageCmd in options.packages.split('|'):
-                cmd = packageCmd.strip()
-                if cmd == "show":
-                    showPackages = True
-                elif cmd == "temp":
-                    savePackagesChanges = False
-                elif cmd.startswith("+"):
-                    packageInfo = PackageManager.addPackage(self, cmd[1:], options.packageManifestName)
-                    if packageInfo:
-                        self.addToLog(_("Addition of package {0} successful.").format(packageInfo.get("name")),
-                                      messageCode="info", file=packageInfo.get("URL"))
-                    else:
-                        self.addToLog(_("Unable to load package."), messageCode="info", file=cmd[1:])
-                elif cmd.startswith("~"):
-                    if PackageManager.reloadPackageModule(self, cmd[1:]):
-                        self.addToLog(_("Reload of package successful."), messageCode="info", file=cmd[1:])
-                    else:
-                        self.addToLog(_("Unable to reload package."), messageCode="info", file=cmd[1:])
-                elif cmd.startswith("-"):
-                    if PackageManager.removePackageModule(self, cmd[1:]):
-                        self.addToLog(_("Deletion of package successful."), messageCode="info", file=cmd[1:])
-                    else:
-                        self.addToLog(_("Unable to delete package."), messageCode="info", file=cmd[1:])
-                else: # assume it is a module or package
-                    savePackagesChanges = False
-                    packageInfo = PackageManager.addPackage(self, cmd, options.packageManifestName)
-                    if packageInfo:
-                        self.addToLog(_("Activation of package {0} successful.").format(packageInfo.get("name")),
-                                      messageCode="info", file=packageInfo.get("URL"))
-                        resetPlugins = True
-                    else:
-                        self.addToLog(_("Unable to load package \"%(name)s\". "),
-                                      messageCode="arelle:packageLoadingError",
-                                      messageArgs={"name": cmd, "file": cmd}, level=logging.ERROR)
-            if PackageManager.packagesConfigChanged:
-                PackageManager.rebuildRemappings(self)
-            if savePackagesChanges:
-                PackageManager.save(self)
-            else:
-                PackageManager.packagesConfigChanged = False
-            if showPackages:
-                self.addToLog(_("Taxonomy packages:"), messageCode="info")
-                for packageInfo in PackageManager.orderedPackagesConfig()["packages"]:
-                    self.addToLog(_("Package: {0}; version: {1}; status: {2}; date: {3}; description: {4}.").format(
-                                  packageInfo.get("name"), packageInfo.get("version"), packageInfo.get("status"),
-                                  packageInfo.get("fileDate"), packageInfo.get("description")),
-                                  messageCode="info", file=packageInfo.get("URL"))
+            self.loadPackages(options.packages, options.packageManifestName)
 
         if options.showEnvironment:
             self.addToLog(_("Config directory: {0}").format(self.configDir))
@@ -1183,6 +1135,63 @@ class CntlrCmdLine(Cntlr.Cntlr):
                 #with open("Z:\\temp\\trace.log", "at", encoding="utf-8") as fh:
                 #    fh.write("Status pipe exception {} {}\n".format(type(ex), ex))
                 system.exit()
+
+    def loadPackages(self, packages: str, packageManifestName: str):
+        """
+        Loads specified packages.
+
+        :param packages: Pipe-separated list of options. See CLI documentation for 'packages'.
+        :param packageManifestName: Unix shell style pattern used to find package manifest.
+        """
+        from arelle import PackageManager
+        savePackagesChanges = True
+        showPackages = False
+        for packageCmd in packages.split('|'):
+            cmd = packageCmd.strip()
+            if cmd == "show":
+                showPackages = True
+            elif cmd == "temp":
+                savePackagesChanges = False
+            elif cmd.startswith("+"):
+                packageInfo = PackageManager.addPackage(self, cmd[1:], packageManifestName)
+                if packageInfo:
+                    self.addToLog(_("Addition of package {0} successful.").format(packageInfo.get("name")),
+                                  messageCode="info", file=packageInfo.get("URL"))
+                else:
+                    self.addToLog(_("Unable to load package."), messageCode="info", file=cmd[1:])
+            elif cmd.startswith("~"):
+                if PackageManager.reloadPackageModule(self, cmd[1:]):
+                    self.addToLog(_("Reload of package successful."), messageCode="info", file=cmd[1:])
+                else:
+                    self.addToLog(_("Unable to reload package."), messageCode="info", file=cmd[1:])
+            elif cmd.startswith("-"):
+                if PackageManager.removePackageModule(self, cmd[1:]):
+                    self.addToLog(_("Deletion of package successful."), messageCode="info", file=cmd[1:])
+                else:
+                    self.addToLog(_("Unable to delete package."), messageCode="info", file=cmd[1:])
+            else:  # assume it is a module or package
+                savePackagesChanges = False
+                packageInfo = PackageManager.addPackage(self, cmd, packageManifestName)
+                if packageInfo:
+                    self.addToLog(_("Activation of package {0} successful.").format(packageInfo.get("name")),
+                                  messageCode="info", file=packageInfo.get("URL"))
+                else:
+                    self.addToLog(_("Unable to load package \"%(name)s\". "),
+                                  messageCode="arelle:packageLoadingError",
+                                  messageArgs={"name": cmd, "file": cmd}, level=logging.ERROR)
+        if PackageManager.packagesConfigChanged:
+            PackageManager.rebuildRemappings(self)
+        if savePackagesChanges:
+            PackageManager.save(self)
+        else:
+            PackageManager.packagesConfigChanged = False
+        if showPackages:
+            self.addToLog(_("Taxonomy packages:"), messageCode="info")
+            for packageInfo in PackageManager.orderedPackagesConfig()["packages"]:
+                self.addToLog(_("Package: {0}; version: {1}; status: {2}; date: {3}; description: {4}.").format(
+                    packageInfo.get("name"), packageInfo.get("version"), packageInfo.get("status"),
+                    packageInfo.get("fileDate"), packageInfo.get("description")),
+                    messageCode="info", file=packageInfo.get("URL"))
 
 if __name__ == "__main__":
     '''

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -616,6 +616,13 @@ class CntlrCmdLine(Cntlr.Cntlr):
 
         setDisableRTL(options.disableRtl) # not saved to config
 
+        # Some options below (e.g. `packages`) may trigger web requests,
+        # so the `workOffline` flag needs to be set early on.
+        if options.internetConnectivity == "offline":
+            self.webCache.workOffline = True
+        elif options.internetConnectivity == "online":
+            self.webCache.workOffline = False
+
         if options.proxy:
             if options.proxy != "show":
                 proxySettings = proxyTuple(options.proxy)
@@ -795,10 +802,6 @@ class CntlrCmdLine(Cntlr.Cntlr):
         if options.outputAttribution:
             self.modelManager.outputAttribution = options.outputAttribution
         self.modelManager.validateTestcaseSchema = options.validateTestcaseSchema
-        if options.internetConnectivity == "offline":
-            self.webCache.workOffline = True
-        elif options.internetConnectivity == "online":
-            self.webCache.workOffline = False
         if options.internetTimeout is not None:
             self.webCache.timeout = (options.internetTimeout or None)  # use None if zero specified to disable timeout
         if options.internetLogDownloads:

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -301,7 +301,7 @@ class WebCache:
     def encodeForFilename(self, pathpart):
         return self.encodeFileChars.sub(lambda m: '^{0:03}'.format(ord(m.group(0))), pathpart)
 
-    def urlToCacheFilepath(self, url):
+    def urlToCacheFilepath(self, url: str) -> str:
         scheme, sep, path = url.partition("://")
         filepath = [self.cacheDir, scheme]
         pathparts = path.split('/')


### PR DESCRIPTION
#### Reason for change
Resolves #684

#### Description of change
Adds a `workingOnlineOrInCache` helper that can be used to check whether the web cache is in offline mode OR if the specified file is already in the cache.

Updates the package manager to make use of this by skipping validation against the schema (and logging a warning explaining this) if the web cache is in offline mode and the schema isn't cached.

#### Steps to Test
_Note: the below steps can be modified accordingly to test via CLI_
- Find a taxonomy package available online as an example (here's one: https://xbrl.sec.gov/2023.zip)
- Make sure Arelle is "online" (not configured to "Work offline")
- Clear cache
- *Confirming package loads successfully when "online"*
  - Confirm the package loads as expected, no warnings/errors
    - Help > Manage packages > On Web > (paste URL) > OK 
  - Confirm files in cache: xml.xsd, taxonomy-package.xsd, taxonomy-package-catalog.xsd, your .zip
  - Remove package 
- *Confirming package loads when cached in "offline" mode* 
  - Enable "Work offline" mode
  - Confirm the package loads as expected, no warnings/errors
  - Remove package 
- *Confirming xml.xsd is not loaded when in "offline" mode*
  - Still in "Work offline" mode 
  - Remove xml.xsd from cache
  - Confirm the package loads as expected, no warnings/errors
  - Confirm xml.xsd not added back to cache
  - Remove package 
- *Confirming  taxonomy-package.xsd, taxonomy-package-catalog.xsd are not loaded when in "offline" mode*
  - Still in "Work offline" mode 
  - Remove taxonomy-package.xsd, taxonomy-package-catalog.xsd from cache (your .zip should be only thing left in cache)
  - Confirm the package loads as expected
  - Confirm warnings are logged for both of the 2 missing schemas
  - Confirm nothing added back to the cache

**review**:
@Arelle/arelle
