### PR TITLE
NL FR KVK 2.01 validation

### DIFF
--- a/arelle/plugin/validate/NL/rules/fr_kvk.py
+++ b/arelle/plugin/validate/NL/rules/fr_kvk.py
@@ -20,6 +20,9 @@ from ..PluginValidationDataExtension import PluginValidationDataExtension
 _: TypeGetText
 
 
+ACCEPTED_LANGUAGES = ('de', 'en', 'fr', 'nl')
+
+
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
     disclosureSystems=[
@@ -45,4 +48,35 @@ def rule_fr_kvk_1_01(
                     msg=_('An XBRL instance document MUST have the file extension .xbrl: %(fileName)s'),
                     modelObject=doc,
                     fileName=doc.basename,
+                )
+
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=[
+        DISCLOSURE_SYSTEM_NT16,
+        DISCLOSURE_SYSTEM_NT17,
+    ],
+)
+def rule_fr_kvk_2_01(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    FR-KVK-2.01: The XBRL instance root node MUST contain attribute "xml:lang" with value "nl", "en", "de" or "fr"
+    """
+    modelXbrl = val.modelXbrl
+    for doc in modelXbrl.urlDocs.values():
+        if doc.type == ModelDocument.Type.INSTANCE:
+            lang = doc.xmlRootElement.get('{http://www.w3.org/XML/1998/namespace}lang')
+            if lang not in ACCEPTED_LANGUAGES:
+                yield Validation.error(
+                    codes='NL.FR-KVK-2.01',
+                    msg=_('The XBRL instance root node MUST contain attribute "xml:lang" with one of the following values: %(acceptedLangs)s. Provided: %(lang)s'),
+                    modelObject=doc,
+                    acceptedLangs=", ".join(ACCEPTED_LANGUAGES),
+                    lang=lang,
                 )

--- a/tests/resources/validation/NL/fr_kvk/2.01/fail/invalid.xbrl
+++ b/tests/resources/validation/NL/fr_kvk/2.01/fail/invalid.xbrl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xbrl
+  xml:lang="zz"
+  xmlns="http://www.xbrl.org/2003/instance"
+  xmlns:bzk-wnt-i="http://www.nltaxonomie.nl/nt16/bzk/20211208/dictionary/bzk-wnt-data"
+  xmlns:iso4217="http://www.xbrl.org/2003/iso4217"
+  xmlns:jenv-bw2-dim="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-axes"
+  xmlns:jenv-bw2-dm="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-domains"
+  xmlns:jenv-bw2-i="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-data"
+  xmlns:kvk-i="http://www.nltaxonomie.nl/nt16/kvk/20211208/dictionary/kvk-data"
+  xmlns:link="http://www.xbrl.org/2003/linkbase"
+  xmlns:nl-cd="http://www.nltaxonomie.nl/nt16/sbr/20210301/dictionary/nl-common-data"
+  xmlns:rj-dim="http://www.nltaxonomie.nl/nt16/rj/20211208/dictionary/rj-axes"
+  xmlns:rj-dm="http://www.nltaxonomie.nl/nt16/rj/20211208/dictionary/rj-domains"
+  xmlns:rj-i="http://www.nltaxonomie.nl/nt16/rj/20211208/dictionary/rj-data"
+  xmlns:xbrldi="http://xbrl.org/2006/xbrldi"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+    <link:schemaRef
+      xlink:href="http://www.nltaxonomie.nl/nt16/kvk/20211208/entrypoints/kvk-rpt-jaarverantwoording-2021-nlgaap-klein-publicatiestukken.xsd"
+      xlink:type="simple"/>
+    <context id="ctx-1">
+        <entity>
+            <identifier scheme="http://www.kvk.nl/kvk-id">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-31</endDate>
+        </period>
+    </context>
+    <nl-cd:LegalEntityName contextRef="ctx-1" xml:lang="en">Testing Entity Name</nl-cd:LegalEntityName>
+    <jenv-bw2-i:LegalEntityRegisteredOffice contextRef="ctx-1" xml:lang="en">Address</jenv-bw2-i:LegalEntityRegisteredOffice>
+    <nl-cd:ChamberOfCommerceRegistrationNumber contextRef="ctx-1" xml:lang="en">12345678</nl-cd:ChamberOfCommerceRegistrationNumber>
+    <kvk-i:BusinessNames contextRef="ctx-1" xml:lang="en">Testing Entity Name</kvk-i:BusinessNames>
+    <kvk-i:LegalSizeCriteriaClassificationSmall contextRef="ctx-1" xml:lang="en">Klein</kvk-i:LegalSizeCriteriaClassificationSmall>
+</xbrl>

--- a/tests/resources/validation/NL/fr_kvk/2.01/fail/missing.xbrl
+++ b/tests/resources/validation/NL/fr_kvk/2.01/fail/missing.xbrl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xbrl
+  xmlns="http://www.xbrl.org/2003/instance"
+  xmlns:bzk-wnt-i="http://www.nltaxonomie.nl/nt16/bzk/20211208/dictionary/bzk-wnt-data"
+  xmlns:iso4217="http://www.xbrl.org/2003/iso4217"
+  xmlns:jenv-bw2-dim="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-axes"
+  xmlns:jenv-bw2-dm="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-domains"
+  xmlns:jenv-bw2-i="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-data"
+  xmlns:kvk-i="http://www.nltaxonomie.nl/nt16/kvk/20211208/dictionary/kvk-data"
+  xmlns:link="http://www.xbrl.org/2003/linkbase"
+  xmlns:nl-cd="http://www.nltaxonomie.nl/nt16/sbr/20210301/dictionary/nl-common-data"
+  xmlns:rj-dim="http://www.nltaxonomie.nl/nt16/rj/20211208/dictionary/rj-axes"
+  xmlns:rj-dm="http://www.nltaxonomie.nl/nt16/rj/20211208/dictionary/rj-domains"
+  xmlns:rj-i="http://www.nltaxonomie.nl/nt16/rj/20211208/dictionary/rj-data"
+  xmlns:xbrldi="http://xbrl.org/2006/xbrldi"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+    <link:schemaRef
+      xlink:href="http://www.nltaxonomie.nl/nt16/kvk/20211208/entrypoints/kvk-rpt-jaarverantwoording-2021-nlgaap-klein-publicatiestukken.xsd"
+      xlink:type="simple"/>
+    <context id="ctx-1">
+        <entity>
+            <identifier scheme="http://www.kvk.nl/kvk-id">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-31</endDate>
+        </period>
+    </context>
+    <nl-cd:LegalEntityName contextRef="ctx-1" xml:lang="en">Testing Entity Name</nl-cd:LegalEntityName>
+    <jenv-bw2-i:LegalEntityRegisteredOffice contextRef="ctx-1" xml:lang="en">Address</jenv-bw2-i:LegalEntityRegisteredOffice>
+    <nl-cd:ChamberOfCommerceRegistrationNumber contextRef="ctx-1" xml:lang="en">12345678</nl-cd:ChamberOfCommerceRegistrationNumber>
+    <kvk-i:BusinessNames contextRef="ctx-1" xml:lang="en">Testing Entity Name</kvk-i:BusinessNames>
+    <kvk-i:LegalSizeCriteriaClassificationSmall contextRef="ctx-1" xml:lang="en">Klein</kvk-i:LegalSizeCriteriaClassificationSmall>
+</xbrl>


### PR DESCRIPTION
#### Description of change
FR-KVK-2.01: The XBRL instance root node MUST contain attribute "xml:lang" with value "nl", "en", "de" or "fr"

#### Steps to Test
```
python arelleCmdLine.py -f ./tests/resources/validation/NL/example/a.xbrl 
--plugins="validate/NL" --validate --disclosureSystem NT17-preview
```
Result: no NL validation errors
___
```
python arelleCmdLine.py -f ./tests/resources/validation/NL/fr_kvk/2.01/fail/invalid.xbrl 
--plugins="validate/NL" --validate --disclosureSystem NT17-preview
```
Result: Errors include `[NL.FR-KVK-2.01] The XBRL instance root node MUST contain attribute "xml:lang" with one of the following values: de, en, fr, nl. Provided: zz - invalid.xbrl`
___
```
python arelleCmdLine.py -f ./tests/resources/validation/NL/fr_kvk/2.01/fail/missing.xbrl 
--plugins="validate/NL" --validate --disclosureSystem NT17-preview
```
Result: Errors include `[NL.FR-KVK-2.01] The XBRL instance root node MUST contain attribute "xml:lang" with one of the following values: de, en, fr, nl. Provided: (none) - missing.xbrl`

**review**:
@Arelle/arelle
