### PR TITLE
Pin astroid documentation sub dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "astroid"
+        versions:
+          - ">=3"
       - dependency-name: "RDFLib"
         versions:
           - ">=6"

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,0 +1,27 @@
+name: Build Documentation
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build-documentation:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - name: Install Python
+        uses: actions/setup-python@v4.7.0
+        with:
+          cache: 'pip'
+          check-latest: true
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements-docs.txt
+      - name: Build documentation
+        run: make -C docs html

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,5 @@
+# astroid 3 breaks sphinx-autodoc2: https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/31
+astroid==2.15.8
 furo==2023.9.10
 myst-parser==2.0.0
 sphinx==7.1.2


### PR DESCRIPTION
#### Reason for change
Sub dependency update breaks the Sphinx autodoc2 extension: https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/31

#### Description of change
Pin build dependency and add workflow to exercise documentation build on PR

#### Steps to Test
* CI

**review**:
@Arelle/arelle
