### PR TITLE
Avoid writing unitRef="None" for unset unit

### DIFF
--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -273,7 +273,8 @@ def createTargetInstance(modelXbrl, targetUrl, targetDocumentSchemaRefs, filingF
                 if fact.id:
                     attrs["id"] = fact.id
                 if fact.isNumeric:
-                    attrs["unitRef"] = fact.unitID
+                    if fact.unitID:
+                        attrs["unitRef"] = fact.unitID
                     if fact.get("decimals"):
                         attrs["decimals"] = fact.get("decimals")
                     if fact.get("precision"):


### PR DESCRIPTION
#### Reason for change
An invalid numeric fact without a unit is writing `unitRef="None"` rather than omitting the attribute.

#### Description of change

#### Steps to Test
[ixbrl-missing-unit.zip](https://github.com/Arelle/Arelle/files/12784061/ixbrl-missing-unit.zip)

**review**:
@Arelle/arelle
