### PR TITLE
Fix inferDecimals

### DIFF
--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -93,7 +93,7 @@ def validate(modelXbrl, validateCalcs) -> None:
 class ValidateXbrlCalcs:
     def __init__(self, modelXbrl, validateCalcs):
         self.modelXbrl = modelXbrl
-        self.inferDecimals = validateCalcs == ValidateCalcsMode.XBRL_v2_1
+        self.inferDecimals = validateCalcs != ValidateCalcsMode.XBRL_v2_1_INFER_PRECISION
         self.deDuplicate = validateCalcs == ValidateCalcsMode.XBRL_v2_1_DEDUPLICATE
         self.xbrl21 = validateCalcs in (ValidateCalcsMode.XBRL_v2_1_INFER_PRECISION, ValidateCalcsMode.XBRL_v2_1, ValidateCalcsMode.XBRL_v2_1_DEDUPLICATE)
         self.calc11 = validateCalcs in (ValidateCalcsMode.ROUND_TO_NEAREST, ValidateCalcsMode.TRUNCATION)


### PR DESCRIPTION
#### Reason for change
Fixed #866.

#### Description of change
The relevant fact in #866 has `value=0 decimals=0`, and calculations are running in the legacy `inferDecimals=False` mode:
```
[xbrl.5.2.5.2:inferringPrecision] Validating calculations inferring precision. - abc-2019-12-31.xhtml
```
The [algorithm for inferring precision](https://www.xbrl.org/Specification/xbrl-recommendation-2003-12-31+corrected-errata-2008-07-02.htm#_4.6.6) infers `precision=0` (no significant digits), which produces an undefined result (NaN).

However, the legacy `inferDecimals=False` mode should not be used for `--calc xbrl21-dedup`.  Prior to commit c0677ecdc5501c6effc96c5d5eee4d0c25a362ab, the legacy `inferDecimals=False` was (correctly) only used by `--calcPrecision`, and it also should not be used for calculations 1.1 added in that commit since that specification uses the OIM definition of `{decimals}`.

#### Steps to Test
```
python arelleCmdLine.py --file TC1_valid_fixedzero2.zip --validate --calc xbrl21-dedup
```

**review**:
@Arelle/arelle
