### PR TITLE
GUI Archive Multiselect Highlight Inline Files

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -506,7 +506,7 @@ def configAndRunCntlr(options, arellePluginModules):
         return cntlr
 
 
-def filesourceEntrypointFiles(filesource, entrypointFiles=[]):
+def filesourceEntrypointFiles(filesource, entrypointFiles=[], inlineOnly=False):
     if filesource.isArchive:
         if filesource.isTaxonomyPackage:  # if archive is also a taxonomy package, activate mappings
             filesource.loadTaxonomyPackageMappings()
@@ -525,7 +525,7 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=[]):
                 if identifiedType in (ModelDocument.Type.INSTANCE, ModelDocument.Type.INLINEXBRL, ModelDocument.Type.HTML):
                     urlsByType.setdefault(identifiedType, []).append(filesource.url)
         # use inline instances, if any, else non-inline instances
-        for identifiedType in (ModelDocument.Type.INLINEXBRL, ModelDocument.Type.INSTANCE):
+        for identifiedType in ((ModelDocument.Type.INLINEXBRL,) if inlineOnly else (ModelDocument.Type.INLINEXBRL, ModelDocument.Type.INSTANCE)):
             for url in urlsByType.get(identifiedType, []):
                 entrypointFiles.append({"file":url})
             if entrypointFiles:
@@ -534,7 +534,7 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=[]):
                         pluginXbrlMethod(filesource, entrypointFiles) # group into IXDS if plugin feature is available
                 break # found inline (or non-inline) entrypoint files, don't look for any other type
         # for ESEF non-consolidated xhtml documents accept an xhtml entry point
-        if not entrypointFiles:
+        if not entrypointFiles and not inlineOnly:
             for url in urlsByType.get(ModelDocument.Type.HTML, []):
                 entrypointFiles.append({"file":url})
 

--- a/arelle/DialogOpenArchive.py
+++ b/arelle/DialogOpenArchive.py
@@ -28,7 +28,7 @@ PACKAGE = 5
 
 reportIxdsPattern = re.compile(r"^([^/]+/reports/[^/]+)/[^/]+$")
 
-def askArchiveFile(parent, filesource, multiselect=False):
+def askArchiveFile(parent, filesource, multiselect=False, selectFiles=None):
     try:
         filenames = filesource.dir
         if filenames is not None:   # an IO or other error can return None
@@ -48,7 +48,8 @@ def askArchiveFile(parent, filesource, multiselect=False):
                                            filenames,
                                            _("Select Archive File"),
                                            _("File"),
-                                           multiselect=multiselect)
+                                           multiselect=multiselect,
+                                           selectFiles=selectFiles)
             if dialog.accepted:
                 return filesource.url
     except Exception as e:
@@ -108,7 +109,7 @@ def selectPackage(parent, packageChoices):
 
 
 class DialogOpenArchive(Toplevel):
-    def __init__(self, parent, openType, filesource, filenames, title, colHeader, showAltViewButton=False, multiselect=False):
+    def __init__(self, parent, openType, filesource, filenames, title, colHeader, showAltViewButton=False, multiselect=False, selectFiles=None):
         if isinstance(parent, Cntlr):
             cntlr = parent
             parent = parent.parent # parent is cntlrWinMain
@@ -117,6 +118,7 @@ class DialogOpenArchive(Toplevel):
         super(DialogOpenArchive, self).__init__(parent)
         self.parent = parent
         self.showAltViewButton = showAltViewButton
+        self.selectFiles = selectFiles
         parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
@@ -275,7 +277,7 @@ class DialogOpenArchive(Toplevel):
     def loadTreeView(self, openType, title, colHeader):
         self.title(title)
         self.openType = openType
-        selectedNode = None
+        selectedNodes = []
 
         # clear previous treeview entries
         for previousNode in self.treeView.get_children(""):
@@ -352,8 +354,11 @@ class DialogOpenArchive(Toplevel):
                     self.treeView.set(node, "vers", vers)
                     self.treeView.set(node, "descr", descr)
                     self.treeView.set(node, "license", license)
-                if self.selection == filename:
-                    selectedNode = node
+                if self.selectFiles:
+                    if filename in self.selectFiles:
+                        selectedNodes.append(node)
+                elif self.selection == filename:
+                    selectedNodes.append(node)
                 loadedPaths.append(path)
 
         elif openType == ENTRY_POINTS:
@@ -376,9 +381,9 @@ class DialogOpenArchive(Toplevel):
             self.hasToolTip = True
         else: # unknown openType
             return None
-        if selectedNode:
-            self.treeView.see(selectedNode)
-            self.treeView.selection_set(selectedNode)
+        if selectedNodes:
+            self.treeView.see(selectedNodes[0])
+            self.treeView.selection_set(selectedNodes)
 
         if self.showAltViewButton:
             self.altViewButton.config(text=_("Show Files") if openType == ENTRY_POINTS else _("Show Entries"))

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -55,6 +55,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from arelle import FileSource, ModelXbrl, ValidateXbrlDimensions, XbrlConst
 DialogURL = None # dynamically imported when first used
+from arelle.CntlrCmdLine import filesourceEntrypointFiles
 from arelle.PrototypeDtsObject import LocPrototype, ArcPrototype
 from arelle.FileSource import archiveFilenameParts, archiveFilenameSuffixes
 from arelle.ModelInstanceObject import ModelInlineFootnote
@@ -441,8 +442,16 @@ def runOpenInlineDocumentSetMenuCommand(cntlr, filenames, runInBackground=False,
         from arelle.FileSource import openFileSource
         filesource = openFileSource(filenames[0], cntlr)
         if filesource.isArchive:
+            # identify entrypoint files
+            try:
+                entrypointFiles = filesourceEntrypointFiles(filesource, inlineOnly=True)
+                l = len(filesource.baseurl) + 1 # len of the base URL of the archive
+                selectFiles = [e["file"][l:] for e in entrypointFiles if "file" in e] + \
+                              [e["file"][l:] for i in entrypointFiles if "ixds" in i for e in i["ixds"] if "file" in e]
+            except FileSource.ArchiveFileIOError:
+                selectFiles = None
             from arelle import DialogOpenArchive
-            archiveEntries = DialogOpenArchive.askArchiveFile(cntlr, filesource, multiselect=True)
+            archiveEntries = DialogOpenArchive.askArchiveFile(cntlr, filesource, multiselect=True, selectFiles=selectFiles)
             if archiveEntries:
                 ixdsFirstFile = archiveEntries[0]
                 _archiveFilenameParts = archiveFilenameParts(ixdsFirstFile)


### PR DESCRIPTION
#### Reason for change
GUI Inline Multiselect opening SEC archives containing multiple  .htm files of which some might be inline and others was frustrating.  The archive presents a multiselect expecting user to know in advance which of the .htm's were inline and which are plain html attachments.

For a preparer of Fee Exhibit Beta attachment documents, allows local viewing with primary inline IXDS as will be eventually hosted on SEC website.

#### Description of change
This change to File->Open File Inline Doc Set  when selecting a zip or eis archive (for SEC users, inactive for ESEF Report Package users):
  * highlights the inline document files in the archive
  * allows directly pressing "Ok" in most circumstances without individually clicking each inline file
  * subsequently arelle sorts out the primary document IXDS (e.g. htm's of a 10-K) from EX-26 and fee exhibit htm's

#### Steps to Test
Verify on SEC zips and ELO-saved "eis" archives of flat files for single and multi-htm primary IXDS, on multi-IXDS (EX-26 and fee exhibit, as in SEC conformance test suites)

**review**:
@Arelle/arelle
