### PR TITLE
Use relative plugin imports (paths move within frozen macOS build)

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
@@ -16,8 +16,8 @@ from arelle.ModelXbrl import ModelXbrl
 from arelle.UrlUtil import decodeBase64DataImage, scheme
 from arelle.ValidateFilingText import parseImageDataURL, validateGraphicHeaderType
 from arelle.ValidateXbrl import ValidateXbrl
-from arelle.plugin.validate.ESEF.Const import supportedImgTypes
 from arelle.typing import TypeGetText
+from ..Const import supportedImgTypes
 
 _: TypeGetText  # Handle gettext
 


### PR DESCRIPTION
#### Reason for change
Full path imports of plugin modules don't work from the frozen builds (plugins are moved during the build).

#### Description of change
Use relative import within ESEF plugin.

#### Steps to Test
* CI
* Verify you can enable the ESEF plugin from [the macOS build of this branch](https://github.com/Arelle/Arelle/actions/runs/6436640329)

**review**:
@Arelle/arelle
