### PR TITLE
refactor ixds targetDocumentSchemaRefs for EDGAR and Japan FSA manifest-loaded IXDSes

### DIFF
--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -363,7 +363,11 @@ def createTargetInstance(modelXbrl, targetUrl, targetDocumentSchemaRefs, filingF
     return targetInstance
 
 def saveTargetDocument(modelXbrl, targetDocumentFilename, targetDocumentSchemaRefs, outputZip=None, filingFiles=None, xbrliNamespacePrefix=None, *args, **kwargs):
-    targetUrl = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(targetDocumentFilename, modelXbrl.modelDocument.filepath)
+    if not os.path.isabs(targetDocumentFilename) and modelXbrl.fileSource.isArchive:
+        baseFile = modelXbrl.fileSource.basefile # can't store extracted file inside archive zip
+    else:
+        baseFile = modelXbrl.modelDocument.filepath
+    targetUrl = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(targetDocumentFilename, baseFile)
     targetUrlParts = targetUrl.rpartition(".")
     targetUrl = targetUrlParts[0] + "_extracted." + targetUrlParts[2]
     modelXbrl.modelManager.showStatus(_("Extracting instance ") + os.path.basename(targetUrl))


### PR DESCRIPTION
targetDocumentSchemaRefs may be compiled from dynamically-partitioned separate IXDSes (EDGAR) and from Japan FSA manifest-loaded IXDSes, for both of which the stanadard allows multi-target selection.

#### Reason for change
EDGAR multi-instance change broke manifest-loaded documents, target selection was not available for them either.

#### Description of change
Refactor targetDocumentSchemaRefs from plugin at start of ModelDocument.inlineIxdsDiscover to plugin at its conclusion.

#### Steps to Test
Verify operation with Japan FSA manifest-loaded IXDSes and EDGAR multi-doc and multi-instance IXDSes, in both cases checking the extracted xbrl-xml instance documents.

**review**:
@Arelle/arelle
