### PR TITLE
Add CacheBuilder plugin

### DIFF
--- a/arelle/plugin/CacheBuilder.py
+++ b/arelle/plugin/CacheBuilder.py
@@ -1,0 +1,110 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+import os
+import zipfile
+from optparse import OptionParser
+from pathlib import Path, PurePath
+from typing import Any, Literal, cast
+
+from arelle.Cntlr import Cntlr
+from arelle.RuntimeOptions import RuntimeOptions
+from arelle.Version import authorLabel, copyrightLabel
+from arelle.utils.PluginHooks import PluginHooks
+
+PLUGIN_NAME = "Cache Builder"
+
+
+class CacheBuilder:
+    cacheDirectory: str
+    cacheZip: zipfile.ZipFile
+    existingPaths: frozenset[str]
+    visitedPaths: set[str]
+
+    def __init__(self, cntlr: Cntlr, cacheZip: zipfile.ZipFile):
+        self.cacheDirectory = cntlr.webCache.cacheDir
+        self.cacheZip = cacheZip
+        self.existingPaths = frozenset(cacheZip.namelist())
+        self.visitedPaths = set()
+
+    def copyFileToCache(self, filepath: str):
+        """
+        Copies the file at `filepath` to its corresponding location in the output archive if:
+        - `filepath` has not already been seen by the plugin during this run.
+        - `filepath` is a path within `cacheDirectory`
+        - The destination path corresponding to `filepath` does not already exist in the archive.
+        An error will be raised if a source file to be copied does not exist.
+
+        :param filepath: Full filepath of file to copy.
+        """
+        # If filepath is among source filepaths already visited during this run, skip it.
+        if filepath in self.visitedPaths:
+            return
+        self.visitedPaths.add(filepath)
+        # If filepath is not within web cache, skip it.
+        filePurePath = PurePath(filepath)
+        if not filePurePath.is_relative_to(self.cacheDirectory):
+            return
+        # If the destination path is among the destination filepaths that already existed in the archive, skip it.
+        destination = filePurePath.relative_to(self.cacheDirectory).as_posix()
+        if destination in self.existingPaths:
+            return
+        # If the source file does not exist, skip it.
+        if not Path(filepath).exists():
+            raise IOError(_('Cache builder attempted to copy file that does not exist at "{0}".').format(filepath))
+        self.cacheZip.write(filepath, destination)
+        return
+
+
+class CacheBuilderPlugin(PluginHooks):
+    cacheBuilder: CacheBuilder | None = None
+
+    @staticmethod
+    def cntlrCmdLineOptions(
+        parser: OptionParser,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        parser.add_option(
+            '--cache-builder-path',
+            action='store',
+            dest='cacheBuilderPath',
+            help='Sets the path where the cache builder output should be written to. If an archive does not exist it will be created.',
+        )
+        parser.add_option(
+            '--cache-builder-append',
+            action='store_true',
+            dest='cacheBuilderAppend',
+            help='Sets whether the cache builder should append to an existing archive or overwrite it.',
+        )
+
+    @staticmethod
+    def cntlrCmdLineUtilityRun(cntlr: Cntlr, options: RuntimeOptions, *args: Any, **kwargs: Any) -> None:
+        assert CacheBuilderPlugin.cacheBuilder is None, \
+            'Cache builder attempted to create multiple cache archives in the same plugin lifecycle.'
+        assert options.cacheBuilderPath is not None, \
+            '"cacheBuilderPath" must be set for cache builder to run.'
+        os.makedirs(Path(options.cacheBuilderPath).parent, exist_ok=True)
+        mode = 'a' if options.cacheBuilderAppend else 'w'
+        cacheZip = zipfile.ZipFile(options.cacheBuilderPath, cast(Literal, mode), zipfile.ZIP_DEFLATED)
+        CacheBuilderPlugin.cacheBuilder = CacheBuilder(cntlr, cacheZip)
+
+    @staticmethod
+    def fileSourceFile(cntlr: Cntlr, filepath: str, *args: Any, **kwargs: Any) -> None:
+        if CacheBuilderPlugin.cacheBuilder is not None:
+            CacheBuilderPlugin.cacheBuilder.copyFileToCache(filepath)
+
+
+__pluginInfo__ = {
+    "name": PLUGIN_NAME,
+    "version": "0.0.1",
+    "description": "Generate cache archives from web documents referenced during an Arelle application lifecycle.",
+    "license": "Apache-2",
+    "author": authorLabel,
+    "copyright": copyrightLabel,
+    'CntlrCmdLine.Options': CacheBuilderPlugin.cntlrCmdLineOptions,
+    'CntlrCmdLine.Utility.Run': CacheBuilderPlugin.cntlrCmdLineUtilityRun,
+    "FileSource.File": CacheBuilderPlugin.fileSourceFile,
+}

--- a/arelle/plugin/CacheBuilder.py
+++ b/arelle/plugin/CacheBuilder.py
@@ -3,6 +3,7 @@ See COPYRIGHT.md for copyright information.
 """
 from __future__ import annotations
 
+import atexit
 import os
 import zipfile
 from optparse import OptionParser
@@ -89,6 +90,7 @@ class CacheBuilderPlugin(PluginHooks):
         os.makedirs(Path(options.cacheBuilderPath).parent, exist_ok=True)
         mode = 'a' if options.cacheBuilderAppend else 'w'
         cacheZip = zipfile.ZipFile(options.cacheBuilderPath, cast(Literal, mode), zipfile.ZIP_DEFLATED)
+        atexit.register(cacheZip.close)
         CacheBuilderPlugin.cacheBuilder = CacheBuilder(cntlr, cacheZip)
 
     @staticmethod

--- a/arelle/utils/PluginHooks.py
+++ b/arelle/utils/PluginHooks.py
@@ -7,6 +7,7 @@ from abc import ABC
 from enum import Enum
 from typing import Any, TYPE_CHECKING
 
+from arelle.RuntimeOptions import RuntimeOptions
 
 if TYPE_CHECKING:
     import io
@@ -59,6 +60,33 @@ class PluginHooks(ABC):
         ```
 
         :param parser: the parser class to add options to.
+        :param args: Argument capture to ensure new parameters don't break plugin hook.
+        :param kwargs: Argument capture to ensure new named parameters don't break plugin hook.
+        :return: None
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def cntlrCmdLineUtilityRun(
+        cntlr: Cntlr,
+        options: RuntimeOptions,
+        *args: Any,
+        **kwargs: Any
+    ) -> None:
+        """
+        Plugin hook: `CntlrCmdLine.Utility.Run`
+
+        This hook is triggered after command line options have been parsed.
+        It can be used to handle values for parameters configured in `cntlrCmdLineOptions`.
+
+        Example:
+        ```python
+        if options.myOption:
+            myOptionEnabled = True
+        ```
+
+        :param cntlr: The [Cntlr](#arelle.Cntlr.Cntlr) being initialized.
+        :param options: Parsed options object.
         :param args: Argument capture to ensure new parameters don't break plugin hook.
         :param kwargs: Argument capture to ensure new named parameters don't break plugin hook.
         :return: None

--- a/tests/integration_tests/validation/run_conformance_suites.py
+++ b/tests/integration_tests/validation/run_conformance_suites.py
@@ -24,6 +24,11 @@ ARGUMENTS: list[dict[str, Any]] = [
         "help": "Select all configured conformance suites"
     },
     {
+        "name": "--build-cache",
+        "action": "store_true",
+        "help": "Use CacheBuilder plugin to build cache from conformance suite usage"
+    },
+    {
         "name": "--download-overwrite",
         "action": "store_true",
         "help": "Download (and overwrite) selected conformance suite files"
@@ -98,6 +103,7 @@ def run_conformance_suites(
         select_option: str,
         test_option: bool,
         shard: int | None,
+        build_cache: bool = False,
         download_option: str | None = None,
         log_to_file: bool = False,
         offline_option: bool = False) -> list[ParameterSet]:
@@ -111,7 +117,7 @@ def run_conformance_suites(
     all_results = []
     if test_option:
         for config in conformance_suite_configs:
-            results = get_conformance_suite_test_results(config, shard=shard, log_to_file=log_to_file, offline=offline_option)
+            results = get_conformance_suite_test_results(config, shard=shard, build_cache=build_cache, log_to_file=log_to_file, offline=offline_option)
             all_results.extend(results)
     return all_results
 
@@ -125,6 +131,7 @@ def run_conformance_suites_options(options: Namespace) -> list[ParameterSet]:
         select_option=select_option,
         test_option=options.test,
         shard=options.shard,
+        build_cache=options.build_cache,
         download_option=download_option,
         log_to_file=options.log_to_file,
         offline_option=options.offline

--- a/tests/integration_tests/validation/validation_util.py
+++ b/tests/integration_tests/validation/validation_util.py
@@ -197,6 +197,7 @@ def get_test_shards(config: ConformanceSuiteConfig) -> list[tuple[list[str], fro
 def get_conformance_suite_test_results(
         config: ConformanceSuiteConfig,
         shard: int | None,
+        build_cache: bool = False,
         log_to_file: bool = False,
         offline: bool = False) -> list[ParameterSet]:
     file_path = os.path.join(config.prefixed_local_filepath, config.file)
@@ -232,7 +233,10 @@ def get_conformance_suite_test_results(
             filename = file_path
             expected_empty_testcases = config.expected_empty_testcases
             expected_failure_ids = config.expected_failure_ids
-        plugins = config.plugins | additional_plugins
+        optional_plugins = set()
+        if build_cache:
+            optional_plugins.add('CacheBuilder')
+        plugins = config.plugins | additional_plugins | optional_plugins
         args = [
             '--file', filename,
             '--keepOpen',
@@ -240,10 +244,12 @@ def get_conformance_suite_test_results(
         ]
         if plugins:
             args.extend(['--plugins', '|'.join(sorted(plugins))])
+        shard_str = f'-s{shard}' if use_shards else ''
+        if build_cache:
+            args.extend(['--cache-builder-path', f'conf-{config.name}{shard_str}-cache.zip'])
         if config.capture_warnings:
             args.append('--testcaseResultsCaptureWarnings')
         if log_to_file:
-            shard_str = f'-s{shard}' if use_shards else ''
             args.extend([
                 '--csvTestReport', f'conf-{config.name}{shard_str}-report.csv',
                 '--logFile', f'conf-{config.name}{shard_str}-log.txt',


### PR DESCRIPTION
#### Reason for change
#910 added to ability to have conformance suite CI runners download a cache specific to individual conformance suites. In order to make creation of those caches easy and consistent, this implements a `CacheBuilder` plugin.

#### Description of change
This plugin can be run in any Arelle context and will copy any files referenced from the web (or already in the cache) into an archive.

#### Steps to Test
Run `run_conformance_suites` script with `--build-cache` option, or perform any Arelle option of your choosing while activating the `CacheBuilder` plugin.

**review**:
@Arelle/arelle