### PR TITLE
Skip conformance suite CI if no relevant files changed

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -1,6 +1,14 @@
 name: Run Xbrl Conformance Suites
 
-on: pull_request_target
+on:
+  pull_request_target:
+    paths:
+      - '.github/workflows/conformance-suites.yml'
+      - 'arelle/**'
+      - 'tests/**'
+      - '**.py'
+      - '**.pyw'
+      - 'requirements*.txt'
 
 permissions: {}
 

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -1,6 +1,7 @@
 name: Run Xbrl Conformance Suites
 
 on:
+  workflow_dispatch:
   pull_request_target:
     paths:
       - '.github/workflows/conformance-suites.yml'


### PR DESCRIPTION
#### Reason for change
PRs that have changes non-consequential to conformance suites (documentation, assets, unrelated workflows, etc.) create unnecessary noise on those PRs and effect all PRs via the concurrent job limit.

#### Description of change
Use [paths](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) filter to skip conformance suite CI runs if no matching files are changed.

#### Steps to Test
Workflow is `pull_request_target`, so this PR will have no effect until merged.

**review**:
@Arelle/arelle
