### PR TITLE
ESEF 2023

### DIFF
--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -77,6 +77,12 @@ qnDomainItemTypes = frozenset((
     qname("{http://www.xbrl.org/dtr/type/2020-01-21}nonnum:domainItemType"),
 ))
 
+
+qnDomainItemTypes2023 = frozenset((
+    qname("{http://www.xbrl.org/dtr/type/2020-01-21}nonnum:domainItemType"),
+))
+
+
 linkbaseRefTypes = {
     "http://www.xbrl.org/2003/role/calculationLinkbaseRef": "cal",
     "http://www.xbrl.org/2003/role/definitionLinkbaseRef": "def",

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -22,8 +22,9 @@ from ..Const import (
     filenameRegexes,
     linkbaseRefTypes,
     qnDomainItemTypes,
+    qnDomainItemTypes2023,
 )
-from ..Util import isChildOfNotes, isExtension
+from ..Util import isChildOfNotes, isExtension, is2022DisclosureSystem
 
 _: TypeGetText  # Handle gettext
 
@@ -38,7 +39,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
 
     isExtensionDoc = isExtension(val, modelDocument)
     filenamePattern = filenameRegex = None
-    anchorAbstractExtensionElements = val.authParam["extensionElementsAnchoring"] == "include abstract"
+    anchorAbstractExtensionElements = is2022DisclosureSystem(val.modelXbrl) and val.authParam["extensionElementsAnchoring"] == "include abstract"
     allowCapsInLc3Words = val.authParam["LC3AllowCapitalsInWord"]
 
     def lc3wordAdjust(word: str) -> str:
@@ -108,7 +109,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                         val.modelXbrl.error("ESEF.3.4.3.extensionTaxonomyDimensionNotAssignedDefaultMemberInDedicatedPlaceholder",
                             _("Each dimension in an issuer specific extension taxonomy MUST be assigned to a default member in the ELR with role URI http://www.esma.europa.eu/xbrl/role/core/ifrs-dim_role-990000 defined in esef_cor.xsd schema file. %(qname)s"),
                             modelObject=modelConcept, qname=modelConcept.qname)
-                    if modelConcept.isDomainMember and modelConcept in val.domainMembers and modelConcept.typeQname not in qnDomainItemTypes:
+                    if modelConcept.isDomainMember and modelConcept in val.domainMembers and ((is2022DisclosureSystem(val.modelXbrl) and modelConcept.typeQname not in qnDomainItemTypes) or (not is2022DisclosureSystem(val.modelXbrl) and modelConcept.typeQname not in qnDomainItemTypes2023)):
                         domainMembersWrongType.append(modelConcept)
                     if modelConcept.isPrimaryItem and not modelConcept.isAbstract:
                         if modelConcept not in val.primaryItems:

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -24,7 +24,7 @@ from ..Const import (
     qnDomainItemTypes,
     qnDomainItemTypes2023,
 )
-from ..Util import isChildOfNotes, isExtension, is2022DisclosureSystem
+from ..Util import isChildOfNotes, isExtension, getDisclosureSystemYear
 
 _: TypeGetText  # Handle gettext
 
@@ -39,7 +39,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
 
     isExtensionDoc = isExtension(val, modelDocument)
     filenamePattern = filenameRegex = None
-    anchorAbstractExtensionElements = is2022DisclosureSystem(val.modelXbrl) and val.authParam["extensionElementsAnchoring"] == "include abstract"
+    anchorAbstractExtensionElements = getDisclosureSystemYear(val.modelXbrl) < 2023 and val.authParam["extensionElementsAnchoring"] == "include abstract"
     allowCapsInLc3Words = val.authParam["LC3AllowCapitalsInWord"]
 
     def lc3wordAdjust(word: str) -> str:
@@ -109,7 +109,8 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                         val.modelXbrl.error("ESEF.3.4.3.extensionTaxonomyDimensionNotAssignedDefaultMemberInDedicatedPlaceholder",
                             _("Each dimension in an issuer specific extension taxonomy MUST be assigned to a default member in the ELR with role URI http://www.esma.europa.eu/xbrl/role/core/ifrs-dim_role-990000 defined in esef_cor.xsd schema file. %(qname)s"),
                             modelObject=modelConcept, qname=modelConcept.qname)
-                    if modelConcept.isDomainMember and modelConcept in val.domainMembers and ((is2022DisclosureSystem(val.modelXbrl) and modelConcept.typeQname not in qnDomainItemTypes) or (not is2022DisclosureSystem(val.modelXbrl) and modelConcept.typeQname not in qnDomainItemTypes2023)):
+                    esefDomainItemTypes = qnDomainItemTypes if getDisclosureSystemYear(val.modelXbrl) < 2023 else qnDomainItemTypes2023
+                    if modelConcept.isDomainMember and modelConcept in val.domainMembers and modelConcept.typeQname not in esefDomainItemTypes:
                         domainMembersWrongType.append(modelConcept)
                     if modelConcept.isPrimaryItem and not modelConcept.isAbstract:
                         if modelConcept not in val.primaryItems:

--- a/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
@@ -18,7 +18,7 @@ from arelle.ValidateFilingText import parseImageDataURL, validateGraphicHeaderTy
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.typing import TypeGetText
 from ..Const import supportedImgTypes
-from ..Util import is2022DisclosureSystem
+from ..Util import getDisclosureSystemYear
 
 _: TypeGetText  # Handle gettext
 
@@ -88,7 +88,7 @@ def validateImage(
                 checkImageContents(normalizedUri, modelXbrl, elt, os.path.splitext(image)[1], True, imgContents,
                                    val.consolidated, val)
                 imgContents = b""  # deref, may be very large
-            if is2022DisclosureSystem(modelXbrl) and imglen < minExternalRessourceSize:
+            if getDisclosureSystemYear(modelXbrl) < 2023 and imglen < minExternalRessourceSize:
                 modelXbrl.warning(
                     "%s.imageIncludedAndNotEmbeddedAsBase64EncodedString" % contentOtherThanXHTMLGuidance,
                     _("Images SHOULD be included in the XHTML document as a base64 encoded string unless their size exceeds the minimum size for the authority (%(maxImageSize)s): %(file)s."),

--- a/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
@@ -18,6 +18,7 @@ from arelle.ValidateFilingText import parseImageDataURL, validateGraphicHeaderTy
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.typing import TypeGetText
 from ..Const import supportedImgTypes
+from ..Util import is2022DisclosureSystem
 
 _: TypeGetText  # Handle gettext
 
@@ -87,7 +88,7 @@ def validateImage(
                 checkImageContents(normalizedUri, modelXbrl, elt, os.path.splitext(image)[1], True, imgContents,
                                    val.consolidated, val)
                 imgContents = b""  # deref, may be very large
-            if imglen < minExternalRessourceSize:
+            if is2022DisclosureSystem(modelXbrl) and imglen < minExternalRessourceSize:
                 modelXbrl.warning(
                     "%s.imageIncludedAndNotEmbeddedAsBase64EncodedString" % contentOtherThanXHTMLGuidance,
                     _("Images SHOULD be included in the XHTML document as a base64 encoded string unless their size exceeds the minimum size for the authority (%(maxImageSize)s): %(file)s."),

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -143,7 +143,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
 
     # ModelDocument.load has None as a return type. For typing reasons, we need to guard against that here.
     assert modelXbrl.modelDocument is not None
-    checkFilingDTS(val, modelXbrl.modelDocument, esefNotesConcepts, [])
+    checkFilingDTS(val, modelXbrl.modelDocument, esefNotesConcepts, [], ifrsNses=_ifrsNses)
     modelXbrl.profileActivity("... filer DTS checks", minTimeToShow=1.0)
 
     if getDisclosureSystemYear(modelXbrl) >= 2023:

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -64,7 +64,7 @@ from ..Const import (
     untransformableTypes,
 )
 from ..Dimensions import checkFilingDimensions
-from ..Util import checkForMultiLangDuplicates, etreeIterWithDepth, getEsefNotesStatementConcepts, hasEventHandlerAttributes, isExtension, is2022DisclosureSystem
+from ..Util import checkForMultiLangDuplicates, etreeIterWithDepth, getEsefNotesStatementConcepts, hasEventHandlerAttributes, isExtension, getDisclosureSystemYear
 
 _: TypeGetText  # Handle gettext
 
@@ -146,7 +146,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
     checkFilingDTS(val, modelXbrl.modelDocument, esefNotesConcepts, [])
     modelXbrl.profileActivity("... filer DTS checks", minTimeToShow=1.0)
 
-    if not is2022DisclosureSystem(modelXbrl):
+    if getDisclosureSystemYear(modelXbrl) >= 2023:
         instanceNumber = 0
         if modelXbrl.fileSource.dir:
             for file in modelXbrl.fileSource.dir:
@@ -284,7 +284,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                 modelObject=doc, doctype=docinfo.doctype)
 
         reportIncorrectlyPlacedInPackageRef = "https://www.xbrl.org/Specification/report-package/CR-2023-05-03/report-package-CR-2023-05-03.html"
-        if is2022DisclosureSystem(modelXbrl):
+        if getDisclosureSystemYear(modelXbrl) < 2023:
             reportIncorrectlyPlacedInPackageRef = "http://www.xbrl.org/WGN/report-packages/WGN-2018-08-14/report-packages-WGN-2018-08-14.html"
 
         if len(ixdsDocDirs) > 1 and val.consolidated:
@@ -412,7 +412,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                     modelObject=elt, qname=elt.qname)
                         elif any(character in elt.stringValue for character in ['&lt;', '&amp;', '&', '<']):
                             if not (hasattr(elt, 'attrib')) or ('escape' not in elt.attrib or elt.attrib.get('escape').lower() != 'true'):
-                                modelXbrl.error("ESEF.2.2.6.escapedHTMLUsedInBlockTagWithSpecialCharacters" if is2022DisclosureSystem(modelXbrl) else "ESEF.2.2.7.escapedHTMLUsedInBlockTagWithSpecialCharacters",
+                                modelXbrl.error("ESEF.2.2.6.escapedHTMLUsedInBlockTagWithSpecialCharacters" if getDisclosureSystemYear(modelXbrl) < 2023 else "ESEF.2.2.7.escapedHTMLUsedInBlockTagWithSpecialCharacters",
                                         _("A text block containing '&' or '<' character MUST have an 'escape' attribute: %(qname)s."),
                                         modelObject=elt, qname=elt.qname)
                         # Check that continuation elements are in the order of html text as rendered to user

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -51,6 +51,10 @@ def isInEsefTaxonomy(val: ValidateXbrl, modelObject: ModelObject | None) -> bool
     return (any(ns.startswith(esefNsPrefix) for esefNsPrefix in esefTaxonomyNamespaceURIs))
 
 
+def is2022DisclosureSystem(modelXbrl: ModelXbrl) -> bool:
+    return any("2022" in name for name in modelXbrl.modelManager.disclosureSystem.names)
+
+
 def resourcesFilePath(modelManager: ModelManager, fileName: str) -> str:
     # resourcesDir can be in cache dir (production) or in validate/EFM/resources (for development)
     _resourcesDir = os.path.join( os.path.dirname(__file__), "resources") # dev/testing location

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -29,7 +29,7 @@ from .Const import esefCorNsPattern, esefNotesStatementConcepts, esefTaxonomyNam
 _: TypeGetText
 
 YEAR_GROUP = "year"
-DISCLOSURE_SYSTEM_YEAR_PATTERN = re.compile(rf"esef-(?P<{YEAR_GROUP}>20\d\d)")
+DISCLOSURE_SYSTEM_YEAR_PATTERN = re.compile(rf"esef-(?:unconsolidated-)?(?P<{YEAR_GROUP}>20\d\d)")
 
 
 def getDisclosureSystemYear(modelXbrl: ModelXbrl) -> int:

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -8,6 +8,7 @@ import os
 from collections import defaultdict
 from collections.abc import Collection
 from typing import Any, Dict, Generator, List, Union, cast
+import regex as re
 
 from lxml.etree import _Element
 
@@ -26,6 +27,17 @@ from arelle.typing import TypeGetText
 from .Const import esefCorNsPattern, esefNotesStatementConcepts, esefTaxonomyNamespaceURIs, htmlEventHandlerAttributes, svgEventAttributes
 
 _: TypeGetText
+
+YEAR_GROUP = "year"
+DISCLOSURE_SYSTEM_YEAR_PATTERN = re.compile(rf"esef-(?P<{YEAR_GROUP}>20\d\d)")
+
+
+def getDisclosureSystemYear(modelXbrl: ModelXbrl) -> int:
+    for name in modelXbrl.modelManager.disclosureSystem.names:
+        disclosureSystemYear = DISCLOSURE_SYSTEM_YEAR_PATTERN.fullmatch(name)
+        if disclosureSystemYear:
+            return int(disclosureSystemYear.group(YEAR_GROUP))
+    raise ValueError(f"Unable to determine year of ESEF disclosure system matching pattern 'esef-20XX' from {modelXbrl.modelManager.disclosureSystem.names}")
 
 
 # check if a modelDocument URI is an extension URI (document URI)
@@ -49,10 +61,6 @@ def isInEsefTaxonomy(val: ValidateXbrl, modelObject: ModelObject | None) -> bool
     ns = modelObject.qname.namespaceURI
     assert ns is not None
     return (any(ns.startswith(esefNsPrefix) for esefNsPrefix in esefTaxonomyNamespaceURIs))
-
-
-def is2022DisclosureSystem(modelXbrl: ModelXbrl) -> bool:
-    return any("2022" in name for name in modelXbrl.modelManager.disclosureSystem.names)
 
 
 def resourcesFilePath(modelManager: ModelManager, fileName: str) -> str:

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -81,7 +81,8 @@
                 ["https://www.esma.europa.eu/taxonomy/2021-03-24/esef_cor-gen-en.xml"]
         },
         "formulaRunIDs": null,
-        "minExternalResourceSizekB": 0
+        "minExternalResourceSizekB": 0,
+        "validate1_9_1": "false"
     },
     "ESEF-2021": {
         "outdatedTaxonomyURLs": [

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -113,6 +113,22 @@
             "https://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd"
         ]
     },
+    "ESEF-2023": {
+        "outdatedTaxonomyURLs": [
+            "http://www.esma.europa.eu/taxonomy/2017-03-31/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2017-03-31/esef_cor.xsd",
+            "http://www.esma.europa.eu/taxonomy/2019-03-27/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2019-03-27/esef_cor.xsd",
+            "http://www.esma.europa.eu/taxonomy/2020-03-16/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2020-03-16/esef_cor.xsd",
+            "http://www.esma.europa.eu/taxonomy/2021-03-24/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2021-03-24/esef_cor.xsd"
+        ],
+        "effectiveTaxonomyURLs": [
+            "http://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd"
+        ]
+    },
     "AT": {
         "name": "Austria",
         "reportPackageMaxMB": "100",

--- a/arelle/plugin/validate/ESEF/resources/config.xml
+++ b/arelle/plugin/validate/ESEF/resources/config.xml
@@ -5,7 +5,7 @@
     <!-- see ../../../../config/disclosuresystem.xml for full comments -->
 
     <DisclosureSystem
-         names="ESMA RTS on ESEF-2023|ESEF-2023|esef-2023|ESEF|esef"
+         names="ESMA RTS on ESEF-2023|ESEF-2023|esef-2023"
          description="ESMA RTS on ESEF-2023 Validation Checks for Consolidated Financial Statements"
          validationType="ESEF"
          exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
@@ -15,7 +15,7 @@
          />
 
     <DisclosureSystem
-         names="ESMA RTS on ESEF-2023 Unconsolidated|ESEF-Unconsolidated-2023|esef-unconsolidated-2023|ESEF-Unconsolidated|esef-unconsolidated"
+         names="ESMA RTS on ESEF-2023 Unconsolidated|ESEF-Unconsolidated-2023|esef-unconsolidated-2023"
          description="ESMA RTS on ESEF-2023 Validation Checks for Unconsolidated Financial Statements"
          validationType="ESEF"
          exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
@@ -25,7 +25,7 @@
          />
 
     <DisclosureSystem
-            names="ESMA RTS on ESEF-2022|ESEF-2022|esef-2022"
+            names="ESMA RTS on ESEF-2022|ESEF-2022|esef-2022|ESEF|esef"
             description="ESMA RTS on ESEF-2022 Validation Checks for Consolidated Financial Statements"
             validationType="ESEF"
             exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
@@ -35,7 +35,7 @@
     />
 
     <DisclosureSystem
-            names="ESMA RTS on ESEF-2022 Unconsolidated|ESEF-Unconsolidated-2022|esef-unconsolidated-2022"
+            names="ESMA RTS on ESEF-2022 Unconsolidated|ESEF-Unconsolidated-2022|esef-unconsolidated-2022|ESEF-Unconsolidated|esef-unconsolidated"
             description="ESMA RTS on ESEF-2022 Validation Checks for Unconsolidated Financial Statements"
             validationType="ESEF"
             exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"

--- a/arelle/plugin/validate/ESEF/resources/config.xml
+++ b/arelle/plugin/validate/ESEF/resources/config.xml
@@ -5,7 +5,27 @@
     <!-- see ../../../../config/disclosuresystem.xml for full comments -->
 
     <DisclosureSystem
-            names="ESMA RTS on ESEF-2022|ESEF-2022|esef-2022|ESEF|esef"
+         names="ESMA RTS on ESEF-2023|ESEF-2023|esef-2023|ESEF|esef"
+         description="ESMA RTS on ESEF-2023 Validation Checks for Consolidated Financial Statements"
+         validationType="ESEF"
+         exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
+         blockDisallowedReferences="false"
+         validateFileText="false"
+         contextElement="scenario"
+         />
+
+    <DisclosureSystem
+         names="ESMA RTS on ESEF-2023 Unconsolidated|ESEF-Unconsolidated-2023|esef-unconsolidated-2023|ESEF-Unconsolidated|esef-unconsolidated"
+         description="ESMA RTS on ESEF-2023 Validation Checks for Unconsolidated Financial Statements"
+         validationType="ESEF"
+         exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
+         blockDisallowedReferences="false"
+         validateFileText="false"
+         contextElement="scenario"
+         />
+
+    <DisclosureSystem
+            names="ESMA RTS on ESEF-2022|ESEF-2022|esef-2022"
             description="ESMA RTS on ESEF-2022 Validation Checks for Consolidated Financial Statements"
             validationType="ESEF"
             exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
@@ -15,7 +35,7 @@
     />
 
     <DisclosureSystem
-            names="ESMA RTS on ESEF-2022 Unconsolidated|ESEF-Unconsolidated-2022|esef-unconsolidated-2022|ESEF-Unconsolidated|esef-unconsolidated"
+            names="ESMA RTS on ESEF-2022 Unconsolidated|ESEF-Unconsolidated-2022|esef-unconsolidated-2022"
             description="ESMA RTS on ESEF-2022 Validation Checks for Unconsolidated Financial Statements"
             validationType="ESEF"
             exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"


### PR DESCRIPTION
#### Reason for change
The esma published an updated version of the reporting manual for esef 2023

#### Description of change
Add the changed rules.

#### Steps to Test
Open an esef report and select the disclosure system 2023, no conformance suite was released (yet?)

**review**:
@Arelle/arelle
