### PR TITLE
Fix GUI fact table export

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -51,6 +51,7 @@ from arelle import (DialogURL, DialogLanguage,
                     ViewWinFactList, ViewFileFactList, ViewWinFactTable, ViewWinRenderedGrid, ViewWinXml,
                     ViewWinRoleTypes, ViewFileRoleTypes, ViewFileConcepts,
                     ViewWinTests, ViewWinTree, ViewWinVersReport, ViewWinRssFeed,
+                    ViewFileFactTable,
                     ViewFileTests,
                     ViewFileRenderedGrid,
                     ViewFileRelationshipSet,
@@ -634,6 +635,8 @@ class CntlrWinMain (Cntlr.Cntlr):
                         ViewFileConcepts.viewConcepts(modelXbrl, filename, labelrole=view.labelrole, lang=view.lang)
                     elif isinstance(view, ViewWinFactList.ViewFactList):
                         ViewFileFactList.viewFacts(modelXbrl, filename, labelrole=view.labelrole, lang=view.lang)
+                    elif isinstance(view, ViewWinFactTable.ViewFactTable):
+                        ViewFileFactTable.viewFacts(modelXbrl, filename, arcrole=view.arcrole, linkrole=view.linkrole, linkqname=view.linkqname, arcqname=view.arcqname, labelrole=view.labelrole, lang=view.lang)
                     else:
                         ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, filename, view.tabTitle, view.arcrole, labelrole=view.labelrole, lang=view.lang)
                 except (IOError, EnvironmentError) as err:


### PR DESCRIPTION
#### Reason for change
Resolves bug where the view save as functionality in the GUI incorrectly saves the presentation network when the fact tables view is selected.

#### Description of change
* Export the Fact Tables view to Excel if it's selected

#### Steps to Test
* Open a report
* Make sure the the "Fact Table" pane is selected
* From the file menu use the "Save as" dialog to export the fact table as an excel spreadsheet
* Verify that the excel spreadsheet contains a fact table for the selected network and not an export of the presentation network.

**review**:
@Arelle/arelle
