### PR TITLE
Add FR-NL-1-03 to the NL validation plugin

### DIFF
--- a/arelle/plugin/validate/NL/rules/fr_nl.py
+++ b/arelle/plugin/validate/NL/rules/fr_nl.py
@@ -32,6 +32,33 @@ _: TypeGetText
         DISCLOSURE_SYSTEM_NT18
     ],
 )
+def rule_fr_nl_1_03(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    FR-NL-1.03: A DOCTYPE declaration MUST NOT be used in the filing instance document
+    """
+    for doc in val.modelXbrl.urlDocs.values():
+        if doc.type == ModelDocument.Type.INSTANCE:
+            if doc.xmlDocument.docinfo.doctype:
+                yield Validation.error(
+                    codes='NL.FR-NL-1.03',
+                    msg=_('A DOCTYPE declaration MUST NOT be used in the filing instance document'),
+                    modelObject=val.modelXbrl.modelDocument
+                )
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=[
+        DISCLOSURE_SYSTEM_NT16,
+        DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
+    ],
+)
 def rule_fr_nl_1_05(
         pluginData: PluginValidationDataExtension,
         val: ValidateXbrl,
@@ -45,7 +72,7 @@ def rule_fr_nl_1_05(
         if doc.type == ModelDocument.Type.INSTANCE:
             if 'UTF-8' != doc.xmlDocument.docinfo.encoding:
                 yield Validation.error(
-                    codes='FR-NL-1.05',
+                    codes='NL.FR-NL-1.05',
                     msg=_('The XML character encoding \'UTF-8\' MUST be used in the filing instance document'),
                     modelObject=val.modelXbrl.modelDocument
                 )

--- a/tests/resources/conformance_suites/nl_nt16/fr_nl/1-03-invalid-doctype.xbrl
+++ b/tests/resources/conformance_suites/nl_nt16/fr_nl/1-03-invalid-doctype.xbrl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE note SYSTEM "Note.dtd">
+<xbrl xmlns="http://www.xbrl.org/2003/instance">
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt16/fr_nl/1-03-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt16/fr_nl/1-03-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="NL.FR-NL-1.03"
+        description="A DOCTYPE declaration MUST NOT be used in the filing instance document."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-doctype" name="A DOCTYPE declaration MUST NOT be used">
+        <description>
+            A DOCTYPE declaration MUST NOT be used in the filing instance document.
+        </description>
+        <data>
+            <instance readMeFirst="true">1-03-invalid-doctype.xbrl</instance>
+        </data>
+        <result>
+            <error>NL.FR-NL-1.03</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt16/index.xml
+++ b/tests/resources/conformance_suites/nl_nt16/index.xml
@@ -12,6 +12,8 @@
     <testcase uri='br_kvk/4-12-testcase.xml' />
     <testcase uri='br_kvk/4-16-testcase.xml' />
     <testcase uri='fr_nl/1-01-testcase.xml' />
+    <testcase uri='fr_nl/1-03-testcase.xml' />
+    <testcase uri='fr_nl/1-05-testcase.xml' />
     <testcase uri='fr_nl/1-06-testcase.xml' />
     <testcase uri='fr_nl/2-06-testcase.xml' />
 </testcases>

--- a/tests/resources/conformance_suites/nl_nt17/fr_nl/1-03-invalid-doctype.xbrl
+++ b/tests/resources/conformance_suites/nl_nt17/fr_nl/1-03-invalid-doctype.xbrl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE note SYSTEM "Note.dtd">
+<xbrl xmlns="http://www.xbrl.org/2003/instance">
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt17/fr_nl/1-03-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt17/fr_nl/1-03-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="NL.FR-NL-1.03"
+        description="A DOCTYPE declaration MUST NOT be used in the filing instance document."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-doctype" name="A DOCTYPE declaration MUST NOT be used">
+        <description>
+            A DOCTYPE declaration MUST NOT be used in the filing instance document.
+        </description>
+        <data>
+            <instance readMeFirst="true">1-03-invalid-doctype.xbrl</instance>
+        </data>
+        <result>
+            <error>NL.FR-NL-1.03</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt17/index.xml
+++ b/tests/resources/conformance_suites/nl_nt17/index.xml
@@ -12,6 +12,8 @@
     <testcase uri='br_kvk/4-12-testcase.xml' />
     <testcase uri='br_kvk/4-16-testcase.xml' />
     <testcase uri='fr_nl/1-01-testcase.xml' />
+    <testcase uri='fr_nl/1-03-testcase.xml' />
+    <testcase uri='fr_nl/1-05-testcase.xml' />
     <testcase uri='fr_nl/1-06-testcase.xml' />
     <testcase uri='fr_nl/2-06-testcase.xml' />
 </testcases>

--- a/tests/resources/conformance_suites/nl_nt18/fr_nl/1-03-invalid-doctype.xbrl
+++ b/tests/resources/conformance_suites/nl_nt18/fr_nl/1-03-invalid-doctype.xbrl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE note SYSTEM "Note.dtd">
+<xbrl xmlns="http://www.xbrl.org/2003/instance">
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt18/fr_nl/1-03-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt18/fr_nl/1-03-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="NL.FR-NL-1.03"
+        description="A DOCTYPE declaration MUST NOT be used in the filing instance document."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-doctype" name="A DOCTYPE declaration MUST NOT be used">
+        <description>
+            A DOCTYPE declaration MUST NOT be used in the filing instance document.
+        </description>
+        <data>
+            <instance readMeFirst="true">1-03-invalid-doctype.xbrl</instance>
+        </data>
+        <result>
+            <error>NL.FR-NL-1.03</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt18/index.xml
+++ b/tests/resources/conformance_suites/nl_nt18/index.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <testcases name="NL-NT18">
     <testcase uri='fr_nl/1-01-testcase.xml' />
+    <testcase uri='fr_nl/1-03-testcase.xml' />
+    <testcase uri='fr_nl/1-05-testcase.xml' />
     <testcase uri='fr_nl/1-06-testcase.xml' />
     <testcase uri='fr_nl/2-06-testcase.xml' />
 </testcases>


### PR DESCRIPTION
#### Reason for change
Added FR-NL-1.03 validation to NL validation plugin

#### Description of change
FR-NL-1.03: A DOCTYPE declaration MUST NOT be used in the filing instance document.

#### Steps to Test
CI

**review**:
@Arelle/arelle
