### PR TITLE
Require pytz dependency for EFM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ DB = [
 ]
 EFM = [
     'holidays==0.*',
+    'pytz',
 ]
 ESEF = [
     'tinycss2==1.*',

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ NumPy==1.24.4 ; python_version <= "3.8"
 NumPy==1.25.2 ; python_version > "3.8"
 Matplotlib==3.7.3
 holidays==0.35
+pytz==2023.3.post1
 Tornado==6.3.3
 # security plugin
 PyCryptodome==3.19.0


### PR DESCRIPTION
#### Reason for change
pytz is also included if WebServer extra is installed (CherryPy), but needs to be explicitly required for EFM.

#### Description of change
Require pytz for EFM

#### Steps to Test
* CI

**review**:
@Arelle/arelle
