### PR TITLE
Checkout merge commit for pull_request_target conformance suite action

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: build-test-matrix
         run: |
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Checkout EdgarRenderer
         if: ${{ matrix.test.name == 'efm_current' }}

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -19,6 +19,9 @@ jobs:
     outputs:
       matrix: ${{ steps.build-test-matrix.outputs.matrix }}
     steps:
+      - if: github.event.pull_request.mergeable != 'true'
+        name: Exit if PR is not mergeable
+        run: exit 1
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false


### PR DESCRIPTION
#### Reason for change
Our conformance suite action was running on the target branch, without changes from master merged.

#### Description of change
`pull_request` actions checkout a merged version of the repository by default. Our conformance suite action uses `pull_request_target` (for security reasons) which does not have this default behavior. [This discussion](https://github.com/actions/checkout/issues/518#issuecomment-890401887) provides a solution.

#### Steps to Test
CI

**review**:
@Arelle/arelle
