### PR TITLE
Fix saving xBRL-JSON with set-valued enumerations

### DIFF
--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -97,6 +97,9 @@ def saveLoadableOIM(modelXbrl, oimFile, outputZip=None,
         qnOimPeriodAspect}
 
     def oimValue(object, decimals=None):
+        if isinstance(object, list):
+            # set-valued enumeration fact
+            return " ".join([ oimValue(o) for o in object ])
         if isinstance(object, QName):
             if object.namespaceURI not in namespacePrefixes:
                 if object.prefix:


### PR DESCRIPTION
#### Reason for change

Exception when serialising to xBRL-JSON - see #942 

#### Description of change

Set-valued enumeration facts are now serialised as a space-separated list of serialised QNames (was previously attempting to produce a list of QName objects)

#### Steps to Test

See test document /  command line on #942 

**review**:
@Arelle/arelle
