### PR TITLE
FR-NL-1.02, FR-NL-1.04 validations

### DIFF
--- a/arelle/plugin/validate/NL/rules/fr_nl.py
+++ b/arelle/plugin/validate/NL/rules/fr_nl.py
@@ -249,6 +249,7 @@ def rule_fr_nl_2_06(
     """
     pattern = regex.compile(r"]]>")
     modelXbrl = val.modelXbrl
+    sourceFileLines = []
     for doc in modelXbrl.urlDocs.values():
         if doc.type == ModelDocument.Type.INSTANCE:
             # By default, etree parsing replaces CDATA sections with their text content,
@@ -262,13 +263,13 @@ def rule_fr_nl_2_06(
             with modelXbrl.fileSource.file(doc.filepath)[0] as file:
                 for i, line in enumerate(file):
                     for __ in regex.finditer(pattern, line):
-                        yield Validation.error(
-                            codes='NL.FR-NL-2.06',
-                            msg=_('A CDATA end sequence ("]]>") MAY NOT be used in an XBRL instance document. '
-                                  'Found at %(fileName)s:%(lineNumber)s.'),
-                            fileName=doc.basename,
-                            lineNumber=i + 1,
-                        )
+                        sourceFileLines.append((doc.filepath, i + 1))
+    if len(sourceFileLines) > 0:
+        yield Validation.error(
+            codes='NL.FR-NL-2.06',
+            msg=_('A CDATA end sequence ("]]>") MAY NOT be used in an XBRL instance document.'),
+            sourceFileLines=sourceFileLines,
+        )
 
 
 @validation(

--- a/arelle/plugin/validate/NL/rules/fr_nl.py
+++ b/arelle/plugin/validate/NL/rules/fr_nl.py
@@ -42,12 +42,15 @@ BOM_BYTES = sorted({
     codecs.BOM64_BE,
     codecs.BOM64_LE,
 }, key=lambda x: len(x), reverse=True)
-UNICODE_CHARACTER_DECIMAL_RANGES = frozenset({
-    (32, 127),  # 0020 - 007F: Basic Latin
-    (160, 255),  # 00A0 - 00FF: Latin-1 Supplement
-    (8352, 8399),  # 20A0 - 20CF: Currency Symbols
-})
-UNICODE_CHARACTER_RANGES_PATTERN = regex.compile(r"([^\u0020-\u007F\u00A0-\u00FF\u20A0-\u20CF\n])")
+UNICODE_CHARACTER_DECIMAL_RANGES = (
+    (0x0000, 0x007F),  # Basic Latin
+    (0x0080, 0x00FF),  # Latin-1 Supplement
+    (0x20A0, 0x20CF),  # Currency Symbols
+)
+UNICODE_CHARACTER_RANGES_PATTERN = regex.compile(
+    r"[^" +
+    ''.join(fr"\u{min:04x}-\u{max:04x}" for min, max in UNICODE_CHARACTER_DECIMAL_RANGES) +
+    "]")
 
 
 @validation(

--- a/tests/resources/conformance_suites/nl_nt16/fr_nl/1-02-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt16/fr_nl/1-02-invalid.xbrl
@@ -1,0 +1,4 @@
+<xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test∓"> <!-- CAUSE: disallowed character in attribute -->
+    и й  ⃐ ∓ <!-- CAUSE: disallowed characters -->
+     ÿ ⃏ ' " ₠ <!-- CAUSE: allowed characters -->
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt16/fr_nl/1-02-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt16/fr_nl/1-02-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="NL.FR-NL-1.02"
+        description="Characters MUST be from the Unicode ranges Basic Latin, Latin Supplement and Currency Symbols."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-character" name="Invalid Character">
+        <description>
+            The instance document contains characters outside allowed Unicode ranges.
+        </description>
+        <data>
+            <instance readMeFirst="true">1-02-invalid.xbrl</instance>
+        </data>
+        <result>
+            <error>NL.FR-NL-1.02</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt16/fr_nl/1-04-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt16/fr_nl/1-04-invalid.xbrl
@@ -1,0 +1,10 @@
+<xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test&reg;"> <!-- CAUSE: disallowed named reference, in attribute -->
+    <!-- &#1080; &#1081; --> <!-- CAUSE: disallowed decimal references, in comment -->
+    <!-- &reg; &plus; --> <!-- CAUSE: disallowed named references, in comment -->
+    <!-- &apos; --> <!-- allowed named reference, in comment -->
+    <!-- &#x3A3; --> <!-- allowed hexadecimal reference, in comment -->
+    &#1080; &#1081; <!-- CAUSE: disallowed decimal references, in text -->
+    &reg; &plus; <!-- CAUSE: disallowed named references, in text -->
+    &apos; <!-- allowed named reference, in text -->
+    &#x3A3; <!-- allowed hexadecimal reference, in text -->
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt16/fr_nl/1-04-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt16/fr_nl/1-04-invalid.xbrl
@@ -1,10 +1,15 @@
 <xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test&reg;"> <!-- CAUSE: disallowed named reference, in attribute -->
-    <!-- &#1080; &#1081; --> <!-- CAUSE: disallowed decimal references, in comment -->
+    <!-- &#1080; &#1081; --> <!-- CAUSE: disallowed decimal numeric references, in comment -->
+    <!-- &#x0000; &#x20D0; --> <!-- CAUSE: disallowed hexadecimal numeric references, in comment -->
     <!-- &reg; &plus; --> <!-- CAUSE: disallowed named references, in comment -->
-    <!-- &apos; --> <!-- allowed named reference, in comment -->
-    <!-- &#x3A3; --> <!-- allowed hexadecimal reference, in comment -->
-    &#1080; &#1081; <!-- CAUSE: disallowed decimal references, in text -->
+    &#1080; &#1081; <!-- CAUSE: disallowed decimal numeric references, in text -->
+    &#x0000; &#x20D0; <!-- CAUSE: disallowed hexadecimal numeric references, in text -->
     &reg; &plus; <!-- CAUSE: disallowed named references, in text -->
-    &apos; <!-- allowed named reference, in text -->
-    &#x3A3; <!-- allowed hexadecimal reference, in text -->
+
+    <!-- &#32; &#0160; &#8352;--> <!-- CAUSE: allowed decimal numeric references, in comment -->
+    <!--&#x0020; &#x00A0; &#x20A0; --> <!-- CAUSE: allowed hexadecimal numeric references, in comment -->
+    <!-- &lt; &gt; --> <!-- CAUSE: allowed named references, in comment -->
+    &#127; &#0255; &#8399; <!-- CAUSE: allowed decimal numeric references, in text -->
+    &#x007F; &#x00FF; &#x20CF; <!-- CAUSE: allowed hexadecimal numeric references, in text -->
+    &amp; &apos; &quot; <!-- CAUSE: allowed named references, in text -->
 </xbrl>

--- a/tests/resources/conformance_suites/nl_nt16/fr_nl/1-04-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt16/fr_nl/1-04-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="NL.FR-NL-1.04"
+        description="Disallowed character references MUST NOT be used."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-character-reference" name="Invalid Character Reference">
+        <description>
+            The instance document contains disallowed character references.
+        </description>
+        <data>
+            <instance readMeFirst="true">1-04-invalid.xbrl</instance>
+        </data>
+        <result>
+            <error>NL.FR-NL-1.04</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt16/index.xml
+++ b/tests/resources/conformance_suites/nl_nt16/index.xml
@@ -13,6 +13,7 @@
     <testcase uri='br_kvk/4-16-testcase.xml' />
     <testcase uri='br_kvk/4-20-testcase.xml' />
     <testcase uri='fr_nl/1-01-testcase.xml' />
+    <testcase uri='fr_nl/1-02-testcase.xml' />
     <testcase uri='fr_nl/1-03-testcase.xml' />
     <testcase uri='fr_nl/1-04-testcase.xml' />
     <testcase uri='fr_nl/1-05-testcase.xml' />

--- a/tests/resources/conformance_suites/nl_nt16/index.xml
+++ b/tests/resources/conformance_suites/nl_nt16/index.xml
@@ -14,6 +14,7 @@
     <testcase uri='br_kvk/4-20-testcase.xml' />
     <testcase uri='fr_nl/1-01-testcase.xml' />
     <testcase uri='fr_nl/1-03-testcase.xml' />
+    <testcase uri='fr_nl/1-04-testcase.xml' />
     <testcase uri='fr_nl/1-05-testcase.xml' />
     <testcase uri='fr_nl/1-06-testcase.xml' />
     <testcase uri='fr_nl/2-04-testcase.xml' />

--- a/tests/resources/conformance_suites/nl_nt17/fr_nl/1-02-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt17/fr_nl/1-02-invalid.xbrl
@@ -1,0 +1,4 @@
+<xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test∓"> <!-- CAUSE: disallowed character in attribute -->
+    и й  ⃐ ∓ <!-- CAUSE: disallowed characters -->
+     ÿ ⃏ ' " ₠ <!-- CAUSE: allowed characters -->
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt17/fr_nl/1-02-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt17/fr_nl/1-02-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="NL.FR-NL-1.02"
+        description="Characters MUST be from the Unicode ranges Basic Latin, Latin Supplement and Currency Symbols."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-character" name="Invalid Character">
+        <description>
+            The instance document contains characters outside allowed Unicode ranges.
+        </description>
+        <data>
+            <instance readMeFirst="true">1-02-invalid.xbrl</instance>
+        </data>
+        <result>
+            <error>NL.FR-NL-1.02</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt17/fr_nl/1-04-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt17/fr_nl/1-04-invalid.xbrl
@@ -1,0 +1,10 @@
+<xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test&reg;"> <!-- CAUSE: disallowed named reference, in attribute -->
+    <!-- &#1080; &#1081; --> <!-- CAUSE: disallowed decimal references, in comment -->
+    <!-- &reg; &plus; --> <!-- CAUSE: disallowed named references, in comment -->
+    <!-- &apos; --> <!-- allowed named reference, in comment -->
+    <!-- &#x3A3; --> <!-- allowed hexadecimal reference, in comment -->
+    &#1080; &#1081; <!-- CAUSE: disallowed decimal references, in text -->
+    &reg; &plus; <!-- CAUSE: disallowed named references, in text -->
+    &apos; <!-- allowed named reference, in text -->
+    &#x3A3; <!-- allowed hexadecimal reference, in text -->
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt17/fr_nl/1-04-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt17/fr_nl/1-04-invalid.xbrl
@@ -1,10 +1,15 @@
 <xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test&reg;"> <!-- CAUSE: disallowed named reference, in attribute -->
-    <!-- &#1080; &#1081; --> <!-- CAUSE: disallowed decimal references, in comment -->
+    <!-- &#1080; &#1081; --> <!-- CAUSE: disallowed decimal numeric references, in comment -->
+    <!-- &#x0000; &#x20D0; --> <!-- CAUSE: disallowed hexadecimal numeric references, in comment -->
     <!-- &reg; &plus; --> <!-- CAUSE: disallowed named references, in comment -->
-    <!-- &apos; --> <!-- allowed named reference, in comment -->
-    <!-- &#x3A3; --> <!-- allowed hexadecimal reference, in comment -->
-    &#1080; &#1081; <!-- CAUSE: disallowed decimal references, in text -->
+    &#1080; &#1081; <!-- CAUSE: disallowed decimal numeric references, in text -->
+    &#x0000; &#x20D0; <!-- CAUSE: disallowed hexadecimal numeric references, in text -->
     &reg; &plus; <!-- CAUSE: disallowed named references, in text -->
-    &apos; <!-- allowed named reference, in text -->
-    &#x3A3; <!-- allowed hexadecimal reference, in text -->
+
+    <!-- &#32; &#0160; &#8352;--> <!-- CAUSE: allowed decimal numeric references, in comment -->
+    <!--&#x0020; &#x00A0; &#x20A0; --> <!-- CAUSE: allowed hexadecimal numeric references, in comment -->
+    <!-- &lt; &gt; --> <!-- CAUSE: allowed named references, in comment -->
+    &#127; &#0255; &#8399; <!-- CAUSE: allowed decimal numeric references, in text -->
+    &#x007F; &#x00FF; &#x20CF; <!-- CAUSE: allowed hexadecimal numeric references, in text -->
+    &amp; &apos; &quot; <!-- CAUSE: allowed named references, in text -->
 </xbrl>

--- a/tests/resources/conformance_suites/nl_nt17/fr_nl/1-04-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt17/fr_nl/1-04-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="NL.FR-NL-1.04"
+        description="Disallowed character references MUST NOT be used."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-character-reference" name="Invalid Character Reference">
+        <description>
+            The instance document contains disallowed character references.
+        </description>
+        <data>
+            <instance readMeFirst="true">1-04-invalid.xbrl</instance>
+        </data>
+        <result>
+            <error>NL.FR-NL-1.04</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt17/index.xml
+++ b/tests/resources/conformance_suites/nl_nt17/index.xml
@@ -13,6 +13,7 @@
     <testcase uri='br_kvk/4-16-testcase.xml' />
     <testcase uri='br_kvk/4-20-testcase.xml' />
     <testcase uri='fr_nl/1-01-testcase.xml' />
+    <testcase uri='fr_nl/1-02-testcase.xml' />
     <testcase uri='fr_nl/1-03-testcase.xml' />
     <testcase uri='fr_nl/1-04-testcase.xml' />
     <testcase uri='fr_nl/1-05-testcase.xml' />

--- a/tests/resources/conformance_suites/nl_nt17/index.xml
+++ b/tests/resources/conformance_suites/nl_nt17/index.xml
@@ -14,6 +14,7 @@
     <testcase uri='br_kvk/4-20-testcase.xml' />
     <testcase uri='fr_nl/1-01-testcase.xml' />
     <testcase uri='fr_nl/1-03-testcase.xml' />
+    <testcase uri='fr_nl/1-04-testcase.xml' />
     <testcase uri='fr_nl/1-05-testcase.xml' />
     <testcase uri='fr_nl/1-06-testcase.xml' />
     <testcase uri='fr_nl/2-04-testcase.xml' />

--- a/tests/resources/conformance_suites/nl_nt18/fr_nl/1-02-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt18/fr_nl/1-02-invalid.xbrl
@@ -1,0 +1,4 @@
+<xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test∓"> <!-- CAUSE: disallowed character in attribute -->
+    и й  ⃐ ∓ <!-- CAUSE: disallowed characters -->
+     ÿ ⃏ ' " ₠ <!-- CAUSE: allowed characters -->
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt18/fr_nl/1-02-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt18/fr_nl/1-02-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="NL.FR-NL-1.02"
+        description="Characters MUST be from the Unicode ranges Basic Latin, Latin Supplement and Currency Symbols."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-character" name="Invalid Character">
+        <description>
+            The instance document contains characters outside allowed Unicode ranges.
+        </description>
+        <data>
+            <instance readMeFirst="true">1-02-invalid.xbrl</instance>
+        </data>
+        <result>
+            <error>NL.FR-NL-1.02</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt18/fr_nl/1-04-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt18/fr_nl/1-04-invalid.xbrl
@@ -1,0 +1,10 @@
+<xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test&reg;"> <!-- CAUSE: disallowed named reference, in attribute -->
+    <!-- &#1080; &#1081; --> <!-- CAUSE: disallowed decimal references, in comment -->
+    <!-- &reg; &plus; --> <!-- CAUSE: disallowed named references, in comment -->
+    <!-- &apos; --> <!-- allowed named reference, in comment -->
+    <!-- &#x3A3; --> <!-- allowed hexadecimal reference, in comment -->
+    &#1080; &#1081; <!-- CAUSE: disallowed decimal references, in text -->
+    &reg; &plus; <!-- CAUSE: disallowed named references, in text -->
+    &apos; <!-- allowed named reference, in text -->
+    &#x3A3; <!-- allowed hexadecimal reference, in text -->
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt18/fr_nl/1-04-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt18/fr_nl/1-04-invalid.xbrl
@@ -1,10 +1,15 @@
 <xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test&reg;"> <!-- CAUSE: disallowed named reference, in attribute -->
-    <!-- &#1080; &#1081; --> <!-- CAUSE: disallowed decimal references, in comment -->
+    <!-- &#1080; &#1081; --> <!-- CAUSE: disallowed decimal numeric references, in comment -->
+    <!-- &#x0000; &#x20D0; --> <!-- CAUSE: disallowed hexadecimal numeric references, in comment -->
     <!-- &reg; &plus; --> <!-- CAUSE: disallowed named references, in comment -->
-    <!-- &apos; --> <!-- allowed named reference, in comment -->
-    <!-- &#x3A3; --> <!-- allowed hexadecimal reference, in comment -->
-    &#1080; &#1081; <!-- CAUSE: disallowed decimal references, in text -->
+    &#1080; &#1081; <!-- CAUSE: disallowed decimal numeric references, in text -->
+    &#x0000; &#x20D0; <!-- CAUSE: disallowed hexadecimal numeric references, in text -->
     &reg; &plus; <!-- CAUSE: disallowed named references, in text -->
-    &apos; <!-- allowed named reference, in text -->
-    &#x3A3; <!-- allowed hexadecimal reference, in text -->
+
+    <!-- &#32; &#0160; &#8352;--> <!-- CAUSE: allowed decimal numeric references, in comment -->
+    <!--&#x0020; &#x00A0; &#x20A0; --> <!-- CAUSE: allowed hexadecimal numeric references, in comment -->
+    <!-- &lt; &gt; --> <!-- CAUSE: allowed named references, in comment -->
+    &#127; &#0255; &#8399; <!-- CAUSE: allowed decimal numeric references, in text -->
+    &#x007F; &#x00FF; &#x20CF; <!-- CAUSE: allowed hexadecimal numeric references, in text -->
+    &amp; &apos; &quot; <!-- CAUSE: allowed named references, in text -->
 </xbrl>

--- a/tests/resources/conformance_suites/nl_nt18/fr_nl/1-04-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt18/fr_nl/1-04-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="NL.FR-NL-1.04"
+        description="Disallowed character references MUST NOT be used."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-character-reference" name="Invalid Character Reference">
+        <description>
+            The instance document contains disallowed character references.
+        </description>
+        <data>
+            <instance readMeFirst="true">1-04-invalid.xbrl</instance>
+        </data>
+        <result>
+            <error>NL.FR-NL-1.04</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt18/index.xml
+++ b/tests/resources/conformance_suites/nl_nt18/index.xml
@@ -2,6 +2,7 @@
 <testcases name="NL-NT18">
     <testcase uri='fr_nl/1-01-testcase.xml' />
     <testcase uri='fr_nl/1-03-testcase.xml' />
+    <testcase uri='fr_nl/1-04-testcase.xml' />
     <testcase uri='fr_nl/1-05-testcase.xml' />
     <testcase uri='fr_nl/1-06-testcase.xml' />
     <testcase uri='fr_nl/2-06-testcase.xml' />

--- a/tests/resources/conformance_suites/nl_nt18/index.xml
+++ b/tests/resources/conformance_suites/nl_nt18/index.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <testcases name="NL-NT18">
     <testcase uri='fr_nl/1-01-testcase.xml' />
+    <testcase uri='fr_nl/1-02-testcase.xml' />
     <testcase uri='fr_nl/1-03-testcase.xml' />
     <testcase uri='fr_nl/1-04-testcase.xml' />
     <testcase uri='fr_nl/1-05-testcase.xml' />


### PR DESCRIPTION
#### Reason for change
FR-NL-1.02: Characters MUST be from the Unicode ranges Basic Latin, Latin Supplement and Currency Symbols

FR-NL-1.04: Disallowed character references MUST NOT be used. The use of character references (e.g. `&#1080;`) is not allowed unless it concerns numeric character references within the allowed set of characters and except for the entity references listed here: `&lt; &gt; &amp; &apos; &quot;`

#### Description of change
1.02: For each instance doc, iterate by line and match against regex to error on any character outside of the allowed ranges.

1.04: For each instance doc, iterate by line and check against a regex pattern to extract decimal, hexadecimal, or named character references.
Certain ranges of numeric references are allowed (matching same character set from 1.02), certain named references are allowed, everything else triggers an error.

#### Steps to Test
CI

**review**:
@Arelle/arelle
