### PR TITLE
Fix merge check in CS workflow

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -19,12 +19,15 @@ jobs:
     outputs:
       matrix: ${{ steps.build-test-matrix.outputs.matrix }}
     steps:
-      - if: github.event.pull_request.mergeable != 'true'
-        name: Exit if PR is not mergeable
+      - name: Mergeability check
+        # If this is running on a PR (not workflow_dispatch) and a test merge commit does not exist, fail.
+        # This ensures that a merged version of the PR is available so the checkout won't fall back to an un-merged version.
+        if: ${{ github.event.pull_request.head.sha && !github.event.pull_request.merge_commit_sha }}
         run: exit 1
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
+          # If this is a workflow_dispatch run, merge_commit_sha will be empty and this action will default to the branch sha.
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: build-test-matrix


### PR DESCRIPTION
#### Reason for change
`mergeable` isn't populating as expected based on API documentation

#### Description of change
Instead of checking `mergeable`, check `merge_commit_sha`. Testing confirms that `merge_commit_sha` is populated with a test merge commit once available

If the workflow is running on a PR and `merge_commit_sha` is empty (indicating the test merge has not completed yet), the workflow will fail. This will require a manual rerun of `find-tests`. I don't anticipate this being common enough to be a problem (due to delays in jobs being created and finding runners to run them), but we can address it later if it does become a problem.
**Note: `merge_commit_sha` is still populated when merge conflicts exists, so the workflow will still run.**

If the workflow is running from workflow dispatch, `merge_commit_sha` will be empty and the checkout action will fall back to the commit of the selected branch.

#### Steps to Test
Tested on another fork on PR (with and without merge conflict) and workflow dispatch. (Screenshots below also demonstrate `mergeable` and `mergeable_state` not working as expected)
##### `pull_request_target`
Checkout correctly uses the merge commit.
![Screenshot 2023-11-02 at 11 11 37 AM](https://github.com/Arelle/Arelle/assets/105066394/a0eee437-a7f8-4e61-b06e-61986fcd3268)
##### `workflow_dispatch`
In absence of a merge commit, checkout correctly uses commit from the branch.
![Screenshot 2023-11-02 at 11 11 00 AM](https://github.com/Arelle/Arelle/assets/105066394/06230718-26eb-4561-a5ce-ba944c688f47)


**review**:
@Arelle/arelle
