### PR TITLE
Revert conformance suite workflow changes for merging master

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -19,16 +19,10 @@ jobs:
     outputs:
       matrix: ${{ steps.build-test-matrix.outputs.matrix }}
     steps:
-      - name: Mergeability check
-        # If this is running on a PR (not workflow_dispatch) and a test merge commit does not exist, fail.
-        # This ensures that a merged version of the PR is available so the checkout won't fall back to an un-merged version.
-        if: ${{ github.event.pull_request.head.sha && !github.event.pull_request.merge_commit_sha }}
-        run: exit 1
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
-          # If this is a workflow_dispatch run, merge_commit_sha will be empty and this action will default to the branch sha.
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: build-test-matrix
         run: |
@@ -134,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Checkout EdgarRenderer
         if: ${{ matrix.test.name == 'efm_current' }}


### PR DESCRIPTION
#### Reason for change
Solution for merging master in conformance suite workflow was not working consistently and was 

#### Description of change
Revert changes

#### Steps to Test
find-tests may fail on this PR, but this will need to be merged anyway to fix.

**review**:
@Arelle/arelle
