### PR TITLE
Fixes for Edgar 23.3

### DIFF
--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -167,6 +167,7 @@ def inlineXbrlDocumentSetLoader(modelXbrl, normalizedUri, filepath, isEntry=Fals
         ixdocset = create(modelXbrl, Type.INLINEXBRLDOCUMENTSET, docsetUrl, isEntry=True, initialXml="".join(xml))
         ixdocset.type = Type.INLINEXBRLDOCUMENTSET
         ixdocset.targetDocumentSchemaRefs = set()  # union all the instance schemaRefs
+        ixdocset.targetDocumentPreferredFilename = None # possibly no inline docs in this doc set
         for i, elt in enumerate(ixdocset.xmlRootElement.iter(tag="instance")):
             # load ix document
             if ixdocs:
@@ -180,7 +181,7 @@ def inlineXbrlDocumentSetLoader(modelXbrl, normalizedUri, filepath, isEntry=Fals
                     referencedDocument = ModelDocumentReference("inlineDocument", elt)
                     ixdocset.referencesDocument[ixdoc] = referencedDocument
                     ixdocset.ixNS = ixdoc.ixNS # set docset ixNS
-                    if i == 0:
+                    if ixdocset.targetDocumentPreferredFilename is None:
                         ixdocset.targetDocumentPreferredFilename = os.path.splitext(ixdoc.uri)[0] + ".xbrl"
                     ixdoc.inDTS = True # behaves like an entry
                 else:
@@ -487,6 +488,9 @@ def runSaveTargetDocumentMenuCommand(cntlr, runInBackground=False, saveTargetFil
     if modelDocument.type == Type.INLINEXBRLDOCUMENTSET:
         targetFilename = modelDocument.targetDocumentPreferredFilename
         targetSchemaRefs = modelDocument.targetDocumentSchemaRefs
+        if targetFilename is None:
+            cntlr.addToLog("No inline XBRL document in the inline XBRL document set.")
+            return
     else:
         filepath, fileext = os.path.splitext(modelDocument.filepath)
         if fileext not in (".xml", ".xbrl"):

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -4152,7 +4152,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                 if isinf(minDec):
                     maxDiff = 0
                 elif minDec == 0 and immaterialDifferenceFlag:
-                    maxDiff == Decimal(abs(facts[0].xValue)) * Decimal("0.01")
+                    maxDiff = Decimal(abs(facts[0].xValue)) * Decimal("0.01")
                 else:
                     maxDiff = pow(10, -minDec) * tolerance * (len(facts) - 2)
                 if difference > maxDiff:


### PR DESCRIPTION
#### Reason for change

 * Inline XBRL Document Set (IXDS) with non-inline first document caused exception
 * DQC rule 0084 typo

#### Description of change

 * Tolerate IXDS with spurious first document or no IX documents at all
 * Fix 0084

#### Steps to Test

 * @derekgengenbacher-wf - Test with EDGAR filing where first doc is not inline (should work ok and save extracted xml from 2nd really-IX doc), and another where no doc is inline (should not save extracted xml)
 * @RamkumarAlagupandian - nonpublic test case for 0084

**review**:
@Arelle/arelle
