### PR TITLE
Prune plugin modules that fail loading (and attempt reload by name)

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -30,7 +30,7 @@ import tkinter.simpledialog
 from arelle.Locale import format_string, setApplicationLocale
 from arelle.CntlrWinTooltip import ToolTip
 from arelle import XbrlConst
-from arelle.PluginManager import pluginClassMethods
+from arelle.PluginManager import pluginClassMethods, prunePlugins
 from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlCalcs import ValidateCalcsMode as CalcsMode
 from arelle.Version import copyrightLabel
@@ -92,6 +92,7 @@ class CntlrWinMain (Cntlr.Cntlr):
 
         tkinter.CallWrapper = TkinterCallWrapper
 
+        prunePlugins(self)
 
         imgpath = self.imagesDir + os.sep
 


### PR DESCRIPTION
#### Reason for change
Plugin modules that move or are not found at the `moduleURL` specified in the `plugins.json` fail loading. This causes a recurring error until the plugin is manually removed via GUI, and also means that any release that moves a plugin from `/plugins` to a pip-installed version will require manual transition.

#### Description of change
In order to clean up missing plugins, we'll remove them from the config when they fail loading into the GUI.
Additionally, to help with seamlessly transitioning plugins located in `/plugins` to their pip-installed counterparts, we'll attempt to add back the removed plugins by name.

#### Steps to Test
- Add `ixbrl-viewer` plugin to GUI by filepath (via Browse)
- Close GUI
- Alter the `moduleURL` in the `plugins.json` config to ensure the plugin module will fail to load.
- Make sure `ixbrl-viewer` is installed via pip.
- Start GUI
- Expect GUI with ixbrl-viewer to start up successfully. Confirm `moduleURL` in `plugins.json` points to the pip-installed location.

**review**:
@Arelle/arelle
