### PR TITLE
Disallow PNG images for FERC.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Removed trailing whitespace from the entire codebase
 956cfcca1aaa18dd2521172a851da3375abd2978
+# Fixed whitespace in arelle/plugin/validate/FERC/config.xml
+32529af727261eb1e9bf51a78280e558ef80f580

--- a/arelle/plugin/validate/FERC/config.xml
+++ b/arelle/plugin/validate/FERC/config.xml
@@ -19,7 +19,7 @@
      allowedImageTypes = '{
         "data-scheme": true,
         "img-file-extensions": [],
-        "mime-types": ["gif", "jpeg", "png"]
+        "mime-types": ["gif", "jpeg"]
      }'
      contextElement="segment"
      utrUrl="http://www.xbrl.org/utr/utr.xml resources/ferc-utr.xml"
@@ -41,7 +41,7 @@
      allowedImageTypes = '{
         "data-scheme": true,
         "img-file-extensions": [],
-        "mime-types": ["gif", "jpeg", "png"]
+        "mime-types": ["gif", "jpeg"]
      }'
      contextElement="segment"
      utrUrl=""

--- a/arelle/plugin/validate/FERC/config.xml
+++ b/arelle/plugin/validate/FERC/config.xml
@@ -18,7 +18,7 @@
      validateEntryText="true"
      allowedImageTypes = '{
         "data-scheme": true,
-        "img-file-extensions": ["gif", "jpg", "jpeg", "png"],
+        "img-file-extensions": [],
         "mime-types": ["gif", "jpeg", "png"]
      }'
      contextElement="segment"
@@ -40,7 +40,7 @@
      validateEntryText="true"
      allowedImageTypes = '{
         "data-scheme": true,
-        "img-file-extensions": ["gif", "jpg", "jpeg", "png"],
+        "img-file-extensions": [],
         "mime-types": ["gif", "jpeg", "png"]
      }'
      contextElement="segment"

--- a/arelle/plugin/validate/FERC/config.xml
+++ b/arelle/plugin/validate/FERC/config.xml
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<DisclosureSystems  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  
+<?xml version="1.0" encoding="UTF-8"?>
+<DisclosureSystems  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="../../../config/disclosuresystems.xsd" >
   <!-- see ../config/disclosuresystem.xml for full comments -->
-  
+
   <!-- FERC notes: validationType EFM uses their inline HTML element checks -->
 
-  <DisclosureSystem 
+  <DisclosureSystem
      names="Federal Energy Regulatory Commission (US)|FERC|ferc"
      description="FERC (US) Validation Checks\n
      Default language en\n
@@ -13,21 +13,21 @@
      validationType="FERC"
      exclusiveTypesPattern="FERC|EFM|GFM|HMRC|SBR.NL"
      blockDisallowedReferences="false"
-     defaultXmlLang="en" 
-     defaultLanguage="English" 
+     defaultXmlLang="en"
+     defaultLanguage="English"
      validateEntryText="true"
      allowedImageTypes = '{
         "data-scheme": true,
         "img-file-extensions": ["gif", "jpg", "jpeg", "png"],
         "mime-types": ["gif", "jpeg", "png"]
      }'
-     contextElement="segment" 
+     contextElement="segment"
      utrUrl="http://www.xbrl.org/utr/utr.xml resources/ferc-utr.xml"
      utrStatusFilters="REC CR"
      identifierSchemePattern="^http://www\.ferc\.gov/CID$"
-     identifierValuePattern="^[CR][0-9]{6}$" 
+     identifierValuePattern="^[CR][0-9]{6}$"
      />
-  <DisclosureSystem 
+  <DisclosureSystem
      names="Federal Energy Regulatory Commission (US) without UTR validation|FERC-NO-UTR|ferc-no-utr"
      description="FERC (US) Validation Checks\n
      Default language en\n
@@ -35,19 +35,19 @@
      validationType="FERC"
      exclusiveTypesPattern="FERC|EFM|GFM|HMRC|SBR.NL"
      blockDisallowedReferences="false"
-     defaultXmlLang="en" 
-     defaultLanguage="English" 
+     defaultXmlLang="en"
+     defaultLanguage="English"
      validateEntryText="true"
      allowedImageTypes = '{
         "data-scheme": true,
         "img-file-extensions": ["gif", "jpg", "jpeg", "png"],
         "mime-types": ["gif", "jpeg", "png"]
      }'
-     contextElement="segment" 
+     contextElement="segment"
      utrUrl=""
      utrStatusFilters="REC CR"
      identifierSchemePattern="^http://www\.ferc\.gov/CID$"
-     identifierValuePattern="^[CR][0-9]{6}$" 
+     identifierValuePattern="^[CR][0-9]{6}$"
      />
 
 


### PR DESCRIPTION
FERC.5.02.05
Restrictions on HTML Attributes on Allowed Tags 
The attribute src on the `<img>` tag may only reference embedded jpeg and gif graphics converted to base64.

Test with internal document.

**review**:
@Arelle/arelle
