### PR TITLE
Create util for multiprocessing plugins

### DIFF
--- a/arelle/PluginUtils.py
+++ b/arelle/PluginUtils.py
@@ -1,0 +1,54 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Sequence
+from concurrent.futures import ProcessPoolExecutor
+from multiprocessing.context import BaseContext
+from types import ModuleType
+
+
+def _loadPluginModules(pluginModuleLocationsByName: dict[str, str | None]) -> None:
+    for pluginModuleName, pluginModuleLocation in pluginModuleLocationsByName.items():
+        spec = importlib.util.spec_from_file_location(name=pluginModuleName, location=pluginModuleLocation)
+        if spec is None or spec.loader is None:
+            raise ModuleNotFoundError(f"Unable to import plugin module '{pluginModuleName}' from {pluginModuleLocation} in plugin subprocess.")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[pluginModuleName] = module
+        spec.loader.exec_module(module)
+
+
+class PluginProcessPoolExecutor(ProcessPoolExecutor):
+    """
+    Wrapper class for ProcessPoolExecutor which loads a plugin module before
+    executing any other code. This is necessary for dynamically loaded Arelle
+    plugins, as any functions defined within plugin modules are not imported
+    by newly spawned processes.
+    """
+
+    def __init__(
+            self,
+            pluginModules: Sequence[ModuleType] | ModuleType,
+            maxWorkers: int | None = None,
+            mpContext: BaseContext | None = None,
+    ) -> None:
+        if getattr(sys, 'frozen', False):
+            # Revisit this when cx_Freeze is upgraded to 6.16
+            # https://github.com/marcelotduarte/cx_Freeze/pull/1956
+            raise RuntimeError("Multiprocessing plugins aren't supported in frozen builds. Run Arelle from source.")
+        modules = pluginModules if isinstance(pluginModules, Sequence) else [pluginModules]
+        pluginModuleLocationsByName = {}
+        for pluginModule in modules:
+            pluginModuleSpec = pluginModule.__spec__
+            if pluginModuleSpec is None:
+                raise ValueError(f"Unable to create PluginProcessPoolExecutor for plugin '{pluginModule.__name__}' without ModuleSpec.")
+            pluginModuleLocationsByName[pluginModuleSpec.name] = pluginModuleSpec.origin
+        super().__init__(
+            initializer=_loadPluginModules,
+            initargs=(pluginModuleLocationsByName,),
+            max_workers=maxWorkers,
+            mp_context=mpContext,
+        )

--- a/arelle/examples/plugin/multi.py
+++ b/arelle/examples/plugin/multi.py
@@ -1,0 +1,58 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any
+
+from arelle.Cntlr import Cntlr
+from arelle.PluginUtils import PluginProcessPoolExecutor
+from arelle.RuntimeOptions import RuntimeOptions
+from arelle.Version import authorLabel, copyrightLabel
+from arelle.utils.PluginHooks import PluginHooks
+
+
+def sumPositiveNumbers(vals: tuple[int, ...]) -> int:
+    if any(val < 1 for val in vals):
+        raise ValueError("Verify exceptions are logged.")
+    return sum(vals)
+
+
+class MultiPlugin(PluginHooks):
+    @staticmethod
+    def cntlrInit(
+        cntlr: Cntlr,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        jobs = (
+            (0, 1),
+            (2, 3, 4),
+            (5, 6),
+            (7, 8, 9),
+        )
+        with PluginProcessPoolExecutor(sys.modules[__name__]) as pool:
+            jobFutures = [
+                pool.submit(sumPositiveNumbers, job)
+                for job in jobs
+            ]
+            val = 0
+            for future in jobFutures:
+                try:
+                    val += future.result(1)
+                except ValueError as e:
+                    cntlr.addToLog(messageCode="multi:error", message=str(e), level=logging.ERROR)
+            cntlr.addToLog(messageCode="multi:done", message=f"Computed val={val}")
+
+
+__pluginInfo__ = {
+    "name": "multi",
+    "version": "0.0.1",
+    "description": "multiprocessing example",
+    "license": "Apache-2",
+    "author": authorLabel,
+    "copyright": copyrightLabel,
+    "Cntlr.Init": MultiPlugin.cntlrInit,
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ module = [
     'arelle.XmlValidate',
     'arelle.XmlValidateConst',
     'arelle.XmlValidateSchema',
+    'arelle.examples.plugin.multi',
     'arelle.examples.plugin.validate.*',
     'arelle.formula.FactAspectsCache',
     'arelle.formula.XPathContext',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,12 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     'certifi',
-    'python-dateutil==2.*',
     'isodate==0.*',
     'lxml==4.*',
     'numpy==1.*',
     'openpyxl==3.*',
     'pyparsing==3.*',
+    'python-dateutil==2.*',
     'regex',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ module = [
     'arelle.ModelObjectFactory',
     'arelle.ModelValue',
     'arelle.ModelXbrl',
+    'arelle.PluginUtils',
     'arelle.RuntimeOptions',
     'arelle.SocketUtils',
     'arelle.SystemInfo',


### PR DESCRIPTION
#### Reason for change
Plugins can't create a multiprocessing pool which uses the spawn context because the plugin modules are dynamically loaded and therefor not available within a newly spawned process.

#### Description of change
Create ProcessPoolExecutor sub class that provides the ability to import a plugin module before executing the target function. This is specifically to support a multiprocess pool for the XULE compiler.

#### Steps to Test
* Verify that the example multi plugin works including error logging.

**review**:
@Arelle/arelle
