### PR TITLE
Add environment restriction to conformance-suites find-tests job

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.build-test-matrix.outputs.matrix }}
+    environment: integration-tests
     steps:
       - uses: actions/checkout@v4.1.1
         with:


### PR DESCRIPTION
#### Reason for change
GitHub kicks off a job for every conformance suite with every change to the PR branch, prior to approval. All of these jobs wait for approval, generating a message on the PR. This causes premature clutter on the PR.

#### Description of change
Add environment restriction to find-tests so approval is needed before generating jobs.
**NOTE: This does appear to require approving `integration-tests` twice to get tests to run**

#### Steps to Test
Test on [fork](https://github.com/aaroncameron-wk/arelle-public/pull/164)
![Screenshot 2023-11-13 at 10 27 15 AM](https://github.com/Arelle/Arelle/assets/105066394/38737bd9-2781-48e4-934b-6461ce97e713)

**review**:
@Arelle/arelle
