### PR TITLE
Identify separate IXDSes and  target instances in cmd line zip

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1007,76 +1007,76 @@ class CntlrCmdLine(Cntlr.Cntlr):
                                 traceback.format_tb(sys.exc_info()[2])))
             if success:
                 try:
-                    modelXbrl = self.modelManager.modelXbrl
-                    hasFormulae = modelXbrl.hasFormulae
-                    isAlreadyValidated = False
-                    for pluginXbrlMethod in pluginClassMethods("ModelDocument.IsValidated"):
-                        if pluginXbrlMethod(modelXbrl): # e.g., streaming extensions already has validated
-                            isAlreadyValidated = True
-                    if options.validate and not isAlreadyValidated:
-                        startedAt = time.time()
-                        if options.formulaAction: # don't automatically run formulas
-                            modelXbrl.hasFormulae = False
-                        self.modelManager.validate()
-                        if options.formulaAction: # restore setting
-                            modelXbrl.hasFormulae = hasFormulae
-                        self.addToLog(format_string(self.modelManager.locale,
-                                                    _("validated in %.2f secs"),
-                                                    time.time() - startedAt),
-                                                    messageCode="info", file=self.entrypointFile)
-                    if (modelXbrl.modelDocument.type not in ModelDocument.Type.TESTCASETYPES and
-                            options.formulaAction in ("validate", "run") and  # do nothing here if "none"
-                            not isAlreadyValidated):  # formulas can't run if streaming has validated the instance
-                        from arelle import ValidateXbrlDimensions
-                        from arelle.formula import ValidateFormula
-                        startedAt = time.time()
-                        if not options.validate:
-                            ValidateXbrlDimensions.loadDimensionDefaults(modelXbrl)
-                        # setup fresh parameters from formula optoins
-                        modelXbrl.parameters = fo.typedParameters(modelXbrl.prefixedNamespaces)
-                        ValidateFormula.validate(modelXbrl, compileOnly=(options.formulaAction != "run"))
-                        self.addToLog(format_string(self.modelManager.locale,
-                                                    _("formula validation and execution in %.2f secs")
-                                                    if options.formulaAction == "run"
-                                                    else _("formula validation only in %.2f secs"),
-                                                    time.time() - startedAt),
-                                                    messageCode="info", file=self.entrypointFile)
+                    for modelXbrl in [self.modelManager.modelXbrl] + getattr(self.modelManager.modelXbrl, "supplementalModelXbrls", []):
+                        hasFormulae = modelXbrl.hasFormulae
+                        isAlreadyValidated = False
+                        for pluginXbrlMethod in pluginClassMethods("ModelDocument.IsValidated"):
+                            if pluginXbrlMethod(modelXbrl): # e.g., streaming extensions already has validated
+                                isAlreadyValidated = True
+                        if options.validate and not isAlreadyValidated:
+                            startedAt = time.time()
+                            if options.formulaAction: # don't automatically run formulas
+                                modelXbrl.hasFormulae = False
+                            self.modelManager.validate()
+                            if options.formulaAction: # restore setting
+                                modelXbrl.hasFormulae = hasFormulae
+                            self.addToLog(format_string(self.modelManager.locale,
+                                                        _("validated in %.2f secs"),
+                                                        time.time() - startedAt),
+                                                        messageCode="info", file=self.entrypointFile)
+                        if (modelXbrl.modelDocument.type not in ModelDocument.Type.TESTCASETYPES and
+                                options.formulaAction in ("validate", "run") and  # do nothing here if "none"
+                                not isAlreadyValidated):  # formulas can't run if streaming has validated the instance
+                            from arelle import ValidateXbrlDimensions
+                            from arelle.formula import ValidateFormula
+                            startedAt = time.time()
+                            if not options.validate:
+                                ValidateXbrlDimensions.loadDimensionDefaults(modelXbrl)
+                            # setup fresh parameters from formula optoins
+                            modelXbrl.parameters = fo.typedParameters(modelXbrl.prefixedNamespaces)
+                            ValidateFormula.validate(modelXbrl, compileOnly=(options.formulaAction != "run"))
+                            self.addToLog(format_string(self.modelManager.locale,
+                                                        _("formula validation and execution in %.2f secs")
+                                                        if options.formulaAction == "run"
+                                                        else _("formula validation only in %.2f secs"),
+                                                        time.time() - startedAt),
+                                                        messageCode="info", file=self.entrypointFile)
 
 
-                    if options.testReport:
-                        ViewFileTests.viewTests(self.modelManager.modelXbrl, options.testReport, options.testReportCols)
+                        if options.testReport:
+                            ViewFileTests.viewTests(self.modelManager.modelXbrl, options.testReport, options.testReportCols)
 
-                    if options.rssReport:
-                        ViewFileRssFeed.viewRssFeed(self.modelManager.modelXbrl, options.rssReport, options.rssReportCols)
+                        if options.rssReport:
+                            ViewFileRssFeed.viewRssFeed(self.modelManager.modelXbrl, options.rssReport, options.rssReportCols)
 
-                    if options.DTSFile:
-                        ViewFileDTS.viewDTS(modelXbrl, options.DTSFile)
-                    if options.factsFile:
-                        ViewFileFactList.viewFacts(modelXbrl, options.factsFile, labelrole=options.labelRole, lang=options.labelLang, cols=options.factListCols)
-                    if options.factTableFile:
-                        ViewFileFactTable.viewFacts(modelXbrl, options.factTableFile, labelrole=options.labelRole, lang=options.labelLang, cols=options.factTableCols)
-                    if options.conceptsFile:
-                        ViewFileConcepts.viewConcepts(modelXbrl, options.conceptsFile, labelrole=options.labelRole, lang=options.labelLang)
-                    if options.preFile:
-                        ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.preFile, "Presentation Linkbase", XbrlConst.parentChild, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
-                    if options.tableFile:
-                        ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.tableFile, "Table Linkbase", "Table-rendering", labelrole=options.labelRole, lang=options.labelLang)
-                    if options.calFile:
-                        ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.calFile, "Calculation Linkbase", XbrlConst.summationItem, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
-                    if options.dimFile:
-                        ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.dimFile, "Dimensions", "XBRL-dimensions", labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
-                    if options.anchFile:
-                        ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.anchFile, "Anchoring", XbrlConst.widerNarrower, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
-                    if options.formulaeFile:
-                        ViewFileFormulae.viewFormulae(modelXbrl, options.formulaeFile, "Formulae", lang=options.labelLang)
-                    if options.viewArcrole and options.viewFile:
-                        ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.viewFile, os.path.basename(options.viewArcrole), options.viewArcrole, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
-                    if options.roleTypesFile:
-                        ViewFileRoleTypes.viewRoleTypes(modelXbrl, options.roleTypesFile, "Role Types", isArcrole=False, lang=options.labelLang)
-                    if options.arcroleTypesFile:
-                        ViewFileRoleTypes.viewRoleTypes(modelXbrl, options.arcroleTypesFile, "Arcrole Types", isArcrole=True, lang=options.labelLang)
-                    for pluginXbrlMethod in pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
-                        pluginXbrlMethod(self, options, modelXbrl, _entrypoint, responseZipStream=responseZipStream)
+                        if options.DTSFile:
+                            ViewFileDTS.viewDTS(modelXbrl, options.DTSFile)
+                        if options.factsFile:
+                            ViewFileFactList.viewFacts(modelXbrl, options.factsFile, labelrole=options.labelRole, lang=options.labelLang, cols=options.factListCols)
+                        if options.factTableFile:
+                            ViewFileFactTable.viewFacts(modelXbrl, options.factTableFile, labelrole=options.labelRole, lang=options.labelLang, cols=options.factTableCols)
+                        if options.conceptsFile:
+                            ViewFileConcepts.viewConcepts(modelXbrl, options.conceptsFile, labelrole=options.labelRole, lang=options.labelLang)
+                        if options.preFile:
+                            ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.preFile, "Presentation Linkbase", XbrlConst.parentChild, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
+                        if options.tableFile:
+                            ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.tableFile, "Table Linkbase", "Table-rendering", labelrole=options.labelRole, lang=options.labelLang)
+                        if options.calFile:
+                            ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.calFile, "Calculation Linkbase", XbrlConst.summationItem, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
+                        if options.dimFile:
+                            ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.dimFile, "Dimensions", "XBRL-dimensions", labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
+                        if options.anchFile:
+                            ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.anchFile, "Anchoring", XbrlConst.widerNarrower, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
+                        if options.formulaeFile:
+                            ViewFileFormulae.viewFormulae(modelXbrl, options.formulaeFile, "Formulae", lang=options.labelLang)
+                        if options.viewArcrole and options.viewFile:
+                            ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.viewFile, os.path.basename(options.viewArcrole), options.viewArcrole, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
+                        if options.roleTypesFile:
+                            ViewFileRoleTypes.viewRoleTypes(modelXbrl, options.roleTypesFile, "Role Types", isArcrole=False, lang=options.labelLang)
+                        if options.arcroleTypesFile:
+                            ViewFileRoleTypes.viewRoleTypes(modelXbrl, options.arcroleTypesFile, "Arcrole Types", isArcrole=True, lang=options.labelLang)
+                        for pluginXbrlMethod in pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
+                            pluginXbrlMethod(self, options, modelXbrl, _entrypoint, responseZipStream=responseZipStream)
 
                 except (IOError, EnvironmentError) as err:
                     self.addToLog(_("[IOError] Failed to save output:\n {0}").format(err),

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1017,7 +1017,8 @@ class CntlrCmdLine(Cntlr.Cntlr):
                             startedAt = time.time()
                             if options.formulaAction: # don't automatically run formulas
                                 modelXbrl.hasFormulae = False
-                            self.modelManager.validate()
+                            from arelle import Validate
+                            Validate.validate(modelXbrl)
                             if options.formulaAction: # restore setting
                                 modelXbrl.hasFormulae = hasFormulae
                             self.addToLog(format_string(self.modelManager.locale,

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -1025,16 +1025,22 @@ class CntlrWinMain (Cntlr.Cntlr):
                 thread = threading.Thread(target=self.backgroundValidate, daemon=True).start()
 
     def backgroundValidate(self):
+        from arelle import Validate
         startedAt = time.time()
-        modelXbrl = self.modelManager.modelXbrl
-        priorOutputInstance = modelXbrl.formulaOutputInstance
-        modelXbrl.formulaOutputInstance = None # prevent closing on background thread by validateFormula
-        self.modelManager.validate()
-        self.addToLog(format_string(self.modelManager.locale,
-                                    _("validated in %.2f secs"),
-                                    time.time() - startedAt))
-        if not modelXbrl.isClosed and (priorOutputInstance or modelXbrl.formulaOutputInstance):
-            self.uiThreadQueue.put((self.showFormulaOutputInstance, [priorOutputInstance, modelXbrl.formulaOutputInstance]))
+        for modelXbrl in [self.modelManager.modelXbrl] + getattr(self.modelManager.modelXbrl, "supplementalModelXbrls", []):
+            priorOutputInstance = modelXbrl.formulaOutputInstance
+            modelXbrl.formulaOutputInstance = None # prevent closing on background thread by validateFormula
+            try:
+                Validate.validate(modelXbrl)
+            except Exception as err:
+                self.addToLog(_("[exception] Validation exception: {0} at {1}").format(
+                               err,
+                               traceback.format_tb(sys.exc_info()[2])))
+            self.addToLog(format_string(self.modelManager.locale,
+                                        _("validated in %.2f secs"),
+                                        time.time() - startedAt))
+            if not modelXbrl.isClosed and (priorOutputInstance or modelXbrl.formulaOutputInstance):
+                self.uiThreadQueue.put((self.showFormulaOutputInstance, [priorOutputInstance, modelXbrl.formulaOutputInstance]))
 
         self.uiThreadQueue.put((self.logSelect, []))
 

--- a/arelle/plugin/validate/EFM/__init__.py
+++ b/arelle/plugin/validate/EFM/__init__.py
@@ -578,7 +578,7 @@ def testcaseVariationXbrlValidated(testcaseModelXbrl, instanceModelXbrl, *args, 
     if (hasattr(modelManager, "efmFiling") and
         instanceModelXbrl.modelDocument.type in (Type.INSTANCE, Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET)):
         efmFiling = modelManager.efmFiling
-        _report = efmFiling.getReport(modelXbrl)
+        _report = efmFiling.getReport(instanceModelXbrl)
         if _report is not None: # HF TESTING: not (options.abortOnMajorError and len(modelXbrl.errors) > 0):
             for pluginXbrlMethod in pluginClassMethods("EdgarRenderer.Xbrl.Run"):
                 pluginXbrlMethod(modelManager.cntlr, efmFiling.options, instanceModelXbrl, efmFiling, _report)


### PR DESCRIPTION
#### Reason for change
Zip of files for EDGAR filing with multiple Inline XBRL docs which compose more than one IXDS weren't identifying and isolating the separate IXDSes.  Same issue for multi-target inline files in flat zip, to isolate instances for each target.

#### Description of change
Enhance CmdLine processing to consider supplemental XBRL instances gleaned from separation of IXDSes in EDGAR submission and additional targets in IXDS docs.

#### Steps to Test
Verify that prior operation with CmdLine using json IXDS arguments and GUI operation are still behaving.

**review**:
@Arelle/arelle
