### PR TITLE
Fix Arelle startup crash on missing validation plugin

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -30,7 +30,7 @@ import tkinter.simpledialog
 from arelle.Locale import format_string, setApplicationLocale
 from arelle.CntlrWinTooltip import ToolTip
 from arelle import XbrlConst
-from arelle.PluginManager import pluginClassMethods, prunePlugins
+from arelle.PluginManager import pluginClassMethods
 from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlCalcs import ValidateCalcsMode as CalcsMode
 from arelle.Version import copyrightLabel
@@ -90,8 +90,6 @@ class CntlrWinMain (Cntlr.Cntlr):
             toolbarButtonPadding = 4
 
         tkinter.CallWrapper = TkinterCallWrapper
-
-        prunePlugins(self)
 
         imgpath = self.imagesDir + os.sep
 

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -67,6 +67,9 @@ DOCUMENTATION_URL = "https://arelle.readthedocs.io/"
 class CntlrWinMain (Cntlr.Cntlr):
 
     def __init__(self, parent):
+        # Background processes communicate with UI thread through this queue
+        # Prepare before calling super so messages encountered during initialization can be queued for logging
+        self.uiThreadQueue = queue.Queue()
         super(CntlrWinMain, self).__init__(hasGui=True)
         self.parent = parent
         self.filename = None
@@ -75,10 +78,6 @@ class CntlrWinMain (Cntlr.Cntlr):
         localeSetupMessage = self.modelManager.setLocale() # set locale before GUI for menu strings, pass any msg to logger after log pane starts up
         self.labelLang = overrideLang if overrideLang else self.modelManager.defaultLang
         self.data = {}
-
-        # Background processes communicate with UI thread through this queue
-        # Prepare early so messages encountered during initialization can be queued for logging
-        self.uiThreadQueue = queue.Queue()
 
         if self.isMac: # mac Python fonts bigger than other apps (terminal, text edit, Word), and to windows Arelle
             _defaultFont = tkFont.nametofont("TkDefaultFont") # label, status bar, treegrid


### PR DESCRIPTION
#### Reason for change
The prior call to prune plugins occurs after plugin hooks can be potentially called by the cntrl constructor. In particular, if a validation plugin is removed it will throw an exception and crash Arelle before the call to prune plugins is made.

#### Description of change
Handle pruning and migration (to pip) directly within the module refresh.

#### Steps to Test
1. Using a system installed frozen version of Arelle
	1. enable `ixbrl-viewer`
	2. enable `validate/GFM`
	3. enable `xbrlDB`
4. Using this branch
	1. Delete the `validate/GFM` plugin directory
	2. Within the arelle directory pip install a local version of `ixbrl-viewer` (`pip install -e ../ixbrl-viewer`)
	4. Launch Arelle from source (`python arelleGUI.pyw`)
	5. Confirm message in log that `validate/GFM` plugin is missing and was removed
	6. Verify pip installed `ixbrl-viewer` and built-in `xbrlDB` plugin are still enabled

**review**:
@Arelle/arelle
