### PR TITLE
Update BR-KVK-4.17 to fire on the aggragate total between previous year and current year

### DIFF
--- a/arelle/plugin/validate/NL/rules/br_kvk.py
+++ b/arelle/plugin/validate/NL/rules/br_kvk.py
@@ -305,26 +305,18 @@ def rule_br_kvk_4_17(
     BR-KVK-4.17: The current and previous financial reporting period MUST be less than 2 years.
     """
     modelXbrl = val.modelXbrl
-    periodStart = _getReportingPeriodDateValue(modelXbrl, pluginData.financialReportingPeriodCurrentStartDateQn)
-    periodEnd = _getReportingPeriodDateValue(modelXbrl, pluginData.financialReportingPeriodCurrentEndDateQn)
-    previousPeriodStart = _getReportingPeriodDateValue(modelXbrl, pluginData.financialReportingPeriodPreviousStartDateQn)
-    previousPeriodEnd = _getReportingPeriodDateValue(modelXbrl, pluginData.financialReportingPeriodPreviousEndDateQn)
-    errors = dict()
-    if periodStart and periodEnd:
-        if periodStart >= periodEnd + relativedelta.relativedelta(years=+2):
-            errors.update({'current': [periodStart, periodEnd]})
-    if previousPeriodStart and previousPeriodEnd:
-        if previousPeriodStart >= previousPeriodEnd + relativedelta.relativedelta(years=+2):
-            errors.update({'previous': [previousPeriodStart, previousPeriodEnd]})
-    for period, dates in errors.items():
-        yield Validation.error(
-            codes='NL.BR-KVK-4.17',
-            msg=_('The %(period)s financial reporting period is not shorter than 2 years. '
-                  'Period Start: %(start)s  Period End: %(end)s '),
-            period=period,
-            start=dates[0],
-            end=dates[1]
-        )
+    current_period_end = _getReportingPeriodDateValue(modelXbrl, pluginData.financialReportingPeriodCurrentEndDateQn)
+    previous_period_start = _getReportingPeriodDateValue(modelXbrl, pluginData.financialReportingPeriodPreviousStartDateQn)
+    if current_period_end is not None and previous_period_start is not None:
+        delta = relativedelta.relativedelta(current_period_end, previous_period_start)
+        if (delta.years == 2 and (delta.months > 0 or delta.days > 0)) or delta.years > 2:
+            yield Validation.error(
+                codes='NL.BR-KVK-4.17',
+                msg=_('The current and previous financial reporting period MUST be less than 2 years. '
+                      'Previous Period Start: %(start)s  Current Period End: %(end)s '),
+                start=previous_period_start,
+                end=current_period_end
+            )
 
 
 @validation(

--- a/tests/resources/conformance_suites/nl_nt16/br_kvk/4-17-invalid-period.xbrl
+++ b/tests/resources/conformance_suites/nl_nt16/br_kvk/4-17-invalid-period.xbrl
@@ -2,23 +2,15 @@
 <xbrl
   xml:lang="en"
   xmlns="http://www.xbrl.org/2003/instance"
-  xmlns:bzk-wnt-i="http://www.nltaxonomie.nl/nt16/bzk/20211208/dictionary/bzk-wnt-data"
   xmlns:iso4217="http://www.xbrl.org/2003/iso4217"
   xmlns:jenv-bw2-dim="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-axes"
   xmlns:jenv-bw2-dm="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-domains"
   xmlns:jenv-bw2-i="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-data"
-  xmlns:kvk-i="http://www.nltaxonomie.nl/nt16/kvk/20211208/dictionary/kvk-data"
   xmlns:link="http://www.xbrl.org/2003/linkbase"
-  xmlns:nl-cd="http://www.nltaxonomie.nl/nt16/sbr/20210301/dictionary/nl-common-data"
-  xmlns:rj-dim="http://www.nltaxonomie.nl/nt16/rj/20211208/dictionary/rj-axes"
-  xmlns:rj-dm="http://www.nltaxonomie.nl/nt16/rj/20211208/dictionary/rj-domains"
-  xmlns:rj-i="http://www.nltaxonomie.nl/nt16/rj/20211208/dictionary/rj-data"
   xmlns:xbrldi="http://xbrl.org/2006/xbrldi"
   xmlns:xbrli="http://www.xbrl.org/2003/instance"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-    <link:schemaRef
-      xlink:href="http://www.nltaxonomie.nl/nt16/kvk/20211208/entrypoints/kvk-rpt-jaarverantwoording-2021-nlgaap-klein-publicatiestukken.xsd"
-      xlink:type="simple"/>
+  	<link:schemaRef xlink:href="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-data.xsd" xlink:type="simple"/>
     <context id="ctx-1">
         <entity>
             <identifier scheme="http://www.kvk.nl/kvk-id">12345678</identifier>
@@ -28,12 +20,11 @@
             <endDate>2022-01-01</endDate>
         </period>
     </context>
-    <nl-cd:LegalEntityName contextRef="ctx-1" xml:lang="en">Testing Entity Name</nl-cd:LegalEntityName>
     <jenv-bw2-i:LegalEntityRegisteredOffice contextRef="ctx-1" xml:lang="en">Address</jenv-bw2-i:LegalEntityRegisteredOffice>
     <jenv-bw2-i:FinancialReportingPeriodCurrentStartDate contextRef="ctx-1">2021-01-01</jenv-bw2-i:FinancialReportingPeriodCurrentStartDate>
-    <jenv-bw2-i:FinancialReportingPeriodCurrentEndDate contextRef="ctx-1">2018-12-31</jenv-bw2-i:FinancialReportingPeriodCurrentEndDate>
-    <jenv-bw2-i:FinancialReportingPeriodPreviousStartDate contextRef="ctx-1">2018-01-01</jenv-bw2-i:FinancialReportingPeriodPreviousStartDate>
-    <jenv-bw2-i:FinancialReportingPeriodPreviousEndDate contextRef="ctx-1">2011-12-31</jenv-bw2-i:FinancialReportingPeriodPreviousEndDate>
+    <jenv-bw2-i:FinancialReportingPeriodCurrentEndDate contextRef="ctx-1">2021-12-31</jenv-bw2-i:FinancialReportingPeriodCurrentEndDate>
+    <jenv-bw2-i:FinancialReportingPeriodPreviousStartDate contextRef="ctx-1">2019-01-01</jenv-bw2-i:FinancialReportingPeriodPreviousStartDate>
+    <jenv-bw2-i:FinancialReportingPeriodPreviousEndDate contextRef="ctx-1">2019-12-31</jenv-bw2-i:FinancialReportingPeriodPreviousEndDate>
     <jenv-bw2-i:DocumentAdoptionDate contextRef="ctx-1">2022-01-01</jenv-bw2-i:DocumentAdoptionDate>
     <jenv-bw2-i:DocumentAdoptionStatus contextRef="ctx-1">Ja</jenv-bw2-i:DocumentAdoptionStatus>
     <xbrli:unit id="usd">

--- a/tests/resources/conformance_suites/nl_nt17/br_kvk/4-17-invalid-period.xbrl
+++ b/tests/resources/conformance_suites/nl_nt17/br_kvk/4-17-invalid-period.xbrl
@@ -2,23 +2,15 @@
 <xbrl
   xml:lang="en"
   xmlns="http://www.xbrl.org/2003/instance"
-  xmlns:bzk-wnt-i="http://www.nltaxonomie.nl/nt17/bzk/20221214/dictionary/bzk-wnt-data"
   xmlns:iso4217="http://www.xbrl.org/2003/iso4217"
   xmlns:jenv-bw2-dim="http://www.nltaxonomie.nl/nt17/jenv/20221214/dictionary/jenv-bw2-axes"
   xmlns:jenv-bw2-dm="http://www.nltaxonomie.nl/nt17/jenv/20221214/dictionary/jenv-bw2-domains"
   xmlns:jenv-bw2-i="http://www.nltaxonomie.nl/nt17/jenv/20221214/dictionary/jenv-bw2-data"
-  xmlns:kvk-i="http://www.nltaxonomie.nl/nt17/kvk/20221214/dictionary/kvk-data"
   xmlns:link="http://www.xbrl.org/2003/linkbase"
-  xmlns:nl-cd="http://www.nltaxonomie.nl/nt17/sbr/20220301/dictionary/nl-common-data"
-  xmlns:rj-dim="http://www.nltaxonomie.nl/nt17/rj/20221214/dictionary/rj-axes"
-  xmlns:rj-dm="http://www.nltaxonomie.nl/nt17/rj/20221214/dictionary/rj-domains"
-  xmlns:rj-i="http://www.nltaxonomie.nl/nt17/rj/20221214/dictionary/rj-data"
   xmlns:xbrldi="http://xbrl.org/2006/xbrldi"
   xmlns:xbrli="http://www.xbrl.org/2003/instance"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-    <link:schemaRef
-      xlink:href="http://www.nltaxonomie.nl/nt17/kvk/20221214/entrypoints/kvk-rpt-jaarverantwoording-2022-nlgaap-klein-publicatiestukken.xsd"
-      xlink:type="simple"/>
+  	<link:schemaRef xlink:href="http://www.nltaxonomie.nl/nt17/jenv/20221214/dictionary/jenv-bw2-data.xsd" xlink:type="simple"/>
     <context id="ctx-1">
         <entity>
             <identifier scheme="http://www.kvk.nl/kvk-id">12345678</identifier>
@@ -28,12 +20,11 @@
             <endDate>2021-12-31</endDate>
         </period>
     </context>
-    <nl-cd:LegalEntityName contextRef="ctx-1" xml:lang="en">Testing Entity Name</nl-cd:LegalEntityName>
     <jenv-bw2-i:LegalEntityRegisteredOffice contextRef="ctx-1" xml:lang="en">Address</jenv-bw2-i:LegalEntityRegisteredOffice>
     <jenv-bw2-i:FinancialReportingPeriodCurrentStartDate contextRef="ctx-1">2021-01-01</jenv-bw2-i:FinancialReportingPeriodCurrentStartDate>
-    <jenv-bw2-i:FinancialReportingPeriodCurrentEndDate contextRef="ctx-1">2018-12-31</jenv-bw2-i:FinancialReportingPeriodCurrentEndDate>
-    <jenv-bw2-i:FinancialReportingPeriodPreviousStartDate contextRef="ctx-1">2018-01-01</jenv-bw2-i:FinancialReportingPeriodPreviousStartDate>
-    <jenv-bw2-i:FinancialReportingPeriodPreviousEndDate contextRef="ctx-1">2011-12-31</jenv-bw2-i:FinancialReportingPeriodPreviousEndDate>
+    <jenv-bw2-i:FinancialReportingPeriodCurrentEndDate contextRef="ctx-1">2021-12-31</jenv-bw2-i:FinancialReportingPeriodCurrentEndDate>
+    <jenv-bw2-i:FinancialReportingPeriodPreviousStartDate contextRef="ctx-1">2019-01-01</jenv-bw2-i:FinancialReportingPeriodPreviousStartDate>
+    <jenv-bw2-i:FinancialReportingPeriodPreviousEndDate contextRef="ctx-1">2019-12-31</jenv-bw2-i:FinancialReportingPeriodPreviousEndDate>
     <jenv-bw2-i:DocumentAdoptionDate contextRef="ctx-1">2022-01-01</jenv-bw2-i:DocumentAdoptionDate>
     <jenv-bw2-i:DocumentAdoptionStatus contextRef="ctx-1">Ja</jenv-bw2-i:DocumentAdoptionStatus>
     <xbrli:unit id="usd">


### PR DESCRIPTION
#### Reason for change
BR-KVK-4.17 is checking the current and previous periods independently rather than the aggregate. Updated the rule so that the start of the previous period to the end of the current period is no more than 2 years.

#### Steps to Test
CI

**review**:
@Arelle/arelle
