### PR TITLE
Load all targets for cmd line IXDS

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1017,10 +1017,6 @@ class CntlrCmdLine(Cntlr.Cntlr):
                             startedAt = time.time()
                             if options.formulaAction: # don't automatically run formulas
                                 modelXbrl.hasFormulae = False
-                            self.addToLog(format_string(self.modelManager.locale,
-                                                        _("validated in %.2f secs"),
-                                                        time.time() - startedAt),
-                                                        messageCode="info", file=self.entrypointFile)
                             from arelle import Validate
                             Validate.validate(modelXbrl)
                             if options.formulaAction: # restore setting

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1017,6 +1017,10 @@ class CntlrCmdLine(Cntlr.Cntlr):
                             startedAt = time.time()
                             if options.formulaAction: # don't automatically run formulas
                                 modelXbrl.hasFormulae = False
+                            self.addToLog(format_string(self.modelManager.locale,
+                                                        _("validated in %.2f secs"),
+                                                        time.time() - startedAt),
+                                                        messageCode="info", file=self.entrypointFile)
                             from arelle import Validate
                             Validate.validate(modelXbrl)
                             if options.formulaAction: # restore setting

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -1609,6 +1609,19 @@ def inlineIxdsDiscover(modelXbrl, modelIxdsDocument, setTargetModelXbrl=False):
                             for _target in sourceFactTargets:
                                 targetRoleUris[_target].add(footnoteRole)
 
+    allContextRefs = set()
+    targetsShareContexts = False
+    for contextRefs in factTargetContextRefs.values():
+        if contextRefs & allContextRefs:
+            targetsShareContexts = True
+        allContextRefs |= contextRefs
+    allUnitRefs = set()
+    targetsShareUnits = False
+    for unitRefs in factTargetUnitRefs.values():
+        if unitRefs & allUnitRefs:
+            targetsShareUnits = True
+        allUnitRefs |= unitRefs
+
     # discovery of contexts, units and roles which are used by target document
     for htmlElement in modelXbrl.ixdsHtmlElements:
         mdlDoc = htmlElement.modelDocument
@@ -1616,9 +1629,7 @@ def inlineIxdsDiscover(modelXbrl, modelIxdsDocument, setTargetModelXbrl=False):
 
         for inlineElement in htmlElement.iterdescendants(tag=ixNStag + "resources"):
             contextRefs = factTargetContextRefs[ixdsTarget]
-            allContextRefs = set.union(*factTargetContextRefs.values())
             unitRefs = factTargetUnitRefs[ixdsTarget]
-            allUnitRefs = set.union(*factTargetUnitRefs.values())
             for elt in inlineElement.iterchildren("{http://www.xbrl.org/2003/instance}context"):
                 id = elt.get("id")
                 if id in contextRefs or (not ixdsTarget and id not in allContextRefs):

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -1458,7 +1458,7 @@ class ModelDocument:
 # inline document set level compilation
 # modelIxdsDocument is an inlineDocumentSet or entry inline document (if not a document set)
 #   note that multi-target and multi-instance facts may have html elements belonging to primary ixds instead of this instance ixds
-def inlineIxdsDiscover(modelXbrl, modelIxdsDocument):
+def inlineIxdsDiscover(modelXbrl, modelIxdsDocument, setTargetModelXbrl=False):
     for pluginMethod in pluginClassMethods("ModelDocument.SelectIxdsTarget"):
         pluginMethod(modelXbrl, modelIxdsDocument)
     # extract for a single target document
@@ -1751,6 +1751,8 @@ def inlineIxdsDiscover(modelXbrl, modelIxdsDocument):
                 checkTupleIxDescendants(tupleFact, childElt)
 
     def addItemFactToTarget(modelInlineFact):
+        if setTargetModelXbrl:
+            modelInlineFact.targetModelXbrl = modelXbrl # fact's owning IXDS overrides initial loading document IXDS
         if modelInlineFact.concept is None:
                 modelXbrl.error(ixMsgCode("missingReferences", modelInlineFact, name="references", sect="validation"),
                                 _("Instance fact missing schema definition: %(qname)s of Inline Element %(localName)s"),
@@ -2079,6 +2081,17 @@ def inlineIxdsDiscover(modelXbrl, modelIxdsDocument):
     if ixdsTarget in modelXbrl.ixTargetRootElements:
         modelIxdsDocument.targetXbrlRootElement = modelXbrl.ixTargetRootElements[ixdsTarget]
         modelIxdsDocument.targetXbrlElementTree = PrototypeElementTree(modelIxdsDocument.targetXbrlRootElement)
+
+    # set dimension and unit targetModelXbrl to first DTS defining the concept/measure QNames
+    for cntx in modelXbrl.contexts.values():
+        for dim in cntx.qnameDims.values():
+            if not hasattr(dim, "targetModelXbrl"):
+                dim.targetModelXbrl = modelXbrl
+                if hasattr(dim, "_dimension") and dim._dimension is None:
+                    del dim._dimension
+    for unit in modelXbrl.units.values():
+        if not hasattr(unit, "targetModelXbrl"):
+            unit.targetModelXbrl = modelXbrl
 
     for pluginMethod in pluginClassMethods("ModelDocument.IxdsTargetDiscovered"):
         pluginMethod(modelXbrl, modelIxdsDocument)

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -1609,18 +1609,10 @@ def inlineIxdsDiscover(modelXbrl, modelIxdsDocument, setTargetModelXbrl=False):
                             for _target in sourceFactTargets:
                                 targetRoleUris[_target].add(footnoteRole)
 
-    allContextRefs = set()
-    targetsShareContexts = False
-    for contextRefs in factTargetContextRefs.values():
-        if contextRefs & allContextRefs:
-            targetsShareContexts = True
-        allContextRefs |= contextRefs
-    allUnitRefs = set()
-    targetsShareUnits = False
-    for unitRefs in factTargetUnitRefs.values():
-        if unitRefs & allUnitRefs:
-            targetsShareUnits = True
-        allUnitRefs |= unitRefs
+    contextRefs = factTargetContextRefs[ixdsTarget]
+    unitRefs = factTargetUnitRefs[ixdsTarget]
+    allContextRefs = set.union(*factTargetContextRefs.values())
+    allUnitRefs = set.union(*factTargetUnitRefs.values())
 
     # discovery of contexts, units and roles which are used by target document
     for htmlElement in modelXbrl.ixdsHtmlElements:
@@ -1628,8 +1620,6 @@ def inlineIxdsDiscover(modelXbrl, modelIxdsDocument, setTargetModelXbrl=False):
         ixNStag = mdlDoc.ixNStag
 
         for inlineElement in htmlElement.iterdescendants(tag=ixNStag + "resources"):
-            contextRefs = factTargetContextRefs[ixdsTarget]
-            unitRefs = factTargetUnitRefs[ixdsTarget]
             for elt in inlineElement.iterchildren("{http://www.xbrl.org/2003/instance}context"):
                 id = elt.get("id")
                 if id in contextRefs or (not ixdsTarget and id not in allContextRefs):

--- a/arelle/ModelFormulaObject.py
+++ b/arelle/ModelFormulaObject.py
@@ -1234,7 +1234,7 @@ class ModelConceptDataType(ModelConceptFilterWithQnameExpression):
         return set(fact for fact in facts
                    for qn in (self.evalQname(xpCtx,fact),)
                    for c in (fact.concept,)
-                   if cmplmt ^ (c.typeQname == qn or (notStrict and c.type.isDerivedFrom(qn))))
+                   if c is not None and cmplmt ^ (c.typeQname == qn or (notStrict and c.type.isDerivedFrom(qn))))
 
     @property
     def propertyView(self):
@@ -1264,7 +1264,7 @@ class ModelConceptSubstitutionGroup(ModelConceptFilterWithQnameExpression):
             return set(fact for fact in facts
                        if cmplmt ^ (fact.concept.substitutionGroupQname == self.evalQname(xpCtx,fact)))
         return set(fact for fact in facts
-                   if cmplmt ^ fact.concept.substitutesForQname(self.evalQname(xpCtx,fact)))
+                   if fact.concept is not None and cmplmt ^ fact.concept.substitutesForQname(self.evalQname(xpCtx,fact)))
 
     @property
     def propertyView(self):

--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -145,6 +145,8 @@ class ModelObject(ElementBase):
 
     @property
     def modelXbrl(self) -> ModelXbrl | None:
+        if hasattr(self, "targetModelXbrl"):
+            return self.targetModelXbrl
         modelDocument = getattr(self, "modelDocument", None)
         return modelDocument.modelXbrl if modelDocument is not None else None
 

--- a/arelle/ModelObject.py
+++ b/arelle/ModelObject.py
@@ -116,6 +116,7 @@ class ModelObject(ElementBase):
     xValueError: Exception | None
     xValid: int
     xlinkLabel: str
+    targetModelXbrl: ModelXbrl
 
     def _init(self) -> None:
         self.isChanged = False

--- a/arelle/ModelRelationshipSet.py
+++ b/arelle/ModelRelationshipSet.py
@@ -249,12 +249,16 @@ class ModelRelationshipSet:
         return self.loadModelRelationshipsFrom()
 
     def fromModelObject(self, modelFrom) -> list[ModelRelationship]:
+        if getattr(self.modelXbrl, "isSupplementalIxdsTarget", False) and modelFrom is not None and modelFrom.modelXbrl != self.modelXbrl:
+            modelFrom = self.modelXbrl.qnameConcepts.get(modelFrom.qname, None)
         return self.loadModelRelationshipsFrom().get(modelFrom, [])
 
     def toModelObjects(self) -> dict[Any, list[ModelRelationship]]:
         return self.loadModelRelationshipsTo()
 
     def toModelObject(self, modelTo) -> list[ModelRelationship]:
+        if getattr(self.modelXbrl, "isSupplementalIxdsTarget", False) and modelTo is not None and modelTo.modelXbrl != self.modelXbrl:
+            modelFrom = self.modelXbrl.qnameConcepts.get(modelTo.qname, None)
         return self.loadModelRelationshipsTo().get(modelTo, [])
 
     def fromToModelObjects(self, modelFrom, modelTo, checkBothDirections=False) -> list[ModelRelationship]:
@@ -280,6 +284,11 @@ class ModelRelationshipSet:
     # if only modelFrom, determine that there are relationships present of specified axis
     def isRelated(self, modelFrom, axis, modelTo=None, visited=None, isDRS=False): # either model concept or qname
         assert self.modelXbrl is not None
+        if getattr(self.modelXbrl, "isSupplementalIxdsTarget", False):
+            if modelFrom is not None and modelFrom.modelXbrl != self.modelXbrl:
+                modelFrom = modelFrom.qname
+            if modelTo is not None and modelTo.modelXbrl != self.modelXbrl:
+                modelTo = modelTo.qname
         if isinstance(modelFrom,ModelValue.QName):
             modelFrom = self.modelXbrl.qnameConcepts.get(modelFrom) # fails if None
         if isinstance(modelTo,ModelValue.QName):

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -803,7 +803,7 @@ class ModelXbrl:
             self._factsByDatatype[notStrict, typeQname] = fbdt = set()
             for f in self.factsInInstance:
                 c = f.concept
-                if c.typeQname == typeQname or (notStrict and c.type.isDerivedFrom(typeQname)):
+                if c is not None and (c.typeQname == typeQname or (notStrict and c.type.isDerivedFrom(typeQname))):
                     fbdt.add(f)
             return fbdt
 

--- a/arelle/formula/XPathContext.py
+++ b/arelle/formula/XPathContext.py
@@ -858,7 +858,7 @@ class XPathContext:
         if isinstance(x, ModelFact):
             if x.isTuple:
                 raise XPathException(p, 'err:FOTY0012', _('Atomizing tuple {0} that does not have a typed value').format(x))
-            if x.isNil:
+            if x.isNil or x.concept is None:
                 return []
             baseXsdType = x.concept.baseXsdType
             v = x.value  # resolves default value

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -188,6 +188,7 @@ def inlineXbrlDocumentSetLoader(modelXbrl, normalizedUri, filepath, isEntry=Fals
         if hasattr(modelXbrl, "ixdsHtmlElements"): # has any inline root elements
             if ixdocs:
                 loadDTS(modelXbrl, ixdocset)
+                modelXbrl.isSupplementalIxdsTarget = True
             inlineIxdsDiscover(modelXbrl, ixdocset, bool(ixdocs)) # compile cross-document IXDS references
             return ixdocset
     return None

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -770,10 +770,12 @@ def selectTargetDocument(modelXbrl, modelIxdsDocument):
                 dlg = TargetChoiceDialog(modelXbrl.modelManager.cntlr.parent, _targets)
                 _target = dlg.selection
         else:
+            # load all targets (supplemental are accessed from first via modelXbrl.loadedModelXbrls)
+            modelXbrl.targetIXDSesToLoad.insert(0, [_targets[1:],modelXbrl.ixdsHtmlElements])
             _target = _targets[0]
-            modelXbrl.warning("arelle:unspecifiedTargetDocument",
-                              _("Target document not specified, loading %(target)s, found targets %(targets)s"),
-                              modelObject=modelXbrl, target=_target, targets=_targets)
+            #modelXbrl.warning("arelle:unspecifiedTargetDocument",
+            #                  _("Target document not specified, loading %(target)s, found targets %(targets)s"),
+            #                  modelObject=modelXbrl, target=_target, targets=_targets)
         modelXbrl.ixdsTarget = None if _target == DEFAULT_TARGET else _target or None
         # load referenced schemas and linkbases (before validating inline HTML
         loadDTS(modelXbrl, modelIxdsDocument)

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -172,7 +172,6 @@ def inlineXbrlDocumentSetLoader(modelXbrl, normalizedUri, filepath, isEntry=Fals
             # load ix document
             if ixdocs:
                 ixdoc = ixdocs[i]
-                ixdoc.modelXbrl = modelXbrl # TODO: this won't work for multi-targets sharing same html
             else:
                 ixdoc = load(modelXbrl, elt.text, referringElement=elt, isDiscovered=True)
             if ixdoc is not None:
@@ -194,7 +193,7 @@ def inlineXbrlDocumentSetLoader(modelXbrl, normalizedUri, filepath, isEntry=Fals
         if hasattr(modelXbrl, "ixdsHtmlElements"): # has any inline root elements
             if ixdocs:
                 loadDTS(modelXbrl, ixdocset)
-            inlineIxdsDiscover(modelXbrl, ixdocset) # compile cross-document IXDS references
+            inlineIxdsDiscover(modelXbrl, ixdocset, bool(ixdocs)) # compile cross-document IXDS references
             for referencedDoc in ixdocset.referencesDocument.keys():
                 if referencedDoc.type == Type.SCHEMA:
                     ixdocset.targetDocumentSchemaRefs.add(ixdoc.relativeUri(referencedDoc.uri))


### PR DESCRIPTION
#### Reason for change
Loading of a multi-target IXDS by command line did not load all targests as now done with GUI

#### Description of change
Load multiple IXDS targets as now done with GUI

#### Steps to Test
Verify that primary IXDS modelXbrl.supplementalModelXbrls identifies the supplemental loaded targets.

Commit [e176311](https://github.com/Arelle/Arelle/pull/973/commits/e1763110ecf41525fa873c049969cc1c83503c30) needs either code review or a test case, wherein the secondary target's DTS has same (shared) dimensions with default target's DTS but with different labels and references discovered by secondary target's DTS, or even a different dimensional structure. 

**review**:
@Arelle/arelle
