### PR TITLE
Python 3.12 Support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,17 +17,10 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "astroid"
-        versions:
-          - ">=3"
       - dependency-name: "RDFLib"
         versions:
           - ">=6"
       - dependency-name: "cx_Freeze"
-      - dependency-name: "matplotlib"
-        versions:
-          - "3.7.2"
-      - dependency-name: "packaging"
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           cache: 'pip'
           check-latest: true
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,7 +22,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.11.5'
+        default: '3.11.7'
         description: 'Python version to use'
         required: false
         type: string
@@ -58,7 +58,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.11.5'
+        default: '3.11.7'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -121,11 +121,7 @@ jobs:
           echo "artifact_versioned_name=arelle-macos-${{ env.BUILD_VERSION }}.dmg" >> $GITHUB_OUTPUT
           echo "uploaded_artifact_name=macos distribution" >> $GITHUB_OUTPUT
           echo "DMG_BUILD_ARTIFACT_PATH=dist_dmg/arelle-macos-${{ env.BUILD_VERSION }}.dmg" >> $GITHUB_ENV
-      - name: Build app
-        run: ./scripts/buildMacDist.sh
-      - name: Remove git directories
-        run: find build/Arelle.app/Contents -name .git -exec rm -fR {} \;
-      - name: Install certificate and sign code
+      - name: Install certificate
         env:
           MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
           MAC_BUILD_CERTIFICATE_NAME: 'Developer ID Application: Workiva Inc. (5ZF66U48UD)'
@@ -149,49 +145,10 @@ jobs:
           security find-identity
           security find-certificate -a -p | openssl x509 -subject -noout
           echo MAC_BUILD_CERTIFICATE_NAME="$MAC_BUILD_CERTIFICATE_NAME"
-
-          # Move python modules to Resources
-          for f in archive config doc examples images locale plugin scripts Tktable2.11 ;
-            do
-              mv build/Arelle.app/Contents/MacOS/$f build/Arelle.app/Contents/Resources/
-            done
-          mkdir build/Arelle.app/Contents/Resources/lib
-          ls build/Arelle.app/Contents/MacOS/lib | \
-            fgrep -vx --regexp={Python,encodings,codecs,collections,importlib,matplotlib,re,zlib,library.zip} | \
-            grep -v '\.so$' | \
-            while IFS= read -r f
-            do
-              mv build/Arelle.app/Contents/MacOS/lib/$f build/Arelle.app/Contents/Resources/lib/
-            done
-
-          # Code signing (*.so, *.dylib, etc)
-          for i in $(find build/Arelle.app -type f -perm +111 -exec file "{}" \; | \
-            grep -v "(for architecture" | \
-            grep -v -E "^- Mach-O" | \
-            grep -E "Mach-O executable|Mach-O 64-bit executable|Mach-O 64-bit bundle|Mach-O 64-bit dynamically linked shared library" | \
-            awk -F":" '{print $1}' | \
-            uniq)
-          do
-            codesign --deep --force --verify --verbose --timestamp \
-            --options runtime \
-            --sign "$MAC_BUILD_CERTIFICATE_NAME" \
-            "$i"
-          done
-
-          find build/Arelle.app -type f -name "*.dylib*" -exec \
-            codesign --deep --force --verify --verbose --timestamp \
-            --options runtime \
-            --sign "$MAC_BUILD_CERTIFICATE_NAME" \
-            {} \;
-
-          # Create symlinks (some libraries can't be code signed in /MacOS but need to be found within it)
-          ln -s ../../Resources/lib/tkinter build/Arelle.app/Contents/MacOS/lib/tkinter
-          # Symlink plugins folder so /Resources/plugin is found when searching in default /MacOS/plugin location
-          ln -s ../Resources/plugin build/Arelle.app/Contents/MacOS/plugin
-
-          # Executable code signing (slightly redundant, but ensures all necessary files are code signed)
-          codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleCmdLine
-          codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleGUI
+      - name: Build app
+        run: ./scripts/buildMacDist.sh
+      - name: Remove git directories
+        run: find build/Arelle.app/Contents -name .git -exec rm -fR {} \;
       - name: Notarize app
         env:
           USERNAME: ${{ secrets.MAC_BUILD_NOTARIZATION_USERNAME }}

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -41,7 +41,7 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
-          - '3.11'
+          - '3.12'
         test: ${{ fromJson(needs.find-tests.outputs.matrix) }}
         include:
           - os: windows-2022
@@ -89,6 +89,19 @@ jobs:
               name: xbrl_2_1
           - os: macos-12
             python-version: '3.11'
+            test:
+              name: xbrl_2_1
+          - os: ubuntu-22.04
+            python-version: '3.11'
+            test:
+              name: xbrl_2_1
+
+          - os: windows-2022
+            python-version: '3.12'
+            test:
+              name: xbrl_2_1
+          - os: macos-12
+            python-version: '3.12'
             test:
               name: xbrl_2_1
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,14 +4,14 @@ on:
   workflow_call:
     inputs:
       python_version:
-        default: '3.11'
+        default: '3.12'
         description: 'Python version to use'
         required: false
         type: string
   workflow_dispatch:
     inputs:
       python_version:
-        default: '3.11'
+        default: '3.12'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.1.1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 python:
   install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,12 +68,12 @@ Here's how to set up your environment:
   2. Install a supported version of Python.
     For example, 
     
-    pyenv install 3.11.5
+    pyenv install 3.12.0
 
   3. Create a virtual env using the Python version you just installed.
     For example, 
 
-    PYENV_VERSION=3.11.5 pyenv exec python -m venv venv
+    PYENV_VERSION=3.12.0 pyenv exec python -m venv venv
   4. Activate your environment: 
     
     source venv/bin/activate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.6
+FROM python:3.12.0
 
 WORKDIR /usr/src/app
 

--- a/arelle/CntlrWebMain.py
+++ b/arelle/CntlrWebMain.py
@@ -19,7 +19,7 @@ POST = 'POST'
 
 def startWebserver(_cntlr, options):
     """Called once from main program in CmtlrCmdLine to initiate web server on specified local port.
-    To test WebServer run from source in IIS, use an entry like this: c:\python33\python.exe c:\\users\\myname\\mySourceFolder\\arelleCmdLine.py %s
+    To test WebServer run from source in IIS, use an entry like this: c:\\python33\\python.exe c:\\users\\myname\\mySourceFolder\\arelleCmdLine.py %s
 
     :param options: OptionParser options from parse_args of main argv arguments (the argument *webserver* provides hostname and port), port being used to startup the webserver on localhost.
     :type options: optparse.Values
@@ -582,7 +582,7 @@ document at c:/a/b/c.xbrl (on local drive) and return structured xml results.</t
 <tr><td style="text-align=right;">Example:</td><td><code>/rest/xbrl/validation?file=c:/a/b/c.xbrl&amp;media=xml</code>: Validate entry instance
 document at c:/a/b/c.xbrl (on local drive) and return structured xml results.</td></tr>
 ''')) +
-_('''
+_(r'''
 <tr><td></td><td>Parameters are optional after "?" character, and are separated by "&amp;" characters,
 as follows:</td></tr>
 <tr><td style="text-indent: 1em;">flavor</td><td><code>standard</code>: XBRL 2.1 and XDT validation.  (If formulas are present they will also be compiled and run.)  (default)
@@ -644,8 +644,8 @@ as follows:</td></tr>
 
 <tr><th colspan="2">Views</th></tr>
 <tr><td>/rest/xbrl/{file}/{view}</td><td>View document at {file}.</td></tr>
-<tr><td>\u00A0</td><td>{file} may be local or web url, and may have "/" characters replaced by ";" characters (but that is not necessary).</td></tr>
-<tr><td>\u00A0</td><td>{view} may be <code>DTS</code>, <code>concepts</code>, <code>pre</code>, <code>table</code>, <code>cal</code>, <code>dim</code>, <code>facts</code>, <code>factTable</code>, <code>formulae</code>, <code>roleTypes</code>, or <code>arcroleTypes</code>.</td></tr>
+<tr><td>&nbsp;</td><td>{file} may be local or web url, and may have "/" characters replaced by ";" characters (but that is not necessary).</td></tr>
+<tr><td>&nbsp;</td><td>{view} may be <code>DTS</code>, <code>concepts</code>, <code>pre</code>, <code>table</code>, <code>cal</code>, <code>dim</code>, <code>facts</code>, <code>factTable</code>, <code>formulae</code>, <code>roleTypes</code>, or <code>arcroleTypes</code>.</td></tr>
 <tr><td style="text-align=right;">Example:</td><td><code>/rest/xbrl/c:/a/b/c.xbrl/dim?media=html</code>: View dimensions of
 document at c:/a/b/c.xbrl (on local drive) and return html result.</td></tr>
 <tr><td>/rest/xbrl/view</td><td>(Alternative syntax) View document, file and view are provided as parameters (see below).</td></tr>

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -392,7 +392,7 @@ class CntlrWinMain (Cntlr.Cntlr):
             w = screenW
             h = screenH
         else:
-            priorGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)",self.config.get('windowGeometry'))
+            priorGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)",self.config.get('windowGeometry'))
             if priorGeometry and priorGeometry.lastindex >= 4:
                 try:
                     w = int(priorGeometry.group(1))

--- a/arelle/DialogAbout.py
+++ b/arelle/DialogAbout.py
@@ -19,7 +19,7 @@ class DialogAbout(Toplevel):
     def __init__(self, parent, title, imageFile, body):
         super(DialogAbout, self).__init__(parent)
         self.parent = parent
-        parentGeometry = re_match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re_match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.transient(self.parent)

--- a/arelle/DialogArcroleGroup.py
+++ b/arelle/DialogArcroleGroup.py
@@ -27,7 +27,7 @@ class DialogArcroleGroup(Toplevel):
         self.mainWin = mainWin
         self.parent = parent
         self.modelXbrl = modelXbrl
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.selectedGroup = None

--- a/arelle/DialogFind.py
+++ b/arelle/DialogFind.py
@@ -54,7 +54,7 @@ class DialogFind(Toplevel):
         self.modelXbrl = None   # set when Find pressed, this blocks next prematurely
         if options is None: options = newFindOptions
         self.options = options
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogW = int(parentGeometry.group(1))
         dialogH = int(parentGeometry.group(2))
         dialogX = int(parentGeometry.group(3))

--- a/arelle/DialogFormulaParameters.py
+++ b/arelle/DialogFormulaParameters.py
@@ -27,7 +27,7 @@ class DialogFormulaParameters(Toplevel):
         super(DialogFormulaParameters, self).__init__(parent)
         self.parent = parent
         self.options = options
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogLanguage.py
+++ b/arelle/DialogLanguage.py
@@ -25,7 +25,7 @@ class DialogLanguage(Toplevel):
         super(DialogLanguage, self).__init__(mainWin.parent)
         self.mainWin = mainWin
         self.parent = mainWin.parent
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.transient(self.parent)

--- a/arelle/DialogNewFactItem.py
+++ b/arelle/DialogNewFactItem.py
@@ -57,7 +57,7 @@ class DialogNewFactItemOptions(Toplevel):
         super(DialogNewFactItemOptions, self).__init__(parent)
         self.parent = parent
         self.options = options
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogOpenArchive.py
+++ b/arelle/DialogOpenArchive.py
@@ -119,7 +119,7 @@ class DialogOpenArchive(Toplevel):
         self.parent = parent
         self.showAltViewButton = showAltViewButton
         self.selectFiles = selectFiles
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogPackageManager.py
+++ b/arelle/DialogPackageManager.py
@@ -47,7 +47,7 @@ class DialogPackageManager(Toplevel):
         self.packagesConfigChanged = False
         self.packageNamesWithNewerFileDates = packageNamesWithNewerFileDates
 
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
 

--- a/arelle/DialogPluginManager.py
+++ b/arelle/DialogPluginManager.py
@@ -60,7 +60,7 @@ class DialogPluginManager(Toplevel):
         self.hostSystemFeaturesChanged = False
         self.modulesWithNewerFileDates = modulesWithNewerFileDates
 
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
 

--- a/arelle/DialogRssWatch.py
+++ b/arelle/DialogRssWatch.py
@@ -48,7 +48,7 @@ class DialogRssWatch(Toplevel):
         super(DialogRssWatch, self).__init__(parent)
         self.parent = parent
         self.options = options
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogURL.py
+++ b/arelle/DialogURL.py
@@ -23,7 +23,7 @@ class DialogURL(Toplevel):
     def __init__(self, parent, url=None, buttonSEC=False, buttonRSS=False):
         super(DialogURL, self).__init__(parent)
         self.parent = parent
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogUserPassword.py
+++ b/arelle/DialogUserPassword.py
@@ -98,7 +98,7 @@ class DialogUserPassword(Toplevel):
                  userLabel=None, passwordLabel=None, hidePassword=True):
         super(DialogUserPassword, self).__init__(parent)
         self.parent = parent
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/ViewWinXml.py
+++ b/arelle/ViewWinXml.py
@@ -35,4 +35,4 @@ class ViewXml(ViewWinList.ViewList):
             import traceback
             Validate.validate(self.modelXbrl)
         except Exception as err:
-            self.modelXbrl.exception("exception", _("Validation exception: \s%(error)s"), error=err, exc_info=True)
+            self.modelXbrl.exception("exception", _(r"Validation exception: \s%(error)s"), error=err, exc_info=True)

--- a/arelle/archive/plugin/objectmaker.py
+++ b/arelle/archive/plugin/objectmaker.py
@@ -95,7 +95,7 @@ def drawDiagram(modelXbrl, diagramFile, diagramNetwork=None, viewDiagram=False):
         if modelObject is not None:
             mdl.attr("node", style="") # white classes
             if isUML:
-                _properties = "".join("+{} {}\l".format(rel.toModelObject.qname.localName, rel.toModelObject.niceType)
+                _properties = "".join(r"+{} {}\l".format(rel.toModelObject.qname.localName, rel.toModelObject.niceType)
                                                         for rel in propertiesRelationshipSet.fromModelObject(modelObject)
                                                         if rel.toModelObject is not None)
                 mdl.node(id, "{{{}|{}}}".format(modelObject.qname.localName, _properties))

--- a/arelle/archive/plugin/sphinx/SphinxParser.py
+++ b/arelle/archive/plugin/sphinx/SphinxParser.py
@@ -811,7 +811,7 @@ def compileSphinxGrammar( cntlr ):
                   ).set_name("ncName").set_debug(debugParsing)
 
     #annotationName = Word("@",alphanums + '_-.').set_name("annotationName").set_debug(debugParsing)
-    annotationName = Regex("@[A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD_]\w*").set_name("annotationName").set_debug(debugParsing)
+    annotationName = Regex("@[A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD_]\\w*").set_name("annotationName").set_debug(debugParsing)
 
 
     decimalPoint = Literal('.')

--- a/arelle/archive/plugin/transforms/tester.py
+++ b/arelle/archive/plugin/transforms/tester.py
@@ -154,7 +154,7 @@ def transformationTesterMenuExtender(cntlr, menu, *args, **kwargs):
             parent = self.mainWin.parent
             super(DialogTransformTester, self).__init__(parent)
             self.parent = parent
-            parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+            parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
             dialogX = int(parentGeometry.group(3))
             dialogY = int(parentGeometry.group(4))
             self.selectedGroup = None

--- a/arelle/archive/plugin/validate/USSecTagging.py
+++ b/arelle/archive/plugin/validate/USSecTagging.py
@@ -12,13 +12,13 @@ from collections import defaultdict
 def compile(list, traceRows):
     if traceRows:
         # compile so each row can be traced by separate expression (slow)
-        return [(rowNbr, re.compile("(^|\s)" + pattern + "($|\W+)", re.IGNORECASE))
+        return [(rowNbr, re.compile(r"(^|\s)" + pattern + r"($|\W+)", re.IGNORECASE))
                 for rowNbr, pattern in list]
     else:
         # compile single expression for fast execution
-        return re.compile("(^|\s)" +  # always be sure first word starts at start or after space
-                          "($|\W+)|(^|\s)".join(pattern for rowNbr, pattern in list)
-                          .replace(r" ",r"\W+") + "($|\W+)",
+        return re.compile(r"(^|\s)" +  # always be sure first word starts at start or after space
+                          r"($|\W+)|(^|\s)".join(pattern for rowNbr, pattern in list)
+                          .replace(r" ",r"\W+") + r"($|\W+)",
                           re.IGNORECASE)
 
 def setup(val, traceRows=False, *args, **kwargs):

--- a/arelle/plugin/formulaLoader.py
+++ b/arelle/plugin/formulaLoader.py
@@ -1332,8 +1332,8 @@ def compileXfsGrammar( cntlr, debugParsing ):
                   "[A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040\xB7_.-]*)"
                   ).set_name("ncName").set_debug(debugParsing)
 
-    dateTime = Regex("([0-9]{4})-([0-9]{2})-([0-9]{2})[T ](24:00:00(\.0+)?|(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]))|"
-                     "([0-9]{4})-([0-9]{2})-([0-9]{2})")
+    dateTime = Regex(r"([0-9]{4})-([0-9]{2})-([0-9]{2})[T ](24:00:00(\.0+)?|(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]))|"
+                     r"([0-9]{4})-([0-9]{2})-([0-9]{2})")
 
 
     decimalPoint = Literal('.')

--- a/arelle/plugin/internet/proxyNTLM/HTTPNtlmAuthHandler.py
+++ b/arelle/plugin/internet/proxyNTLM/HTTPNtlmAuthHandler.py
@@ -83,7 +83,7 @@ class AbstractNtlmAuthHandler:
 
             # some Exchange servers send two WWW-Authenticate headers, one with the NTLM challenge
             # and another with the 'Negotiate' keyword - make sure we operate on the right one
-            m = re.match('(NTLM [A-Za-z0-9+\-/=]+)', auth_header_value)
+            m = re.match(r'(NTLM [A-Za-z0-9+\-/=]+)', auth_header_value)
             if m:
                 auth_header_value, = m.groups()
 

--- a/arelle/plugin/validate/EFM/tools/CheckTxmyRefs.py
+++ b/arelle/plugin/validate/EFM/tools/CheckTxmyRefs.py
@@ -29,7 +29,7 @@ fishInDirsForMissing = {
         "url-root": "https://xbrl.sec.gov",
         # "local-root": r"C:/gns/w/git-osd/stx/xbrl.sec.gov",
         "local-root": r"C:/gns/w/git-group2/sec-arelle/xbrl_taxonomies/xbrl_taxonomies/resources/System/cache/https/xbrl.sec.gov",
-        "entrypoint-pattern": "https?://xbrl.sec.gov/[^/]+/2023[^/]*/[^/]+(-sub-)[^.]+\.xsd"
+        "entrypoint-pattern": r"https?://xbrl.sec.gov/[^/]+/2023[^/]*/[^/]+(-sub-)[^.]+\.xsd"
         }
     # not sure what we load for US-GAAP and IFRS to determine needed ref and doc linkbases
     }
@@ -80,12 +80,12 @@ def utilityRun(cntlr, options, *args, **kwargs):
                     for refUrl in modelXbrl.urlDocs:
                         if refUrl not in edTxmyHrefs and refUrl != hRef:
                             log(f"ref taxonomy also missing from edgartaxonomies: ref {refUrl}, loaded from {hRef}")
-                    if not re.match(".*([-_](lab|ref|pre|cal|def|sub)(-\n\n\n\n)?\.xsd)", hRef):
+                    if not re.match(r".*([-_](lab|ref|pre|cal|def|sub)(-\n\n\n\n)?\.xsd)", hRef):
                         cachePath = os.path.dirname(cntlr.webCache.getfilename(hRef))
                         docRefs = defaultdict(set)
                         for root, dir, files in os.walk(cachePath):
                             for file in files:
-                                m = re.match(".*(doc|ref)\.(xsd|xml)", file)
+                                m = re.match(r".*(doc|ref)\.(xsd|xml)", file)
                                 if m:
                                     docRefs[m.group(1)].add(file)
                         addOn = txmyAddons.get(os.path.basename(hRef))
@@ -124,12 +124,12 @@ def utilityRun(cntlr, options, *args, **kwargs):
                             for refUrl in modelXbrl.urlDocs:
                                 if refUrl not in edTxmyHrefs and refUrl != hRef:
                                     log(f"ref taxonomy also missing from edgartaxonomies: ref {refUrl}, loaded from {hRef}")
-                            if not re.match(".*([-_](lab|ref|pre|cal|def|sub)(-\n\n\n\n)?\.xsd)", hRef):
+                            if not re.match(r".*([-_](lab|ref|pre|cal|def|sub)(-\n\n\n\n)?\.xsd)", hRef):
                                 cachePath = os.path.dirname(cntlr.webCache.getfilename(hRef))
                                 docRefs = defaultdict(set)
                                 for root, dir, files in os.walk(cachePath):
                                     for file in files:
-                                        m = re.match(".*(doc|ref)\.(xsd|xml)", file)
+                                        m = re.match(r".*(doc|ref)\.(xsd|xml)", file)
                                         if m:
                                             docRefs[m.group(1)].add(file)
                                 addOn = txmyAddons.get(os.path.basename(hRef))

--- a/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
+++ b/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
@@ -21,7 +21,7 @@ Arelle uses 9.1, via Python DB API 2.0 interface, using the pg8000 library.
 Information for the 'official' XBRL US-maintained database (this schema, containing SEC filings):
     Database Name: edgar_db
     Database engine: Postgres version 8.4
-    \Host: public.xbrl.us
+    Host: public.xbrl.us
     Port: 5432
 
 to use from command line:

--- a/arelle/webserver/bottle.py
+++ b/arelle/webserver/bottle.py
@@ -69,10 +69,10 @@ if __name__ == '__main__':
 # Imports and Python 2/3 unification ##########################################
 ###############################################################################
 
-import base64, calendar, cgi, email.utils, functools, hmac, imp, itertools,\
+import base64, calendar, cgi, email.utils, functools, hmac, itertools,\
        mimetypes, os, re, tempfile, threading, time, warnings, weakref, hashlib
 
-from types import FunctionType
+from types import FunctionType, ModuleType
 from datetime import date as datedate, datetime, timedelta
 from tempfile import TemporaryFile
 from traceback import format_exc, print_exc
@@ -2057,7 +2057,7 @@ class _ImportRedirect(object):
         """ Create a virtual package that redirects imports (see PEP 302). """
         self.name = name
         self.impmask = impmask
-        self.module = sys.modules.setdefault(name, imp.new_module(name))
+        self.module = sys.modules.setdefault(name, ModuleType(name))
         self.module.__dict__.update({
             '__file__': __file__,
             '__path__': [],

--- a/distro.py
+++ b/distro.py
@@ -112,7 +112,7 @@ else:
 setup(
     executables=[guiExecutable, cliExecutable],
     options=options,
-    setup_requires=["setuptools_scm~=7.1"],
+    setup_requires=["setuptools_scm~=8.0"],
     use_scm_version={
         "tag_regex": r"^(?:[\w-]+-?)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
         "write_to": os.path.normcase("arelle/_version.py"),

--- a/distro.py
+++ b/distro.py
@@ -88,6 +88,11 @@ elif sys.platform == MACOS_PLATFORM:
     options["bdist_mac"] = {
         "iconfile": "arelle/images/arelle.icns",
         "bundle_name": "Arelle",
+        "codesign_identity": "Developer ID Application: Workiva Inc. (5ZF66U48UD)",
+        "codesign_deep": True,
+        "codesign_timestamp": True,
+        "codesign_verify": True,
+        "codesign_options": "runtime",
     }
 elif sys.platform == WINDOWS_PLATFORM:
     guiExecutable = Executable(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Operating System :: OS Independent',
     'Topic :: Text Processing :: Markup :: XML'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ markers = [
 # Warn when a # type: ignore comment does not specify any error codes
 enable_error_code = "ignore-without-code"
 
-python_version = "3.11"
+python_version = "3.12"
 
 show_error_codes = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=68.0", "wheel~=0.40", "setuptools_scm[toml]~=7.1"]
+requires = ["setuptools~=69.0", "wheel~=0.42", "setuptools_scm[toml]~=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,4 @@
-cx-Freeze==6.14.7
-# A dependency of cx_Freeze that we specify explicitly in order to pin
-packaging==21.3
+cx-Freeze==6.15.11
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
 -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ flake8==6.1.0
 flake8-noqa==1.3.2
 
 mock==5.1.0
-mypy==1.7.0
+mypy==1.7.1
 pytest==7.4.3
 
 typing-extensions==4.8.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,8 +1,6 @@
-# astroid 3 breaks sphinx-autodoc2: https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/31
-astroid==2.15.8
 furo==2023.9.10
 myst-parser==2.0.0
-sphinx==7.1.2
+sphinx==7.2.6
 sphinx-autobuild==2021.3.14
-sphinx-autodoc2==0.4.2
+sphinx-autodoc2==0.5.0
 sphinx-copybutton==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,16 +9,16 @@ aniso8601==9.0.1
 CherryPy==18.8.0
 Cheroot==10.0.0
 python-dateutil==2.8.2
-# special note: pip install --no-cache --use-pep517 pycountry
 pycountry==22.3.5
 # plugins
 # EdgarRenderer plugin
 NumPy==1.24.4 ; python_version <= "3.8"
-NumPy==1.25.2 ; python_version > "3.8"
-Matplotlib==3.7.4
-holidays==0.36
+NumPy==1.26.2 ; python_version > "3.8"
+Matplotlib==3.7.4 ; python_version <= "3.8"
+Matplotlib==3.8.2 ; python_version > "3.8"
+holidays==0.37
 pytz==2023.3.post1
-Tornado==6.3.3
+Tornado==6.4
 # security plugin
 PyCryptodome==3.19.0
 # xbrlDB plugin

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,2 +1,2 @@
 # https://github.com/dependabot/dependabot-core/blob/8ab4d78efe7cf9a75bef76dd883d7ee3fffffb40/python/lib/dependabot/python/file_parser/python_requirement_parser.rb#L76-L85
-python-3.8.17
+python-3.8.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -150,5 +150,3 @@ ignore =
     W503,
     # line break after binary operator
     W504,
-    # invalid escape sequence '\d'
-    W605

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, lint, typing
+envlist = py38, py39, py310, py311, py312, lint, typing
 isolated_build = True
 skip_missing_interpreters = False
 
@@ -8,7 +8,8 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
-  3.11: py311, lint, typing
+  3.11: py311
+  3.12: py312, lint, typing
 
 [testenv]
 commands =


### PR DESCRIPTION
#### Reason for change
Python 3.12 was released.
Resolves #818.

#### Description of change
Make Arelle compatible with Python 3.12 and update workflows (besides frozen builds) to use it.
cx_Freeze doesn't support 3.12 yet, so frozen builds will continue to use 3.11 for the time being, but cx_Freeze was updated to the latest release to support newer versions of Matplotlib and NumPy that support Python 3.12.

Updating cx_Freeze broke the code signing step of our macOS build workflow as the library recently overhauled their macOS builds. Fortunately a large part of the overhaul was to make code signing work from within the library, so I was able to delete our code signing step and configure cx_Freeze to handle signing instead.

#### Steps to Test
* CI
* Frozen builds already tested for [Linux](https://github.com/austinmatherne-wk/Arelle/actions/runs/7121274287), [macOS](https://github.com/austinmatherne-wk/Arelle/actions/runs/7121274802), and [Windows](https://github.com/austinmatherne-wk/Arelle/actions/runs/7121275133).

**review**:
@Arelle/arelle
