### PR TITLE
Replace packages based off of package identifier

### DIFF
--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -543,6 +543,7 @@ def packageInfo(cntlr, URL, reload=False, packageManifestName=None, errors=[]):
                 return None
             package = {'name': ", ".join(packageNames),
                        'status': 'enabled',
+                       'identifier': parsedPackage.get('identifier'),
                        'version': parsedPackage.get('version'),
                        'license': parsedPackage.get('license'),
                        'fileDate': time.strftime('%Y-%m-%dT%H:%M:%S UTC', fileDateTuple),
@@ -619,13 +620,12 @@ def mappedUrl(url):
 
 def addPackage(cntlr, url, packageManifestName=None):
     newPackageInfo = packageInfo(cntlr, url, packageManifestName=packageManifestName)
-    if newPackageInfo and newPackageInfo.get("name"):
-        name = newPackageInfo.get("name")
-        version = newPackageInfo.get("version")
+    if newPackageInfo and newPackageInfo.get("identifier"):
+        identifier = newPackageInfo.get("identifier")
         j = -1
         packagesList = packagesConfig["packages"]
         for i, _packageInfo in enumerate(packagesList):
-            if _packageInfo['name'] == name and _packageInfo['version'] == version:
+            if _packageInfo['identifier'] == identifier:
                 j = i
                 break
         if 0 <= j < len(packagesList): # replace entry


### PR DESCRIPTION
#### Reason for change
Resolves #964 

#### Description of change
Load "identifier" into package config. Use it instead of "name" and "version" when determining whether or not to replace or add a package.

#### Steps to Test
Create two identical packages A and B locally. In taxonomy package B, modify the `identifier` in `taxonomyPackage.xml`.

Use this command:
```
python arelleCmdLine.py --packages="path to package A.zip" --packages="path to package B.zip" -f test.xsd
```

Before this change, running this command will result in only one package ending up loaded into `packagesConfig` (since they still have matching `name` and `version` values).
After this change, two packages will end up loaded into `packagesConfig` (since they have different `identifier` values).

**review**:
@Arelle/arelle
