### PR TITLE
FR-NL-1.02 validation: element tree based approach

### DIFF
--- a/tests/resources/conformance_suites/nl_nt16/fr_nl/1-02-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt16/fr_nl/1-02-invalid.xbrl
@@ -1,4 +1,31 @@
-<xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test∓"> <!-- CAUSE: disallowed character in attribute -->
-    и й  ⃐ ∓ <!-- CAUSE: disallowed characters -->
-     ÿ ⃏ ' " ₠ <!-- CAUSE: allowed characters -->
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:mock="http://www.mock.com/mock"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        title="Test∓"> <!-- CAUSE: disallowed character in attribute -->
+     ÿ ⃏ ' " ₠ <!-- allowed characters -->
+    <link:schemaRef
+            xlink:href="mock-taxonomy.xsd"
+            xlink:type="simple"/>
+    <context id="ctx-1">
+        ⃐ <!-- CAUSE: disallowed character in context -->
+        <entity>
+            <identifier scheme="http://www.kvk.nl/kvk-id">12345678и</identifier> <!-- CAUSE: disallowed character in identifier -->
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-31</endDate>
+        </period>
+    </context>
+    <mock:String contextRef="ctx-1">
+        FACT 1 и  <!-- CAUSE: disallowed character in fact value -->
+    </mock:String>
+    <mock:String contextRef="ctx-1">
+        FACT 2
+        <!-- й --> <!-- CAUSE: disallowed character in comment in fact value -->
+    </mock:String>
+    <mock:String contextRef="ctx-1">
+        FACT 3 
+    </mock:String>
 </xbrl>

--- a/tests/resources/conformance_suites/nl_nt17/fr_nl/1-02-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt17/fr_nl/1-02-invalid.xbrl
@@ -1,4 +1,31 @@
-<xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test∓"> <!-- CAUSE: disallowed character in attribute -->
-    и й  ⃐ ∓ <!-- CAUSE: disallowed characters -->
-     ÿ ⃏ ' " ₠ <!-- CAUSE: allowed characters -->
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:mock="http://www.mock.com/mock"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        title="Test∓"> <!-- CAUSE: disallowed character in attribute -->
+     ÿ ⃏ ' " ₠ <!-- allowed characters -->
+    <link:schemaRef
+            xlink:href="mock-taxonomy.xsd"
+            xlink:type="simple"/>
+    <context id="ctx-1">
+        ⃐ <!-- CAUSE: disallowed character in context -->
+        <entity>
+            <identifier scheme="http://www.kvk.nl/kvk-id">12345678и</identifier> <!-- CAUSE: disallowed character in identifier -->
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-31</endDate>
+        </period>
+    </context>
+    <mock:String contextRef="ctx-1">
+        FACT 1 и  <!-- CAUSE: disallowed character in fact value -->
+    </mock:String>
+    <mock:String contextRef="ctx-1">
+        FACT 2
+        <!-- й --> <!-- CAUSE: disallowed character in comment in fact value -->
+    </mock:String>
+    <mock:String contextRef="ctx-1">
+        FACT 3 
+    </mock:String>
 </xbrl>

--- a/tests/resources/conformance_suites/nl_nt18/fr_nl/1-02-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt18/fr_nl/1-02-invalid.xbrl
@@ -1,4 +1,31 @@
-<xbrl xmlns="http://www.xbrl.org/2003/instance" title="Test∓"> <!-- CAUSE: disallowed character in attribute -->
-    и й  ⃐ ∓ <!-- CAUSE: disallowed characters -->
-     ÿ ⃏ ' " ₠ <!-- CAUSE: allowed characters -->
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:mock="http://www.mock.com/mock"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        title="Test∓"> <!-- CAUSE: disallowed character in attribute -->
+     ÿ ⃏ ' " ₠ <!-- allowed characters -->
+    <link:schemaRef
+            xlink:href="mock-taxonomy.xsd"
+            xlink:type="simple"/>
+    <context id="ctx-1">
+        ⃐ <!-- CAUSE: disallowed character in context -->
+        <entity>
+            <identifier scheme="http://www.kvk.nl/kvk-id">12345678и</identifier> <!-- CAUSE: disallowed character in identifier -->
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-31</endDate>
+        </period>
+    </context>
+    <mock:String contextRef="ctx-1">
+        FACT 1 и  <!-- CAUSE: disallowed character in fact value -->
+    </mock:String>
+    <mock:String contextRef="ctx-1">
+        FACT 2
+        <!-- й --> <!-- CAUSE: disallowed character in comment in fact value -->
+    </mock:String>
+    <mock:String contextRef="ctx-1">
+        FACT 3 
+    </mock:String>
 </xbrl>


### PR DESCRIPTION
#### Reason for change
The current line-by-line approach does not provide meaningful model object references in the output validation error. Move to a an element-tree based approach so useful refs can be included (while acknowledging that this approach isn't as thorough, it is more useful).

#### Description of change
Navigate through all elements and check all available text content for disallowed characters.

#### Steps to Test
CI

**review**:
@Arelle/arelle