### PR TITLE
Add ixbrl-viewer as build dependency

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,11 +12,6 @@ on:
         description: 'OpenSSL version to use'
         required: false
         type: string
-      node_version:
-        default: '20'
-        description: 'Node.js version to use'
-        required: false
-        type: string
       python_version:
         default: '3.11.5'
         description: 'Python version to use'
@@ -42,11 +37,6 @@ on:
       openssl_version:
         default: '1.1.1s'
         description: 'OpenSSL version to use'
-        required: true
-        type: string
-      node_version:
-        default: '20'
-        description: 'Node.js version to use'
         required: true
         type: string
       python_version:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -7,10 +7,6 @@ on:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
-      ixbrl_viewer_ref:
-        description: 'Workiva/ixbrl-viewer branch, tag or SHA to checkout (blank for default)'
-        required: false
-        type: string
       openssl_version:
         default: '1.1.1s'
         description: 'OpenSSL version to use'
@@ -41,10 +37,6 @@ on:
     inputs:
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
-        required: false
-        type: string
-      ixbrl_viewer_ref:
-        description: 'Workiva/ixbrl-viewer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
       openssl_version:
@@ -102,26 +94,6 @@ jobs:
           mv xule/plugin/* arelle/plugin/
       - name: Cleanup XULE
         run: rm -rf xule
-      - name: Checkout ixbrl-viewer
-        uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0
-          repository: Workiva/ixbrl-viewer
-          path: ixbrl-viewer
-          ref: ${{ inputs.ixbrl_viewer_ref }}
-      - name: Set up Node JS
-        uses: actions/setup-node@v4.0.1
-        with:
-          node-version: ${{ inputs.node_version }}
-      - name: Build ixbrl-viewer
-        working-directory: ixbrl-viewer
-        run: |
-          npm install
-          make prod
-      - name: Move ixbrl-viewer plugin
-        run: mv ixbrl-viewer/iXBRLViewerPlugin arelle/plugin/
-      - name: Cleanup ixbrl-viewer
-        run: rm -rf ixbrl-viewer
       - name: Docker setup buildx
         uses: docker/setup-buildx-action@v3.0.0
       - name: Docker build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,10 +12,6 @@ on:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
-      ixbrl_viewer_ref:
-        description: 'Workiva/ixbrl-viewer branch, tag or SHA to checkout (blank for default)'
-        required: false
-        type: string
       node_version:
         default: '20'
         description: 'Node.js version to use'
@@ -46,10 +42,6 @@ on:
         type: boolean
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
-        required: false
-        type: string
-      ixbrl_viewer_ref:
-        description: 'Workiva/ixbrl-viewer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
       node_version:
@@ -106,22 +98,6 @@ jobs:
           mv tmp/plugin/validate/* arelle/plugin/validate/
           rm -rf tmp/plugin/validate
           mv tmp/plugin/* arelle/plugin/
-          rm -rf tmp
-      - uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0
-          repository: Workiva/ixbrl-viewer
-          path: tmp/ixbrl-viewer
-          ref: ${{ inputs.ixbrl_viewer_ref }}
-      - uses: actions/setup-node@v4.0.1
-        with:
-          node-version: ${{ inputs.node_version }}
-      - run: |
-          cd tmp/ixbrl-viewer
-          npm install
-          make prod
-          cd ../..
-          mv tmp/ixbrl-viewer/iXBRLViewerPlugin arelle/plugin/
           rm -rf tmp
       - name: Capture build version
         run: echo "BUILD_VERSION=$(python -W ignore distro.py --version)" >> $GITHUB_ENV

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,11 +12,6 @@ on:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
-      node_version:
-        default: '20'
-        description: 'Node.js version to use'
-        required: false
-        type: string
       python_version:
         default: '3.11'
         description: 'Python version to use'
@@ -43,11 +38,6 @@ on:
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
-        type: string
-      node_version:
-        default: '20'
-        description: 'Node.js version to use'
-        required: true
         type: string
       python_version:
         default: '3.11'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,11 +7,6 @@ on:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
-      node_version:
-        default: '20'
-        description: 'Node.js version to use'
-        required: false
-        type: string
       python_version:
         default: '3.11'
         description: 'Python version to use'
@@ -39,11 +34,6 @@ on:
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
-        type: string
-      node_version:
-        default: '20'
-        description: 'Node.js version to use'
-        required: true
         type: string
       python_version:
         default: '3.11'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,10 +7,6 @@ on:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
-      ixbrl_viewer_ref:
-        description: 'Workiva/ixbrl-viewer branch, tag or SHA to checkout (blank for default)'
-        required: false
-        type: string
       node_version:
         default: '20'
         description: 'Node.js version to use'
@@ -42,10 +38,6 @@ on:
     inputs:
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
-        required: false
-        type: string
-      ixbrl_viewer_ref:
-        description: 'Workiva/ixbrl-viewer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
       node_version:
@@ -102,24 +94,6 @@ jobs:
         mv xule\plugin\* arelle\plugin\
     - shell: cmd
       run: rmdir /s /q xule
-    - name: Checkout ixbrl-viewer
-      uses: actions/checkout@v4.1.1
-      with:
-        fetch-depth: 0
-        repository: Workiva/ixbrl-viewer
-        path: ixbrl-viewer
-        ref: ${{ inputs.ixbrl_viewer_ref }}
-    - name: Set up Node JS
-      uses: actions/setup-node@v4.0.1
-      with:
-        node-version: ${{ inputs.node_version }}
-    - name: Build ixbrl-viewer
-      working-directory: ixbrl-viewer
-      run: |
-        npm install
-        make prod
-    - shell: cmd
-      run: move ixbrl-viewer\iXBRLViewerPlugin arelle\plugin\iXBRLViewerPlugin && rmdir /s /q ixbrl-viewer
     - name: Set up Python ${{ inputs.python_version }}
       uses: actions/setup-python@v5.0.0
       with:

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -7,11 +7,6 @@ on:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
-      node_version:
-        default: '20'
-        description: 'Node.js version to use'
-        required: false
-        type: string
       python_version:
         default: '3.11'
         description: 'Python version to use'
@@ -34,7 +29,6 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       edgar_renderer_ref: ${{ inputs.edgar_renderer_ref }}
-      node_version: ${{ inputs.node_version }}
       python_version: ${{ inputs.python_version }}
       xule_ref: ${{ inputs.xule_ref }}
   build-windows-pr:

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -7,10 +7,6 @@ on:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
-      ixbrl_viewer_ref:
-        description: 'Workiva/ixbrl-viewer branch, tag or SHA to checkout (blank for default)'
-        required: false
-        type: string
       node_version:
         default: '20'
         description: 'Node.js version to use'
@@ -38,7 +34,6 @@ jobs:
     uses: ./.github/workflows/build-windows.yml
     with:
       edgar_renderer_ref: ${{ inputs.edgar_renderer_ref }}
-      ixbrl_viewer_ref: ${{ inputs.ixbrl_viewer_ref }}
       node_version: ${{ inputs.node_version }}
       python_version: ${{ inputs.python_version }}
       xule_ref: ${{ inputs.xule_ref }}

--- a/distro.py
+++ b/distro.py
@@ -2,7 +2,9 @@
 See COPYRIGHT.md for copyright information.
 """
 import os
+import site
 import sys
+from importlib.metadata import entry_points
 
 from cx_Freeze import Executable, setup
 from setuptools import find_packages
@@ -22,6 +24,35 @@ includeFiles = [
     (os.path.normcase("arelle/locale"), "locale"),
     (os.path.normcase("arelle/plugin"), "plugin"),
 ]
+
+# Pip-installed plugins cannot be discovered in frozen builds because
+# the `ast` library can't parse `__pluginInfo__` from compiled .pyc files
+# Instead, pip-intalled plugins can be copied directly into the plugins folder
+
+# Built list of absolute paths to available pip packages
+packageDirectories = []
+sitePackagesDirectories = site.getsitepackages()
+for sitePackagesDirectory in sitePackagesDirectories:
+    if not sitePackagesDirectory.endswith('site-packages'):
+        continue
+    packageDirectories.extend([os.path.join(sitePackagesDirectory, x) for x in os.listdir(sitePackagesDirectory)])
+
+# For each entry point discovered, find the pip package containing it
+# and stage for copying into the plugins build directory
+if sys.version_info < (3, 10):
+    entryPoints = [e for e in entry_points().get('arelle.plugin', [])]
+else:
+    entryPoints = list(entry_points(group='arelle.plugin'))
+for entryPoint in entryPoints:
+    pluginUrl = entryPoint.load()()
+    pluginDirectory = None
+    for packageDirectory in packageDirectories:
+        if pluginUrl.startswith(packageDirectory):
+            pluginDirectory = packageDirectory
+            break
+    assert pluginDirectory, f"Corresponding package could not be found for plugin path: {pluginUrl}"
+    includeFiles.append((pluginDirectory, os.path.join('plugin', os.path.basename(pluginDirectory))))
+
 includeLibs = [
     "aniso8601",
     "graphviz",

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -3,4 +3,5 @@ cx-Freeze==6.14.7
 packaging==21.3
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
+-r requirements-plugins.txt
 -r requirements.txt


### PR DESCRIPTION
#### Reason for change
Resolves #734 
We currently clone and build ixbrl-viewer in build scripts.

#### Description of change
Remove ixbrl-viewer references from workflows, it will be installed into the /plugins directory of frozen builds instead.

#### Steps to Test
Test build workflow changes on fork and confirm ixbrl-viewer is in frozen build /plugins directory. Examples: 
* Mac: https://github.com/Arelle/Arelle/actions/runs/7186302183
* Windows: https://github.com/Arelle/Arelle/actions/runs/7186303637

**review**:
@Arelle/arelle
