### PR TITLE
Windows Installer/Uninstaller improvements

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,7 +5,7 @@ Copyright © 2011-present Workiva, Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+<http://www.apache.org/licenses/LICENSE-2.0>
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/installWin64.nsi
+++ b/installWin64.nsi
@@ -128,11 +128,8 @@ Section "Uninstall"
 
   ;ADD YOUR OWN FILES HERE...
 
-  Delete "$INSTDIR\Uninstall.exe"
-  Delete "$INSTDIR\*.*"
-
-  RMDir /r "$INSTDIR\*"
-  RMDir "$INSTDIR"
+  RMDir /r "$INSTDIR"
+  RMDir /r "$LOCALAPPDATA\Arelle"
 
   !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
     

--- a/installWin86.nsi
+++ b/installWin86.nsi
@@ -124,11 +124,8 @@ Section "Uninstall"
 
   ;ADD YOUR OWN FILES HERE...
 
-  Delete "$INSTDIR\Uninstall.exe"
-  Delete "$INSTDIR\*.*"
-
-  RMDir /r "$INSTDIR\*"
-  RMDir "$INSTDIR"
+  RMDir /r "$INSTDIR"
+  RMDir /r "$LOCALAPPDATA\Arelle"
 
   !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
     


### PR DESCRIPTION
#### Reason for change
* NSIS Installer doesn't support markdown.
* Uninstaller didn't remove Arelle config directory.

#### Description of change
* Modify the license file markdown to improve display in the Windows installer (license URL was displayed twice).
* Modify the uninstaller to also remove the Arelle config directory (uninstall and reinstall now gives you a clean install).

#### Steps to Test
* CI
* Uninstaller already tested on Windows

**review**:
@Arelle/arelle
