### PR TITLE
Fix calculation of bounds with negative weight

### DIFF
--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -250,6 +250,8 @@ class ValidateXbrlCalcs:
                                                 x1, x2, iX1, iX2 = boundIntervals.get(itemBindKey, ZERO_RANGE)
                                                 y1 *= w
                                                 y2 *= w
+                                                if y2 < y1:
+                                                    y1, y2 = y2, y1
                                                 boundIntervals[itemBindKey] = (x1 + y1, x2 + y2, iX1 and iY1, iX2 and iY2)
                                                 boundIntervalItems[itemBindKey].extend(_itemFacts)
                             for sumBindKey in boundSumKeys:


### PR DESCRIPTION
#### Reason for change

Arelle returns the wrong result on calc 1.1 checks with negative weights.

#### Description of change

When a calculation involves a negative weight, Arelle fails to swap the bounds of fact.

For example, if you have bounds of `[1,2]` and multiply by a weight of `-1`, you get bounds of `[-1, -2]`  which causes all calculations to fail because the lower bound is above the upper bound.

Previously reported/discussed [here](https://github.com/Arelle/Arelle/pull/843#pullrequestreview-1606790648)

#### Steps to Test

I created a new conformance suite test here:

https://gitlab.xbrl.org/base-spec/calculations/-/merge_requests/35 but it's not yet merged into the main conformance suite.

Draft conformance suite with test here:

https://base-spec.ci.xbrl.org/calculations/pdw-negative-weight-test/conformance/calculation-1.1-conformance-DRAFT-YYYY-MM-DD.zip

Any Calc 1.1 calculation with a negative weight on the total should trigger the bug.

**review**:
@Arelle/arelle
