### PR TITLE
Implement integration test script runner

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -145,6 +145,25 @@ jobs:
           [[ $(echo dist/*.tgz) =~ -([0-9]+\.[0-9]+\.[0-9]+)\.tgz$ ]] && echo "artifact_versioned_name=arelle-ubuntu-${BASH_REMATCH[1]}.tgz" >> $GITHUB_OUTPUT
           echo "BUILD_ARTIFACT_PATH=$(echo dist/*.tgz)" >> $GITHUB_ENV
           echo "uploaded_artifact_name=ubuntu distribution" >> $GITHUB_OUTPUT
+      - name: "[Test] Set up Python ${{ inputs.python_version }}"
+        uses: actions/setup-python@v5.0.0
+        with:
+          cache: 'pip'
+          check-latest: true
+          python-version: ${{ inputs.python_version }}
+      - name: "[Test] Test build artifact"
+        run : |
+          mkdir .test
+          tar -xvzf "${{ env.BUILD_ARTIFACT_PATH }}" -C .test
+          pip install -r requirements-integration.txt
+          python3 tests/integration_tests/download_cache.py --name "all_scripts.zip"
+          pytest -s --disable-warnings --all --cli=".test/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
+      - if: failure()
+        name: "[Test] Upload failed test artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+          path: '*.testlog.xml'
       - name: Capture build env
         run: |
           echo "ARTIFACT_NAME=arelle-ubuntu.tgz" >> $GITHUB_ENV

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -3,6 +3,11 @@ name: Build macOS
 on:
   workflow_call:
     inputs:
+      codesign_and_notarize:
+        description: 'Sign and notarize code'
+        required: false
+        default: 'true'
+        type: boolean
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
@@ -34,6 +39,11 @@ on:
         value: ${{ jobs.build-macos.outputs.uploaded_artifact_name }}
   workflow_dispatch:
     inputs:
+      codesign_and_notarize:
+        description: 'Sign and notarize code'
+        required: false
+        default: 'true'
+        type: boolean
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
@@ -126,6 +136,7 @@ jobs:
       - name: Remove git directories
         run: find build/Arelle.app/Contents -name .git -exec rm -fR {} \;
       - name: Install certificate and sign code
+        if: ${{ inputs.codesign_and_notarize == 'true' }}
         env:
           MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
           MAC_BUILD_CERTIFICATE_NAME: 'Developer ID Application: Workiva Inc. (5ZF66U48UD)'
@@ -193,6 +204,7 @@ jobs:
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleCmdLine
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleGUI
       - name: Notarize app
+        if: ${{ inputs.codesign_and_notarize == 'true' }}
         env:
           USERNAME: ${{ secrets.MAC_BUILD_NOTARIZATION_USERNAME }}
           PASSWORD: ${{ secrets.MAC_BUILD_NOTARIZATION_PASSWORD }}
@@ -201,6 +213,17 @@ jobs:
           ditto -c -k --keepParent "build/Arelle.app" "notarization.zip"
           xcrun notarytool submit "notarization.zip" -v --apple-id "$USERNAME" --password "$PASSWORD" --team-id "$TEAM_ID" --wait --timeout 30m --output-format json
           xcrun stapler staple -v "build/Arelle.app"
+      - name: "[Test] Test build artifact"
+        run : |
+          pip install -r requirements-integration.txt
+          python3 tests/integration_tests/download_cache.py --name "all_scripts.zip"
+          pytest -s --disable-warnings --all --cli="build/Arelle.app/Contents/MacOS/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
+      - if: failure()
+        name: "[Test] Upload failed test artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+          path: '*.testlog.xml'
       - name: Build DMG
         run: |
           pwd

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -150,6 +150,17 @@ jobs:
     - name: Delete .git
       shell: cmd
       run: if exist "${{ env.BUILD_PATH }}\.git" rmdir /s /q ${{ env.BUILD_PATH }}\.git
+    - name: "[Test] Test build"
+      run: |
+        pip install -r requirements-integration.txt
+        python3 tests/integration_tests/download_cache.py --name "all_scripts.zip"
+        pytest -s --disable-warnings --all --cli="start ${{ env.BUILD_PATH }}/arelleCmdLine.exe" tests/integration_tests/scripts/test_scripts.py
+    - if: failure()
+      name: "[Test] Upload failed test artifacts"
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+        path: '*.testlog.xml'
     - name: Make installer
       run: makensis installWin64.nsi
     - name: Version installer

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -100,28 +100,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: us-east-1
-      - name: Download XBRL validation config
-        if: ${{ matrix.test.cache }}
-        shell: bash
-        run: aws s3api get-object --bucket arelle --key caches/${{ matrix.test.name }}.zip config.zip
-      - name: Unpack XBRL validation config
-        if: ${{ matrix.test.cache && startsWith(matrix.os, 'ubuntu') }}
-        run: |
-          mkdir -p "$XDG_CONFIG_HOME/arelle/cache"
-          unzip -d "$XDG_CONFIG_HOME/arelle/cache" config.zip 'http/*' 'https/*'
-          rm config.zip
-      - name: Unpack XBRL validation config
-        if: ${{ matrix.test.cache && startsWith(matrix.os, 'macos') }}
-        run: |
-          mkdir -p ~/Library/Caches/Arelle
-          unzip -d ~/Library/Caches/Arelle config.zip 'http/*' 'https/*'
-          rm config.zip
-      - name: Unpack XBRL validation config
-        if: ${{ matrix.test.cache && startsWith(matrix.os, 'windows') }}
-        run: |
-          mkdir -p $env:LOCALAPPDATA\Arelle\cache
-          7z x config.zip -o"$env:LOCALAPPDATA\Arelle\cache" 'http/*' 'https/*'
-          rm config.zip
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
@@ -143,7 +121,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements-dev.txt
-      - name: Download from S3
+      - name: Download cache from S3
+        run: python3 tests/integration_tests/download_cache.py --private --name "${{ matrix.test.name }}.zip"
+      - name: Download conformance suites from S3
         run: aws s3 sync s3://arelle/conformance_suites tests/resources/conformance_suites
       - name: Run integration tests with pytest
         run: pytest -s --disable-warnings --offline --name=${{ matrix.test.name }}${{ matrix.test.shard && format(' --shard={0}', matrix.test.shard) || '' }} tests/integration_tests/validation/test_conformance_suites.py

--- a/.github/workflows/test-scripts-parallel.yml
+++ b/.github/workflows/test-scripts-parallel.yml
@@ -1,0 +1,97 @@
+name: Run Integration Test Scripts (Parallel)
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  find-tests:
+    runs-on: ubuntu-22.04
+    outputs:
+      names: ${{ steps.get-test-names.outputs.names }}
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - id: get-test-names
+        run: echo "names=$(find tests/integration_tests/scripts/tests \( -name "*.sh" -o -name "*.bat" \) | xargs basename -a | sed 's/\.[^.]*$//' | uniq |  jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+  run-test:
+    name: ${{ matrix.name }} - ${{ matrix.os }} - ${{ matrix.python-version }}
+    needs: find-tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJson(needs.find-tests.outputs.names) }}
+        os:
+          - ubuntu-22.04
+        python-version:
+          - '3.11'
+        include:
+          - os: windows-2022
+            python-version: '3.8'
+            name: ixbrl-viewer_cli
+          - os: macos-12
+            python-version: '3.8'
+            name: ixbrl-viewer_cli
+          - os: ubuntu-22.04
+            python-version: '3.8'
+            name: ixbrl-viewer_cli
+
+          - os: windows-2022
+            python-version: '3.9'
+            name: ixbrl-viewer_cli
+          - os: macos-12
+            python-version: '3.9'
+            name: ixbrl-viewer_cli
+          - os: ubuntu-22.04
+            python-version: '3.9'
+            name: ixbrl-viewer_cli
+
+          - os: windows-2022
+            python-version: '3.10'
+            name: ixbrl-viewer_cli
+          - os: macos-12
+            python-version: '3.10'
+            name: ixbrl-viewer_cli
+          - os: ubuntu-22.04
+            python-version: '3.10'
+            name: ixbrl-viewer_cli
+
+          - os: windows-2022
+            python-version: '3.11'
+            name: ixbrl-viewer_cli
+          - os: macos-12
+            python-version: '3.11'
+            name: ixbrl-viewer_cli
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Install Python 3
+        uses: actions/setup-python@v5.0.0
+        with:
+          cache: 'pip'
+          check-latest: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements-integration.txt
+      - name: Download cache
+        run: python3 tests/integration_tests/download_cache.py --name "${{ matrix.name }}.zip"
+      - name: Run integration tests with pytest
+        run: pytest -s --disable-warnings --name="${{ matrix.name }}" --cli="python3 arelleCmdLine.py" tests/integration_tests/scripts/test_scripts.py
+      - if: failure()
+        name: Upload log artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}_${{ matrix.os }}_${{ matrix.python-version }}_logs
+          path: '*.testlog.xml'

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,75 @@
+name: Run Integration Test Scripts
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/test-scripts.yml'
+      - 'arelle/**'
+      - 'tests/**'
+      - '**.py'
+      - '**.pyw'
+      - 'requirements*.txt'
+
+permissions: {}
+
+jobs:
+  run-tests:
+    name: ${{ matrix.os }} - ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+        python-version:
+          - '3.11'
+        include:
+          - os: windows-2022
+            python-version: '3.8'
+          - os: macos-12
+            python-version: '3.8'
+          - os: ubuntu-22.04
+            python-version: '3.8'
+
+          - os: windows-2022
+            python-version: '3.9'
+          - os: macos-12
+            python-version: '3.9'
+          - os: ubuntu-22.04
+            python-version: '3.9'
+
+          - os: windows-2022
+            python-version: '3.10'
+          - os: macos-12
+            python-version: '3.10'
+          - os: ubuntu-22.04
+            python-version: '3.10'
+
+          - os: windows-2022
+            python-version: '3.11'
+          - os: macos-12
+            python-version: '3.11'
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Install Python 3
+        uses: actions/setup-python@v5.0.0
+        with:
+          cache: 'pip'
+          check-latest: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements-integration.txt
+      - name: Download cache
+        run: python3 tests/integration_tests/download_cache.py --name "all_scripts.zip"
+      - name: Run integration tests with pytest
+        run: pytest -s --disable-warnings --all --cli="python3 arelleCmdLine.py" tests/integration_tests/scripts/test_scripts.py
+      - if: failure()
+        name: Upload log artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+          path: '*.testlog.xml'

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -331,9 +331,9 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
                 if entryPoint:
                     moduleInfo["moduleURL"] = moduleFilename  # pip-installed plugins need absolute filepath
                     moduleInfo["entryPoint"] = {
-                        "module": entryPoint.module,
+                        "module": getattr(entryPoint, 'module', None),
                         "name": entryPoint.name,
-                        "version": entryPoint.dist.version,
+                        "version": entryPoint.dist.version if hasattr(entryPoint, 'dist') else None,
                     }
                     if not moduleInfo.get("version"):
                         moduleInfo["version"] = entryPoint.dist.version  # If no explicit version, retrieve from entry point

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -1,0 +1,3 @@
+ixbrl-viewer==1.4.10
+
+-r requirements-dev.txt

--- a/tests/integration_tests/download_cache.py
+++ b/tests/integration_tests/download_cache.py
@@ -1,0 +1,90 @@
+import argparse
+import os
+import subprocess
+import urllib.request
+import zipfile
+
+PRIVATE_BUCKET = 'arelle'
+PRIVATE_CACHE_PATTERN = 'caches/{}'
+PUBLIC_BUCKET = 'arelle-public'
+PUBLIC_CACHE_PATTERN = 'https://{}.s3.amazonaws.com/ci/caches/{}'
+TEMP_ZIP_NAME = '_tempcache.zip'
+
+
+def get_cache_directory() -> str:
+    """
+    Determines the default cache directory
+    ubuntu: "$XDG_CONFIG_HOME/arelle/cache"
+    macos: ~/Library/Caches/Arelle
+    windows: "$env:LOCALAPPDATA\Arelle\cache"
+    :return: Cache directory path
+    """
+    xdg_config_home = os.getenv('XDG_CONFIG_HOME')
+    if xdg_config_home:
+        return os.path.join(xdg_config_home, 'arelle', 'cache')
+    local_app_data = os.getenv('LOCALAPPDATA')
+    if local_app_data:
+        return os.path.join(local_app_data, 'Arelle', 'cache')
+    return os.path.join(os.path.expanduser('~'), 'Library', 'Caches', 'Arelle')
+
+
+def download_and_apply_cache(name: str, private: bool, cache_directory: str) -> None:
+    """
+    :param name: Filename (including extension) of cache package to download
+    :param private: True if the package is located in the private S3 bucket
+    :param cache_directory: Directory to unpack cache package into
+    """
+    # Download ZIP from either public or private bucket.
+    # Private bucket requires AWS CLI tool to be installed with credentials already configured
+    if private:
+        print(f'Downloading private package: {name}')
+        if not os.getenv('AWS_ACCESS_KEY_ID'):
+            raise ValueError('AWS_ACCESS_KEY_ID environment variable not set.')
+        if not os.getenv('AWS_SECRET_ACCESS_KEY'):
+            raise ValueError('AWS_SECRET_ACCESS_KEY environment variable not set.')
+        if not os.getenv('AWS_DEFAULT_REGION'):
+            raise ValueError('AWS_DEFAULT_REGION environment variable not set.')
+        result = subprocess.run([
+            'aws', 's3api', 'get-object',
+            '--bucket', PRIVATE_BUCKET,
+            '--key', PRIVATE_CACHE_PATTERN.format(name),
+            TEMP_ZIP_NAME])
+        if result.returncode != 0:
+            raise Exception(f'Download failed with return code {result.returncode}')
+    else:
+        print(f'Downloading public package: {name}')
+        urllib.request.urlretrieve(PUBLIC_CACHE_PATTERN.format(PUBLIC_BUCKET, name), TEMP_ZIP_NAME)
+    # Unzip into cache directory
+    with zipfile.ZipFile(TEMP_ZIP_NAME, 'r') as zip_ref:
+        zip_ref.extractall(cache_directory)
+    os.remove(TEMP_ZIP_NAME)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog='Download Cache',
+        description='Downloads a cache package from either '
+                    'the public or private Arelle S3 buckets '
+                    'and applies it to the local cache.')
+    parser.add_argument('--name', '-n', action='append', required=True,
+                        help='Filename (including extension) of'
+                             'cache package to download.')
+    parser.add_argument('--private', action='store_true',
+                        help='AWS CLI must be installed and '
+                             'credentials must be configured '
+                             'in environment prior to running.')
+    parser.add_argument('--print', action='store_true',
+                        help='Print cache directory tree structure.')
+
+    args = parser.parse_args()
+    cache_directory = get_cache_directory()
+    for name in args.name:
+        download_and_apply_cache(name, args.private, cache_directory)
+    if args.print:
+        for path in [
+            os.path.join(dirpath, f)
+            for (dirpath, dirnames, filenames) in os.walk(cache_directory)
+            for f in filenames
+        ]:
+            print(path)
+

--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os.path
+from collections import Counter
+from pathlib import PurePath
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from arelle import ModelDocument, PackageManager, PluginManager
+from arelle.CntlrCmdLine import parseAndRun
+from arelle.FileSource import archiveFilenameParts
+
+if TYPE_CHECKING:
+    from _pytest.mark import ParameterSet
+
+
+def get_document_id(doc: ModelDocument.ModelDocument) -> str:
+    file_source = doc.modelXbrl.fileSource
+    basepath = getattr(file_source, 'basefile', None)
+    if basepath is None:
+        # Try and find a basepath from referenced documents
+        ref_file_source = next(iter(file_source.referencedFileSources.values()), None)
+        if ref_file_source is not None:
+            basepath = ref_file_source.basefile
+    if basepath is None:
+        # Try and find a basepath based on archive in path
+        archivePathParts = archiveFilenameParts(doc.filepath)
+        if archivePathParts is not None:
+            return archivePathParts[1]
+    if basepath is None:
+        # Use file source URL as fallback if basepath not found
+        basepath = os.path.dirname(file_source.url) + os.sep
+    return PurePath(doc.filepath).relative_to(basepath).as_posix()
+
+
+def get_test_data(
+        args: list[str],
+        expected_failure_ids: frozenset[str] = frozenset(),
+        expected_empty_testcases: frozenset[str] = frozenset(),
+        expected_model_errors: frozenset[str] = frozenset(),
+        strict_testcase_index: bool = True,
+) -> list[ParameterSet]:
+    """
+    Produces a list of Pytest Params that can be fed into a parameterized pytest function
+
+    :param args: The args to be parsed by arelle in order to correctly produce the desired result set
+    :param expected_failure_ids: The set of string test IDs that are expected to fail
+    :param expected_empty_testcases: The set of paths of empty testcases, relative to the suite zip
+    :param expected_model_errors: The set of error codes expected to be in the ModelXbrl errors
+    :param strict_testcase_index: Don't allow IOerrors when loading the testcase index
+    :return: A list of PyTest Params that can be used to run a parameterized pytest function
+    """
+    cntlr = parseAndRun(args)  # type: ignore[no-untyped-call]
+    try:
+        results = []
+        test_cases_with_no_variations = set()
+        test_cases_with_unrecognized_type = {}
+        model_document = cntlr.modelManager.modelXbrl.modelDocument
+        test_cases: list[ModelDocument.ModelDocument] = []
+        if model_document.type in (ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRYTESTCASE):
+            test_cases.append(model_document)
+        elif model_document.type == ModelDocument.Type.TESTCASESINDEX:
+            if strict_testcase_index:
+                model_errors = sorted(cntlr.modelManager.modelXbrl.errors)
+                assert 'IOerror' not in model_errors, f'One or more testcases referenced by testcases index "{model_document.filepath}" were not found.'
+            referenced_documents = model_document.referencesDocument.keys()
+            child_document_types = {doc.type for doc in referenced_documents}
+            assert len(child_document_types) == 1, f'Multiple child document types found in {model_document.uri}: {child_document_types}.'
+            [child_document_type] = child_document_types
+            # the formula function registry conformance suite points to a list of registries, so we need to search one level deeper.
+            if child_document_type == ModelDocument.Type.REGISTRY:
+                referenced_documents = [case for doc in referenced_documents for case in doc.referencesDocument.keys()]
+            test_cases = sorted(referenced_documents, key=lambda doc: doc.uri)
+        elif model_document.type == ModelDocument.Type.INSTANCE:
+            test_id = get_document_id(model_document)
+            model_errors = sorted(cntlr.modelManager.modelXbrl.errors)
+            expected_model_errors_list = sorted(expected_model_errors)
+            param = pytest.param(
+                {
+                    'status': 'pass' if model_errors == expected_model_errors_list else 'fail',
+                    'expected': expected_model_errors_list,
+                    'actual': model_errors
+                },
+                id=test_id,
+                marks=[pytest.mark.xfail()] if test_id in expected_failure_ids else []
+            )
+            results.append(param)
+        else:
+            raise Exception('Unhandled model document type: {}'.format(model_document.type))
+        for test_case in test_cases:
+            test_case_file_id = get_document_id(test_case)
+            if test_case.type not in (ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRYTESTCASE):
+                test_cases_with_unrecognized_type[test_case_file_id] = test_case.type
+            if not getattr(test_case, "testcaseVariations", None):
+                test_cases_with_no_variations.add(test_case_file_id)
+            else:
+                for mv in test_case.testcaseVariations:
+                    test_id = f'{test_case_file_id}:{mv.id}'
+                    param = pytest.param(
+                        {
+                            'status': mv.status,
+                            'expected': mv.expected,
+                            'actual': mv.actual
+                        },
+                        id=test_id,
+                        marks=[pytest.mark.xfail()] if test_id in expected_failure_ids else []
+                    )
+                    results.append(param)
+        if test_cases_with_unrecognized_type:
+            raise Exception(f"Some test cases have an unrecognized document type: {sorted(test_cases_with_unrecognized_type.items())}.")
+        unrecognized_expected_empty_testcases = expected_empty_testcases.difference(map(get_document_id, test_cases))
+        if unrecognized_expected_empty_testcases:
+            raise Exception(f"Some expected empty test cases weren't found: {sorted(unrecognized_expected_empty_testcases)}.")
+        unexpected_empty_testcases = test_cases_with_no_variations - expected_empty_testcases
+        if unexpected_empty_testcases:
+            raise Exception(f"Some test cases don't have any variations: {sorted(unexpected_empty_testcases)}.")
+        test_id_frequencies = Counter(cast(str, p.id) for p in results)
+        nonunique_test_ids = {test_id: count for test_id, count in test_id_frequencies.items() if count > 1}
+        if nonunique_test_ids:
+            raise Exception(f'Some test IDs are not unique.  Frequencies of nonunique test IDs: {nonunique_test_ids}.')
+        nonexistent_expected_failure_ids = expected_failure_ids - test_id_frequencies.keys()
+        if nonexistent_expected_failure_ids:
+            raise Exception(f"Some expected failure IDs don't match any test cases: {sorted(nonexistent_expected_failure_ids)}.")
+        return results
+    finally:
+        cntlr.modelManager.close()
+        PackageManager.close()  # type: ignore[no-untyped-call]
+        PluginManager.close()  # type: ignore[no-untyped-call]

--- a/tests/integration_tests/scripts/README.md
+++ b/tests/integration_tests/scripts/README.md
@@ -1,0 +1,32 @@
+# Running integration test scripts
+
+> Note: Conformance suites are run using a different entry point.
+> See `tests/integration_tests/validation/README.md` for more information.
+
+### Run scripts directly:
+Run the following to view script runner options:
+```
+python -m tests.integration_tests.scripts.run_conformance_suites --help
+
+  -h, --help            show this help message and exit
+  --all                 Select all scripts
+  --list                List names of all scripts
+  --name NAME           Select only scripts with given names, comma
+                        delimited
+```
+One of the following options *must* be provided to select which suites to use:
+* `--all`: select all scripts
+* `--name`: provide a comma-delimited list of script names (use `--list` to see names)
+
+Example that runs the Japan IXDS script:
+```
+python -m tests.integration_tests.scripts.run_scripts --name japan_ixds
+```
+
+### Run scripts via pytest:
+The same options for `run_scripts` can be passed through `pytest`.
+
+This example runs all scripts through pytest:
+```
+pytest ./tests/integration_tests/scripts/test_scripts.py --all
+```

--- a/tests/integration_tests/scripts/conftest.py
+++ b/tests/integration_tests/scripts/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+from tests.integration_tests.scripts.run_scripts import (
+    ARGUMENTS,
+    run_script_options
+)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    for arg in ARGUMENTS:
+        arg_without_name = {k: v for k, v in arg.items() if k != "name"}
+        parser.addoption(arg["name"], **arg_without_name)
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """
+    Parameterizes script_results for passing results to test_script
+    https://docs.pytest.org/en/latest/how-to/parametrize.html#basic-pytest-generate-tests-example
+    """
+    config = metafunc.config
+    options = config.option
+    results = run_script_options(options)
+    metafunc.parametrize("script_results", results)

--- a/tests/integration_tests/scripts/run_scripts.py
+++ b/tests/integration_tests/scripts/run_scripts.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from _pytest.mark import ParameterSet
+
+
+ARGUMENTS: list[dict[str, Any]] = [
+    {
+        "name": "--all",
+        "action": "store_true",
+        "help": "Select all configured integration tests"
+    },
+    {
+        "name": "--cli",
+        "action": "store",
+        "help": "Determines the arelleCmdLine command"
+    },
+    {
+        "name": "--list",
+        "action": "store_true",
+        "help": "List names of all integration tests"
+    },
+    {
+        "name": "--name",
+        "action": "append",
+        "help": "Only run scripts whose name (stem) matches given name(s)"
+    },
+]
+EXT_BAT = '.bat'
+EXT_SH = '.sh'
+SCRIPT_TYPES = (EXT_BAT, EXT_SH)
+TESTS_PATH = './tests/integration_tests/scripts/tests'
+
+
+def _get_all_scripts() -> list[Path]:
+    """
+    Returns absolute paths of runnable scripts based on the operating system.
+    :return: Tuple of runnable scripts.
+    """
+    script_type = EXT_BAT if os.name == 'nt' else EXT_SH
+    return [x.resolve() for x in Path(TESTS_PATH).glob('**/*') if x.suffix == script_type]
+
+
+def run_script_options(options: Namespace) -> list[ParameterSet]:
+    assert options.cli, '--cli is required'
+    all_scripts = _get_all_scripts()
+    if options.all:
+        scripts = all_scripts
+    else:
+        names = options.name
+        assert names, '--name or --all is required'
+        scripts = [s for s in all_scripts if s.stem in names]
+    all_results = []
+    assert scripts, 'No scripts found'
+    for script in scripts:
+        scriptPath = script.as_posix()
+        print('Running integration test script: ' + scriptPath)
+        result = subprocess.run([scriptPath, options.cli], capture_output=True)
+        stderr = result.stderr.decode()
+        param = pytest.param(
+            {
+                'status': 'pass' if result.returncode == 0 else 'fail',
+                'expected': '',
+                'actual': stderr.strip()
+            },
+            id=scriptPath,
+            marks=[],
+        )
+        all_results.append(param)
+    return all_results
+
+
+def run() -> None:
+    parser = ArgumentParser(prog=sys.argv[0])
+    for arg in ARGUMENTS:
+        arg_without_name = {k: v for k, v in arg.items() if k != "name"}
+        parser.add_argument(arg["name"], **arg_without_name)
+    options = parser.parse_args(sys.argv[1:])
+    if options.list:
+        for name in _get_all_scripts():
+            print(name)
+    else:
+        run_script_options(options)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/integration_tests/scripts/test_scripts.py
+++ b/tests/integration_tests/scripts/test_scripts.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from typing import Any
+
+
+def test_script(script_results: dict[str, Any]) -> None:
+    """
+    See conftest.py for context around the parameterization of conformance suite results.
+    It is critical that this file is not imported or referenced by other modules to ensure that it is not evaluated
+    before pytest can evaluate conformance suite results via the pytest_configure hook.
+    """
+    assert script_results.get('status') == 'pass', \
+        'Expected these validation suffixes: {}, but received these validations: {}'.format(
+            script_results.get('expected'), script_results.get('actual')
+        )

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.bat
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.bat
@@ -1,0 +1,31 @@
+@REM Download samples:
+curl "-LOs" "https://arelle-public.s3.amazonaws.com/ci/packages/IXBRLViewerSamples.zip"
+@REM Unzip package:
+7z x "IXBRLViewerSamples.zip" -o"IXBRLViewerSamples" -aoa
+set ARELLE_CMD=%~1
+@REM Generate ixbrl viewer
+%ARELLE_CMD%^
+    "--plugins=ixbrl-viewer"^
+    "-f" "IXBRLViewerSamples\samples\src\ixds-test\document1.html"^
+    "--save-viewer" "viewer.html"^
+    "--logFile" "ixbrl-viewer_cli.testlog.xml"
+
+IF NOT EXIST "ixbrl-viewer_cli.testlog.xml" (
+  echo "Output log was not generated" 1>&2
+  EXIT "1"
+)
+>nul find "level=""error""" "ixbrl-viewer_cli.testlog.xml" && (
+  echo "Output log contains errors" 1>&2
+  EXIT "1"
+)
+IF NOT EXIST "viewer.html" (
+  echo "Viewer was not generated"
+  exit "1"
+)
+
+@REM Cleanup
+DEL  "viewer.html"
+DEL  "ixbrlviewer.js"
+DEL  "IXBRLViewerSamples.zip"
+DEL /S /Q "IXBRLViewerSamples"
+DEL  "ixbrl-viewer_cli.testlog.xml"

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.sh
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Download samples:
+curl -LOs https://arelle-public.s3.amazonaws.com/ci/packages/IXBRLViewerSamples.zip
+# Unzip report:
+unzip -d IXBRLViewerSamples IXBRLViewerSamples.zip
+# Generate ixbrl viewer
+$1 \
+  --internetConnectivity=offline \
+  --plugins="ixbrl-viewer" \
+  -f IXBRLViewerSamples/samples/src/ixds-test/document1.html \
+  --save-viewer viewer.html \
+  --logFile ixbrl-viewer_cli.testlog.xml
+
+if [[ ! -f ixbrl-viewer_cli.testlog.xml ]] ; then
+    >&2 echo "Output log was not generated"
+    exit 1
+fi
+if grep -q "level=\"error\"" ixbrl-viewer_cli.testlog.xml; then
+    >&2 echo "Output log contains errors"
+    exit 1
+fi
+if [[ ! -f viewer.html ]] ; then
+    >&2 echo "Viewer was not generated"
+    exit 1
+fi
+
+# Cleanup
+rm -f viewer.html
+rm -f ixbrlviewer.js
+rm -f IXBRLViewerSamples.zip
+rm -r IXBRLViewerSamples
+rm -f ixbrl-viewer_cli.testlog.xml

--- a/tests/integration_tests/scripts/tests/japan_ixds.bat
+++ b/tests/integration_tests/scripts/tests/japan_ixds.bat
@@ -1,0 +1,31 @@
+@REM Download report:
+curl "-LOs" "https://arelle-public.s3.amazonaws.com/ci/packages/JapaneseXBRLReport.zip"
+@REM Unzip report:
+7z x JapaneseXBRLReport.zip -o"JapaneseXBRLReport" -aoa
+set ARELLE_CMD=%~1
+@REM Extract instance:
+%ARELLE_CMD%^
+    "--internetConnectivity=offline"^
+    "--plugin" "inlineXbrlDocumentSet"^
+    "--saveInstance" "--file" "JapaneseXBRLReport\manifest.xml"^
+    "--logFile" "japan_ixds.testlog.xml"
+@REM Validate instance
+%ARELLE_CMD%^
+    "--internetConnectivity=offline"^
+    "--validate"^
+    "--file" "JapaneseXBRLReport\tse-acedjpfr-19990-2023-06-30-01-2023-08-18_extracted.xbrl"^
+    "--logFile" "japan_ixds.testlog.xml"
+
+IF NOT EXIST "japan_ixds.testlog.xml" (
+  echo "Output log was not generated" 1>&2
+  EXIT "1"
+)
+>nul find "level=""error""" "japan_ixds.testlog.xml" && (
+  echo "Output log contains errors" 1>&2
+  EXIT "1"
+)
+
+@REM Cleanup
+DEL /S /Q "JapaneseXBRLReport"
+DEL  "JapaneseXBRLReport.zip"
+DEL  "japan_ixds.testlog.xml"

--- a/tests/integration_tests/scripts/tests/japan_ixds.sh
+++ b/tests/integration_tests/scripts/tests/japan_ixds.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Download report:
+curl -LOs https://arelle-public.s3.amazonaws.com/ci/packages/JapaneseXBRLReport.zip
+# Unzip report:
+unzip -d JapaneseXBRLReport JapaneseXBRLReport.zip
+# Extract instance:
+$1 \
+  --internetConnectivity=offline \
+  --plugins="inlineXbrlDocumentSet" \
+  --saveInstance --file JapaneseXBRLReport/manifest.xml \
+  --logFile japan_ixds.testlog.xml
+# Verify no schemaImportMissing errors in extracted doc:
+$1 \
+  --internetConnectivity=offline \
+  --validate \
+  --file JapaneseXBRLReport/tse-acedjpfr-19990-2023-06-30-01-2023-08-18_extracted.xbrl \
+  --logFile japan_ixds.testlog.xml
+
+if [[ ! -f japan_ixds.testlog.xml ]] ; then
+    >&2 echo "Output log was not generated"
+    exit 1
+fi
+if grep -q "level=\"error\"" japan_ixds.testlog.xml; then
+    >&2 echo "Output log contains errors"
+    exit 1
+fi
+
+# Cleanup
+rm -r JapaneseXBRLReport
+rm -f JapaneseXBRLReport.zip
+rm -f japan_ixds.testlog.xml

--- a/tests/integration_tests/validation/validation_util.py
+++ b/tests/integration_tests/validation/validation_util.py
@@ -1,140 +1,24 @@
 from __future__ import annotations
+
 import os.path
-import pytest
 import tempfile
-from collections import Counter, defaultdict
+from collections import defaultdict
 from contextlib import nullcontext
 from dataclasses import dataclass
 from heapq import heapreplace
-from lxml import etree
 from pathlib import PurePath, PurePosixPath
 from typing import Any, Callable, ContextManager, TYPE_CHECKING, cast
 from unittest.mock import patch
 from zipfile import ZipFile
 
-from arelle import ModelDocument, PackageManager, PluginManager
-from arelle.CntlrCmdLine import parseAndRun
-from arelle.FileSource import archiveFilenameParts
-from arelle.WebCache import WebCache
+from lxml import etree
 
+from arelle.WebCache import WebCache
+from tests.integration_tests.integration_test_util import get_test_data
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig
 
 if TYPE_CHECKING:
     from _pytest.mark import ParameterSet
-
-
-def get_document_id(doc: ModelDocument.ModelDocument) -> str:
-    file_source = doc.modelXbrl.fileSource
-    basepath = getattr(file_source, 'basefile', None)
-    if basepath is None:
-        # Try and find a basepath from referenced documents
-        ref_file_source = next(iter(file_source.referencedFileSources.values()), None)
-        if ref_file_source is not None:
-            basepath = ref_file_source.basefile
-    if basepath is None:
-        # Try and find a basepath based on archive in path
-        archivePathParts = archiveFilenameParts(doc.filepath)
-        if archivePathParts is not None:
-            return archivePathParts[1]
-    if basepath is None:
-        # Use file source URL as fallback if basepath not found
-        basepath = os.path.dirname(file_source.url) + os.sep
-    return PurePath(doc.filepath).relative_to(basepath).as_posix()
-
-
-def get_test_data(
-        args: list[str],
-        expected_failure_ids: frozenset[str] = frozenset(),
-        expected_empty_testcases: frozenset[str] = frozenset(),
-        expected_model_errors: frozenset[str] = frozenset(),
-        strict_testcase_index: bool = True,
-) -> list[ParameterSet]:
-    """
-    Produces a list of Pytest Params that can be fed into a parameterized pytest function
-
-    :param args: The args to be parsed by arelle in order to correctly produce the desired result set
-    :param expected_failure_ids: The set of string test IDs that are expected to fail
-    :param expected_empty_testcases: The set of paths of empty testcases, relative to the suite zip
-    :param expected_model_errors: The set of error codes expected to be in the ModelXbrl errors
-    :param strict_testcase_index: Don't allow IOerrors when loading the testcase index
-    :return: A list of PyTest Params that can be used to run a parameterized pytest function
-    """
-    cntlr = parseAndRun(args)  # type: ignore[no-untyped-call]
-    try:
-        results = []
-        test_cases_with_no_variations = set()
-        test_cases_with_unrecognized_type = {}
-        model_document = cntlr.modelManager.modelXbrl.modelDocument
-        test_cases: list[ModelDocument.ModelDocument] = []
-        if model_document.type in (ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRYTESTCASE):
-            test_cases.append(model_document)
-        elif model_document.type == ModelDocument.Type.TESTCASESINDEX:
-            if strict_testcase_index:
-                model_errors = sorted(cntlr.modelManager.modelXbrl.errors)
-                assert 'IOerror' not in model_errors, f'One or more testcases referenced by testcases index "{model_document.filepath}" were not found.'
-            referenced_documents = model_document.referencesDocument.keys()
-            child_document_types = {doc.type for doc in referenced_documents}
-            assert len(child_document_types) == 1, f'Multiple child document types found in {model_document.uri}: {child_document_types}.'
-            [child_document_type] = child_document_types
-            # the formula function registry conformance suite points to a list of registries, so we need to search one level deeper.
-            if child_document_type == ModelDocument.Type.REGISTRY:
-                referenced_documents = [case for doc in referenced_documents for case in doc.referencesDocument.keys()]
-            test_cases = sorted(referenced_documents, key=lambda doc: doc.uri)
-        elif model_document.type == ModelDocument.Type.INSTANCE:
-            test_id = get_document_id(model_document)
-            model_errors = sorted(cntlr.modelManager.modelXbrl.errors)
-            expected_model_errors_list = sorted(expected_model_errors)
-            param = pytest.param(
-                {
-                    'status': 'pass' if model_errors == expected_model_errors_list else 'fail',
-                    'expected': expected_model_errors_list,
-                    'actual': model_errors
-                },
-                id=test_id,
-                marks=[pytest.mark.xfail()] if test_id in expected_failure_ids else []
-            )
-            results.append(param)
-        else:
-            raise Exception('Unhandled model document type: {}'.format(model_document.type))
-        for test_case in test_cases:
-            test_case_file_id = get_document_id(test_case)
-            if test_case.type not in (ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRYTESTCASE):
-                test_cases_with_unrecognized_type[test_case_file_id] = test_case.type
-            if not getattr(test_case, "testcaseVariations", None):
-                test_cases_with_no_variations.add(test_case_file_id)
-            else:
-                for mv in test_case.testcaseVariations:
-                    test_id = f'{test_case_file_id}:{mv.id}'
-                    param = pytest.param(
-                        {
-                            'status': mv.status,
-                            'expected': mv.expected,
-                            'actual': mv.actual
-                        },
-                        id=test_id,
-                        marks=[pytest.mark.xfail()] if test_id in expected_failure_ids else []
-                    )
-                    results.append(param)
-        if test_cases_with_unrecognized_type:
-            raise Exception(f"Some test cases have an unrecognized document type: {sorted(test_cases_with_unrecognized_type.items())}.")
-        unrecognized_expected_empty_testcases = expected_empty_testcases.difference(map(get_document_id, test_cases))
-        if unrecognized_expected_empty_testcases:
-            raise Exception(f"Some expected empty test cases weren't found: {sorted(unrecognized_expected_empty_testcases)}.")
-        unexpected_empty_testcases = test_cases_with_no_variations - expected_empty_testcases
-        if unexpected_empty_testcases:
-            raise Exception(f"Some test cases don't have any variations: {sorted(unexpected_empty_testcases)}.")
-        test_id_frequencies = Counter(cast(str, p.id) for p in results)
-        nonunique_test_ids = {test_id: count for test_id, count in test_id_frequencies.items() if count > 1}
-        if nonunique_test_ids:
-            raise Exception(f'Some test IDs are not unique.  Frequencies of nonunique test IDs: {nonunique_test_ids}.')
-        nonexistent_expected_failure_ids = expected_failure_ids - test_id_frequencies.keys()
-        if nonexistent_expected_failure_ids:
-            raise Exception(f"Some expected failure IDs don't match any test cases: {sorted(nonexistent_expected_failure_ids)}.")
-        return results
-    finally:
-        cntlr.modelManager.close()
-        PackageManager.close()  # type: ignore[no-untyped-call]
-        PluginManager.close()  # type: ignore[no-untyped-call]
 
 
 original_normalize_url_function = WebCache.normalizeUrl


### PR DESCRIPTION
#### Reason for change
There will be a need for running general integration test scripts, separate from the conformance suite pattern we currently use. These integration tests should be as flexible as possible.

#### Description of change
- Implemented standalone `download_cache.py` script for downloading public or private caches in a cross platform way (to remove the need separate conditional steps in workflows)
- Created script running framework in `tests/integration_tests/scripts` based off of the existing conformance suite running framework
- Created `requirements-integration.txt` requirements set for integration tests
- Implemented test for Japan IXDS (Resolves #901)
- Implemented test for triggering `ixbrl-viewer` from the command line (to help test #734)
- Created workflow to run integration test scripts on pull requests
  - Added dispatch-only version that runs the tests in parallel 
- Added steps to build workflows to run these tests against builds

#### Steps to Test
Test on fork:
- [ ] test-scripts.yml
- [ ] test-scripts-parallel.yml
- [ ] build-macos.yml (Note: codesign/notarize can now be optionally skipped)
- [ ] build-windows.yml
- [ ] build-linux.yml
- [ ] conformance-suites.yml

**review**:
@Arelle/arelle
