### PR TITLE
Implement integration test script runner

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -161,7 +161,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+          name: 'test logs'
           path: '.test/**/*.logfile.xml'
       - name: Capture build env
         run: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -145,6 +145,25 @@ jobs:
           [[ $(echo dist/*.tgz) =~ -([0-9]+\.[0-9]+\.[0-9]+)\.tgz$ ]] && echo "artifact_versioned_name=arelle-ubuntu-${BASH_REMATCH[1]}.tgz" >> $GITHUB_OUTPUT
           echo "BUILD_ARTIFACT_PATH=$(echo dist/*.tgz)" >> $GITHUB_ENV
           echo "uploaded_artifact_name=ubuntu distribution" >> $GITHUB_OUTPUT
+      - name: "[Test] Set up Python ${{ inputs.python_version }}"
+        uses: actions/setup-python@v5.0.0
+        with:
+          cache: 'pip'
+          check-latest: true
+          python-version: ${{ inputs.python_version }}
+      - name: "[Test] Test build artifact"
+        run : |
+          mkdir .test_build
+          tar -xvzf "${{ env.BUILD_ARTIFACT_PATH }}" -C .test_build
+          pip install -r requirements-dev.txt
+          pip install -r requirements-plugins.txt
+          pytest -s --disable-warnings --all --download-cache --offline --arelle=".test_build/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
+      - name: "[Test] Upload test artifacts"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+          path: '.test/**/*.logfile.xml'
       - name: Capture build env
         run: |
           echo "ARTIFACT_NAME=arelle-ubuntu.tgz" >> $GITHUB_ENV

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -156,7 +156,6 @@ jobs:
           mkdir .test_build
           tar -xvzf "${{ env.BUILD_ARTIFACT_PATH }}" -C .test_build
           pip install -r requirements-dev.txt
-          pip install -r requirements-plugins.txt
           pytest -s --disable-warnings --all --download-cache --offline --arelle=".test_build/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
       - name: "[Test] Upload test artifacts"
         if: always()

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -221,7 +221,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+          name: 'test logs'
           path: '.test/**/*.logfile.xml'
       - name: Build DMG
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -3,6 +3,11 @@ name: Build macOS
 on:
   workflow_call:
     inputs:
+      codesign_and_notarize:
+        description: 'Sign and notarize code'
+        required: false
+        default: 'true'
+        type: boolean
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
@@ -34,6 +39,11 @@ on:
         value: ${{ jobs.build-macos.outputs.uploaded_artifact_name }}
   workflow_dispatch:
     inputs:
+      codesign_and_notarize:
+        description: 'Sign and notarize code'
+        required: false
+        default: 'true'
+        type: boolean
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
         required: false
@@ -126,6 +136,7 @@ jobs:
       - name: Remove git directories
         run: find build/Arelle.app/Contents -name .git -exec rm -fR {} \;
       - name: Install certificate and sign code
+        if: ${{ inputs.codesign_and_notarize == 'true' }}
         env:
           MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
           MAC_BUILD_CERTIFICATE_NAME: 'Developer ID Application: Workiva Inc. (5ZF66U48UD)'
@@ -193,6 +204,7 @@ jobs:
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleCmdLine
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleGUI
       - name: Notarize app
+        if: ${{ inputs.codesign_and_notarize == 'true' }}
         env:
           USERNAME: ${{ secrets.MAC_BUILD_NOTARIZATION_USERNAME }}
           PASSWORD: ${{ secrets.MAC_BUILD_NOTARIZATION_PASSWORD }}
@@ -201,6 +213,16 @@ jobs:
           ditto -c -k --keepParent "build/Arelle.app" "notarization.zip"
           xcrun notarytool submit "notarization.zip" -v --apple-id "$USERNAME" --password "$PASSWORD" --team-id "$TEAM_ID" --wait --timeout 30m --output-format json
           xcrun stapler staple -v "build/Arelle.app"
+      - name: "[Test] Test build artifact"
+        run : |
+          pip install -r requirements-dev.txt
+          pytest -s --disable-warnings --all --download-cache --offline --arelle="build/Arelle.app/Contents/MacOS/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
+      - name: "[Test] Upload test artifacts"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+          path: '.test/**/*.logfile.xml'
       - name: Build DMG
         run: |
           pwd

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -158,7 +158,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+        name: 'test logs'
         path: '.test/**/*.logfile.xml'
     - name: Make installer
       run: makensis installWin64.nsi

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -150,6 +150,16 @@ jobs:
     - name: Delete .git
       shell: cmd
       run: if exist "${{ env.BUILD_PATH }}\.git" rmdir /s /q ${{ env.BUILD_PATH }}\.git
+    - name: "[Test] Test build"
+      run: |
+        pip install -r requirements-dev.txt
+        pytest -s --disable-warnings --all --download-cache --offline --arelle="${{ env.BUILD_PATH }}\arelleCmdLine.exe" tests/integration_tests/scripts/test_scripts.py
+    - name: "[Test] Upload test artifacts"
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+        path: '.test/**/*.logfile.xml'
     - name: Make installer
       run: makensis installWin64.nsi
     - name: Version installer

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -48,28 +48,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: us-east-1
-      - name: Download XBRL validation config
-        if: ${{ matrix.test.cache }}
-        shell: bash
-        run: aws s3api get-object --bucket arelle --key caches/${{ matrix.test.name }}.zip config.zip
-      - name: Unpack XBRL validation config
-        if: ${{ matrix.test.cache && startsWith(matrix.test.os, 'ubuntu') }}
-        run: |
-          mkdir -p "$XDG_CONFIG_HOME/arelle/cache"
-          unzip -d "$XDG_CONFIG_HOME/arelle/cache" config.zip 'http/*' 'https/*'
-          rm config.zip
-      - name: Unpack XBRL validation config
-        if: ${{ matrix.test.cache && startsWith(matrix.test.os, 'macos') }}
-        run: |
-          mkdir -p ~/Library/Caches/Arelle
-          unzip -d ~/Library/Caches/Arelle config.zip 'http/*' 'https/*'
-          rm config.zip
-      - name: Unpack XBRL validation config
-        if: ${{ matrix.test.cache && startsWith(matrix.test.os, 'windows') }}
-        run: |
-          mkdir -p $env:LOCALAPPDATA\Arelle\cache
-          7z x config.zip -o"$env:LOCALAPPDATA\Arelle\cache" 'http/*' 'https/*'
-          rm config.zip
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
@@ -91,7 +69,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements-dev.txt
-      - name: Download from S3
+      - name: Download cache from S3
+        if: ${{ matrix.test.cache }}
+        run: python tests/integration_tests/download_cache.py --name "conformance_suites/${{ matrix.test.name }}.zip"
+      - name: Download conformance suites from S3
         run: aws s3 sync s3://arelle/conformance_suites tests/resources/conformance_suites
       - name: Run integration tests with pytest
         run: pytest -s --disable-warnings --offline --log-to-file --name=${{ matrix.test.name }}${{ matrix.test.shard && format(' --shard={0}', matrix.test.shard) || '' }} tests/integration_tests/validation/test_conformance_suites.py

--- a/.github/workflows/test-scripts-parallel.yml
+++ b/.github/workflows/test-scripts-parallel.yml
@@ -1,0 +1,63 @@
+name: Run Integration Test Scripts (Parallel)
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  find-tests:
+    runs-on: ubuntu-22.04
+    outputs:
+      names: ${{ steps.get-test-names.outputs.names }}
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - id: get-test-names
+        run: echo "names=$(find tests/integration_tests/scripts/tests \( -name "*.py" \) | xargs basename -a | sed 's/\.[^.]*$//' |  jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+  run-test:
+    name: ${{ matrix.name }} - ${{ matrix.os }} - ${{ matrix.python-version }}
+    needs: find-tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ${{ fromJson(needs.find-tests.outputs.names) }}
+        os:
+          - macos-12
+          - ubuntu-22.04
+          - windows-2022
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Install Python 3
+        uses: actions/setup-python@v5.0.0
+        with:
+          cache: 'pip'
+          check-latest: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements-dev.txt
+          pip install -r requirements-plugins.txt
+      - name: Run integration tests with pytest
+        run: |
+          pytest -s --disable-warnings --name="${{ matrix.name }}" --download-cache --offline --arelle="python arelleCmdLine.py" tests/integration_tests/scripts/test_scripts.py
+      - name: Upload log artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}_${{ matrix.os }}_${{ matrix.python-version }}_logs
+          path: '.test/**/*.logfile.xml'

--- a/.github/workflows/test-scripts-parallel.yml
+++ b/.github/workflows/test-scripts-parallel.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Run integration tests with pytest
         run: |
           pytest -s --disable-warnings --name="${{ matrix.name }}" --download-cache --offline --arelle="python arelleCmdLine.py" tests/integration_tests/scripts/test_scripts.py
-      - name: Upload log artifacts
+      - name: Upload test artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}_${{ matrix.os }}_${{ matrix.python-version }}_logs

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,52 @@
+name: Run Integration Test Scripts
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/test-scripts.yml'
+      - 'arelle/**'
+      - 'tests/**'
+      - '**.py'
+      - '**.pyw'
+      - 'requirements*.txt'
+
+permissions: {}
+
+jobs:
+  run-tests:
+    name: ${{ matrix.os }} - ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-12
+          - ubuntu-22.04
+          - windows-2022
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Install Python 3
+        uses: actions/setup-python@v5.0.0
+        with:
+          cache: 'pip'
+          check-latest: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements-dev.txt
+          pip install -r requirements-plugins.txt
+      - name: Run integration tests with pytest
+        run: |
+          pytest -s --disable-warnings --all --download-cache --offline --arelle="python arelleCmdLine.py" tests/integration_tests/scripts/test_scripts.py
+      - name: Upload log artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}_${{ matrix.python-version }}_logs
+          path: '.test/**/*.logfile.xml'

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           pytest -s --disable-warnings --all --download-cache --offline --arelle="python arelleCmdLine.py" tests/integration_tests/scripts/test_scripts.py
       - name: Upload log artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}_${{ matrix.python-version }}_logs

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ tests/resources/conformance_suites/*
 
 # Visual Studio
 .vs/
+.test

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -331,9 +331,9 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
                 if entryPoint:
                     moduleInfo["moduleURL"] = moduleFilename  # pip-installed plugins need absolute filepath
                     moduleInfo["entryPoint"] = {
-                        "module": entryPoint.module,
+                        "module": getattr(entryPoint, 'module', None),  # TODO: Simplify after Python 3.8 retired
                         "name": entryPoint.name,
-                        "version": entryPoint.dist.version,
+                        "version": entryPoint.dist.version if hasattr(entryPoint, 'dist') else None,
                     }
                     if not moduleInfo.get("version"):
                         moduleInfo["version"] = entryPoint.dist.version  # If no explicit version, retrieve from entry point

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -3,4 +3,5 @@ cx-Freeze==6.14.7
 packaging==21.3
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
+-r requirements-plugins.txt
 -r requirements.txt

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -1,0 +1,1 @@
+ixbrl-viewer==1.4.10

--- a/tests/integration_tests/download_cache.py
+++ b/tests/integration_tests/download_cache.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+import argparse
+import os
+import urllib.request
+import zipfile
+
+
+PUBLIC_CACHE_PATTERN = 'https://arelle-public.s3.amazonaws.com/ci/caches/{}'
+TEMP_ZIP_NAME = '_tempcache.zip'
+
+
+def download_and_apply_cache(name: str, cache_directory: str | None = None) -> None:
+    """
+    :param name: Filename (including extension) of cache package to download
+    :param cache_directory: Directory to unpack cache package into
+    """
+    if cache_directory is None:
+        cache_directory = get_cache_directory()
+    # Download ZIP from public S3 bucket.
+    urllib.request.urlretrieve(PUBLIC_CACHE_PATTERN.format(name), TEMP_ZIP_NAME)
+    # Unzip into cache directory
+    with zipfile.ZipFile(TEMP_ZIP_NAME, 'r') as zip_ref:
+        zip_ref.extractall(cache_directory)
+    os.remove(TEMP_ZIP_NAME)
+
+
+def download_program() -> None:
+    parser = argparse.ArgumentParser(
+        prog='Download Cache',
+        description='Downloads a cache package from the '
+                    'public arelle S3 bucket and applies '
+                    'it to the local environment cache.')
+    parser.add_argument('--name', '-n', action='append', required=True,
+                        help='Filename (including extension) of'
+                             'cache package to download.')
+    parser.add_argument('--print', action='store_true',
+                        help='Print cache directory tree structure.')
+
+    args = parser.parse_args()
+    cache_directory = get_cache_directory()
+    for name in args.name:
+        download_and_apply_cache(name, cache_directory)
+    if args.print:
+        for path in [
+            os.path.join(dirpath, f)
+            for (dirpath, dirnames, filenames) in os.walk(cache_directory)
+            for f in filenames
+        ]:
+            print(path)
+
+
+def get_cache_directory() -> str:
+    r"""
+    Determines the default cache directory
+    ubuntu: "$XDG_CONFIG_HOME/arelle/cache"
+    macos: ~/Library/Caches/Arelle
+    windows: "$env:LOCALAPPDATA\Arelle\cache"
+    :return: Cache directory path
+    """
+    xdg_config_home = os.getenv('XDG_CONFIG_HOME')
+    if xdg_config_home:
+        return os.path.join(xdg_config_home, 'arelle', 'cache')
+    local_app_data = os.getenv('LOCALAPPDATA')
+    if local_app_data:
+        return os.path.join(local_app_data, 'Arelle', 'cache')
+    return os.path.join(os.path.expanduser('~'), 'Library', 'Caches', 'Arelle')
+
+
+if __name__ == '__main__':
+    download_program()

--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os.path
+from collections import Counter
+from pathlib import PurePath
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from arelle import ModelDocument, PackageManager, PluginManager
+from arelle.CntlrCmdLine import parseAndRun
+from arelle.FileSource import archiveFilenameParts
+
+if TYPE_CHECKING:
+    from _pytest.mark import ParameterSet
+
+
+def get_document_id(doc: ModelDocument.ModelDocument) -> str:
+    file_source = doc.modelXbrl.fileSource
+    basepath = getattr(file_source, 'basefile', None)
+    if basepath is None:
+        # Try and find a basepath from referenced documents
+        ref_file_source = next(iter(file_source.referencedFileSources.values()), None)
+        if ref_file_source is not None:
+            basepath = ref_file_source.basefile
+    if basepath is None:
+        # Try and find a basepath based on archive in path
+        archivePathParts = archiveFilenameParts(doc.filepath)
+        if archivePathParts is not None:
+            return archivePathParts[1]
+    if basepath is None:
+        # Use file source URL as fallback if basepath not found
+        basepath = os.path.dirname(file_source.url) + os.sep
+    return PurePath(doc.filepath).relative_to(basepath).as_posix()
+
+
+def get_test_data(
+        args: list[str],
+        expected_failure_ids: frozenset[str] = frozenset(),
+        expected_empty_testcases: frozenset[str] = frozenset(),
+        expected_model_errors: frozenset[str] = frozenset(),
+        strict_testcase_index: bool = True,
+) -> list[ParameterSet]:
+    """
+    Produces a list of Pytest Params that can be fed into a parameterized pytest function
+
+    :param args: The args to be parsed by arelle in order to correctly produce the desired result set
+    :param expected_failure_ids: The set of string test IDs that are expected to fail
+    :param expected_empty_testcases: The set of paths of empty testcases, relative to the suite zip
+    :param expected_model_errors: The set of error codes expected to be in the ModelXbrl errors
+    :param strict_testcase_index: Don't allow IOerrors when loading the testcase index
+    :return: A list of PyTest Params that can be used to run a parameterized pytest function
+    """
+    cntlr = parseAndRun(args)  # type: ignore[no-untyped-call]
+    try:
+        results = []
+        test_cases_with_no_variations = set()
+        test_cases_with_unrecognized_type = {}
+        model_document = cntlr.modelManager.modelXbrl.modelDocument
+        test_cases: list[ModelDocument.ModelDocument] = []
+        if model_document.type in (ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRYTESTCASE):
+            test_cases.append(model_document)
+        elif model_document.type == ModelDocument.Type.TESTCASESINDEX:
+            if strict_testcase_index:
+                model_errors = sorted(cntlr.modelManager.modelXbrl.errors)
+                assert 'IOerror' not in model_errors, f'One or more testcases referenced by testcases index "{model_document.filepath}" were not found.'
+            referenced_documents = model_document.referencesDocument.keys()
+            child_document_types = {doc.type for doc in referenced_documents}
+            assert len(child_document_types) == 1, f'Multiple child document types found in {model_document.uri}: {child_document_types}.'
+            [child_document_type] = child_document_types
+            # the formula function registry conformance suite points to a list of registries, so we need to search one level deeper.
+            if child_document_type == ModelDocument.Type.REGISTRY:
+                referenced_documents = [case for doc in referenced_documents for case in doc.referencesDocument.keys()]
+            test_cases = sorted(referenced_documents, key=lambda doc: doc.uri)
+        elif model_document.type == ModelDocument.Type.INSTANCE:
+            test_id = get_document_id(model_document)
+            model_errors = sorted(cntlr.modelManager.modelXbrl.errors)
+            expected_model_errors_list = sorted(expected_model_errors)
+            param = pytest.param(
+                {
+                    'status': 'pass' if model_errors == expected_model_errors_list else 'fail',
+                    'expected': expected_model_errors_list,
+                    'actual': model_errors
+                },
+                id=test_id,
+                marks=[pytest.mark.xfail()] if test_id in expected_failure_ids else []
+            )
+            results.append(param)
+        else:
+            raise Exception('Unhandled model document type: {}'.format(model_document.type))
+        for test_case in test_cases:
+            test_case_file_id = get_document_id(test_case)
+            if test_case.type not in (ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRYTESTCASE):
+                test_cases_with_unrecognized_type[test_case_file_id] = test_case.type
+            if not getattr(test_case, "testcaseVariations", None):
+                test_cases_with_no_variations.add(test_case_file_id)
+            else:
+                for mv in test_case.testcaseVariations:
+                    test_id = f'{test_case_file_id}:{mv.id}'
+                    param = pytest.param(
+                        {
+                            'status': mv.status,
+                            'expected': mv.expected,
+                            'actual': mv.actual
+                        },
+                        id=test_id,
+                        marks=[pytest.mark.xfail()] if test_id in expected_failure_ids else []
+                    )
+                    results.append(param)
+        if test_cases_with_unrecognized_type:
+            raise Exception(f"Some test cases have an unrecognized document type: {sorted(test_cases_with_unrecognized_type.items())}.")
+        unrecognized_expected_empty_testcases = expected_empty_testcases.difference(map(get_document_id, test_cases))
+        if unrecognized_expected_empty_testcases:
+            raise Exception(f"Some expected empty test cases weren't found: {sorted(unrecognized_expected_empty_testcases)}.")
+        unexpected_empty_testcases = test_cases_with_no_variations - expected_empty_testcases
+        if unexpected_empty_testcases:
+            raise Exception(f"Some test cases don't have any variations: {sorted(unexpected_empty_testcases)}.")
+        test_id_frequencies = Counter(cast(str, p.id) for p in results)
+        nonunique_test_ids = {test_id: count for test_id, count in test_id_frequencies.items() if count > 1}
+        if nonunique_test_ids:
+            raise Exception(f'Some test IDs are not unique.  Frequencies of nonunique test IDs: {nonunique_test_ids}.')
+        nonexistent_expected_failure_ids = expected_failure_ids - test_id_frequencies.keys()
+        if nonexistent_expected_failure_ids:
+            raise Exception(f"Some expected failure IDs don't match any test cases: {sorted(nonexistent_expected_failure_ids)}.")
+        return results
+    finally:
+        cntlr.modelManager.close()
+        PackageManager.close()  # type: ignore[no-untyped-call]
+        PluginManager.close()  # type: ignore[no-untyped-call]

--- a/tests/integration_tests/scripts/README.md
+++ b/tests/integration_tests/scripts/README.md
@@ -1,0 +1,36 @@
+# Running integration test scripts
+
+> Note: Conformance suites are run using a different entry point.
+> See `tests/integration_tests/validation/README.md` for more information.
+
+### Run scripts directly:
+Run the following to view script runner options:
+```
+python -m tests.integration_tests.scripts.run_scripts --help
+
+  -h, --help            show this help message and exit
+  --all                 Select all configured integration tests.
+  --arelle ARELLE       CLI command to run Arelle
+  --download-cache      Whether or not to download and apply cache.
+  --list                List names of all integration tests.
+  --name NAME           Only run scripts whose name (stem) matches given name(s).
+  --offline             Whether or not Arelle should run in offline mode.
+  --working-directory WORKING_DIRECTORY
+                        Directory to place temporary files and log output.
+```
+One of the following options *must* be provided to select which suites to use:
+* `--all`: select all scripts
+* `--name`: provide with script name, one or more times (use `--list` to see names)
+
+Example that runs the Japan IXDS script:
+```
+python -m tests.integration_tests.scripts.run_scripts --name japan_ixds --arelle="python arelleCmdLine.py" 
+```
+
+### Run scripts via pytest:
+The same options for `run_scripts` can be passed through `pytest`.
+
+This example runs all scripts through pytest:
+```
+pytest ./tests/integration_tests/scripts/test_scripts.py --all --arelle="python arelleCmdLine.py"
+```

--- a/tests/integration_tests/scripts/conftest.py
+++ b/tests/integration_tests/scripts/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+from tests.integration_tests.scripts.run_scripts import (
+    ARGUMENTS,
+    run_script_options
+)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    for arg in ARGUMENTS:
+        arg_without_name = {k: v for k, v in arg.items() if k != "name"}
+        parser.addoption(arg["name"], **arg_without_name)
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """
+    Parameterizes script_results for passing results to test_script
+    https://docs.pytest.org/en/latest/how-to/parametrize.html#basic-pytest-generate-tests-example
+    """
+    config = metafunc.config
+    options = config.option
+    results = run_script_options(options)
+    metafunc.parametrize("script_results", results)

--- a/tests/integration_tests/scripts/run_scripts.py
+++ b/tests/integration_tests/scripts/run_scripts.py
@@ -100,8 +100,6 @@ def run_script_options(options: Namespace) -> list[ParameterSet]:
             marks=[],
         )
         all_results.append(param)
-        # if returncode != 0:
-        #     print(f"Failed: {script.stem}. Return code: {returncode}\n{stderr}", file=sys.stderr)
     return all_results
 
 

--- a/tests/integration_tests/scripts/run_scripts.py
+++ b/tests/integration_tests/scripts/run_scripts.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import Any, TYPE_CHECKING, cast
+
+import pytest
+
+from tests.integration_tests.download_cache import download_and_apply_cache
+
+if TYPE_CHECKING:
+    from _pytest.mark import ParameterSet
+
+ALL_SCRIPTS_ZIP = "scripts/all_scripts.zip"
+ARGUMENTS: list[dict[str, Any]] = [
+    {
+        "name": "--all",
+        "action": "store_true",
+        "help": "Select all configured integration tests."
+    },
+    {
+        "name": "--arelle",
+        "action": "store",
+        "help": "CLI command to run Arelle"
+    },
+    {
+        "name": "--download-cache",
+        "action": "store_true",
+        "help": "Whether or not to download and apply cache."
+    },
+    {
+        "name": "--list",
+        "action": "store_true",
+        "help": "List names of all integration tests."
+    },
+    {
+        "name": "--name",
+        "action": "append",
+        "help": "Only run scripts whose name (stem) matches given name(s)."
+    },
+    {
+        "name": "--offline",
+        "action": "store_true",
+        "help": "Whether or not Arelle should run in offline mode."
+    },
+    {
+        "name": "--working-directory",
+        "action": "store",
+        "help": "Directory to place temporary files and log output."
+    },
+]
+TESTS_PATH = './tests/integration_tests/scripts/tests'
+
+
+def _get_all_scripts() -> list[Path]:
+    """
+    Returns absolute paths of runnable scripts based on the operating system.
+    :return: Tuple of runnable scripts.
+    """
+    return [x for x in Path(TESTS_PATH).glob('**/*.py')]
+
+
+def run_script_options(options: Namespace) -> list[ParameterSet]:
+    assert options.arelle, '--arelle is required'
+    all_scripts = _get_all_scripts()
+    if options.all:
+        scripts = all_scripts
+        if options.download_cache:
+            download_and_apply_cache(ALL_SCRIPTS_ZIP)
+    else:
+        names = options.name
+        assert names, '--name or --all is required'
+        scripts = [s for s in all_scripts if s.stem in names]
+    all_results = []
+    assert scripts, 'No scripts found'
+    for script in scripts:
+        modulePath = script.parent.joinpath(script.stem).as_posix().replace('/', '.')
+        args = [sys.executable, '-m', modulePath]
+        args.extend(['--arelle', options.arelle])
+        if options.download_cache and not options.all:
+            # Only pass download cache arg if we didn't just download ALL_SCRIPTS_ZIP above
+            args.append('--download-cache')
+        if options.offline:
+            args.append('--offline')
+        if options.working_directory is not None:
+            args.extend(['--working-directory', options.working_directory])
+
+        print(f'Running integration test script "{script.stem}": {args}')
+        result = subprocess.run(args, capture_output=True)
+        returncode = result.returncode
+        stderr = result.stderr.decode().strip()
+        param = pytest.param(
+            {
+                'returncode': returncode,
+                'stderr': stderr
+            },
+            id=script.stem,
+            marks=[],
+        )
+        all_results.append(param)
+        # if returncode != 0:
+        #     print(f"Failed: {script.stem}. Return code: {returncode}\n{stderr}", file=sys.stderr)
+    return all_results
+
+
+def run() -> None:
+    parser = ArgumentParser(prog=sys.argv[0])
+    for arg in ARGUMENTS:
+        arg_without_name = {k: v for k, v in arg.items() if k != "name"}
+        parser.add_argument(arg["name"], **arg_without_name)
+    options = parser.parse_args(sys.argv[1:])
+    if options.list:
+        for name in _get_all_scripts():
+            print(name)
+    else:
+        results = run_script_options(options)
+        for result in results:
+            values = cast(dict[str, Any], result.values[0])
+            returncode = values.get("returncode")
+            if returncode == 0:
+                print(f"{result.id} passed")
+            else:
+                stderr = values.get("stderr")
+                print(f'"{result.id}" failed with code {returncode}:\n{stderr}\n', file=sys.stderr)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/integration_tests/scripts/script_util.py
+++ b/tests/integration_tests/scripts/script_util.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import os
 import shlex
-import shutil
 import subprocess
 import sys
 from os import linesep
@@ -17,19 +16,6 @@ from tests.integration_tests.download_cache import download_and_apply_cache
 
 def assert_result(errors: list[str]) -> None:
     assert len(errors) == 0, f"Errors encountered during test:\n{linesep.join(errors)}"
-
-
-def cleanup(
-        working_directory: Path,
-        paths: list[Path]
-) -> None:
-    for path in paths:
-        assert working_directory in path.parents, \
-            f'Attempted to cleanup directory "{path}" not within working directory "{working_directory}"'
-        if path.is_dir():
-            shutil.rmtree(path)
-        else:
-            path.unlink()
 
 
 def parse_args(
@@ -63,10 +49,10 @@ def parse_args(
         download_and_apply_cache(f"scripts/{cache}")
         print(f"Downloaded and applied cache: {cache}")
     if working_directory:
-        directory = Path(parsed_args.working_directory).joinpath(name).absolute()
-        parsed_args.working_directory = directory
-        directory.mkdir(parents=True, exist_ok=True)
-        print(f"Set working directory: {directory}")
+        test_directory = Path(parsed_args.working_directory).joinpath(name).absolute()
+        parsed_args.test_directory = test_directory
+        test_directory.mkdir(parents=True, exist_ok=True)
+        print(f"Set test directory: {test_directory}")
     return parsed_args
 
 
@@ -95,10 +81,7 @@ def run_arelle(
     args.extend(additional_args or [])
     if logFile:
         args.extend(["--logFile", str(logFile)])
-    if os.name == 'nt':
-        result = subprocess.run(args, capture_output=True, shell=True)
-    else:
-        result = subprocess.run(args, capture_output=True)
+    result = subprocess.run(args, capture_output=True)
     assert result.returncode == 0, result.stderr.decode().strip()
 
 

--- a/tests/integration_tests/scripts/script_util.py
+++ b/tests/integration_tests/scripts/script_util.py
@@ -60,15 +60,15 @@ def parse_args(
                         help=f"Whether or not to download and apply cache.")
     parser.add_argument("--offline", action="store_true",
                         help="True if Arelle should run in offline mode.")
-    default_directory = Path(".test").joinpath(name)
-    parser.add_argument("--working-directory", action="store", default=default_directory.as_posix(),
+    parser.add_argument("--working-directory", action="store", default=".test",
                         help="Directory to place temporary files and log output.")
     parsed_args = parser.parse_args()
     if cache and parsed_args.download_cache:
         download_and_apply_cache(f"scripts/{cache}")
         print(f"Downloaded and applied cache: {cache}")
     if working_directory:
-        directory = Path(parsed_args.working_directory).absolute()
+        directory = Path(parsed_args.working_directory).joinpath(name).absolute()
+        parsed_args.working_directory = directory
         directory.mkdir(parents=True, exist_ok=True)
         print(f"Set working directory: {directory}")
     return parsed_args

--- a/tests/integration_tests/scripts/script_util.py
+++ b/tests/integration_tests/scripts/script_util.py
@@ -32,10 +32,6 @@ def cleanup(
             path.unlink()
 
 
-def get_standard_logfile_path(path: Path) -> Path:
-    return Path(f"{path.stem}.logfile.xml")
-
-
 def parse_args(
     name: str,
     description: str,
@@ -74,9 +70,9 @@ def parse_args(
     return parsed_args
 
 
-def prepare_logfile(working_directory: Path, script_path: Path, number: int | None = None) -> Path:
-    number_part = "" if number is None else f".{number}"
-    logfile_path = working_directory.joinpath(f"{script_path.stem}{number_part}.logfile.xml")
+def prepare_logfile(working_directory: Path, script_path: Path, name: str | None = None) -> Path:
+    name_part = "" if name is None else f".{name}"
+    logfile_path = working_directory.joinpath(script_path.stem).with_suffix(f"{name_part}.logfile.xml")
     logfile_path.unlink(missing_ok=True)
     return logfile_path
 

--- a/tests/integration_tests/scripts/script_util.py
+++ b/tests/integration_tests/scripts/script_util.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from os import linesep
+from pathlib import Path
+from typing import cast, Iterable, Any
+
+from lxml import etree
+
+from tests.integration_tests.download_cache import download_and_apply_cache
+
+
+def assert_result(errors: list[str]) -> None:
+    assert len(errors) == 0, f"Errors encountered during test:\n{linesep.join(errors)}"
+
+
+def cleanup(
+        working_directory: Path,
+        paths: list[Path]
+) -> None:
+    for path in paths:
+        assert working_directory in path.parents, \
+            f'Attempted to cleanup directory "{path}" not within working directory "{working_directory}"'
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+
+def get_standard_logfile_path(path: Path) -> Path:
+    return Path(f"{path.stem}.logfile.xml")
+
+
+def parse_args(
+    name: str,
+    description: str,
+    arelle: bool = True,
+    cache: str | None = None,
+    working_directory: bool = True,
+) -> argparse.Namespace:
+    """
+    Parses standard integration test script arguments and returns the results
+    after some preprocessing based on values.
+    :param name: Name of the test. Note that this is used in the default working directory path.
+    :param description: Human-readable description of the test.
+    :param arelle: Whether '--arelle' argument is required.
+    :param cache: Name of the cache that will be downloaded if `--download-cache` is provided.
+    :param working_directory: Whether a working directory should be configured.
+    :return: Parsed argument Namespace.
+    """
+    parser = argparse.ArgumentParser(prog=name, description=description)
+    parser.add_argument("--arelle", action="store", required=arelle,
+                        help="CLI command to run Arelle.")
+    parser.add_argument("--download-cache", action="store_true",
+                        help=f"Whether or not to download and apply cache.")
+    parser.add_argument("--offline", action="store_true",
+                        help="True if Arelle should run in offline mode.")
+    default_directory = Path(".test").joinpath(name)
+    parser.add_argument("--working-directory", action="store", default=default_directory.as_posix(),
+                        help="Directory to place temporary files and log output.")
+    parsed_args = parser.parse_args()
+    if cache and parsed_args.download_cache:
+        download_and_apply_cache(f"scripts/{cache}")
+        print(f"Downloaded and applied cache: {cache}")
+    if working_directory:
+        directory = Path(parsed_args.working_directory).absolute()
+        directory.mkdir(parents=True, exist_ok=True)
+        print(f"Set working directory: {directory}")
+    return parsed_args
+
+
+def prepare_logfile(working_directory: Path, script_path: Path, number: int | None = None) -> Path:
+    number_part = "" if number is None else f".{number}"
+    logfile_path = working_directory.joinpath(f"{script_path.stem}{number_part}.logfile.xml")
+    logfile_path.unlink(missing_ok=True)
+    return logfile_path
+
+
+def run_arelle(
+    arelle_command: str,
+    plugins: list[str] | None = None,
+    additional_args: list[str] | None = None,
+    offline: bool = False,
+    logFile: Path | None = None,
+) -> None:
+    if os.name == 'nt':
+        args = [sys.executable if w == 'python' else w for w in arelle_command.split()]
+    else:
+        args = shlex.split(arelle_command)
+    if plugins:
+        args.append(f"--plugins={'|'.join(plugins)}")
+    if offline:
+        args.append("--internetConnectivity=offline")
+    args.extend(additional_args or [])
+    if logFile:
+        args.extend(["--logFile", str(logFile)])
+    if os.name == 'nt':
+        result = subprocess.run(args, capture_output=True, shell=True)
+    else:
+        result = subprocess.run(args, capture_output=True)
+    assert result.returncode == 0, result.stderr.decode().strip()
+
+
+def validate_log_file(
+    logfile_path: Path
+) -> list[str]:
+    if not logfile_path.exists():
+        return [f'Log file "{logfile_path}" not found.']
+    tree = etree.parse(logfile_path)
+    matches = cast(Iterable[Any], tree.xpath("//log/entry[@level='error']/message/text()"))
+    return [str(x) for x in matches]

--- a/tests/integration_tests/scripts/test_scripts.py
+++ b/tests/integration_tests/scripts/test_scripts.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from typing import Any
+
+
+def test_script(script_results: dict[str, Any]) -> None:
+    """
+    See conftest.py for context around the parameterization of conformance suite results.
+    It is critical that this file is not imported or referenced by other modules to ensure that it is not evaluated
+    before pytest can evaluate conformance suite results via the pytest_configure hook.
+    """
+    assert script_results.get('returncode') == 0, script_results.get('stderr')

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
@@ -1,0 +1,62 @@
+import urllib.request
+import zipfile
+
+from pathlib import Path
+
+from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, cleanup, prepare_logfile
+
+errors = []
+this_file = Path(__file__)
+args = parse_args(
+    this_file.stem,
+    "Confirm ixbrl-viewer plugin runs successfully from the command line.",
+    cache=this_file.with_suffix(".zip").name,
+)
+arelle_command = args.arelle
+arelle_offline = args.offline
+working_directory = Path(args.working_directory)
+arelle_log_file = prepare_logfile(working_directory, this_file)
+samples_zip_path = working_directory.joinpath('samples.zip')
+samples_directory = working_directory.joinpath('samples')
+target_path = samples_directory.joinpath("samples/src/ixds-test/document1.html")
+viewer_path = working_directory.joinpath("viewer.html")
+
+
+print(f"Downloading samples: {samples_zip_path}")
+urllib.request.urlretrieve("https://arelle-public.s3.amazonaws.com/ci/packages/IXBRLViewerSamples.zip", samples_zip_path)
+
+print(f"Extracting samples: {samples_directory}")
+with zipfile.ZipFile(samples_zip_path, "r") as zip_ref:
+    zip_ref.extractall(samples_directory)
+
+print(f"Generating IXBRL viewer: {viewer_path}")
+run_arelle(
+    arelle_command,
+    plugins=["ixbrl-viewer"],
+    additional_args=[
+        "-f", str(target_path),
+        "--save-viewer", str(viewer_path),
+    ],
+    offline=arelle_offline,
+    logFile=arelle_log_file,
+)
+
+print(f"Checking for viewer: {viewer_path}")
+if not viewer_path.exists():
+    errors.append(f'Viewer not generated at "{viewer_path}"')
+
+print(f"Checking for log errors: {arelle_log_file}")
+errors += validate_log_file(arelle_log_file)
+
+assert_result(errors)
+
+print(f"Cleaning up")
+cleanup(
+    working_directory,
+    [
+        samples_directory,
+        samples_zip_path,
+        viewer_path,
+        working_directory.joinpath("ixbrlviewer.js")
+    ]
+)

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
@@ -50,7 +50,7 @@ errors += validate_log_file(arelle_log_file)
 
 assert_result(errors)
 
-print(f"Cleaning up")
+print("Cleaning up")
 cleanup(
     working_directory,
     [

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
@@ -1,9 +1,11 @@
+import os
 import urllib.request
 import zipfile
 
 from pathlib import Path
+from shutil import rmtree
 
-from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, cleanup, prepare_logfile
+from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
 this_file = Path(__file__)
@@ -15,11 +17,12 @@ args = parse_args(
 arelle_command = args.arelle
 arelle_offline = args.offline
 working_directory = Path(args.working_directory)
-arelle_log_file = prepare_logfile(working_directory, this_file)
-samples_zip_path = working_directory.joinpath('samples.zip')
-samples_directory = working_directory.joinpath('samples')
-target_path = samples_directory.joinpath("samples/src/ixds-test/document1.html")
-viewer_path = working_directory.joinpath("viewer.html")
+test_directory = Path(args.test_directory)
+arelle_log_file = prepare_logfile(test_directory, this_file)
+samples_zip_path = test_directory / 'samples.zip'
+samples_directory = test_directory / 'samples'
+target_path = samples_directory / "samples/src/ixds-test/document1.html"
+viewer_path = test_directory / "viewer.html"
 
 
 print(f"Downloading samples: {samples_zip_path}")
@@ -51,12 +54,7 @@ errors += validate_log_file(arelle_log_file)
 assert_result(errors)
 
 print("Cleaning up")
-cleanup(
-    working_directory,
-    [
-        samples_directory,
-        samples_zip_path,
-        viewer_path,
-        working_directory.joinpath("ixbrlviewer.js")
-    ]
-)
+rmtree(working_directory / 'ixbrl-viewer_cli' / 'samples')
+os.unlink(working_directory / 'ixbrl-viewer_cli' / 'samples.zip')
+os.unlink(working_directory / 'ixbrl-viewer_cli' / 'viewer.html')
+os.unlink(working_directory / 'ixbrl-viewer_cli' / 'ixbrlviewer.js')

--- a/tests/integration_tests/scripts/tests/japan_ixds.py
+++ b/tests/integration_tests/scripts/tests/japan_ixds.py
@@ -1,0 +1,71 @@
+import urllib.request
+import zipfile
+
+from pathlib import Path
+
+from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, cleanup, prepare_logfile
+
+errors = []
+this_file = Path(__file__)
+args = parse_args(
+    this_file.stem,
+    "Extract and validate Japanese IXDS instance.",
+    cache=this_file.with_suffix(".zip").name,
+)
+arelle_command = args.arelle
+arelle_offline = args.offline
+working_directory = Path(args.working_directory)
+arelle_log_file1 = prepare_logfile(working_directory, this_file, number=1)
+arelle_log_file2 = prepare_logfile(working_directory, this_file, number=2)
+report_zip_path = working_directory.joinpath('report.zip')
+report_directory = working_directory.joinpath('report')
+manifest_path = report_directory.joinpath("manifest.xml")
+extracted_path = report_directory.joinpath("tse-acedjpfr-19990-2023-06-30-01-2023-08-18_extracted.xbrl")
+report_zip_url = "https://arelle-public.s3.amazonaws.com/ci/packages/JapaneseXBRLReport.zip"
+
+print(f"Downloading report: {report_zip_url}")
+urllib.request.urlretrieve(report_zip_url, report_zip_path)
+
+print(f"Extracting report: {report_directory}")
+with zipfile.ZipFile(report_zip_path, "r") as zip_ref:
+    zip_ref.extractall(report_directory)
+
+print(f"Extracting instance: {manifest_path}")
+run_arelle(
+    arelle_command,
+    plugins=["inlineXbrlDocumentSet"],
+    additional_args=[
+        "--file", str(manifest_path),
+        "--saveInstance"
+    ],
+    offline=arelle_offline,
+    logFile=arelle_log_file1,
+)
+
+# Verify no schemaImportMissing errors in extracted doc
+print(f"Validating instance: {extracted_path}")
+run_arelle(
+    arelle_command,
+    additional_args=[
+        "--validate",
+        "--file", str(extracted_path),
+    ],
+    offline=arelle_offline,
+    logFile=arelle_log_file2,
+)
+
+print(f"Checking for log errors: {arelle_log_file1}")
+errors += validate_log_file(arelle_log_file1)
+print(f"Checking for log errors: {arelle_log_file2}")
+errors += validate_log_file(arelle_log_file2)
+
+assert_result(errors)
+
+print(f"Cleaning up")
+cleanup(
+    working_directory,
+    [
+        report_directory,
+        report_zip_path,
+    ]
+)

--- a/tests/integration_tests/scripts/tests/japan_ixds.py
+++ b/tests/integration_tests/scripts/tests/japan_ixds.py
@@ -1,9 +1,11 @@
+import os
 import urllib.request
 import zipfile
 
 from pathlib import Path
+from shutil import rmtree
 
-from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, cleanup, prepare_logfile
+from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
 this_file = Path(__file__)
@@ -15,12 +17,13 @@ args = parse_args(
 arelle_command = args.arelle
 arelle_offline = args.offline
 working_directory = Path(args.working_directory)
-arelle_log_file1 = prepare_logfile(working_directory, this_file, name="save")
-arelle_log_file2 = prepare_logfile(working_directory, this_file, name="validate")
-report_zip_path = working_directory.joinpath('report.zip')
-report_directory = working_directory.joinpath('report')
-manifest_path = report_directory.joinpath("manifest.xml")
-extracted_path = report_directory.joinpath("tse-acedjpfr-19990-2023-06-30-01-2023-08-18_extracted.xbrl")
+test_directory = Path(args.test_directory)
+arelle_log_file1 = prepare_logfile(test_directory, this_file, name="save")
+arelle_log_file2 = prepare_logfile(test_directory, this_file, name="validate")
+report_zip_path = test_directory / 'report.zip'
+report_directory = test_directory / 'report'
+manifest_path = report_directory / "manifest.xml"
+extracted_path = report_directory / "tse-acedjpfr-19990-2023-06-30-01-2023-08-18_extracted.xbrl"
 report_zip_url = "https://arelle-public.s3.amazonaws.com/ci/packages/JapaneseXBRLReport.zip"
 
 print(f"Downloading report: {report_zip_url}")
@@ -62,10 +65,5 @@ errors += validate_log_file(arelle_log_file2)
 assert_result(errors)
 
 print("Cleaning up")
-cleanup(
-    working_directory,
-    [
-        report_directory,
-        report_zip_path,
-    ]
-)
+rmtree(working_directory / 'japan_ixds' / 'report')
+os.unlink(working_directory / 'japan_ixds' / 'report.zip')

--- a/tests/integration_tests/scripts/tests/japan_ixds.py
+++ b/tests/integration_tests/scripts/tests/japan_ixds.py
@@ -15,8 +15,8 @@ args = parse_args(
 arelle_command = args.arelle
 arelle_offline = args.offline
 working_directory = Path(args.working_directory)
-arelle_log_file1 = prepare_logfile(working_directory, this_file, number=1)
-arelle_log_file2 = prepare_logfile(working_directory, this_file, number=2)
+arelle_log_file1 = prepare_logfile(working_directory, this_file, name="save")
+arelle_log_file2 = prepare_logfile(working_directory, this_file, name="validate")
 report_zip_path = working_directory.joinpath('report.zip')
 report_directory = working_directory.joinpath('report')
 manifest_path = report_directory.joinpath("manifest.xml")
@@ -61,7 +61,7 @@ errors += validate_log_file(arelle_log_file2)
 
 assert_result(errors)
 
-print(f"Cleaning up")
+print("Cleaning up")
 cleanup(
     working_directory,
     [

--- a/tests/integration_tests/validation/validation_util.py
+++ b/tests/integration_tests/validation/validation_util.py
@@ -1,141 +1,26 @@
 from __future__ import annotations
+
 import multiprocessing
 import os.path
-import pytest
 import tempfile
-from collections import Counter, defaultdict
-from contextlib import ExitStack, nullcontext
+from collections import defaultdict
+from contextlib import ExitStack
+from contextlib import nullcontext
 from dataclasses import dataclass
 from heapq import heapreplace
-from lxml import etree
 from pathlib import PurePath, PurePosixPath
 from typing import Any, Callable, ContextManager, TYPE_CHECKING, cast
 from unittest.mock import patch
 from zipfile import ZipFile
 
-from arelle import ModelDocument, PackageManager, PluginManager
-from arelle.CntlrCmdLine import parseAndRun
-from arelle.FileSource import archiveFilenameParts
-from arelle.WebCache import WebCache
+from lxml import etree
 
+from arelle.WebCache import WebCache
+from tests.integration_tests.integration_test_util import get_test_data
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig
 
 if TYPE_CHECKING:
     from _pytest.mark import ParameterSet
-
-
-def get_document_id(doc: ModelDocument.ModelDocument) -> str:
-    file_source = doc.modelXbrl.fileSource
-    basepath = getattr(file_source, 'basefile', None)
-    if basepath is None:
-        # Try and find a basepath from referenced documents
-        ref_file_source = next(iter(file_source.referencedFileSources.values()), None)
-        if ref_file_source is not None:
-            basepath = ref_file_source.basefile
-    if basepath is None:
-        # Try and find a basepath based on archive in path
-        archivePathParts = archiveFilenameParts(doc.filepath)
-        if archivePathParts is not None:
-            return archivePathParts[1]
-    if basepath is None:
-        # Use file source URL as fallback if basepath not found
-        basepath = os.path.dirname(file_source.url) + os.sep
-    return PurePath(doc.filepath).relative_to(basepath).as_posix()
-
-
-def get_test_data(
-        args: list[str],
-        expected_failure_ids: frozenset[str] = frozenset(),
-        expected_empty_testcases: frozenset[str] = frozenset(),
-        expected_model_errors: frozenset[str] = frozenset(),
-        strict_testcase_index: bool = True,
-) -> list[ParameterSet]:
-    """
-    Produces a list of Pytest Params that can be fed into a parameterized pytest function
-
-    :param args: The args to be parsed by arelle in order to correctly produce the desired result set
-    :param expected_failure_ids: The set of string test IDs that are expected to fail
-    :param expected_empty_testcases: The set of paths of empty testcases, relative to the suite zip
-    :param expected_model_errors: The set of error codes expected to be in the ModelXbrl errors
-    :param strict_testcase_index: Don't allow IOerrors when loading the testcase index
-    :return: A list of PyTest Params that can be used to run a parameterized pytest function
-    """
-    cntlr = parseAndRun(args)  # type: ignore[no-untyped-call]
-    try:
-        results = []
-        test_cases_with_no_variations = set()
-        test_cases_with_unrecognized_type = {}
-        model_document = cntlr.modelManager.modelXbrl.modelDocument
-        test_cases: list[ModelDocument.ModelDocument] = []
-        if model_document.type in (ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRYTESTCASE):
-            test_cases.append(model_document)
-        elif model_document.type == ModelDocument.Type.TESTCASESINDEX:
-            if strict_testcase_index:
-                model_errors = sorted(cntlr.modelManager.modelXbrl.errors)
-                assert 'IOerror' not in model_errors, f'One or more testcases referenced by testcases index "{model_document.filepath}" were not found.'
-            referenced_documents = model_document.referencesDocument.keys()
-            child_document_types = {doc.type for doc in referenced_documents}
-            assert len(child_document_types) == 1, f'Multiple child document types found in {model_document.uri}: {child_document_types}.'
-            [child_document_type] = child_document_types
-            # the formula function registry conformance suite points to a list of registries, so we need to search one level deeper.
-            if child_document_type == ModelDocument.Type.REGISTRY:
-                referenced_documents = [case for doc in referenced_documents for case in doc.referencesDocument.keys()]
-            test_cases = sorted(referenced_documents, key=lambda doc: doc.uri)
-        elif model_document.type == ModelDocument.Type.INSTANCE:
-            test_id = get_document_id(model_document)
-            model_errors = sorted(cntlr.modelManager.modelXbrl.errors)
-            expected_model_errors_list = sorted(expected_model_errors)
-            param = pytest.param(
-                {
-                    'status': 'pass' if model_errors == expected_model_errors_list else 'fail',
-                    'expected': expected_model_errors_list,
-                    'actual': model_errors
-                },
-                id=test_id,
-                marks=[pytest.mark.xfail()] if test_id in expected_failure_ids else []
-            )
-            results.append(param)
-        else:
-            raise Exception('Unhandled model document type: {}'.format(model_document.type))
-        for test_case in test_cases:
-            test_case_file_id = get_document_id(test_case)
-            if test_case.type not in (ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRYTESTCASE):
-                test_cases_with_unrecognized_type[test_case_file_id] = test_case.type
-            if not getattr(test_case, "testcaseVariations", None):
-                test_cases_with_no_variations.add(test_case_file_id)
-            else:
-                for mv in test_case.testcaseVariations:
-                    test_id = f'{test_case_file_id}:{mv.id}'
-                    param = pytest.param(
-                        {
-                            'status': mv.status,
-                            'expected': mv.expected,
-                            'actual': mv.actual
-                        },
-                        id=test_id,
-                        marks=[pytest.mark.xfail()] if test_id in expected_failure_ids else []
-                    )
-                    results.append(param)
-        if test_cases_with_unrecognized_type:
-            raise Exception(f"Some test cases have an unrecognized document type: {sorted(test_cases_with_unrecognized_type.items())}.")
-        unrecognized_expected_empty_testcases = expected_empty_testcases.difference(map(get_document_id, test_cases))
-        if unrecognized_expected_empty_testcases:
-            raise Exception(f"Some expected empty test cases weren't found: {sorted(unrecognized_expected_empty_testcases)}.")
-        unexpected_empty_testcases = test_cases_with_no_variations - expected_empty_testcases
-        if unexpected_empty_testcases:
-            raise Exception(f"Some test cases don't have any variations: {sorted(unexpected_empty_testcases)}.")
-        test_id_frequencies = Counter(cast(str, p.id) for p in results)
-        nonunique_test_ids = {test_id: count for test_id, count in test_id_frequencies.items() if count > 1}
-        if nonunique_test_ids:
-            raise Exception(f'Some test IDs are not unique.  Frequencies of nonunique test IDs: {nonunique_test_ids}.')
-        nonexistent_expected_failure_ids = expected_failure_ids - test_id_frequencies.keys()
-        if nonexistent_expected_failure_ids:
-            raise Exception(f"Some expected failure IDs don't match any test cases: {sorted(nonexistent_expected_failure_ids)}.")
-        return results
-    finally:
-        cntlr.modelManager.close()
-        PackageManager.close()  # type: ignore[no-untyped-call]
-        PluginManager.close()  # type: ignore[no-untyped-call]
 
 
 original_normalize_url_function = WebCache.normalizeUrl


### PR DESCRIPTION
#### Reason for change
There will be a need for running general integration test scripts, separate from the conformance suite pattern we currently use. These integration tests should be as flexible as possible.

#### Description of change
- Implemented standalone `download_cache.py` script for downloading public caches in a cross platform way (to remove the need separate conditional steps in workflows)
- Created script running framework in `tests/integration_tests/scripts` based off of the existing conformance suite running framework
- Created `requirements-plugins.txt` requirements set for integration tests and builds
- Implemented test for Japan IXDS (Resolves #901)
- Implemented test for triggering `ixbrl-viewer` from the command line (to help test #734)
- Created workflow to run integration test scripts on pull requests
  - Added dispatch-only version that runs the tests in parallel 
- Added steps to build workflows to run these tests against builds

#### Steps to Test
Should pass on this PR (pull_request trigger):
- [ ] test-scripts.yml

Run on fork (see recent runs on my fork [here](https://github.com/aaroncameron-wk/arelle-public/actions)):
- [ ] test-scripts-parallel.yml
- [ ] conformance-suites.yml
- [ ] build-macos.yml (Note: codesign/notarize can now be optionally skipped)
- [ ] build-windows.yml
- [ ] build-linux.yml

**review**:
@Arelle/arelle
