### PR TITLE
Fix exceptions with "save Xbrl Formula file" in GUI.

### DIFF
--- a/arelle/plugin/formulaSaver.py
+++ b/arelle/plugin/formulaSaver.py
@@ -470,7 +470,7 @@ class GenerateXbrlFormula:
 
 def saveXfMenuEntender(cntlr, menu, *args, **kwargs):
     # Extend menu with an item for the savedts plugin
-    menu.add_command(label="Save Xbrl Formula file",
+    menu.add_command(label="Save Formula as XF...",
                      underline=0,
                      command=lambda: saveXfMenuCommand(cntlr) )
 
@@ -497,7 +497,7 @@ def saveXfMenuCommand(cntlr):
         GenerateXbrlFormula(cntlr, modelXbrl, xbrlFormulaFile)
     except Exception as ex:
         modelXbrl.error("exception",
-            _("Xbrl Formula file generation exception: %(error)s"), error=ex,
+            _("XF file generation exception: %(error)s"), error=ex,
             modelXbrl=modelXbrl,
             exc_info=True)
 

--- a/arelle/plugin/formulaSaver.py
+++ b/arelle/plugin/formulaSaver.py
@@ -494,9 +494,9 @@ def saveXfMenuCommand(cntlr):
 
     modelXbrl = cntlr.modelManager.modelXbrl
     try:
-        GenerateXbrlFormula(cntlr, modelXbrl, xbrlFormulaFile, mode)
+        GenerateXbrlFormula(cntlr, modelXbrl, xbrlFormulaFile)
     except Exception as ex:
-        dts.error("exception",
+        modelXbrl.error("exception",
             _("Xbrl Formula file generation exception: %(error)s"), error=ex,
             modelXbrl=modelXbrl,
             exc_info=True)


### PR DESCRIPTION
#### Reason for change

Exception thrown when trying to using `FormulaSaver` plugin.  Use "Tools->Save Xbrl Formula File" on any DTS and you get:

![image](https://github.com/Arelle/Arelle/assets/45077928/ba54e271-c086-4161-b1b0-64f9e47b30d0)

This error is in the exception handling code, and the exception that it's trying to report is passing a non-existent `mode` variable as a parameter to `GenerateXbrlFormula`.

#### Description of change

Fixes logging of exception, fixes underlying cause of exception.

This PR also renames the menu option to "Save Formula as XF..." because "Save as Xbrl Formula" is confusing (and badly capitalised).  We try to use the term "XF" to refer to the text-based XBRL Formula format.  Ellipsis also added, because it opens  a file chooser dialog.

#### Steps to Test

Open GUI with any XBRL and the "Formula Saver" plugin enabled. Use Tools->Save Xbrl Formula File and check that a file is produced instead of an exception.

**review**:
@Arelle/arelle
