### PR TITLE
Duplicate fact detection

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -6,7 +6,7 @@ This module is Arelle's controller in command line non-interactive mode
 See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
-from arelle import PythonUtil # define 2.x or 3.x string types
+from arelle import PythonUtil, ValidateDuplicateFacts  # define 2.x or 3.x string types
 import gettext, time, datetime, os, shlex, sys, traceback, fnmatch, threading, json, logging, platform
 from optparse import OptionGroup, OptionParser, SUPPRESS_HELP
 import regex as re
@@ -130,6 +130,10 @@ def parseArgs(args):
                              "are individually so validated. "
                              "If formulae are present they will be validated and run unless --formula=none is specified. "
                              ))
+    parser.add_option("--validateDuplicateFacts", "--validateduplicatefacts",
+                      choices=[a.value for a in ValidateDuplicateFacts.DUPLICATE_TYPE_ARG_MAP],
+                      dest="validateDuplicateFacts",
+                      help=_("Select which types of duplicates should trigger warnings."))
     parser.add_option("--noValidateTestcaseSchema", "--novalidatetestcaseschema", action="store_false", dest="validateTestcaseSchema", default=True,
                       help=_("Validate testcases against their schemas."))
     betaGroup = OptionGroup(parser, "Beta Features",
@@ -748,6 +752,10 @@ class CntlrCmdLine(Cntlr.Cntlr):
         else:
             self.modelManager.disclosureSystem.select(None) # just load ordinary mappings
             self.modelManager.validateDisclosureSystem = False
+        if options.validateDuplicateFacts:
+            duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(options.validateDuplicateFacts)
+            duplicateType = duplicateTypeArg.duplicateType()
+            self.modelManager.validateDuplicateFacts = duplicateType
         if options.utrUrl:  # override disclosureSystem utrUrl
             self.modelManager.disclosureSystem.utrUrl = [options.utrUrl]
             # can be set now because the utr is first loaded at validation time

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -5,7 +5,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 
-from arelle import PythonUtil # define 2.x or 3.x string types
+from arelle import ValidateDuplicateFacts
 import os, sys, subprocess, pickle, time, locale, fnmatch, platform, webbrowser
 import regex as re
 
@@ -165,6 +165,10 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.validateUtr = BooleanVar(value=self.modelManager.validateUtr)
         self.validateUtr.trace("w", self.setValidateUtr)
         validateMenu.add_checkbutton(label=_("Unit Type Registry validation"), underline=0, variable=self.validateUtr, onvalue=True, offvalue=False)
+
+        self.validateDuplicateFacts = None
+        self.buildValidateDuplicateFactsMenu(validateMenu)
+
         for pluginMenuExtender in pluginClassMethods("CntlrWinMain.Menu.Validation"):
             pluginMenuExtender(self, validateMenu)
 
@@ -452,6 +456,25 @@ class CntlrWinMain (Cntlr.Cntlr):
             lastArg = arg
         self.setValidateTooltipText()
 
+    def buildValidateDuplicateFactsMenu(self, validateMenu: Menu) -> None:
+        defaultArg = ValidateDuplicateFacts.DuplicateTypeArg.NONE.value
+        validateDuplicateFactsStr = self.config.setdefault("validateDuplicateFacts", defaultArg)
+        try:
+            duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(validateDuplicateFactsStr)
+        except ValueError:
+            duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(defaultArg)
+        self.modelManager.validateDuplicateFacts = duplicateTypeArg.duplicateType()
+        self.validateDuplicateFacts = StringVar(value=duplicateTypeArg.value)
+        self.validateDuplicateFacts.trace("w", self.setValidateDuplicateFacts)
+        duplicateFactWarningMenu = Menu(validateMenu, tearoff=0)
+        for duplicateTypeArg in ValidateDuplicateFacts.DuplicateTypeArg:
+            duplicateFactWarningMenu.add_checkbutton(
+                label=duplicateTypeArg.value.title(),
+                variable=self.validateDuplicateFacts,
+                underline=0,
+                onvalue=duplicateTypeArg.value
+            )
+        validateMenu.add_cascade(label="Warn on duplicate facts", menu=duplicateFactWarningMenu, underline=0)
 
     def onTabChanged(self, event, *args):
         try:
@@ -1124,6 +1147,15 @@ class CntlrWinMain (Cntlr.Cntlr):
 
     def restart(self, event=None):
         self.quit(event, restartAfterQuit=True)
+
+    def setValidateDuplicateFacts(self, *args):
+        value = self.validateDuplicateFacts.get()
+        duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(value)
+        self.modelManager.validateDuplicateFacts = duplicateTypeArg.duplicateType()
+        self.config["validateDuplicateFacts"] = value
+        self.addToLog('ModelManager.validateDuplicateFacts = {}'.format(
+            self.modelManager.validateDuplicateFacts), messageCode='debug', level=logging.DEBUG)
+        self.saveConfig()
 
     def setWorkOffline(self, *args):
         self.webCache.workOffline = self.workOffline.get()

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 import gc, sys, traceback, logging
-from arelle import ModelXbrl, Validate, DisclosureSystem, PackageManager, ValidateXbrlCalcs
+from arelle import ModelXbrl, Validate, DisclosureSystem, PackageManager, ValidateXbrlCalcs, ValidateDuplicateFacts
 from arelle.ModelFormulaObject import FormulaOptions
 from arelle.PluginManager import pluginClassMethods
 from arelle.typing import LocaleDict
@@ -67,6 +67,7 @@ class ModelManager:
         self.loadedModelXbrls = []
         self.customTransforms: dict[QName, Callable[[str], str]] | None = None
         self.isLocaleSet = False
+        self.validateDuplicateFacts = ValidateDuplicateFacts.DuplicateType.NONE
         self.setLocale()
         ValidateXbrlCalcs.init() # required due to circular dependencies in module
 

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -123,6 +123,7 @@ class RuntimeOptions:
     utrUrl: Optional[str] = None
     utrValidate: Optional[bool] = None
     validate: Optional[bool] = None
+    validateDuplicateFacts: Optional[str] = None
     validateEFM: Optional[bool] = None
     validateEFMCalcTree: Optional[bool] = None
     validateHMRC: Optional[bool] = None

--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -185,6 +185,10 @@ class DuplicateType(Flag):
             yield DuplicateType(b)
             num ^= b
 
+    @property
+    def description(self) -> str:
+        return '|'.join([str(n.name) for n in self if n.name]).lower()
+
 
 class DuplicateTypeArg(Enum):
     NONE = 'none'

--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from enum import auto, Flag, Enum
 from functools import cached_property
 from math import isnan
-from typing import cast, Iterator, Any, SupportsFloat
+from typing import cast, Iterator, Any, SupportsFloat, Tuple
 
 from arelle import XmlValidateConst
 from arelle.ModelInstanceObject import ModelFact, ModelContext, ModelUnit
@@ -314,7 +314,7 @@ class FactValueEqualityType(Enum):
     LANGUAGE = 'language'
 
 
-TypeFactValueEqualityKey = tuple[FactValueEqualityType, tuple[Any, ...]]
+TypeFactValueEqualityKey = Tuple[FactValueEqualityType, Tuple[Any, ...]]
 
 
 def getFactValueEqualityKey(fact: ModelFact) -> TypeFactValueEqualityKey:

--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -141,6 +141,7 @@ class DuplicateType(Flag):
     NONE = 0
     INCONSISTENT = auto()
     CONSISTENT = auto()
+    INCOMPLETE = auto()
     COMPLETE = auto()
 
     # Flags before 3.11 did not support iterating Flag values,
@@ -158,6 +159,7 @@ class DuplicateTypeArg(Enum):
     NONE = 'none'
     INCONSISTENT = 'inconsistent'
     CONSISTENT = 'consistent'
+    INCOMPLETE = 'incomplete'
     COMPLETE = 'complete'
     ALL = 'all'
 
@@ -169,6 +171,7 @@ DUPLICATE_TYPE_ARG_MAP = {
     DuplicateTypeArg.NONE: DuplicateType.NONE,
     DuplicateTypeArg.INCONSISTENT: DuplicateType.INCONSISTENT,
     DuplicateTypeArg.CONSISTENT: DuplicateType.CONSISTENT,
+    DuplicateTypeArg.INCOMPLETE: DuplicateType.INCOMPLETE,
     DuplicateTypeArg.COMPLETE: DuplicateType.COMPLETE,
     DuplicateTypeArg.ALL: DuplicateType.INCONSISTENT | DuplicateType.CONSISTENT,
 }
@@ -184,14 +187,18 @@ def areDuplicatesOfType(duplicateFacts: DuplicateFactSet, duplicateType: Duplica
     """
     inconsistent = DuplicateType.INCONSISTENT in duplicateType
     consistent = DuplicateType.CONSISTENT in duplicateType
+    incomplete = DuplicateType.INCOMPLETE in duplicateType
     complete = DuplicateType.COMPLETE in duplicateType
+    if (inconsistent and consistent) or (incomplete and complete):
+        return True
     if inconsistent:
-        if consistent:
-            return True
         if duplicateFacts.areInconsistentDuplicates:
             return True
     if consistent:
         if duplicateFacts.areConsistentDuplicates:
+            return True
+    if incomplete:
+        if not duplicateFacts.areCompleteDuplicates:
             return True
     if complete:
         if duplicateFacts.areCompleteDuplicates:

--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -24,20 +24,20 @@ class DuplicateFactSet:
         return iter(self.facts)
 
     @cached_property
-    def areCompleteDuplicates(self) -> bool:
+    def areAllComplete(self) -> bool:
         """
         Returns whether these duplicates are complete duplicates.
         :return: True if complete, False if incomplete consistent, or inconsistent.
         """
-        return self.areDecimalsEqual and self.areValueEqual
+        return self.areAllDecimalsEqual and self.areAllValueEqual
 
     @cached_property
-    def areConsistentDuplicates(self) -> bool:
+    def areAllConsistent(self) -> bool:
         """
         Returns whether these duplicates are consistent with each other.
         :return: True if consistent or complete, False if incomplete inconsistent.
         """
-        if self.areCompleteDuplicates:
+        if self.areAllComplete:
             return True
         if self.areNumeric:
             # If facts are numeric but NOT complete duplicates,
@@ -47,7 +47,7 @@ class DuplicateFactSet:
         return False
 
     @cached_property
-    def areDecimalsEqual(self) -> bool:
+    def areAllDecimalsEqual(self) -> bool:
         """
         :return: Whether these facts have matching decimals values.
         """
@@ -59,16 +59,16 @@ class DuplicateFactSet:
         return True
 
     @cached_property
-    def areInconsistentDuplicates(self) -> bool:
+    def areAnyInconsistent(self) -> bool:
         """
         Returns whether these duplicates are inconsistent with each other.
         :return: True if inconsistent, False if consistent or complete.
         """
         if self.areNumeric:
             # If facts are numeric, they are inconsistent if they are not consistent
-            return not self.areConsistentDuplicates
+            return not self.areAllConsistent
         # If facts are not numeric, they are inconsistent if they are not fact-value equal
-        return not self.areValueEqual
+        return not self.areAllValueEqual
 
     @cached_property
     def areNumeric(self) -> bool:
@@ -78,7 +78,7 @@ class DuplicateFactSet:
         return self.facts[0].isNumeric
 
     @cached_property
-    def areValueEqual(self) -> bool:
+    def areAllValueEqual(self) -> bool:
         """
         :return: Whether all facts in this set are fact-value equal.
         """
@@ -128,11 +128,11 @@ class DuplicateFactSet:
         """
         # Access __dict__ directly to check if given properties have been evaluated
         # and, if so, what the evaluated value is.
-        if self.__dict__.get('areCompleteDuplicates'):
+        if self.__dict__.get('areAllComplete'):
             return DuplicateType.COMPLETE
-        if self.__dict__.get('areConsistentDuplicates'):
+        if self.__dict__.get('areAllConsistent'):
             return DuplicateType.CONSISTENT
-        if self.__dict__.get('areInconsistentDuplicates'):
+        if self.__dict__.get('areAnyInconsistent'):
             return DuplicateType.INCONSISTENT
         return None
 
@@ -191,18 +191,14 @@ def areDuplicatesOfType(duplicateFacts: DuplicateFactSet, duplicateType: Duplica
     complete = DuplicateType.COMPLETE in duplicateType
     if (inconsistent and consistent) or (incomplete and complete):
         return True
-    if inconsistent:
-        if duplicateFacts.areInconsistentDuplicates:
-            return True
-    if consistent:
-        if duplicateFacts.areConsistentDuplicates:
-            return True
-    if incomplete:
-        if not duplicateFacts.areCompleteDuplicates:
-            return True
-    if complete:
-        if duplicateFacts.areCompleteDuplicates:
-            return True
+    if inconsistent and duplicateFacts.areAnyInconsistent:
+        return True
+    if consistent and duplicateFacts.areAllConsistent:
+        return True
+    if incomplete and not duplicateFacts.areAllComplete:
+        return True
+    if complete and duplicateFacts.areAllComplete:
+        return True
     return False
 
 

--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -1,0 +1,299 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import auto, Flag, Enum
+from functools import cached_property
+from math import isnan
+from typing import cast, Iterator
+
+from arelle import XmlValidateConst
+from arelle.ModelInstanceObject import ModelFact, ModelContext, ModelUnit
+from arelle.ModelValue import DateTime, QName
+from arelle.ValidateXbrlCalcs import rangeValue, inferredDecimals
+
+
+@dataclass(frozen=True)
+class DuplicateFactSet:
+    facts: list[ModelFact]
+
+    def __iter__(self):
+        return iter(self.facts)
+
+    @cached_property
+    def areCompleteDuplicates(self) -> bool:
+        """
+        Returns whether these duplicates are complete duplicates.
+        :return: True if complete, False if incomplete consistent, or inconsistent.
+        """
+        return self.areDecimalsEqual and self.areValueEqual
+
+    @cached_property
+    def areConsistentDuplicates(self) -> bool:
+        """
+        Returns whether these duplicates are consistent with each other.
+        :return: True if consistent or complete, False if incomplete inconsistent.
+        """
+        if self.areCompleteDuplicates:
+            return True
+        if self.areNumeric:
+            # If facts are numeric but NOT complete duplicates,
+            # they must be within rounding error to be consistent
+            return self.areWithinRoundingError
+        # If facts are not complete duplicates and not numeric, then they are not consistent
+        return False
+
+    @cached_property
+    def areDecimalsEqual(self) -> bool:
+        """
+        :return: Whether these facts have matching decimals values.
+        """
+        firstFact = self.facts[0]
+        for fact in self.facts[1:]:
+            if firstFact.decimals != fact.decimals:
+                # If facts do not have matching decimal values, they are not complete
+                return False
+        return True
+
+    @cached_property
+    def areInconsistentDuplicates(self) -> bool:
+        """
+        Returns whether these duplicates are inconsistent with each other.
+        :return: True if inconsistent, False if consistent or complete.
+        """
+        if self.areNumeric:
+            # If facts are numeric, they are inconsistent if they are not consistent
+            return not self.areConsistentDuplicates
+        # If facts are not numeric, they are inconsistent if they are not fact-value equal
+        return not self.areValueEqual
+
+    @cached_property
+    def areNumeric(self) -> bool:
+        """
+        :return: Whether the duplicate set consists of numeric facts.
+        """
+        return self.facts[0].isNumeric
+
+    @cached_property
+    def areValueEqual(self) -> bool:
+        """
+        :return: Whether all facts in this set are fact-value equal.
+        """
+        firstFact = self.facts[0]
+        for fact in self.facts[1:]:
+            if not areFactsValueEqual(firstFact, fact):
+                # If facts are not value-equal, they are not complete
+                return False
+        return True
+
+    @cached_property
+    def areWithinRoundingError(self) -> bool:
+        """
+        :return: Whether the set of numeric fact values are within rounding error of each other.
+        """
+        maxLower = float("-inf")
+        minUpper = float("inf")
+        decimalValues = {}
+        for fact in self.facts:
+            value = fact.xValue
+            if isnan(value):
+                # NaN values are not comparable, can't be equal/consistent.
+                return False
+            decimals = inferredDecimals(fact)
+            if decimals in decimalValues:
+                if value != decimalValues[decimals]:
+                    # Facts with the same `decimals` value MUST have the same numeric value in order to be considered consistent.
+                    return False
+            else:
+                decimalValues[decimals] = value
+            lower, upper, __, ___ = rangeValue(value, decimals)
+            if lower > maxLower:
+                maxLower = lower
+            if upper < minUpper:
+                minUpper = upper
+            if minUpper < maxLower:
+                # One fact's upper bound is less than another fact's lower bound, not consistent
+                return False
+        return True
+
+    @property
+    def duplicateType(self) -> DuplicateType | None:
+        """
+        Determines type of duplicate based on previously evaluated conditions.
+        If duplicate type status has not been evaluated, returns None.
+        :return: Duplicate type, or None
+        """
+        # Access __dict__ directly to check if given properties have been evaluated
+        # and, if so, what the evaluated value is.
+        if self.__dict__.get('areCompleteDuplicates'):
+            return DuplicateType.COMPLETE
+        if self.__dict__.get('areConsistentDuplicates'):
+            return DuplicateType.CONSISTENT
+        if self.__dict__.get('areInconsistentDuplicates'):
+            return DuplicateType.INCONSISTENT
+        return None
+
+
+class DuplicateType(Flag):
+    NONE = 0
+    INCONSISTENT = auto()
+    CONSISTENT = auto()
+    COMPLETE = auto()
+
+    # Flags before 3.11 did not support iterating Flag values,
+    # so we have to override with our own iterator. Remove when we no longer support 3.10
+    def __iter__(self):
+        # num must be a positive integer
+        num = self.value
+        while num:
+            b = num & (~num + 1)
+            yield DuplicateType(b)
+            num ^= b
+
+
+class DuplicateTypeArg(Enum):
+    NONE = 'none'
+    INCONSISTENT = 'inconsistent'
+    CONSISTENT = 'consistent'
+    COMPLETE = 'complete'
+    ALL = 'all'
+
+    def duplicateType(self) -> DuplicateType:
+        return DUPLICATE_TYPE_ARG_MAP.get(self, DuplicateType.NONE)
+
+
+DUPLICATE_TYPE_ARG_MAP = {
+    DuplicateTypeArg.NONE: DuplicateType.NONE,
+    DuplicateTypeArg.INCONSISTENT: DuplicateType.INCONSISTENT,
+    DuplicateTypeArg.CONSISTENT: DuplicateType.CONSISTENT,
+    DuplicateTypeArg.COMPLETE: DuplicateType.COMPLETE,
+    DuplicateTypeArg.ALL: DuplicateType.INCONSISTENT | DuplicateType.CONSISTENT,
+}
+
+
+def areDuplicatesOfType(duplicateFacts: DuplicateFactSet, duplicateType: DuplicateType) -> bool:
+    """
+    Returns whether or not the given duplicate facts should be disallowed
+    based on the disallowed mode.
+    :param duplicateFacts:
+    :param duplicateType:
+    :return: True if disallowed, False if allowed.
+    """
+    inconsistent = DuplicateType.INCONSISTENT in duplicateType
+    consistent = DuplicateType.CONSISTENT in duplicateType
+    complete = DuplicateType.COMPLETE in duplicateType
+    if inconsistent:
+        if consistent:
+            return True
+        if duplicateFacts.areInconsistentDuplicates:
+            return True
+    if consistent:
+        if duplicateFacts.areConsistentDuplicates:
+            return True
+    if complete:
+        if duplicateFacts.areCompleteDuplicates:
+            return True
+    return False
+
+
+def areFactsValueEqual(factA: ModelFact, factB: ModelFact) -> bool:
+    """
+    Returns whether the given facts are value-equal
+    :param factA:
+    :param factB:
+    :return: True if the given facts are value-equal
+    """
+    if factA.context is None or factA.concept is None:
+        return False  # need valid context and concept for v-Equality of nonTuple
+    if factA.isNil:
+        return factB.isNil
+    if factB.isNil:
+        return False
+    if not factA.context.isEqualTo(factB.context):
+        return False
+    xValueA = factA.xValue
+    xValueB = factB.xValue
+    if isinstance(xValueA, type(xValueB)):
+        if factA.concept.isLanguage and factB.concept.isLanguage and xValueA is not None and xValueB is not None:
+            return xValueA.lower() == xValueB.lower()  # required to handle case insensitivity
+        if isinstance(xValueA, DateTime):  # with/without time makes values unequal
+            return xValueA.dateOnly == cast(DateTime, xValueB).dateOnly and xValueA == xValueB
+        return xValueA == xValueB  # required to handle date/time with 24 hrs.
+    return factA.value == factB.value
+
+
+def getAspectEqualFacts(hashEquivalentFacts: list[ModelFact]) -> Iterator[list[ModelFact]]:
+    """
+    Given a list of concept/context/unit hash-equivalent facts,
+    yields sublists of aspect-equal facts from this list.
+    :param hashEquivalentFacts:
+    :return: Lists of aspect-equal facts.
+    """
+    aspectEqualFacts: dict[tuple[QName, str], dict[tuple[ModelContext, ModelUnit], list[ModelFact]]] = defaultdict(dict)
+    for fact in hashEquivalentFacts:  # check for hash collision by value checks on context and unit
+        contextUnitDict = aspectEqualFacts[(
+            fact.qname,
+            (fact.xmlLang or "").lower() if fact.concept.type.isWgnStringFactType else None
+        )]
+        _matched = False
+        for (context, unit), contextUnitFacts in contextUnitDict.items():
+            if fact.context is None:
+                if context is not None:
+                    continue
+            elif not fact.context.isEqualTo(context):
+                continue
+            if fact.unit is None:
+                if unit is not None:
+                    continue
+            elif not fact.unit.isEqualTo(unit):
+                continue
+            _matched = True
+            contextUnitFacts.append(fact)
+            break
+        if not _matched:
+            contextUnitDict[(fact.context, fact.unit)] = [fact]
+    for contextUnitDict in aspectEqualFacts.values():  # dups by qname, lang
+        for duplicateFacts in contextUnitDict.values():  # dups by equal-context equal-unit
+            if len(duplicateFacts) < 2:
+                continue
+            yield duplicateFacts
+
+
+def getDuplicateFactSets(facts: list[ModelFact]) -> Iterator[DuplicateFactSet]:
+    """
+    Yields each pairing of facts from the provided set that are duplicates of the given type(s).
+    :param facts: Facts to find duplicate sets from.
+    :return: Yields duplicate fact sets.
+    """
+    hashEquivalentFactGroups = getHashEquivalentFactGroups(facts)
+    for hashEquivalentFacts in hashEquivalentFactGroups:
+        if len(hashEquivalentFacts) < 2:
+            continue
+        for duplicateFactList in getAspectEqualFacts(hashEquivalentFacts):  # dups by equal-context equal-unit
+            duplicateFactSet = DuplicateFactSet(facts=duplicateFactList)
+            yield duplicateFactSet
+
+
+def getDuplicateFactSetsOfType(facts: list[ModelFact], duplicateType: DuplicateType) -> Iterator[DuplicateFactSet]:
+    if duplicateType == DuplicateType.NONE:
+        return
+    for duplicateFactSet in getDuplicateFactSets(facts):
+        if areDuplicatesOfType(duplicateFactSet, duplicateType):
+            yield duplicateFactSet
+
+
+def getHashEquivalentFactGroups(facts: list[ModelFact]) -> list[list[ModelFact]]:
+    """
+    Given a list of facts in an instance, returns a list of lists of facts
+    that are concept/context/unit hash-equivalent.
+    :param facts:
+    :return: List of hash-equivalent fact lists
+    """
+    hashDict = defaultdict(list)
+    for f in facts:
+        if (f.isNil or getattr(f, "xValid", XmlValidateConst.UNVALIDATED) >= XmlValidateConst.VALID) and f.context is not None and f.concept is not None and f.concept.type is not None:
+            hashDict[f.conceptContextUnitHash].append(f)
+    return list(hashDict.values())

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -684,7 +684,7 @@ class ValidateXbrl:
                                 xlinkLabel=resourceArcToLabel)
 
     def checkDuplicateFacts(self, facts: list[ModelFact], duplicateType: ValidateDuplicateFacts.DuplicateType) -> None:
-        for duplicateFactSet in ValidateDuplicateFacts.getDuplicateFactSetsOfType(facts, duplicateType):
+        for duplicateFactSet in ValidateDuplicateFacts.getDuplicateFactSetsWithType(facts, duplicateType):
             self.modelXbrl.warning(
                 "arelle:duplicateFacts",
                 "Duplicate fact set with%(duplicateType)s duplicate(s) %(qname)s: %(values)s, %(contextIDs)s.",

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -687,9 +687,9 @@ class ValidateXbrl:
         for duplicateFactSet in ValidateDuplicateFacts.getDuplicateFactSetsWithType(facts, duplicateType):
             self.modelXbrl.warning(
                 "arelle:duplicateFacts",
-                "Duplicate fact set with%(duplicateType)s duplicate(s) %(qname)s: %(values)s, %(contextIDs)s.",
+                "Duplicate fact set with %(duplicateType)s duplicate(s) %(qname)s: %(values)s, %(contextIDs)s.",
                 modelObject=duplicateFactSet.facts,
-                duplicateType=f" {duplicateType.name.lower()}" if duplicateType.name else "",
+                duplicateType=duplicateType.description,
                 qname=duplicateFactSet.facts[0].qname,
                 contextIDs=", ".join(sorted(set(f.contextID for f in duplicateFactSet.facts))),
                 values=", ".join(strTruncate(f.value, 64) for f in duplicateFactSet.facts),

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -684,15 +684,12 @@ class ValidateXbrl:
                                 xlinkLabel=resourceArcToLabel)
 
     def checkDuplicateFacts(self, facts: list[ModelFact], duplicateType: ValidateDuplicateFacts.DuplicateType) -> None:
-        duplicateFactSets = ValidateDuplicateFacts.getDuplicateFactSetsOfType(facts, duplicateType)
-        if not duplicateFactSets:
-            return
-        for duplicateFactSet in duplicateFactSets:
-            self.modelXbrl.error(
-                "arelle:disallowedDuplicateFacts",
-                "Duplicate facts (%(duplicateType)s) %(qname)s: %(values)s, Example pair: %(contextIDs)s.",
+        for duplicateFactSet in ValidateDuplicateFacts.getDuplicateFactSetsOfType(facts, duplicateType):
+            self.modelXbrl.warning(
+                "arelle:duplicateFacts",
+                "Duplicate fact set with%(duplicateType)s duplicate(s) %(qname)s: %(values)s, %(contextIDs)s.",
                 modelObject=duplicateFactSet.facts,
-                duplicateType=" or ".join(str(t.name).lower() for t in (duplicateFactSet.duplicateType or duplicateType)),
+                duplicateType=f" {duplicateType.name.lower()}" if duplicateType.name else "",
                 qname=duplicateFactSet.facts[0].qname,
                 contextIDs=", ".join(sorted(set(f.contextID for f in duplicateFactSet.facts))),
                 values=", ".join(strTruncate(f.value, 64) for f in duplicateFactSet.facts),

--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -50,7 +50,7 @@ from arelle.ModelValue import qname, dateTime, DateTime, DATETIME, yearMonthDura
 from arelle.PrototypeInstanceObject import DimValuePrototype
 from arelle.PythonUtil import attrdict, flattenToSet, strTruncate
 from arelle.UrlUtil import isHttpUrl, isAbsolute as isAbsoluteUri, isValidUriReference
-from arelle.ValidateDuplicateFacts import DuplicateTypeArg, getDuplicateFactSetsOfType
+from arelle.ValidateDuplicateFacts import DuplicateTypeArg, getDuplicateFactSetsWithType
 from arelle.Version import authorLabel, copyrightLabel
 from arelle.XbrlConst import (xbrli, qnLinkLabel, standardLabelRoles, qnLinkReference, standardReferenceRoles,
                               qnLinkPart, gen, link, defaultLinkRole, footnote, factFootnote, isStandardRole,
@@ -677,7 +677,7 @@ def oimEquivalentFacts(f1, f2):
 
 def checkForDuplicates(modelXbrl, allowedDups, footnoteIDs):
     duplicateTypeArg = DuplicateTypeArgMap[allowedDups]
-    for duplicateFactSet in getDuplicateFactSetsOfType(modelXbrl.facts, duplicateTypeArg.duplicateType()):
+    for duplicateFactSet in getDuplicateFactSetsWithType(modelXbrl.facts, duplicateTypeArg.duplicateType()):
         fList = duplicateFactSet.facts
         f0 = fList[0]
         modelXbrl.error("oime:disallowedDuplicateFacts",

--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -50,6 +50,7 @@ from arelle.ModelValue import qname, dateTime, DateTime, DATETIME, yearMonthDura
 from arelle.PrototypeInstanceObject import DimValuePrototype
 from arelle.PythonUtil import attrdict, flattenToSet, strTruncate
 from arelle.UrlUtil import isHttpUrl, isAbsolute as isAbsoluteUri, isValidUriReference
+from arelle.ValidateDuplicateFacts import DuplicateTypeArg, getDuplicateFactSetsOfType
 from arelle.Version import authorLabel, copyrightLabel
 from arelle.XbrlConst import (xbrli, qnLinkLabel, standardLabelRoles, qnLinkReference, standardReferenceRoles,
                               qnLinkPart, gen, link, defaultLinkRole, footnote, factFootnote, isStandardRole,
@@ -257,6 +258,7 @@ CONSISTENT = 3
 ALL = 4
 AllowedDuplicatesFeatureValues = {"none": NONE, "complete": COMPLETE, "consistent": CONSISTENT, "all": ALL}
 DisallowedDescription = {NONE: "Disallowed", COMPLETE: "Non-complete", CONSISTENT: "Inconsistent", ALL: "Allowed"}
+DuplicateTypeArgMap = {NONE: DuplicateTypeArg.ALL, COMPLETE: DuplicateTypeArg.INCOMPLETE, CONSISTENT: DuplicateTypeArg.INCONSISTENT, ALL: DuplicateTypeArg.NONE}
 
 class SQNameType:
     pass # fake class for detecting SQName type in JSON structure check
@@ -672,95 +674,18 @@ def oimEquivalentFacts(f1, f2):
             return f1.xValue == f2.xValue # required to handle date/time with 24 hrs.
         return f1.value == f2.value
 
-def checkForDuplicates(modelXbrl, allowedDups, footnoteIDs):
-    # intended to be use after loading OIM or possibly in future for xBRL-XML
-    if allowedDups != ALL:
-        factForConceptContextUnitHash = defaultdict(list)
-        for f in modelXbrl.factsInInstance:
-            if (f.isNil or getattr(f,"xValid", 0) >= 4) and f.context is not None and f.concept is not None and f.concept.type is not None:
-                factForConceptContextUnitHash[f.conceptContextUnitHash].append(f)
-        aspectEqualFacts = defaultdict(dict) # dict [(qname,lang)] of dict(cntx,unit) of [fact, fact]
-        decVals = {}
-        for hashEquivalentFacts in factForConceptContextUnitHash.values():
-            if len(hashEquivalentFacts) > 1:
-                for f in hashEquivalentFacts: # check for hash collision by value checks on context and unit
-                    cuDict = aspectEqualFacts[(f.qname,
-                                               (f.xmlLang or "").lower() if f.concept.type.isWgnStringFactType else None)]
-                    _matched = False
-                    for (_cntx,_unit),fList in cuDict.items():
-                        if (((_cntx is None and f.context is None) or (f.context is not None and f.context.isEqualTo(_cntx))) and
-                            ((_unit is None and f.unit is None) or (f.unit is not None and f.unit.isEqualTo(_unit)))):
-                            _matched = True
-                            fList.append(f)
-                            break
-                    if not _matched:
-                        cuDict[(f.context,f.unit)] = [f]
-                for cuDict in aspectEqualFacts.values(): # dups by qname, lang
-                    for fList in cuDict.values():  # dups by equal-context equal-unit
-                        if len(fList) > 1:
-                            f0 = fList[0]
-                            if allowedDups == NONE:
-                                _inConsistent = True
-                            elif allowedDups == CONSISTENT and f0.concept.isNumeric:
-                                if any(f.isNil for f in fList):
-                                    _inConsistent = not all(f.isNil for f in fList)
-                                else: # not all have same decimals
-                                    _d = inferredDecimals(f0)
-                                    _v = f0.xValue
-                                    _inConsistent = isnan(_v) # NaN is incomparable, always makes dups inconsistent
-                                    decVals[_d] = _v
-                                    aMax, bMin, _inclA, _inclB = rangeValue(_v, _d)
-                                    for f in fList[1:]:
-                                        _d = inferredDecimals(f)
-                                        _v = f.xValue
-                                        if isnan(_v) or _inConsistent: # may have been inconsistent from f0.value
-                                            _inConsistent = True
-                                            break
-                                        if _d in decVals:
-                                            _inConsistent |= _v != decVals[_d]
-                                        else:
-                                            decVals[_d] = _v
-                                        a, b, _inclA, _inclB = rangeValue(_v, _d)
-                                        if a > aMax: aMax = a
-                                        if b < bMin: bMin = b
-                                    if not _inConsistent:
-                                        _inConsistent = (bMin < aMax)
-                                    decVals.clear()
-                            else: # includes COMPLETE
-                                _inConsistent = any(not oimEquivalentFacts(f0, f) for f in fList[1:])
-                            if _inConsistent:
-                                modelXbrl.error("oime:disallowedDuplicateFacts",
-                                    "%(disallowance)s duplicate fact values %(element)s: %(values)s, %(contextIDs)s.",
-                                    modelObject=fList, disallowance=DisallowedDescription[allowedDups], element=f0.qname,
-                                    contextIDs=", ".join(sorted(set(f.contextID for f in fList))),
-                                    values=", ".join(strTruncate(f.value,64) for f in fList))
-                aspectEqualFacts.clear()
-        del factForConceptContextUnitHash, aspectEqualFacts
 
-        ''' impossible to have dup footnotes (?)
-        aspectEqualFootnotes = defaultdict(list) # dict [lang] of footnotes
-        for footnoteID in  footnoteIDs:
-            f = modelXbrl.modelDocument.idObjects[footnoteID]
-            aspectEqualFootnotes[f.xmlLang.lower()].append(f)
-        for lang, footnotes in aspectEqualFootnotes.items():
-            fByValue = sorted(footnotes, key=lambda f: f.viewText())
-            lenF = len(fByValue)
-            for i, f in enumerate(fByValue):
-                if i == 0:
-                    fText = f.viewText()
-                else:
-                    fText = fNext
-                if i < lenF - 1:
-                    f2 = fByValue[i+1]
-                    fNext = f2.viewText()
-                    if fText == fNext:
-                        modelXbrl.error("oime:disallowedDuplicateFacts",
-                            "%(disallowance)s duplicate footnote ids %(IDs)s: value: %(value)s.",
-                            modelObject=(f, f2), disallowance=DisallowedDescription[allowedDups],
-                            IDs="{}, {}".format(f.id, f2.id),
-                            value=fText[:64])
-        del aspectEqualFootnotes
-        '''
+def checkForDuplicates(modelXbrl, allowedDups, footnoteIDs):
+    duplicateTypeArg = DuplicateTypeArgMap[allowedDups]
+    for duplicateFactSet in getDuplicateFactSetsOfType(modelXbrl.facts, duplicateTypeArg.duplicateType()):
+        fList = duplicateFactSet.facts
+        f0 = fList[0]
+        modelXbrl.error("oime:disallowedDuplicateFacts",
+                        "%(disallowance)s duplicate fact values %(element)s: %(values)s, %(contextIDs)s.",
+                        modelObject=fList, disallowance=DisallowedDescription[allowedDups], element=f0.qname,
+                        contextIDs=", ".join(sorted(set(f.contextID for f in fList))),
+                        values=", ".join(strTruncate(f.value,64) for f in fList))
+
 
 def getTaxonomyContextElement(modelXbrl):
     # https://www.xbrl.org/Specification/xbrl-xml/REC-2021-10-13/xbrl-xml-REC-2021-10-13.html#sec-dimensions
@@ -2884,6 +2809,7 @@ def loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                   _("These footnote groups are not defined in footnoteGroups: %(ftGroups)s."),
                   modelObject=modelXbrl, ftGroups=", ".join(sorted(undefinedFootnoteGroups)))
 
+        currentAction = "checking for duplicates"
         checkForDuplicates(modelXbrl, allowedDuplicatesFeature, footnotesIdTargets)
 
         currentAction = "done loading facts and footnotes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ module = [
     'arelle.SystemInfo',
     'arelle.Updater',
     'arelle.UrlUtil',
+    'arelle.ValidateDuplicateFacts',
     'arelle.ValidateXbrl',
     'arelle.XbrlConst',
     'arelle.XbrlUtil',

--- a/tests/integration_tests/scripts/tests/fact_deduplication.py
+++ b/tests/integration_tests/scripts/tests/fact_deduplication.py
@@ -36,29 +36,29 @@ with zipfile.ZipFile(report_zip_path, "r") as zip_ref:
 test_cases: dict[str, dict[regex.Pattern[str], int]] = {
     'none': {},
     'inconsistent': {
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent\).*mock:StringIncomplete'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent\).*mock:MonetaryInconsistent'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with inconsistent duplicate.*mock:StringIncomplete'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with inconsistent duplicate.*mock:MonetaryInconsistent'): 1,
     },
     'consistent': {
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(complete\).*mock:StringComplete'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(complete\).*mock:MonetaryComplete'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(consistent\).*mock:MonetaryConsistent'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with consistent duplicate.*mock:StringComplete'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with consistent duplicate.*mock:MonetaryComplete'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with consistent duplicate.*mock:MonetaryConsistent'): 1,
     },
     'incomplete': {
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(incomplete\).*mock:StringIncomplete'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(incomplete\).*mock:MonetaryConsistent'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(incomplete\).*mock:MonetaryInconsistent'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with incomplete duplicate.*mock:StringIncomplete'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with incomplete duplicate.*mock:MonetaryConsistent'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with incomplete duplicate.*mock:MonetaryInconsistent'): 1,
     },
     'complete': {
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(complete\).*mock:StringComplete'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(complete\).*mock:MonetaryComplete'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with complete duplicate.*mock:StringComplete'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with complete duplicate.*mock:MonetaryComplete'): 1,
     },
     'all': {
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:StringComplete'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:StringIncomplete'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:MonetaryComplete'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:MonetaryConsistent'): 1,
-        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:MonetaryInconsistent'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with inconsistent\|consistent duplicate.*mock:StringComplete'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with inconsistent\|consistent duplicate.*mock:StringIncomplete'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with inconsistent\|consistent duplicate.*mock:MonetaryComplete'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with inconsistent\|consistent duplicate.*mock:MonetaryConsistent'): 1,
+        regex.compile(r'^\[arelle:duplicateFacts].*with inconsistent\|consistent duplicate.*mock:MonetaryInconsistent'): 1,
     },
 }
 for arg, expected_errors in test_cases.items():
@@ -74,7 +74,7 @@ for arg, expected_errors in test_cases.items():
         offline=arelle_offline,
         logFile=log_file,
     )
-    errors += validate_log_file(log_file, expected_results={"error": expected_errors})
+    errors += validate_log_file(log_file, expected_results={"warning": expected_errors})
     assert_result(errors)
 
 assert_result(errors)

--- a/tests/integration_tests/scripts/tests/fact_deduplication.py
+++ b/tests/integration_tests/scripts/tests/fact_deduplication.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import urllib.request
+import zipfile
+from pathlib import Path
+from shutil import rmtree
+
+import regex
+
+from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
+
+errors = []
+this_file = Path(__file__)
+args = parse_args(
+    this_file.stem,
+    "Confirm duplicate facts trigger warnings as expected.",
+)
+arelle_command = args.arelle
+arelle_offline = args.offline
+working_directory = Path(args.working_directory)
+test_directory = Path(args.test_directory)
+
+report_zip_path = test_directory / 'report.zip'
+report_directory = test_directory / 'report'
+report_path = report_directory / "report.xbrl"
+report_zip_url = "https://arelle-public.s3.amazonaws.com/ci/packages/fact_deduplication.zip"
+
+print(f"Downloading report: {report_zip_url}")
+urllib.request.urlretrieve(report_zip_url, report_zip_path)
+
+print(f"Extracting report: {report_directory}")
+with zipfile.ZipFile(report_zip_path, "r") as zip_ref:
+    zip_ref.extractall(report_directory)
+
+test_cases: dict[str, dict[regex.Pattern[str], int]] = {
+    'none': {},
+    'inconsistent': {
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent\).*mock:StringIncomplete'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent\).*mock:MonetaryInconsistent'): 1,
+    },
+    'consistent': {
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(complete\).*mock:StringComplete'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(complete\).*mock:MonetaryComplete'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(consistent\).*mock:MonetaryConsistent'): 1,
+    },
+    'incomplete': {
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(incomplete\).*mock:StringIncomplete'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(incomplete\).*mock:MonetaryConsistent'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(incomplete\).*mock:MonetaryInconsistent'): 1,
+    },
+    'complete': {
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(complete\).*mock:StringComplete'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(complete\).*mock:MonetaryComplete'): 1,
+    },
+    'all': {
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:StringComplete'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:StringIncomplete'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:MonetaryComplete'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:MonetaryConsistent'): 1,
+        regex.compile(r'^\[arelle:disallowedDuplicateFacts].*\(inconsistent or consistent\).*mock:MonetaryInconsistent'): 1,
+    },
+}
+for arg, expected_errors in test_cases.items():
+    print(f"Running with argument: {arg}")
+    log_file = prepare_logfile(test_directory, this_file, name=arg)
+    run_arelle(
+        arelle_command,
+        additional_args=[
+            "--file", str(report_path),
+            "--validate",
+            "--validateDuplicateFacts", arg
+        ],
+        offline=arelle_offline,
+        logFile=log_file,
+    )
+    errors += validate_log_file(log_file, expected_results={"error": expected_errors})
+    assert_result(errors)
+
+assert_result(errors)
+
+print("Cleaning up")
+rmtree(working_directory / 'fact_deduplication' / 'report')
+os.unlink(working_directory / 'fact_deduplication' / 'report.zip')


### PR DESCRIPTION
#### Reason for change
Resolves #1001
Continuing from previous closed PR #1015 
Note: Not mentioned in the original issue was an "incomplete" parameter that OIM requires. The use case of retrieving any duplicates that are *not* complete was not captured in the original issue.

#### Description of change
Implement `ValidateDuplicateFacts` for retrieving duplicate facts of various "types" within an instance.
Add `--validateDuplicateFacts` CLI argument to trigger logging of duplicate facts
Add `Tools > Validation > Warn on duplicate facts` menu to trigger logging of duplicate facts from GUI
Add `fact_deduplication.py` integration test script to test duplicate fact detection (and eventually deduplication as well: #1002)
Replace `loadFromOIM` implementation of duplicate fact detection with internal implementation.

#### Steps to Test
`fact_deduplication.py` integration test script tests this via CLI fairly thoroughly.
New GUI option should be tested manually (ensure option defaults to "None" on first launch)

**review**:
@Arelle/arelle
