### PR TITLE
Fix macOS Build

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -145,6 +145,15 @@ jobs:
           [[ $(echo dist/*.tgz) =~ -([0-9]+\.[0-9]+\.[0-9]+)\.tgz$ ]] && echo "artifact_versioned_name=arelle-ubuntu-${BASH_REMATCH[1]}.tgz" >> $GITHUB_OUTPUT
           echo "BUILD_ARTIFACT_PATH=$(echo dist/*.tgz)" >> $GITHUB_ENV
           echo "uploaded_artifact_name=ubuntu distribution" >> $GITHUB_OUTPUT
+      - name: Capture build env
+        run: |
+          echo "ARTIFACT_NAME=arelle-ubuntu.tgz" >> $GITHUB_ENV
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4.0.0
+        with:
+          name: ${{ steps.define-artifact-names.outputs.uploaded_artifact_name }}
+          if-no-files-found: error
+          path: ${{ env.BUILD_ARTIFACT_PATH }}
       - name: "[Test] Set up Python ${{ inputs.python_version }}"
         uses: actions/setup-python@v5.0.0
         with:
@@ -163,12 +172,3 @@ jobs:
         with:
           name: 'test logs'
           path: '.test/**/*.logfile.xml'
-      - name: Capture build env
-        run: |
-          echo "ARTIFACT_NAME=arelle-ubuntu.tgz" >> $GITHUB_ENV
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4.0.0
-        with:
-          name: ${{ steps.define-artifact-names.outputs.uploaded_artifact_name }}
-          if-no-files-found: error
-          path: ${{ env.BUILD_ARTIFACT_PATH }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -213,16 +213,6 @@ jobs:
           ditto -c -k --keepParent "build/Arelle.app" "notarization.zip"
           xcrun notarytool submit "notarization.zip" -v --apple-id "$USERNAME" --password "$PASSWORD" --team-id "$TEAM_ID" --wait --timeout 30m --output-format json
           xcrun stapler staple -v "build/Arelle.app"
-      - name: "[Test] Test build artifact"
-        run : |
-          pip install -r requirements-dev.txt
-          pytest -s --disable-warnings --all --download-cache --offline --arelle="build/Arelle.app/Contents/MacOS/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
-      - name: "[Test] Upload test artifacts"
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: 'test logs'
-          path: '.test/**/*.logfile.xml'
       - name: Build DMG
         run: |
           pwd
@@ -271,3 +261,13 @@ jobs:
           name: ${{ steps.define-artifact-names.outputs.uploaded_artifact_name }}
           if-no-files-found: error
           path: ${{ env.DMG_BUILD_ARTIFACT_PATH }}
+      - name: "[Test] Test build artifact"
+        run : |
+          pip install -r requirements-dev.txt
+          pytest -s --disable-warnings --all --download-cache --offline --arelle="build/Arelle.app/Contents/MacOS/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
+      - name: "[Test] Upload test artifacts"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'test logs'
+          path: '.test/**/*.logfile.xml'

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,7 +6,7 @@ on:
       codesign_and_notarize:
         description: 'Sign and notarize code'
         required: false
-        default: 'true'
+        default: true
         type: boolean
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
@@ -42,7 +42,7 @@ on:
       codesign_and_notarize:
         description: 'Sign and notarize code'
         required: false
-        default: 'true'
+        default: true
         type: boolean
       edgar_renderer_ref:
         description: 'Arelle/EdgarRenderer branch, tag or SHA to checkout (blank for default)'
@@ -136,7 +136,7 @@ jobs:
       - name: Remove git directories
         run: find build/Arelle.app/Contents -name .git -exec rm -fR {} \;
       - name: Install certificate and sign code
-        if: ${{ inputs.codesign_and_notarize == 'true' }}
+        if: ${{ inputs.codesign_and_notarize }}
         env:
           MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
           MAC_BUILD_CERTIFICATE_NAME: 'Developer ID Application: Workiva Inc. (5ZF66U48UD)'
@@ -204,7 +204,7 @@ jobs:
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleCmdLine
           codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleGUI
       - name: Notarize app
-        if: ${{ inputs.codesign_and_notarize == 'true' }}
+        if: ${{ inputs.codesign_and_notarize }}
         env:
           USERNAME: ${{ secrets.MAC_BUILD_NOTARIZATION_USERNAME }}
           PASSWORD: ${{ secrets.MAC_BUILD_NOTARIZATION_PASSWORD }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -150,16 +150,6 @@ jobs:
     - name: Delete .git
       shell: cmd
       run: if exist "${{ env.BUILD_PATH }}\.git" rmdir /s /q ${{ env.BUILD_PATH }}\.git
-    - name: "[Test] Test build"
-      run: |
-        pip install -r requirements-dev.txt
-        pytest -s --disable-warnings --all --download-cache --offline --arelle="${{ env.BUILD_PATH }}\arelleCmdLine.exe" tests/integration_tests/scripts/test_scripts.py
-    - name: "[Test] Upload test artifacts"
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: 'test logs'
-        path: '.test/**/*.logfile.xml'
     - name: Make installer
       run: makensis installWin64.nsi
     - name: Version installer
@@ -181,3 +171,13 @@ jobs:
         name: ${{ steps.define-artifact-names.outputs.zip_uploaded_artifact_name }}
         if-no-files-found: error
         path: ${{ steps.define-artifact-names.outputs.zip_build_artifact_path }}
+    - name: "[Test] Test build"
+      run: |
+        pip install -r requirements-dev.txt
+        pytest -s --disable-warnings --all --download-cache --offline --arelle="${{ env.BUILD_PATH }}\arelleCmdLine.exe" tests/integration_tests/scripts/test_scripts.py
+    - name: "[Test] Upload test artifacts"
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: 'test logs'
+        path: '.test/**/*.logfile.xml'

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -3,5 +3,4 @@ cx-Freeze==6.14.7
 packaging==21.3
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
--r requirements-plugins.txt
 -r requirements.txt


### PR DESCRIPTION
#### Reason for change
#1007 broke the macOS build.

#### Description of change
* Run tests in build workflows only after builds have been completed and packaged (running tests before DMG creation introduced unsigned code into the macOS build).
* macOS build workflow input `codesign_and_notarize` is a boolean when run from workflow_dispatch and a string of `true` when run from the release pipeline. Make it always a boolean.
* ixbrl-viewer is installed in the frozen builds twice (pip installed and built and copied manually). Remove the pip install until #990.

#### Steps to Test
* confirm app artifact from the macOS [build for this branch](https://github.com/Arelle/Arelle/actions/runs/7387811942) can be launched.

**review**:
@Arelle/arelle
