### PR TITLE
Use unique test log file names

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -170,5 +170,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: 'test logs'
+          name: 'linux test logs'
           path: '.test/**/*.logfile.xml'

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -269,5 +269,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: 'test logs'
+          name: 'macos test logs'
           path: '.test/**/*.logfile.xml'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -179,5 +179,5 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: 'test logs'
+        name: 'windows test logs'
         path: '.test/**/*.logfile.xml'


### PR DESCRIPTION
#### Reason for change
Test log names conflict on release workflow which uploads test logs from all three frozen builds.
https://github.com/Arelle/Arelle/actions/runs/7389708323/attempts/1

#### Description of change
Make test log file names unique.

#### Steps to Test
CI

**review**:
@Arelle/arelle
