### PR TITLE
Python 3.12 Support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,14 +17,7 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "astroid"
-        versions:
-          - ">=3"
-      - dependency-name: "RDFLib"
-        versions:
-          - ">=6"
       - dependency-name: "cx_Freeze"
-      - dependency-name: "packaging"
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           cache: 'pip'
           check-latest: true
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       openssl_version:
-        default: '1.1.1s'
+        default: '1.1.1w'
         description: 'OpenSSL version to use'
         required: false
         type: string
@@ -22,7 +22,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.11.5'
+        default: '3.11.7'
         description: 'Python version to use'
         required: false
         type: string
@@ -48,7 +48,7 @@ on:
         required: false
         type: string
       openssl_version:
-        default: '1.1.1s'
+        default: '1.1.1w'
         description: 'OpenSSL version to use'
         required: true
         type: string
@@ -58,7 +58,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.11.5'
+        default: '3.11.7'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -131,11 +131,7 @@ jobs:
           echo "artifact_versioned_name=arelle-macos-${{ env.BUILD_VERSION }}.dmg" >> $GITHUB_OUTPUT
           echo "uploaded_artifact_name=macos distribution" >> $GITHUB_OUTPUT
           echo "DMG_BUILD_ARTIFACT_PATH=dist_dmg/arelle-macos-${{ env.BUILD_VERSION }}.dmg" >> $GITHUB_ENV
-      - name: Build app
-        run: ./scripts/buildMacDist.sh
-      - name: Remove git directories
-        run: find build/Arelle.app/Contents -name .git -exec rm -fR {} \;
-      - name: Install certificate and sign code
+      - name: Install certificate
         if: ${{ inputs.codesign_and_notarize }}
         env:
           MAC_BUILD_CERTIFICATE_BASE64: ${{ secrets.MAC_BUILD_CERTIFICATE_BASE64 }}
@@ -160,49 +156,11 @@ jobs:
           security find-identity
           security find-certificate -a -p | openssl x509 -subject -noout
           echo MAC_BUILD_CERTIFICATE_NAME="$MAC_BUILD_CERTIFICATE_NAME"
-
-          # Move python modules to Resources
-          for f in archive config doc examples images locale plugin scripts Tktable2.11 ;
-            do
-              mv build/Arelle.app/Contents/MacOS/$f build/Arelle.app/Contents/Resources/
-            done
-          mkdir build/Arelle.app/Contents/Resources/lib
-          ls build/Arelle.app/Contents/MacOS/lib | \
-            fgrep -vx --regexp={Python,encodings,codecs,collections,importlib,matplotlib,re,zlib,library.zip} | \
-            grep -v '\.so$' | \
-            while IFS= read -r f
-            do
-              mv build/Arelle.app/Contents/MacOS/lib/$f build/Arelle.app/Contents/Resources/lib/
-            done
-
-          # Code signing (*.so, *.dylib, etc)
-          for i in $(find build/Arelle.app -type f -perm +111 -exec file "{}" \; | \
-            grep -v "(for architecture" | \
-            grep -v -E "^- Mach-O" | \
-            grep -E "Mach-O executable|Mach-O 64-bit executable|Mach-O 64-bit bundle|Mach-O 64-bit dynamically linked shared library" | \
-            awk -F":" '{print $1}' | \
-            uniq)
-          do
-            codesign --deep --force --verify --verbose --timestamp \
-            --options runtime \
-            --sign "$MAC_BUILD_CERTIFICATE_NAME" \
-            "$i"
-          done
-
-          find build/Arelle.app -type f -name "*.dylib*" -exec \
-            codesign --deep --force --verify --verbose --timestamp \
-            --options runtime \
-            --sign "$MAC_BUILD_CERTIFICATE_NAME" \
-            {} \;
-
-          # Create symlinks (some libraries can't be code signed in /MacOS but need to be found within it)
-          ln -s ../../Resources/lib/tkinter build/Arelle.app/Contents/MacOS/lib/tkinter
-          # Symlink plugins folder so /Resources/plugin is found when searching in default /MacOS/plugin location
-          ln -s ../Resources/plugin build/Arelle.app/Contents/MacOS/plugin
-
-          # Executable code signing (slightly redundant, but ensures all necessary files are code signed)
-          codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleCmdLine
-          codesign --options runtime --force --deep --timestamp -s "$MAC_BUILD_CERTIFICATE_NAME" build/Arelle.app/Contents/MacOS/arelleGUI
+          echo "CODESIGN_IDENTITY=${{ env.MAC_BUILD_CERTIFICATE_NAME }}" >> $GITHUB_ENV
+      - name: Build app
+        run: ./scripts/buildMacDist.sh
+      - name: Remove git directories
+        run: find build/Arelle.app/Contents -name .git -exec rm -fR {} \;
       - name: Notarize app
         if: ${{ inputs.codesign_and_notarize }}
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,14 +4,14 @@ on:
   workflow_call:
     inputs:
       python_version:
-        default: '3.11'
+        default: '3.12'
         description: 'Python version to use'
         required: false
         type: string
   workflow_dispatch:
     inputs:
       python_version:
-        default: '3.11'
+        default: '3.12'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/test-scripts-parallel.yml
+++ b/.github/workflows/test-scripts-parallel.yml
@@ -36,6 +36,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
     steps:
       - uses: actions/checkout@v4.1.1
         with:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -29,6 +29,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install Python 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.1.1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 python:
   install:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,12 +68,12 @@ Here's how to set up your environment:
   2. Install a supported version of Python.
     For example, 
     
-    pyenv install 3.11.5
+    pyenv install 3.12.1
 
   3. Create a virtual env using the Python version you just installed.
     For example, 
 
-    PYENV_VERSION=3.11.5 pyenv exec python -m venv venv
+    PYENV_VERSION=3.12.1 pyenv exec python -m venv venv
   4. Activate your environment: 
     
     source venv/bin/activate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.7
+FROM python:3.12.1
 
 WORKDIR /usr/src/app
 

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -309,12 +309,9 @@ class Cntlr:
 
     def setUiLanguage(self, locale: str | None, fallbackToDefault: bool = False) -> None:
         try:
-            self.uiLocale = locale
             langCodes = Locale.getLanguageCodes(locale)
             gettext.translation("arelle", self.localeDir, langCodes).install()
             self.uiLang = langCodes[0]
-            if not locale and self.uiLang:
-                self.uiLocale = self.uiLang
         except Exception as ex:
             if fallbackToDefault and not locale and langCodes:
                 locale = langCodes[0]
@@ -323,9 +320,8 @@ class Cntlr:
                     self.uiLang = locale  # may be en other than defaultLocale
                 else:
                     self.uiLang = XbrlConst.defaultLocale  # must work with gettext or will raise an exception
-                if not self.uiLocale:
-                    self.uiLocale = self.uiLang
                 gettext.install("arelle", self.localeDir)
+        self.uiLocale = locale or getattr(self, "uiLang", None)
 
     def startLogging(
         self,

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import tempfile
 from collections import defaultdict
-from typing import Any, Mapping, TYPE_CHECKING, TextIO
+from typing import Any, Mapping, TYPE_CHECKING, TextIO, cast
 
 import regex as re
 
@@ -315,11 +315,9 @@ class Cntlr:
         except OSError:
             if fallbackToDefault and not locale:
                 locale = langCodes[0]
-            if fallbackToDefault or (locale and locale.lower().startswith("en")):
-                if locale and len(locale) == 5 and locale.lower().startswith("en"):
-                    self.uiLang = locale  # may be en other than defaultLocale
-                else:
-                    self.uiLang = XbrlConst.defaultLocale  # must work with gettext or will raise an exception
+            isEnglishLocale = locale and locale.lower().startswith('en')
+            if fallbackToDefault or isEnglishLocale:
+                self.uiLang = cast(str, locale) if isEnglishLocale else XbrlConst.defaultLocale
                 gettext.install("arelle", self.localeDir)
         self.uiLocale = locale or getattr(self, "uiLang", None)
 

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -124,7 +124,6 @@ class Cntlr:
     isCGI: bool
     systemWordSize: int
     uiLang: str
-    uiLangDir: str
     configDir: str
     imagesDir: str
     localeDir: str
@@ -168,7 +167,6 @@ class Cntlr:
         self.isMac = platformOS == PlatformOS.MACOS
         self.isMSW = platformOS == PlatformOS.WINDOWS
         self.systemWordSize = getSystemWordSize()  # e.g., 32 or 64
-        self.uiLangDir = "ltr"
         self.disablePersistentConfig = disable_persistent_config
 
         # sys.setrecursionlimit(10000) # 1000 default exceeded in some inline documents
@@ -286,6 +284,10 @@ class Cntlr:
 
         self.startLogging(logFileName, logFileMode, logFileEncoding, logFormat)
 
+    @property
+    def uiLangDir(self) -> str:
+        return 'rtl' if getattr(self, 'uiLang', '')[0:2].lower() in {"ar", "he"} else 'ltr'
+
     def postLoggingInit(self, localeSetupMessage: str | None = None) -> None:
         if not self.modelManager.isLocaleSet:
             localeSetupMessage = self.modelManager.setLocale() # set locale after logger started
@@ -304,7 +306,6 @@ class Cntlr:
             self.uiLang = langCodes[0]
             if not locale and self.uiLang:
                 self.uiLocale = self.uiLang
-            self.uiLangDir = 'rtl' if self.uiLang[0:2].lower() in {"ar", "he"} else 'ltr'
         except Exception as ex:
             if fallbackToDefault and not locale and langCodes:
                 locale = langCodes[0]
@@ -315,7 +316,6 @@ class Cntlr:
                     self.uiLang = XbrlConst.defaultLocale  # must work with gettext or will raise an exception
                 if not self.uiLocale:
                     self.uiLocale = self.uiLang
-                self.uiLangDir = "ltr"
                 gettext.install("arelle", self.localeDir)
 
     def startLogging(

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -308,12 +308,12 @@ class Cntlr:
             pluginMethod(self)
 
     def setUiLanguage(self, locale: str | None, fallbackToDefault: bool = False) -> None:
+        langCodes = Locale.getLanguageCodes(locale)
         try:
-            langCodes = Locale.getLanguageCodes(locale)
             gettext.translation("arelle", self.localeDir, langCodes).install()
             self.uiLang = langCodes[0]
-        except Exception as ex:
-            if fallbackToDefault and not locale and langCodes:
+        except OSError:
+            if fallbackToDefault and not locale:
                 locale = langCodes[0]
             if fallbackToDefault or (locale and locale.lower().startswith("en")):
                 if locale and len(locale) == 5 and locale.lower().startswith("en"):

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -167,6 +167,7 @@ class Cntlr:
         self.isMac = platformOS == PlatformOS.MACOS
         self.isMSW = platformOS == PlatformOS.WINDOWS
         self.systemWordSize = getSystemWordSize()  # e.g., 32 or 64
+        self._uiLocale: str | None = None
         self.disablePersistentConfig = disable_persistent_config
 
         # sys.setrecursionlimit(10000) # 1000 default exceeded in some inline documents
@@ -287,6 +288,14 @@ class Cntlr:
     @property
     def uiLangDir(self) -> str:
         return 'rtl' if getattr(self, 'uiLang', '')[0:2].lower() in {"ar", "he"} else 'ltr'
+
+    @property
+    def uiLocale(self) -> str | None:
+        return self._uiLocale
+
+    @uiLocale.setter
+    def uiLocale(self, uiLocale: str | None) -> None:
+        self._uiLocale = Locale.findCompatibleLocale(uiLocale)
 
     def postLoggingInit(self, localeSetupMessage: str | None = None) -> None:
         if not self.modelManager.isLocaleSet:

--- a/arelle/CntlrWebMain.py
+++ b/arelle/CntlrWebMain.py
@@ -19,7 +19,7 @@ POST = 'POST'
 
 def startWebserver(_cntlr, options):
     """Called once from main program in CmtlrCmdLine to initiate web server on specified local port.
-    To test WebServer run from source in IIS, use an entry like this: c:\python33\python.exe c:\\users\\myname\\mySourceFolder\\arelleCmdLine.py %s
+    To test WebServer run from source in IIS, use an entry like this: c:\\python33\\python.exe c:\\users\\myname\\mySourceFolder\\arelleCmdLine.py %s
 
     :param options: OptionParser options from parse_args of main argv arguments (the argument *webserver* provides hostname and port), port being used to startup the webserver on localhost.
     :type options: optparse.Values
@@ -582,7 +582,7 @@ document at c:/a/b/c.xbrl (on local drive) and return structured xml results.</t
 <tr><td style="text-align=right;">Example:</td><td><code>/rest/xbrl/validation?file=c:/a/b/c.xbrl&amp;media=xml</code>: Validate entry instance
 document at c:/a/b/c.xbrl (on local drive) and return structured xml results.</td></tr>
 ''')) +
-_('''
+_(r'''
 <tr><td></td><td>Parameters are optional after "?" character, and are separated by "&amp;" characters,
 as follows:</td></tr>
 <tr><td style="text-indent: 1em;">flavor</td><td><code>standard</code>: XBRL 2.1 and XDT validation.  (If formulas are present they will also be compiled and run.)  (default)
@@ -644,8 +644,8 @@ as follows:</td></tr>
 
 <tr><th colspan="2">Views</th></tr>
 <tr><td>/rest/xbrl/{file}/{view}</td><td>View document at {file}.</td></tr>
-<tr><td>\u00A0</td><td>{file} may be local or web url, and may have "/" characters replaced by ";" characters (but that is not necessary).</td></tr>
-<tr><td>\u00A0</td><td>{view} may be <code>DTS</code>, <code>concepts</code>, <code>pre</code>, <code>table</code>, <code>cal</code>, <code>dim</code>, <code>facts</code>, <code>factTable</code>, <code>formulae</code>, <code>roleTypes</code>, or <code>arcroleTypes</code>.</td></tr>
+<tr><td>&nbsp;</td><td>{file} may be local or web url, and may have "/" characters replaced by ";" characters (but that is not necessary).</td></tr>
+<tr><td>&nbsp;</td><td>{view} may be <code>DTS</code>, <code>concepts</code>, <code>pre</code>, <code>table</code>, <code>cal</code>, <code>dim</code>, <code>facts</code>, <code>factTable</code>, <code>formulae</code>, <code>roleTypes</code>, or <code>arcroleTypes</code>.</td></tr>
 <tr><td style="text-align=right;">Example:</td><td><code>/rest/xbrl/c:/a/b/c.xbrl/dim?media=html</code>: View dimensions of
 document at c:/a/b/c.xbrl (on local drive) and return html result.</td></tr>
 <tr><td>/rest/xbrl/view</td><td>(Alternative syntax) View document, file and view are provided as parameters (see below).</td></tr>

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -393,7 +393,7 @@ class CntlrWinMain (Cntlr.Cntlr):
             w = screenW
             h = screenH
         else:
-            priorGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)",self.config.get('windowGeometry'))
+            priorGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)",self.config.get('windowGeometry'))
             if priorGeometry and priorGeometry.lastindex >= 4:
                 try:
                     w = int(priorGeometry.group(1))

--- a/arelle/DialogAbout.py
+++ b/arelle/DialogAbout.py
@@ -19,7 +19,7 @@ class DialogAbout(Toplevel):
     def __init__(self, parent, title, imageFile, body):
         super(DialogAbout, self).__init__(parent)
         self.parent = parent
-        parentGeometry = re_match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re_match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.transient(self.parent)

--- a/arelle/DialogArcroleGroup.py
+++ b/arelle/DialogArcroleGroup.py
@@ -27,7 +27,7 @@ class DialogArcroleGroup(Toplevel):
         self.mainWin = mainWin
         self.parent = parent
         self.modelXbrl = modelXbrl
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.selectedGroup = None

--- a/arelle/DialogFind.py
+++ b/arelle/DialogFind.py
@@ -54,7 +54,7 @@ class DialogFind(Toplevel):
         self.modelXbrl = None   # set when Find pressed, this blocks next prematurely
         if options is None: options = newFindOptions
         self.options = options
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogW = int(parentGeometry.group(1))
         dialogH = int(parentGeometry.group(2))
         dialogX = int(parentGeometry.group(3))

--- a/arelle/DialogFormulaParameters.py
+++ b/arelle/DialogFormulaParameters.py
@@ -27,7 +27,7 @@ class DialogFormulaParameters(Toplevel):
         super(DialogFormulaParameters, self).__init__(parent)
         self.parent = parent
         self.options = options
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogLanguage.py
+++ b/arelle/DialogLanguage.py
@@ -25,7 +25,7 @@ class DialogLanguage(Toplevel):
         super(DialogLanguage, self).__init__(mainWin.parent)
         self.mainWin = mainWin
         self.parent = mainWin.parent
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.transient(self.parent)

--- a/arelle/DialogLanguage.py
+++ b/arelle/DialogLanguage.py
@@ -1,18 +1,18 @@
-'''
+"""
 See COPYRIGHT.md for copyright information.
-'''
-import os
-from tkinter import Toplevel, StringVar, N, S, E, W, EW, messagebox
+"""
+from tkinter import E, EW, N, S, Toplevel, W, messagebox
+
 try:
     from tkinter.ttk import Frame, Button, Label, Entry
 except ImportError:
     from ttk import Frame, Button, Label, Entry
-from arelle.CntlrWinTooltip import ToolTip
-from arelle.Locale import setDisableRTL
-from arelle.UiUtil import gridHdr, gridCell, gridCombobox, label, checkbox
-import gettext
+
 import regex as re
-from arelle.Locale import getLanguageCodes, languageCodes, getUserLocale, availableLocales
+
+from arelle import Locale
+from arelle.CntlrWinTooltip import ToolTip
+from arelle.UiUtil import checkbox, gridCombobox, gridHdr, label
 
 '''
 allow user to override system language codes for user interface and labels
@@ -30,11 +30,11 @@ class DialogLanguage(Toplevel):
         dialogY = int(parentGeometry.group(4))
         self.transient(self.parent)
         self.title(_("arelle - User Interface and Labels language code settings"))
-        self.languageCodes = languageCodes()
+        self.languageCodes = Locale.languageCodes()
         langs = (["System default language ({0})".format(mainWin.modelManager.defaultLang)] +
                  sorted(self.languageCodes.keys() if self.mainWin.isMSW else
                         [k
-                         for avail in [availableLocales()] # unix/Mac locale -a supported locale codes
+                         for avail in [Locale.availableLocales()] # unix/Mac locale -a supported locale codes
                          for k, v in self.languageCodes.items()
                          if v.partition(" ")[0] in avail]
                         ))
@@ -97,7 +97,7 @@ class DialogLanguage(Toplevel):
     def ok(self, event=None):
         self.mainWin.disableRtl= self.cbDisableRtl.value
         self.mainWin.config['disableRtl']= self.cbDisableRtl.value
-        setDisableRTL(self.cbDisableRtl.value)
+        Locale.setDisableRTL(self.cbDisableRtl.value)
         labelLangIndex = self.cbLabelLang.valueIndex
         if labelLangIndex >= 0 and labelLangIndex != self.labelLangIndex: # changed
             if labelLangIndex == 0:
@@ -114,7 +114,7 @@ class DialogLanguage(Toplevel):
             else:
                 langCode = self.languageCodes[self.cbUiLang.value]
 
-            newLocale = getUserLocale(langCode)
+            newLocale = Locale.getUserLocale(langCode)
             if newLocale is not None:
                 self.mainWin.modelManager.locale = newLocale
             else:

--- a/arelle/DialogLanguage.py
+++ b/arelle/DialogLanguage.py
@@ -13,12 +13,18 @@ import regex as re
 from arelle import Locale
 from arelle.CntlrWinTooltip import ToolTip
 from arelle.UiUtil import checkbox, gridCombobox, gridHdr, label
+from arelle.typing import TypeGetText
+
+_: TypeGetText
 
 '''
 allow user to override system language codes for user interface and labels
 '''
+
+
 def askLanguage(mainWin):
     DialogLanguage(mainWin)
+
 
 class DialogLanguage(Toplevel):
     def __init__(self, mainWin):
@@ -31,20 +37,23 @@ class DialogLanguage(Toplevel):
         self.transient(self.parent)
         self.title(_("arelle - User Interface and Labels language code settings"))
         self.languageCodes = Locale.languageCodes()
-        langs = (["System default language ({0})".format(mainWin.modelManager.defaultLang)] +
-                 sorted(self.languageCodes.keys() if self.mainWin.isMSW else
-                        [k
-                         for avail in [Locale.availableLocales()] # unix/Mac locale -a supported locale codes
-                         for k, v in self.languageCodes.items()
-                         if Locale.bcp47LangToPosixLocale(v.partition(" ")[0]) in avail]
-                        ))
-        self.uiLang = mainWin.config.get("userInterfaceLangOverride", "")
+        if systemLocales := Locale.availableLocales():  # unix/Mac locale -a supported locale codes
+            localeOptionTitles = [
+                title
+                for title, labelCode in self.languageCodes.items()
+                if Locale.bcp47LangToPosixLocale(labelCode) in systemLocales
+            ]
+        else:
+            localeOptionTitles = self.languageCodes.keys()
+        localeOptions = (_("System default locale ({0})").format(mainWin.modelManager.defaultLang), *sorted(localeOptionTitles))
+        labelLanguageOptions = (_("System default language ({0})").format(mainWin.modelManager.defaultLang), *sorted(self.languageCodes.keys()))
+        self.uiLang = Locale.posixLocaleToBCP47Lang(mainWin.config.get("userInterfaceLangOverride", ""))
         if self.uiLang == "" or self.uiLang == mainWin.modelManager.defaultLang:
             self.uiLangIndex = 0
         else:
             self.uiLangIndex = None
-            for i, langName in enumerate(langs):
-                if i > 0 and self.uiLang in self.languageCodes[langName]:
+            for i, langName in enumerate(localeOptions):
+                if i > 0 and self.uiLang == self.languageCodes.get(langName):
                     self.uiLangIndex = i
                     break
         self.labelLang = mainWin.config.get("labelLangOverride", "")
@@ -52,16 +61,16 @@ class DialogLanguage(Toplevel):
             self.labelLangIndex = 0
         else:
             self.labelLangIndex = None
-            for i, langName in enumerate(langs):
-                if i > 0 and self.labelLang in self.languageCodes[langName]:
+            for i, langName in enumerate(labelLanguageOptions):
+                if i > 0 and self.labelLang == self.languageCodes.get(langName):
                     self.labelLangIndex = i
                     break
 
         frame = Frame(self)
 
         defaultLanguage = mainWin.modelManager.defaultLang
-        for langName, langCodes in self.languageCodes.items():
-            if mainWin.modelManager.defaultLang in langCodes:
+        for langName, langCode in self.languageCodes.items():
+            if mainWin.modelManager.defaultLang == langCode:
                 defaultLanguage += ", " + langName
                 break
         gridHdr(frame, 0, 0, _(
@@ -70,9 +79,9 @@ class DialogLanguage(Toplevel):
                 defaultLanguage),
               columnspan=5, wraplength=400)
         label(frame, 0, 1, _("User Interface:"))
-        self.cbUiLang = gridCombobox(frame, 1, 1, values=langs, selectindex=self.uiLangIndex, columnspan=4)
+        self.cbUiLang = gridCombobox(frame, 1, 1, values=localeOptions, selectindex=self.uiLangIndex, columnspan=4)
         label(frame, 0, 2, _("Labels:"))
-        self.cbLabelLang = gridCombobox(frame, 1, 2, values=langs, selectindex=self.labelLangIndex, columnspan=4)
+        self.cbLabelLang = gridCombobox(frame, 1, 2, values=labelLanguageOptions, selectindex=self.labelLangIndex, columnspan=4)
         self.cbUiLang.focus_set()
         self.cbDisableRtl = checkbox(frame, 0, 3,  _('Disable rtl String'), 'disableRtlSting')
         ToolTip(self.cbDisableRtl, _('Disable reversing string read order for right to left languages, useful for some locale settings.'), wraplength=240)
@@ -95,15 +104,14 @@ class DialogLanguage(Toplevel):
         self.wait_window(self)
 
     def ok(self, event=None):
-        self.mainWin.disableRtl= self.cbDisableRtl.value
-        self.mainWin.config['disableRtl']= self.cbDisableRtl.value
+        self.mainWin.config['disableRtl'] = self.cbDisableRtl.value
         Locale.setDisableRTL(self.cbDisableRtl.value)
         labelLangIndex = self.cbLabelLang.valueIndex
         if labelLangIndex >= 0 and labelLangIndex != self.labelLangIndex: # changed
             if labelLangIndex == 0:
                 langCode = self.mainWin.modelManager.defaultLang
             else:
-                langCode, sep, localeCode = self.languageCodes[self.cbLabelLang.value].partition(" ")
+                langCode = self.languageCodes[self.cbLabelLang.value]
             self.mainWin.config["labelLangOverride"] = langCode
             self.mainWin.labelLang = langCode
 

--- a/arelle/DialogLanguage.py
+++ b/arelle/DialogLanguage.py
@@ -36,7 +36,7 @@ class DialogLanguage(Toplevel):
                         [k
                          for avail in [Locale.availableLocales()] # unix/Mac locale -a supported locale codes
                          for k, v in self.languageCodes.items()
-                         if v.partition(" ")[0] in avail]
+                         if Locale.bcp47LangToPosixLocale(v.partition(" ")[0]) in avail]
                         ))
         self.uiLang = mainWin.config.get("userInterfaceLangOverride", "")
         if self.uiLang == "" or self.uiLang == mainWin.modelManager.defaultLang:

--- a/arelle/DialogLanguage.py
+++ b/arelle/DialogLanguage.py
@@ -114,20 +114,21 @@ class DialogLanguage(Toplevel):
             else:
                 langCode = self.languageCodes[self.cbUiLang.value]
 
-            newLocale = Locale.getUserLocale(langCode)
-            if newLocale is not None:
+            localeCode = Locale.findCompatibleLocale(langCode)
+            if localeCode is not None:
+                newLocale = Locale.getUserLocale(localeCode)
                 self.mainWin.modelManager.locale = newLocale
             else:
                 messagebox.showerror(_("User interface locale error"),
                                      _("Locale setting {0} is not supported on this system")
-                                     .format(langCode),
+                                     .format(localeCode),
                                      parent=self)
                 return
             if uiLangIndex != 0: # not the system default
-                self.mainWin.config["userInterfaceLangOverride"] = langCode
+                self.mainWin.config["userInterfaceLangOverride"] = localeCode
             else: # use system default
                 self.mainWin.config.pop("userInterfaceLangOverride", None)
-            self.mainWin.setUiLanguage(langCode)
+            self.mainWin.setUiLanguage(localeCode)
 
             if messagebox.askyesno(
                     _("User interface language changed"),

--- a/arelle/DialogNewFactItem.py
+++ b/arelle/DialogNewFactItem.py
@@ -57,7 +57,7 @@ class DialogNewFactItemOptions(Toplevel):
         super(DialogNewFactItemOptions, self).__init__(parent)
         self.parent = parent
         self.options = options
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogOpenArchive.py
+++ b/arelle/DialogOpenArchive.py
@@ -119,7 +119,7 @@ class DialogOpenArchive(Toplevel):
         self.parent = parent
         self.showAltViewButton = showAltViewButton
         self.selectFiles = selectFiles
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogPackageManager.py
+++ b/arelle/DialogPackageManager.py
@@ -47,7 +47,7 @@ class DialogPackageManager(Toplevel):
         self.packagesConfigChanged = False
         self.packageNamesWithNewerFileDates = packageNamesWithNewerFileDates
 
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
 

--- a/arelle/DialogPluginManager.py
+++ b/arelle/DialogPluginManager.py
@@ -60,7 +60,7 @@ class DialogPluginManager(Toplevel):
         self.hostSystemFeaturesChanged = False
         self.modulesWithNewerFileDates = modulesWithNewerFileDates
 
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", self.parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
 

--- a/arelle/DialogRssWatch.py
+++ b/arelle/DialogRssWatch.py
@@ -48,7 +48,7 @@ class DialogRssWatch(Toplevel):
         super(DialogRssWatch, self).__init__(parent)
         self.parent = parent
         self.options = options
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogURL.py
+++ b/arelle/DialogURL.py
@@ -23,7 +23,7 @@ class DialogURL(Toplevel):
     def __init__(self, parent, url=None, buttonSEC=False, buttonRSS=False):
         super(DialogURL, self).__init__(parent)
         self.parent = parent
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/DialogUserPassword.py
+++ b/arelle/DialogUserPassword.py
@@ -98,7 +98,7 @@ class DialogUserPassword(Toplevel):
                  userLabel=None, passwordLabel=None, hidePassword=True):
         super(DialogUserPassword, self).__init__(parent)
         self.parent = parent
-        parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+        parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
         dialogX = int(parentGeometry.group(3))
         dialogY = int(parentGeometry.group(4))
         self.accepted = False

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -343,7 +343,7 @@ def availableLocales() -> set[str]:
     On Windows system locales can't be easily determined and an empty set is returned.
     """
     return {
-        posixLocaleToBCP47Lang(loc.partition(POSIX_LOCALE_ENCODING_SEPARATOR)[0])
+        loc.partition(POSIX_LOCALE_ENCODING_SEPARATOR)[0]
         for loc in getLocaleList()
     }
 

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -49,6 +49,8 @@ BCP47_LANGUAGE_REGION_SEPARATOR = '-'
 POSIX_LANGUAGE_REGION_SEPARATOR = '_'
 POSIX_LOCALE_ENCODING_SEPARATOR = '.'
 
+BCP47_LANGUAGE_TAG = re.compile(r"^[a-zA-Z]{2,3}(-[a-zA-Z]{2,3}(\-[a-zA-Z0-9]{1,8})*)?$")
+
 
 def _getUserLocaleUnsafe(localeCode: str = '') -> tuple[LocaleDict, str | None]:
     """
@@ -116,7 +118,9 @@ def getUserLocale(posixLocale: str | None = None) -> tuple[LocaleDict, str | Non
 
 def getLanguageCode() -> str:
     if posixLocale := getLocale():
-        return posixLocaleToBCP47Lang(posixLocale)
+        languageTag = posixLocaleToBCP47Lang(posixLocale)
+        if re.match(BCP47_LANGUAGE_TAG, languageTag):
+            return languageTag
     from arelle.XbrlConst import defaultLocale
     return defaultLocale  # XBRL international default locale
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -296,17 +296,17 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
                 classMethods = []
                 importURLs = []
                 for i, key in enumerate(item.value.keys):
-                    _key = key.s
+                    _key = key.value
                     _value = item.value.values[i]
                     _valueType = _value.__class__.__name__
                     if _key == "import":
                         if _valueType == 'Constant':
-                            importURLs.append(_value.s)
+                            importURLs.append(_value.value)
                         elif _valueType in ("List", "Tuple"):
                             for elt in _value.elts:
-                                importURLs.append(elt.s)
+                                importURLs.append(elt.value)
                     elif _valueType == 'Constant':
-                        moduleInfo[_key] = _value.s
+                        moduleInfo[_key] = _value.value
                     elif _valueType == 'Name':
                         if _value.id in constantStrings:
                             moduleInfo[_key] = constantStrings[_value.id]
@@ -316,7 +316,7 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
                         if _value.attr in methodDefNamesByClass[_value.value.id]:
                             classMethods.append(_key)
                     elif _valueType in ("List", "Tuple"):
-                        values = [elt.s for elt in _value.elts]
+                        values = [elt.value for elt in _value.elts]
                         if _key == "imports":
                             importURLs = values
                         else:
@@ -337,9 +337,9 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
                     }
                     if not moduleInfo.get("version"):
                         moduleInfo["version"] = entryPoint.dist.version  # If no explicit version, retrieve from entry point
-            elif isinstance(item.value, ast.Str): # possible constant used in plugininfo, such as VERSION
+            elif isinstance(item.value, ast.Constant) and isinstance(item.value.value, str):  # possible constant used in plugininfo, such as VERSION
                 for assignmentName in item.targets:
-                    constantStrings[assignmentName.id] = item.value.s
+                    constantStrings[assignmentName.id] = item.value.value
         elif isinstance(item, ast.ImportFrom):
             if item.level == 1: # starts with .
                 if item.module is None:  # from . import module1, module2, ...

--- a/arelle/ValidateInfoset.py
+++ b/arelle/ValidateInfoset.py
@@ -207,7 +207,7 @@ def validateRenderingInfoset(modelXbrl, comparisonFile, sourceDoc):
         # skip over nsmap elements used to create output trees
         while (sourceElt is not None and sourceElt.tag == "nsmap"):
             sourceElt = next(sourceIter, None)
-        while (comparisonElt is not None and sourceElt.tag == "nsmap"):
+        while (comparisonElt is not None and comparisonElt.tag == "nsmap"):
             comparisonElt = next(comparisonIter, None)
         while (sourceElt is not None and comparisonElt is not None):
             while (isinstance(sourceElt, etree._Comment)):

--- a/arelle/Version.py
+++ b/arelle/Version.py
@@ -6,8 +6,6 @@ See COPYRIGHT.md for copyright information.
 """
 from __future__ import annotations
 
-from datetime import datetime
-
 
 def getBuildVersion() -> str | None:
     try:
@@ -19,10 +17,10 @@ def getBuildVersion() -> str | None:
 
 def getGitHash() -> str | None:
     import subprocess
-    p = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True, encoding='utf-8')
-    if not p.stderr:
-        return p.stdout.strip()
-    return None
+    try:
+        return subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True, check=True, text=True).stdout.strip()
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
 
 
 def getDefaultVersion() -> str:

--- a/arelle/ViewWinXml.py
+++ b/arelle/ViewWinXml.py
@@ -35,4 +35,4 @@ class ViewXml(ViewWinList.ViewList):
             import traceback
             Validate.validate(self.modelXbrl)
         except Exception as err:
-            self.modelXbrl.exception("exception", _("Validation exception: \s%(error)s"), error=err, exc_info=True)
+            self.modelXbrl.exception("exception", _(r"Validation exception: \s%(error)s"), error=err, exc_info=True)

--- a/arelle/archive/plugin/objectmaker.py
+++ b/arelle/archive/plugin/objectmaker.py
@@ -95,7 +95,7 @@ def drawDiagram(modelXbrl, diagramFile, diagramNetwork=None, viewDiagram=False):
         if modelObject is not None:
             mdl.attr("node", style="") # white classes
             if isUML:
-                _properties = "".join("+{} {}\l".format(rel.toModelObject.qname.localName, rel.toModelObject.niceType)
+                _properties = "".join(r"+{} {}\l".format(rel.toModelObject.qname.localName, rel.toModelObject.niceType)
                                                         for rel in propertiesRelationshipSet.fromModelObject(modelObject)
                                                         if rel.toModelObject is not None)
                 mdl.node(id, "{{{}|{}}}".format(modelObject.qname.localName, _properties))

--- a/arelle/archive/plugin/sphinx/SphinxParser.py
+++ b/arelle/archive/plugin/sphinx/SphinxParser.py
@@ -811,7 +811,7 @@ def compileSphinxGrammar( cntlr ):
                   ).set_name("ncName").set_debug(debugParsing)
 
     #annotationName = Word("@",alphanums + '_-.').set_name("annotationName").set_debug(debugParsing)
-    annotationName = Regex("@[A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD_]\w*").set_name("annotationName").set_debug(debugParsing)
+    annotationName = Regex("@[A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD_]\\w*").set_name("annotationName").set_debug(debugParsing)
 
 
     decimalPoint = Literal('.')

--- a/arelle/archive/plugin/transforms/tester.py
+++ b/arelle/archive/plugin/transforms/tester.py
@@ -154,7 +154,7 @@ def transformationTesterMenuExtender(cntlr, menu, *args, **kwargs):
             parent = self.mainWin.parent
             super(DialogTransformTester, self).__init__(parent)
             self.parent = parent
-            parentGeometry = re.match("(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
+            parentGeometry = re.match(r"(\d+)x(\d+)[+]?([-]?\d+)[+]?([-]?\d+)", parent.geometry())
             dialogX = int(parentGeometry.group(3))
             dialogY = int(parentGeometry.group(4))
             self.selectedGroup = None

--- a/arelle/archive/plugin/validate/USSecTagging.py
+++ b/arelle/archive/plugin/validate/USSecTagging.py
@@ -12,13 +12,13 @@ from collections import defaultdict
 def compile(list, traceRows):
     if traceRows:
         # compile so each row can be traced by separate expression (slow)
-        return [(rowNbr, re.compile("(^|\s)" + pattern + "($|\W+)", re.IGNORECASE))
+        return [(rowNbr, re.compile(r"(^|\s)" + pattern + r"($|\W+)", re.IGNORECASE))
                 for rowNbr, pattern in list]
     else:
         # compile single expression for fast execution
-        return re.compile("(^|\s)" +  # always be sure first word starts at start or after space
-                          "($|\W+)|(^|\s)".join(pattern for rowNbr, pattern in list)
-                          .replace(r" ",r"\W+") + "($|\W+)",
+        return re.compile(r"(^|\s)" +  # always be sure first word starts at start or after space
+                          r"($|\W+)|(^|\s)".join(pattern for rowNbr, pattern in list)
+                          .replace(r" ",r"\W+") + r"($|\W+)",
                           re.IGNORECASE)
 
 def setup(val, traceRows=False, *args, **kwargs):

--- a/arelle/plugin/formulaLoader.py
+++ b/arelle/plugin/formulaLoader.py
@@ -1332,8 +1332,8 @@ def compileXfsGrammar( cntlr, debugParsing ):
                   "[A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040\xB7_.-]*)"
                   ).set_name("ncName").set_debug(debugParsing)
 
-    dateTime = Regex("([0-9]{4})-([0-9]{2})-([0-9]{2})[T ](24:00:00(\.0+)?|(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]))|"
-                     "([0-9]{4})-([0-9]{2})-([0-9]{2})")
+    dateTime = Regex(r"([0-9]{4})-([0-9]{2})-([0-9]{2})[T ](24:00:00(\.0+)?|(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9]))|"
+                     r"([0-9]{4})-([0-9]{2})-([0-9]{2})")
 
 
     decimalPoint = Literal('.')

--- a/arelle/plugin/internet/proxyNTLM/HTTPNtlmAuthHandler.py
+++ b/arelle/plugin/internet/proxyNTLM/HTTPNtlmAuthHandler.py
@@ -83,7 +83,7 @@ class AbstractNtlmAuthHandler:
 
             # some Exchange servers send two WWW-Authenticate headers, one with the NTLM challenge
             # and another with the 'Negotiate' keyword - make sure we operate on the right one
-            m = re.match('(NTLM [A-Za-z0-9+\-/=]+)', auth_header_value)
+            m = re.match(r'(NTLM [A-Za-z0-9+\-/=]+)', auth_header_value)
             if m:
                 auth_header_value, = m.groups()
 

--- a/arelle/plugin/validate/EFM/tools/CheckTxmyRefs.py
+++ b/arelle/plugin/validate/EFM/tools/CheckTxmyRefs.py
@@ -29,7 +29,7 @@ fishInDirsForMissing = {
         "url-root": "https://xbrl.sec.gov",
         # "local-root": r"C:/gns/w/git-osd/stx/xbrl.sec.gov",
         "local-root": r"C:/gns/w/git-group2/sec-arelle/xbrl_taxonomies/xbrl_taxonomies/resources/System/cache/https/xbrl.sec.gov",
-        "entrypoint-pattern": "https?://xbrl.sec.gov/[^/]+/2023[^/]*/[^/]+(-sub-)[^.]+\.xsd"
+        "entrypoint-pattern": r"https?://xbrl.sec.gov/[^/]+/2023[^/]*/[^/]+(-sub-)[^.]+\.xsd"
         }
     # not sure what we load for US-GAAP and IFRS to determine needed ref and doc linkbases
     }
@@ -80,12 +80,12 @@ def utilityRun(cntlr, options, *args, **kwargs):
                     for refUrl in modelXbrl.urlDocs:
                         if refUrl not in edTxmyHrefs and refUrl != hRef:
                             log(f"ref taxonomy also missing from edgartaxonomies: ref {refUrl}, loaded from {hRef}")
-                    if not re.match(".*([-_](lab|ref|pre|cal|def|sub)(-\n\n\n\n)?\.xsd)", hRef):
+                    if not re.match(r".*([-_](lab|ref|pre|cal|def|sub)(-\n\n\n\n)?\.xsd)", hRef):
                         cachePath = os.path.dirname(cntlr.webCache.getfilename(hRef))
                         docRefs = defaultdict(set)
                         for root, dir, files in os.walk(cachePath):
                             for file in files:
-                                m = re.match(".*(doc|ref)\.(xsd|xml)", file)
+                                m = re.match(r".*(doc|ref)\.(xsd|xml)", file)
                                 if m:
                                     docRefs[m.group(1)].add(file)
                         addOn = txmyAddons.get(os.path.basename(hRef))
@@ -124,12 +124,12 @@ def utilityRun(cntlr, options, *args, **kwargs):
                             for refUrl in modelXbrl.urlDocs:
                                 if refUrl not in edTxmyHrefs and refUrl != hRef:
                                     log(f"ref taxonomy also missing from edgartaxonomies: ref {refUrl}, loaded from {hRef}")
-                            if not re.match(".*([-_](lab|ref|pre|cal|def|sub)(-\n\n\n\n)?\.xsd)", hRef):
+                            if not re.match(r".*([-_](lab|ref|pre|cal|def|sub)(-\n\n\n\n)?\.xsd)", hRef):
                                 cachePath = os.path.dirname(cntlr.webCache.getfilename(hRef))
                                 docRefs = defaultdict(set)
                                 for root, dir, files in os.walk(cachePath):
                                     for file in files:
-                                        m = re.match(".*(doc|ref)\.(xsd|xml)", file)
+                                        m = re.match(r".*(doc|ref)\.(xsd|xml)", file)
                                         if m:
                                             docRefs[m.group(1)].add(file)
                                 addOn = txmyAddons.get(os.path.basename(hRef))

--- a/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
+++ b/arelle/plugin/xbrlDB/XbrlPublicPostgresDB.py
@@ -21,7 +21,7 @@ Arelle uses 9.1, via Python DB API 2.0 interface, using the pg8000 library.
 Information for the 'official' XBRL US-maintained database (this schema, containing SEC filings):
     Database Name: edgar_db
     Database engine: Postgres version 8.4
-    \Host: public.xbrl.us
+    Host: public.xbrl.us
     Port: 5432
 
 to use from command line:

--- a/arelle/webserver/bottle.py
+++ b/arelle/webserver/bottle.py
@@ -69,10 +69,10 @@ if __name__ == '__main__':
 # Imports and Python 2/3 unification ##########################################
 ###############################################################################
 
-import base64, calendar, cgi, email.utils, functools, hmac, imp, itertools,\
+import base64, calendar, cgi, email.utils, functools, hmac, itertools,\
        mimetypes, os, re, tempfile, threading, time, warnings, weakref, hashlib
 
-from types import FunctionType
+from types import FunctionType, ModuleType
 from datetime import date as datedate, datetime, timedelta
 from tempfile import TemporaryFile
 from traceback import format_exc, print_exc
@@ -2057,7 +2057,7 @@ class _ImportRedirect(object):
         """ Create a virtual package that redirects imports (see PEP 302). """
         self.name = name
         self.impmask = impmask
-        self.module = sys.modules.setdefault(name, imp.new_module(name))
+        self.module = sys.modules.setdefault(name, ModuleType(name))
         self.module.__dict__.update({
             '__file__': __file__,
             '__path__': [],

--- a/distro.py
+++ b/distro.py
@@ -43,6 +43,7 @@ includeLibs = [
     "pycountry",
     "pymysql",
     "regex",
+    "rdflib",
     "sqlite3",
     "tinycss2",
     "zlib",

--- a/distro.py
+++ b/distro.py
@@ -90,6 +90,14 @@ elif sys.platform == MACOS_PLATFORM:
         "iconfile": "arelle/images/arelle.icns",
         "bundle_name": "Arelle",
     }
+    if codesignIdentity := os.environ.get('CODESIGN_IDENTITY'):
+        options["bdist_mac"].update({
+            "codesign_identity": codesignIdentity,
+            "codesign_deep": True,
+            "codesign_timestamp": True,
+            "codesign_verify": True,
+            "codesign_options": "runtime",
+        })
 elif sys.platform == WINDOWS_PLATFORM:
     guiExecutable = Executable(
         script="arelleGUI.pyw",

--- a/distro.py
+++ b/distro.py
@@ -112,7 +112,7 @@ else:
 setup(
     executables=[guiExecutable, cliExecutable],
     options=options,
-    setup_requires=["setuptools_scm~=7.1"],
+    setup_requires=["setuptools_scm~=8.0"],
     use_scm_version={
         "tag_regex": r"^(?:[\w-]+-?)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
         "write_to": os.path.normcase("arelle/_version.py"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Operating System :: OS Independent',
     'Topic :: Text Processing :: Markup :: XML'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.8"
 dependencies = [
     'certifi',
     'isodate==0.*',
-    'lxml==4.*',
+    'lxml>=4,<6',
     'numpy==1.*',
     'openpyxl==3.*',
     'pyparsing==3.*',
@@ -46,7 +46,7 @@ DB = [
     'pg8000==1.*',
     'PyMySQL==1.*',
     'pyodbc>=4,<6',
-    'rdflib==5.*',
+    'rdflib>=5,<8',
 ]
 EFM = [
     'holidays==0.*',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ markers = [
 # Warn when a # type: ignore comment does not specify any error codes
 enable_error_code = "ignore-without-code"
 
-python_version = "3.11"
+python_version = "3.12"
 
 show_error_codes = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=68.0", "wheel~=0.40", "setuptools_scm[toml]~=7.1"]
+requires = ["setuptools~=69.0", "wheel~=0.42", "setuptools_scm[toml]~=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,4 @@
-cx-Freeze==6.14.7
-# A dependency of cx_Freeze that we specify explicitly in order to pin
-packaging==21.3
+cx-Freeze==6.15.12
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
 -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,17 +2,17 @@ flake8==6.1.0
 flake8-noqa==1.3.2
 
 mock==5.1.0
-mypy==1.7.0
-pytest==7.4.3
+mypy==1.8.0
+pytest==7.4.4
 
-typing-extensions==4.8.0
+typing-extensions==4.9.0
 lxml-stubs==0.4.0
 types-PyMySQL==1.1.0.1
 types-python-dateutil==2.8.19.14
 types-pytz==2023.3.1.1
 types-simplejson==3.19.0.2
-types-ujson==5.8.0.1
-types-regex==2023.10.3.0
+types-ujson==5.9.0.0
+types-regex==2023.12.25.20231225
 types-waitress==2.1.4.9
 
 -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 flake8==6.1.0
 flake8-noqa==1.3.2
 
-mock==5.1.0
 mypy==1.8.0
 pytest==7.4.4
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,8 +1,6 @@
-# astroid 3 breaks sphinx-autodoc2: https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/31
-astroid==2.15.8
 furo==2023.9.10
 myst-parser==2.0.0
-sphinx==7.1.2
+sphinx==7.2.6
 sphinx-autobuild==2021.3.14
-sphinx-autodoc2==0.4.2
+sphinx-autodoc2==0.5.0
 sphinx-copybutton==0.5.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,7 @@
 furo==2023.9.10
 myst-parser==2.0.0
-sphinx==7.2.6
+sphinx==7.1.2 ; python_version <= "3.8"
+sphinx==7.2.6 ; python_version > "3.8"
 sphinx-autobuild==2021.3.14
 sphinx-autodoc2==0.5.0
 sphinx-copybutton==0.5.2

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -1,1 +1,1 @@
-ixbrl-viewer==1.4.10
+ixbrl-viewer==1.4.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,32 +1,32 @@
 # core modules
 certifi==2023.11.17
-lxml==4.9.3
+lxml==5.0.0
 OpenPyXL==3.1.2
 pyparsing==3.1.1
-regex==2023.10.3
+regex==2023.12.25
 isodate==0.6.1
 aniso8601==9.0.1
-CherryPy==18.8.0
+CherryPy==18.9.0
 Cheroot==10.0.0
 python-dateutil==2.8.2
-# special note: pip install --no-cache --use-pep517 pycountry
-pycountry==22.3.5
+pycountry==23.12.11
 # plugins
 # EdgarRenderer plugin
 NumPy==1.24.4 ; python_version <= "3.8"
-NumPy==1.25.2 ; python_version > "3.8"
-Matplotlib==3.7.4
-holidays==0.36
+NumPy==1.26.2 ; python_version > "3.8"
+Matplotlib==3.7.4 ; python_version <= "3.8"
+Matplotlib==3.8.2 ; python_version > "3.8"
+holidays==0.39
 pytz==2023.3.post1
-Tornado==6.3.3
+Tornado==6.4
 # security plugin
-PyCryptodome==3.19.0
+PyCryptodome==3.19.1
 # xbrlDB plugin
 cx_Oracle==8.3.0
 pg8000==1.30.3
 PyMySQL==1.1.0
 pyodbc==5.0.1
-RDFLib==5.0.0
+RDFLib==7.0.0
 # other
 graphviz==0.20.1
 Pillow==10.1.0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,2 +1,2 @@
 # https://github.com/dependabot/dependabot-core/blob/8ab4d78efe7cf9a75bef76dd883d7ee3fffffb40/python/lib/dependabot/python/file_parser/python_requirement_parser.rb#L76-L85
-python-3.8.17
+python-3.8.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -150,5 +150,3 @@ ignore =
     W503,
     # line break after binary operator
     W504,
-    # invalid escape sequence '\d'
-    W605

--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import os
+import re
 from dataclasses import dataclass, field
 
 
@@ -30,6 +31,7 @@ class ConformanceSuiteConfig:
     strict_testcase_index: bool = True
     url_replace: str | None = None
     network_or_cache_required: bool = True
+    required_locale_by_ids: dict[str, re.Pattern[str]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         redundant_plugins = [(prefix, overlap)
@@ -49,6 +51,9 @@ class ConformanceSuiteConfig:
         assert plugin_combinations <= self.shards, \
             'Too few shards to accommodate the number of plugin combinations:' \
             f' combinations={plugin_combinations} shards={self.shards}'
+        overlapping_expected_testcase_ids = self.expected_failure_ids.intersection(self.required_locale_by_ids)
+        assert not overlapping_expected_testcase_ids, \
+            f'Testcase IDs in both expected failures and required locales: {sorted(overlapping_expected_testcase_ids)}'
 
     @property
     def prefixed_extract_filepath(self) -> str | None:

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_formula_1_0_function_registry.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_formula_1_0_function_registry.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import PurePath
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig
 
@@ -13,4 +14,7 @@ config = ConformanceSuiteConfig(
     network_or_cache_required=False,
     plugins=frozenset({'formulaXPathChecker', 'functionsMath'}),
     strict_testcase_index=False,
+    required_locale_by_ids={f'formula/function-registry/{t}': p for t, p in [
+        ('xbrl/90701 xfi.format-number/90701 xfi.format-number testcase.xml:V-05', re.compile(r"^(en|English).*$")),
+    ]},
 )

--- a/tests/integration_tests/validation/discover_tests.py
+++ b/tests/integration_tests/validation/discover_tests.py
@@ -18,8 +18,9 @@ ALL_PYTHON_VERSIONS = (
     '3.9',
     '3.10',
     '3.11',
+    '3.12',
 )
-LATEST_PYTHON_VERSION = '3.11'
+LATEST_PYTHON_VERSION = '3.12'
 # number of cores on the runners
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
 OS_CORES = {

--- a/tests/integration_tests/validation/validation_util.py
+++ b/tests/integration_tests/validation/validation_util.py
@@ -125,6 +125,7 @@ def get_conformance_suite_arguments(config: ConformanceSuiteConfig, filename: st
         expected_failure_ids=expected_failure_ids,
         expected_empty_testcases=expected_empty_testcases,
         expected_model_errors=config.expected_model_errors,
+        required_locale_by_ids=config.required_locale_by_ids,
         strict_testcase_index=config.strict_testcase_index,
     )
     return args + config.args, kws

--- a/tests/unit_tests/arelle/test_cntlr.py
+++ b/tests/unit_tests/arelle/test_cntlr.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from arelle import Cntlr
 

--- a/tests/unit_tests/arelle/test_packagemanager.py
+++ b/tests/unit_tests/arelle/test_packagemanager.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 
 from arelle import PackageManager
 

--- a/tests/unit_tests/arelle/test_pluginmanager.py
+++ b/tests/unit_tests/arelle/test_pluginmanager.py
@@ -119,7 +119,7 @@ def test_function_get_name_dir_prefix(
 
         def __init__(self) -> None:
             """Init controller with logging."""
-            super().__init__(logFileName="logToPrint")
+            super().__init__(logFileName="logToBuffer")
 
     cntlr = Controller()
 
@@ -151,7 +151,7 @@ def test_function_loadModule():
 
         def __init__(self) -> None:
             """Init controller with logging."""
-            super().__init__(logFileName="logToPrint")
+            super().__init__(logFileName="logToBuffer")
 
     Controller()
 

--- a/tests/unit_tests/arelle/test_pluginmanager.py
+++ b/tests/unit_tests/arelle/test_pluginmanager.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from arelle import PluginManager
 from arelle.Cntlr import Cntlr

--- a/tests/unit_tests/arelle/test_runtimeoptions.py
+++ b/tests/unit_tests/arelle/test_runtimeoptions.py
@@ -1,7 +1,7 @@
 import pytest
 import re
 
-from mock import patch
+from unittest.mock import patch
 from arelle.RuntimeOptions import RuntimeOptions, RuntimeOptionsException
 
 

--- a/tests/unit_tests/arelle/test_version.py
+++ b/tests/unit_tests/arelle/test_version.py
@@ -1,6 +1,6 @@
 import subprocess
 
-import mock
+from unittest import mock
 
 import arelle.Version
 from arelle.Version import getDefaultVersion, getGitHash, getVersion

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 import regex
-from mock import Mock
+from unittest.mock import Mock
 
 from arelle.ModelValue import QName, DateTime, Time, isoDuration, gDay, gMonth, gMonthDay, gYear, gYearMonth
 from arelle.XmlValidate import validateValue, VALID, UNKNOWN, INVALID, VALID_ID, NMTOKENPattern, namePattern, NCNamePattern, VALID_NO_CONTENT

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, lint, typing
+envlist = py38, py39, py310, py311, py312, lint, typing
 isolated_build = True
 skip_missing_interpreters = False
 
@@ -8,7 +8,8 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
-  3.11: py311, lint, typing
+  3.11: py311
+  3.12: py312, lint, typing
 
 [testenv]
 commands =


### PR DESCRIPTION
#### Reason for change
Resolves #818

#### Description of change
Update Arelle to be compatible with Python 3.12 and workflows (besides frozen builds) to use it.
cx_Freeze doesn't support 3.12 yet, so frozen builds will continue to use 3.11 for the time being, but cx_Freeze was updated to the latest release to support newer versions of Matplotlib and NumPy that support Python 3.12.

Updating cx_Freeze broke the code signing step of our macOS build workflow as the library recently overhauled their macOS builds. Fortunately a large part of the overhaul was to make code signing work from within the library, so I was able to delete our code signing step and configure cx_Freeze to handle signing instead.

Python versions prior to 3.12 incorrectly mapped the `C` locale to `en_US` this necessitated overhauling local handling in Arelle. Previously locales and preferred label languages were intermingled (`lang.replace('-', '_')` and `lang.replace('_', '-')` used all over the place) when there's no reason that preferred label languages should be limited to system locales.

#### Steps to Test
* CI
* Frozen builds already tested for [Linux](https://github.com/austinmatherne-wk/Arelle/actions/runs/7394873206), [macOS](https://github.com/austinmatherne-wk/Arelle/actions/runs/7394873849), and [Windows](https://github.com/austinmatherne-wk/Arelle/actions/runs/7394874508).

**review**:
@Arelle/arelle
