### PR TITLE
Use Arelle XML encoding detection instead of lxml encoding

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -683,6 +683,8 @@ class ModelDocument:
         Qualifies as a discovered schema per XBRL 2.1
     """
 
+    # The document encoding. The XML declaration is stripped from the document
+    # before lxml parses the document making the lxml DocInfo encoding unreliable.
     documentEncoding: str
     xmlRootElement: Any
     targetXbrlRootElement: ModelObject

--- a/arelle/plugin/validate/NL/rules/fr_nl.py
+++ b/arelle/plugin/validate/NL/rules/fr_nl.py
@@ -227,7 +227,7 @@ def rule_fr_nl_1_05(
     """
     for doc in val.modelXbrl.urlDocs.values():
         if doc.type == ModelDocument.Type.INSTANCE:
-            if 'UTF-8' != doc.xmlDocument.docinfo.encoding:
+            if 'UTF-8' != doc.documentEncoding.upper():
                 yield Validation.error(
                     codes='NL.FR-NL-1.05',
                     msg=_('The XML character encoding \'UTF-8\' MUST be used in the filing instance document'),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-flake8==6.1.0
-flake8-noqa==1.3.2
+flake8==7.0.0
+flake8-noqa==1.4.0
 
 mypy==1.8.0
 pytest==7.4.4
@@ -7,11 +7,11 @@ pytest==7.4.4
 typing-extensions==4.9.0
 lxml-stubs==0.4.0
 types-PyMySQL==1.1.0.1
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.8.19.20240106
 types-pytz==2023.3.1.1
 types-simplejson==3.19.0.2
 types-ujson==5.9.0.0
-types-regex==2023.12.25.20231225
-types-waitress==2.1.4.9
+types-regex==2023.12.25.20240106
+types-waitress==2.1.4.20240106
 
 -r requirements.txt

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -1,1 +1,1 @@
-ixbrl-viewer==1.4.12
+ixbrl-viewer==1.4.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core modules
 certifi==2023.11.17
-lxml==5.0.0
+lxml==5.1.0
 OpenPyXL==3.1.2
 pyparsing==3.1.1
 regex==2023.12.25


### PR DESCRIPTION
#### Reason for change
lxml 5.1.0 [fails the current nl_ntp conformance suites](https://github.com/Arelle/Arelle/actions/runs/7446084583/job/20261413737?pr=1028).

#### Description of change
Use stable ModelDocument encoding instead of lxml.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
