### PR TITLE
Include source file in error message when failing to load image

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
@@ -8,6 +8,7 @@ import os
 from typing import cast
 from urllib.parse import unquote
 
+from arelle import ModelDocument
 from lxml.etree import XML, XMLSyntaxError
 from lxml.etree import _Element
 
@@ -159,8 +160,12 @@ def checkSVGContent(
     guidance: str,
     val: ValidateXbrl,
 ) -> None:
-    _parser, _ignored, _ignored = parser(modelXbrl, baseURI)
-    elt = XML(data, parser=_parser)
+    if baseURI:
+        svgDoc = cast(ModelDocument.ModelDocument, ModelDocument.load(modelXbrl, baseURI, referringElement=imgElts[0]))
+        elt = svgDoc.xmlRootElement
+    else:
+        _parser, _ignored, _ignored = parser(modelXbrl, baseURI)
+        elt = XML(data, parser=_parser)
     checkSVGContentElt(elt, baseURI, modelXbrl, imgElts, guidance, val)
 
 

--- a/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import binascii
 import os
-from typing import Any, Optional, Union
+from typing import cast
 from urllib.parse import unquote
 
 from lxml.etree import XML, XMLSyntaxError
@@ -25,17 +25,21 @@ _: TypeGetText  # Handle gettext
 
 # check image contents against mime/file ext and for Steganography
 def validateImage(
-    baseUrl: Optional[str],
+    baseUrl: str | None,
     image: str,
     modelXbrl: ModelXbrl,
     val: ValidateXbrl,
-    elt: _Element,
+    elts: _Element | list[_Element],
     evaluatedMsg: str,
     contentOtherThanXHTMLGuidance: str,
 ) -> None:
     """
     image: either an url or base64 in data:image style
     """
+    # a list of img elements are maintained because an SVG can reference another SVG
+    # or other type of image and we need to log the entire reference chain.
+    if not isinstance(elts, list):
+        elts = [elts]
     minExternalRessourceSize = val.authParam["minExternalResourceSizekB"]
     if minExternalRessourceSize != -1:
         # transform kb to b
@@ -44,7 +48,7 @@ def validateImage(
         modelXbrl.error("ESEF.4.1.6.xHTMLDocumentContainsExternalReferences" if val.unconsolidated
                         else "ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences",
                         _("Inline XBRL instance documents MUST NOT contain any reference pointing to resources outside the reporting package: %(element)s"),
-                        modelObject=elt, element=elt.tag, evaluatedMsg=evaluatedMsg,
+                        modelObject=elts, element=elts[0].tag, evaluatedMsg=evaluatedMsg,
                         messageCodes=("ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences",
                                       "ESEF.4.1.6.xHTMLDocumentContainsExternalReferences"))
     elif image.startswith("data:image"):
@@ -52,28 +56,28 @@ def validateImage(
         if not dataURLParts or not dataURLParts.isBase64:
             modelXbrl.warning(f"{contentOtherThanXHTMLGuidance}.embeddedImageNotUsingBase64Encoding",
                               _("Images included in the XHTML document SHOULD be base64 encoded: %(src)s."),
-                              modelObject=elt, src=image[:128], evaluatedMsg=evaluatedMsg)
+                              modelObject=elts, src=image[:128], evaluatedMsg=evaluatedMsg)
             if dataURLParts and dataURLParts.mimeSubtype and dataURLParts.data:
-                checkImageContents(None, modelXbrl, elt, dataURLParts.mimeSubtype, False, unquote(dataURLParts.data), val.consolidated, val)
+                checkImageContents(None, modelXbrl, elts, dataURLParts.mimeSubtype, False, unquote(dataURLParts.data), val.consolidated, val)
         else:
             if not dataURLParts.mimeSubtype:
                 modelXbrl.error(f"{contentOtherThanXHTMLGuidance}.MIMETypeNotSpecified",
                                 _("Images included in the XHTML document MUST be saved with MIME type specifying PNG, GIF, SVG or JPG/JPEG formats: %(src)s."),
-                                modelObject=elt, src=image[:128], evaluatedMsg=evaluatedMsg)
+                                modelObject=elts, src=image[:128], evaluatedMsg=evaluatedMsg)
             elif dataURLParts.mimeSubtype not in ("gif", "jpeg", "png", "svg+xml"):
                 modelXbrl.error(f"{contentOtherThanXHTMLGuidance}.imageFormatNotSupported",
                                 _("Images included in the XHTML document MUST be saved in PNG, GIF, SVG or JPG/JPEG formats: %(src)s."),
-                                modelObject=elt, src=image[:128], evaluatedMsg=evaluatedMsg)
+                                modelObject=elts, src=image[:128], evaluatedMsg=evaluatedMsg)
             # check for malicious image contents
             try:  # allow embedded newlines
-                imgContents:Union[bytes, Any, str] = decodeBase64DataImage(dataURLParts.data)
-                checkImageContents(None, modelXbrl, elt, str(dataURLParts.mimeSubtype), False, imgContents, val.consolidated, val)
+                imgContents = decodeBase64DataImage(dataURLParts.data)
+                checkImageContents(None, modelXbrl, elts, str(dataURLParts.mimeSubtype), False, imgContents, val.consolidated, val)
                 imgContents = b""  # deref, may be very large
 
             except binascii.Error as err:
                 modelXbrl.error(f"{contentOtherThanXHTMLGuidance}.embeddedImageNotUsingBase64Encoding",
                                 _("Base64 encoding error %(err)s in image source: %(src)s."),
-                                modelObject=elt, err=str(err), src=image[:128], evaluatedMsg=evaluatedMsg)
+                                modelObject=elts, err=str(err), src=image[:128], evaluatedMsg=evaluatedMsg)
     else:
         # presume it to be an image file, check image contents
         try:
@@ -83,48 +87,48 @@ def validateImage(
                 normalizedUri = modelXbrl.modelManager.cntlr.webCache.getfilename(normalizedUri)
             imglen = 0
             with modelXbrl.fileSource.file(normalizedUri, binary=True)[0] as fh:
-                imgContents = fh.read()
+                imgContents = cast(bytes, fh.read())
                 imglen += len(imgContents or '')
-                checkImageContents(normalizedUri, modelXbrl, elt, os.path.splitext(image)[1], True, imgContents,
+                checkImageContents(normalizedUri, modelXbrl, elts, os.path.splitext(image)[1], True, imgContents,
                                    val.consolidated, val)
                 imgContents = b""  # deref, may be very large
             if getDisclosureSystemYear(modelXbrl) < 2023 and imglen < minExternalRessourceSize:
                 modelXbrl.warning(
                     "%s.imageIncludedAndNotEmbeddedAsBase64EncodedString" % contentOtherThanXHTMLGuidance,
                     _("Images SHOULD be included in the XHTML document as a base64 encoded string unless their size exceeds the minimum size for the authority (%(maxImageSize)s): %(file)s."),
-                    modelObject=elt, maxImageSize=minExternalRessourceSize, file=os.path.basename(normalizedUri), evaluatedMsg=evaluatedMsg)
+                    modelObject=elts, maxImageSize=minExternalRessourceSize, file=os.path.basename(normalizedUri), evaluatedMsg=evaluatedMsg)
         except IOError as err:
             fileReferencingImage = os.path.basename(baseUrl) if baseUrl else ''
             modelXbrl.error(f"{contentOtherThanXHTMLGuidance}.imageFileCannotBeLoaded",
                             _("Error opening the file '%(src)s' referenced by '%(fileReferencingImage)s': %(error)s"),
-                            modelObject=elt, src=image, fileReferencingImage=fileReferencingImage, error=err, evaluatedMsg=evaluatedMsg)
+                            modelObject=elts, src=image, fileReferencingImage=fileReferencingImage, error=err, evaluatedMsg=evaluatedMsg)
 
 
 def checkImageContents(
-    baseURI: Optional[str],
+    baseURI: str | None,
     modelXbrl: ModelXbrl,
-    imgElt: _Element,
+    imgElts: list[_Element],
     imgType: str,
     isFile: bool,
-    data: Union[bytes, Any, str],
+    data: bytes | str,
     consolidated: bool,
     val: ValidateXbrl,
 ) -> None:
     guidance = 'ESEF.2.5.1' if consolidated else 'ESEF.4.1.3'
     if "svg" in imgType:
         try:
-            checkSVGContent(baseURI, modelXbrl, imgElt, data, guidance, val)
+            checkSVGContent(baseURI, modelXbrl, imgElts, data, guidance, val)
         except XMLSyntaxError as err:
             try:
-                checkSVGContent(baseURI, modelXbrl, imgElt, unquote(data), guidance, val)  # Try with utf-8 decoded data as in conformance suite G4-1-3_2/TC2
+                checkSVGContent(baseURI, modelXbrl, imgElts, unquote(data), guidance, val)  # Try with utf-8 decoded data as in conformance suite G4-1-3_2/TC2
             except XMLSyntaxError:
                 modelXbrl.error(f"{guidance}.imageFileCannotBeLoaded",
                                 _("Image SVG has XML error %(error)s"),
-                                modelObject=imgElt, error=err)
+                                modelObject=imgElts, error=err)
         except UnicodeDecodeError as err:
             modelXbrl.error(f"{guidance}.imageFileCannotBeLoaded",
                 _("Image SVG has XML error %(error)s"),
-                modelObject=imgElt, error=err)
+                modelObject=imgElts, error=err)
     else:
         headerType = validateGraphicHeaderType(data)  # type: ignore[arg-type]
         if (("gif" not in imgType and headerType == "gif") or
@@ -139,25 +143,25 @@ def checkImageContents(
                 code = incorrectMIMETypeSpecified
                 message = _("File type %(headerType)s inferred from file signature does not match the data URL media subtype (MIME subtype) %(imgType)s")
             modelXbrl.error(code, message,
-                modelObject=imgElt, imgType=imgType, headerType=headerType,
+                modelObject=imgElts, imgType=imgType, headerType=headerType,
                 messageCodes=(imageDoesNotMatchItsFileExtension, incorrectMIMETypeSpecified))
         elif not any(it in imgType for it in supportedImgTypes[isFile]):
             modelXbrl.error(f"{guidance}.imageFormatNotSupported",
                             _("Images included in the XHTML document MUST be saved in PNG, GIF, SVG or JPEG formats: %(imgType)s is not supported"),
-                            modelObject=imgElt, imgType=imgType)
+                            modelObject=imgElts, imgType=imgType)
 
 
 def checkSVGContent(
-    baseURI: Optional[str],
+    baseURI: str | None,
     modelXbrl: ModelXbrl,
-    imgElt: _Element,
-    data: Union[bytes, Any, str],
+    imgElts: list[_Element],
+    data: bytes | str,
     guidance: str,
     val: ValidateXbrl,
 ) -> None:
     _parser, _ignored, _ignored = parser(modelXbrl, baseURI)
     elt = XML(data, parser=_parser)
-    checkSVGContentElt(elt, baseURI, modelXbrl, imgElt, guidance, val)
+    checkSVGContentElt(elt, baseURI, modelXbrl, imgElts, guidance, val)
 
 
 def getHref(elt:_Element) -> str:
@@ -171,9 +175,9 @@ def getHref(elt:_Element) -> str:
 
 def checkSVGContentElt(
     elt: _Element,
-    baseUrl: Optional[str],
+    baseUrl: str | None,
     modelXbrl: ModelXbrl,
-    imgElt: _Element,
+    imgElts: list[_Element],
     guidance: str,
     val: ValidateXbrl,
 ) -> None:
@@ -183,18 +187,19 @@ def checkSVGContentElt(
             if elt.tag != "{http://www.w3.org/2000/svg}svg":
                 modelXbrl.error(f"{guidance}.imageFileCannotBeLoaded",
                                 _("Image SVG has root element which is not svg"),
-                                modelObject=imgElt)
+                                modelObject=imgElts)
             rootElement = False
         eltTag = elt.tag.rpartition("}")[2] # strip namespace
         if eltTag == "image":
-            validateImage(baseUrl, getHref(elt), modelXbrl, val, elt, "", guidance)
+            imgElts.insert(0, elt)
+            validateImage(baseUrl, getHref(elt), modelXbrl, val, imgElts, "", guidance)
         if eltTag in ("object", "script", "audio", "foreignObject", "iframe", "image", "use", "video"):
             href = elt.get("href","")
             if eltTag in ("object", "script") or "javascript:" in href:
                 modelXbrl.error(f"{guidance}.executableCodePresent",
                                 _("Inline XBRL images MUST NOT contain executable code: %(element)s"),
-                                modelObject=imgElt, element=eltTag)
+                                modelObject=imgElts, element=eltTag)
             elif scheme(href) in ("http", "https", "ftp"):
                 modelXbrl.error(f"{guidance}.referencesPointingOutsideOfTheReportingPackagePresent",
                                 _("Inline XBRL instance document [image] MUST NOT contain any reference pointing to resources outside the reporting package: %(element)s"),
-                                modelObject=imgElt, element=eltTag)
+                                modelObject=imgElts, element=eltTag)

--- a/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
@@ -196,7 +196,7 @@ def checkSVGContentElt(
             rootElement = False
         eltTag = elt.tag.rpartition("}")[2] # strip namespace
         if eltTag == "image":
-            imgElts.insert(0, elt)
+            imgElts = [*imgElts, elt]
             validateImage(baseUrl, getHref(elt), modelXbrl, val, imgElts, "", guidance)
         if eltTag in ("object", "script", "audio", "foreignObject", "iframe", "image", "use", "video"):
             href = elt.get("href","")

--- a/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
@@ -94,9 +94,10 @@ def validateImage(
                     _("Images SHOULD be included in the XHTML document as a base64 encoded string unless their size exceeds the minimum size for the authority (%(maxImageSize)s): %(file)s."),
                     modelObject=elt, maxImageSize=minExternalRessourceSize, file=os.path.basename(normalizedUri), evaluatedMsg=evaluatedMsg)
         except IOError as err:
+            fileReferencingImage = os.path.basename(baseUrl) if baseUrl else ''
             modelXbrl.error(f"{contentOtherThanXHTMLGuidance}.imageFileCannotBeLoaded",
-                            _("Error opening the file '%(src)s': %(error)s"),
-                            modelObject=elt, src=image, error=err, evaluatedMsg=evaluatedMsg)
+                            _("Error opening the file '%(src)s' referenced by '%(fileReferencingImage)s': %(error)s"),
+                            modelObject=elt, src=image, fileReferencingImage=fileReferencingImage, error=err, evaluatedMsg=evaluatedMsg)
 
 
 def checkImageContents(

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -337,7 +337,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                             _("Inline XBRL documents SHOULD NOT contain any 'mailto' URI: %(element)s"),
                                             modelObject=elt, element=eltTag)
                         elif eltTag == "{http://www.w3.org/2000/svg}svg":
-                            checkSVGContentElt(elt, elt.modelDocument.baseForElement(elt), modelXbrl, elt,
+                            checkSVGContentElt(elt, elt.modelDocument.baseForElement(elt), modelXbrl, [elt],
                                            contentOtherThanXHTMLGuidance, val)
                         elif eltTag == "img":
                             src = elt.get("src","").strip()


### PR DESCRIPTION
#### Reason for change
The error that's raised when an image referenced by an SVG cannot be loaded doesn't contain a reference to the SVG which links to the image. This makes it difficult to determine which file needs to be updated.

#### Description of change
Include source file in ESEF error message

#### Steps to Test
* Use [test-2024-01-12-en.zip](https://github.com/Arelle/Arelle/files/13925082/test-2024-01-12-en.zip)
* Run `python arelleCmdLine.py --plugins validate/ESEF --disclosureSystem esef-2023 --validate --file test-2024-01-12-en.zip`
* Expect: `[ESEF.2.5.1.imageFileCannotBeLoaded] Error opening the file '../../missing.jpg' referenced by 'image-reference.svg'`
* Instead of: `[ESEF.2.5.1.imageFileCannotBeLoaded] Error opening the file '../../missing.jpg'`

**review**:
@Arelle/arelle @gmongelli 
