### PR TITLE
Save deduplicated traditional XBRL instance

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -134,6 +134,13 @@ def parseArgs(args):
                       choices=[a.value for a in ValidateDuplicateFacts.DUPLICATE_TYPE_ARG_MAP],
                       dest="validateDuplicateFacts",
                       help=_("Select which types of duplicates should trigger warnings."))
+    parser.add_option("--deduplicateFacts", "--deduplicatefacts",
+                      choices=[a.value for a in ValidateDuplicateFacts.DeduplicationType],
+                      dest="deduplicateFacts",
+                      help=_("When using '--saveDeduplicatedInstance' to save a deduplicated instance, check for duplicates of this type."))
+    parser.add_option("--saveDeduplicatedInstance", "--savededuplicatedinstance",
+                      dest="saveDeduplicatedInstance",
+                      help=_("Save an instance document with duplicates of the provided type ('--deduplicateFacts') deduplicated."))
     parser.add_option("--noValidateTestcaseSchema", "--novalidatetestcaseschema", action="store_false", dest="validateTestcaseSchema", default=True,
                       help=_("Validate testcases against their schemas."))
     betaGroup = OptionGroup(parser, "Beta Features",
@@ -1083,6 +1090,16 @@ class CntlrCmdLine(Cntlr.Cntlr):
                             ViewFileRoleTypes.viewRoleTypes(modelXbrl, options.roleTypesFile, "Role Types", isArcrole=False, lang=options.labelLang)
                         if options.arcroleTypesFile:
                             ViewFileRoleTypes.viewRoleTypes(modelXbrl, options.arcroleTypesFile, "Arcrole Types", isArcrole=True, lang=options.labelLang)
+                        if options.saveDeduplicatedInstance:
+                            if options.deduplicateFacts:
+                                deduplicateFactsArg = ValidateDuplicateFacts.DeduplicationType(options.deduplicateFacts)
+                            else:
+                                deduplicateFactsArg = ValidateDuplicateFacts.DeduplicationType.COMPLETE
+                            if modelXbrl.modelDocument.type == ModelDocument.Type.INSTANCE:
+                                ValidateDuplicateFacts.saveDeduplicatedInstance(modelXbrl, deduplicateFactsArg, options.saveDeduplicatedInstance)
+                        else:
+                            assert not options.deduplicateFacts, "'deduplicateFacts' can only be used with 'saveDeduplicatedInstance'"
+
                         for pluginXbrlMethod in pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
                             pluginXbrlMethod(self, options, modelXbrl, _entrypoint, responseZipStream=responseZipStream)
 

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -137,7 +137,8 @@ def parseArgs(args):
     parser.add_option("--deduplicateFacts", "--deduplicatefacts",
                       choices=[a.value for a in ValidateDuplicateFacts.DeduplicationType],
                       dest="deduplicateFacts",
-                      help=_("When using '--saveDeduplicatedInstance' to save a deduplicated instance, check for duplicates of this type."))
+                      help=_("When using '--saveDeduplicatedInstance' to save a deduplicated instance, check for duplicates of this type. "
+                             "Defaults to 'complete'."))
     parser.add_option("--saveDeduplicatedInstance", "--savededuplicatedinstance",
                       dest="saveDeduplicatedInstance",
                       help=_("Save an instance document with duplicates of the provided type ('--deduplicateFacts') deduplicated."))

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1123,8 +1123,12 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         # Anything depending on the ModelXbrl that runs after this may encounter unexpected behavior,
                         # so we'll run it as a final step in the CLI controller flow.
                         ValidateDuplicateFacts.saveDeduplicatedInstance(modelXbrl, deduplicateFactsArg, options.saveDeduplicatedInstance)
+                        if options.keepOpen:
+                            raise RuntimeError(_("Attempted to keep model connection open after saving deduplicated instance. "
+                                                 "Deduplication modifies the model in ways that can cause unexpected behavior on subsequent use."))
                 else:
-                    assert not options.deduplicateFacts, "'deduplicateFacts' can only be used with 'saveDeduplicatedInstance'"
+                    assert options.saveDeduplicatedInstance or not options.deduplicateFacts, \
+                        "'deduplicateFacts' can only be used with 'saveDeduplicatedInstance'"
 
                 modelXbrl.profileStat(_("total"), time.time() - firstStartedAt)
                 if options.collectProfileStats and modelXbrl:

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1124,11 +1124,14 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         # so we'll run it as a final step in the CLI controller flow.
                         ValidateDuplicateFacts.saveDeduplicatedInstance(modelXbrl, deduplicateFactsArg, options.saveDeduplicatedInstance)
                         if options.keepOpen:
-                            raise RuntimeError(_("Attempted to keep model connection open after saving deduplicated instance. "
-                                                 "Deduplication modifies the model in ways that can cause unexpected behavior on subsequent use."))
+                            success = False
+                            self.addToLog(_("Attempted to keep model connection open after saving deduplicated instance. "
+                                            "Deduplication modifies the model in ways that can cause unexpected behavior on subsequent use."),
+                                          messageCode="error", level=logging.CRITICAL)
                 else:
-                    assert options.saveDeduplicatedInstance or not options.deduplicateFacts, \
-                        "'deduplicateFacts' can only be used with 'saveDeduplicatedInstance'"
+                    success = False
+                    self.addToLog(_("'deduplicateFacts' can only be used with 'saveDeduplicatedInstance'"),
+                                  messageCode="error", level=logging.CRITICAL)
 
                 modelXbrl.profileStat(_("total"), time.time() - firstStartedAt)
                 if options.collectProfileStats and modelXbrl:

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1110,28 +1110,29 @@ class CntlrCmdLine(Cntlr.Cntlr):
                                   level=logging.CRITICAL)
                     success = False
             if modelXbrl:
-                if success and options.saveDeduplicatedInstance:
-                    if options.deduplicateFacts:
-                        deduplicateFactsArg = ValidateDuplicateFacts.DeduplicationType(options.deduplicateFacts)
-                    else:
-                        deduplicateFactsArg = ValidateDuplicateFacts.DeduplicationType.COMPLETE
-                    if modelXbrl.modelDocument.type != ModelDocument.Type.INSTANCE:
-                        self.addToLog(_("Provided file must be a traditional XBRL instance document to save a deduplicated instance."),
-                                      messageCode="error", file=modelXbrl.modelDocument.uri)
-                    else:
-                        # Deduplication modifies the underlying lxml tree and leaves the model in an undefined state.
-                        # Anything depending on the ModelXbrl that runs after this may encounter unexpected behavior,
-                        # so we'll run it as a final step in the CLI controller flow.
-                        ValidateDuplicateFacts.saveDeduplicatedInstance(modelXbrl, deduplicateFactsArg, options.saveDeduplicatedInstance)
-                        if options.keepOpen:
-                            success = False
-                            self.addToLog(_("Attempted to keep model connection open after saving deduplicated instance. "
-                                            "Deduplication modifies the model in ways that can cause unexpected behavior on subsequent use."),
-                                          messageCode="error", level=logging.CRITICAL)
-                else:
-                    success = False
-                    self.addToLog(_("'deduplicateFacts' can only be used with 'saveDeduplicatedInstance'"),
-                                  messageCode="error", level=logging.CRITICAL)
+                if success:
+                    if options.saveDeduplicatedInstance:
+                        if options.deduplicateFacts:
+                            deduplicateFactsArg = ValidateDuplicateFacts.DeduplicationType(options.deduplicateFacts)
+                        else:
+                            deduplicateFactsArg = ValidateDuplicateFacts.DeduplicationType.COMPLETE
+                        if modelXbrl.modelDocument.type != ModelDocument.Type.INSTANCE:
+                            self.addToLog(_("Provided file must be a traditional XBRL instance document to save a deduplicated instance."),
+                                          messageCode="error", file=modelXbrl.modelDocument.uri)
+                        else:
+                            # Deduplication modifies the underlying lxml tree and leaves the model in an undefined state.
+                            # Anything depending on the ModelXbrl that runs after this may encounter unexpected behavior,
+                            # so we'll run it as a final step in the CLI controller flow.
+                            ValidateDuplicateFacts.saveDeduplicatedInstance(modelXbrl, deduplicateFactsArg, options.saveDeduplicatedInstance)
+                            if options.keepOpen:
+                                success = False
+                                self.addToLog(_("Attempted to keep model connection open after saving deduplicated instance. "
+                                                "Deduplication modifies the model in ways that can cause unexpected behavior on subsequent use."),
+                                              messageCode="error", level=logging.CRITICAL)
+                    elif options.deduplicateFacts:
+                        success = False
+                        self.addToLog(_("'deduplicateFacts' can only be used with 'saveDeduplicatedInstance'"),
+                                      messageCode="error", level=logging.CRITICAL)
 
                 modelXbrl.profileStat(_("total"), time.time() - firstStartedAt)
                 if options.collectProfileStats and modelXbrl:

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+from arelle.ValidateDuplicateFacts import DeduplicationType
 from arelle.typing import TypeGetText
 from arelle.SystemInfo import hasWebServer
 from dataclasses import InitVar, dataclass
@@ -35,6 +37,7 @@ class RuntimeOptions:
     calcs: Optional[str] = None
     collectProfileStats: Optional[bool] = None
     conceptsFile: Optional[str] = None
+    deduplicateFacts: Optional[DeduplicationType] = None
     diagnostics: Optional[bool] = None
     diffFile: Optional[str] = None
     dimFile: Optional[str] = None
@@ -107,6 +110,7 @@ class RuntimeOptions:
     roleTypesFile: Optional[str] = None
     rssReport: Optional[str] = None
     rssReportCols: Optional[int] = None
+    saveDeduplicatedInstance: Optional[bool] = None
     showEnvironment: Optional[bool] = None
     showOptions: Optional[bool] = None
     skipDTS: Optional[bool] = None

--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -201,20 +201,22 @@ class DuplicateFactSet:
             decimals = self.getDecimals(fact)
             assert decimals is not None
             decimalsMap[decimals].append(fact)
+        if len(decimalsMap) < 2:
+            return facts
         sortedDecimals = sorted(decimalsMap.keys())
         results = set(facts)
 
-        for a, decimalsA in enumerate(sortedDecimals[:len(sortedDecimals)]):
-            groupA = decimalsMap[decimalsA]
-            for factA in groupA:
+        for a, decimalLower in enumerate(sortedDecimals[:len(sortedDecimals)-1]):
+            groupLower = decimalsMap[decimalLower]
+            for factA in groupLower:
                 lowerA, upperA = self.getRange(factA)
                 if isnan(cast(SupportsFloat, factA.xValue)):
                     continue
                 remove = False
                 # Iterate through each higher decimals group
-                for b, decimalsB in enumerate(sortedDecimals[a+1:]):
-                    groupB = decimalsMap[decimalsB]
-                    for factB in groupB:
+                for b, decimalHigher in enumerate(sortedDecimals[a+1:]):
+                    groupHigher = decimalsMap[decimalHigher]
+                    for factB in groupHigher:
                         lowerB, upperB = self.getRange(factB)
                         if isnan(cast(SupportsFloat, factB.xValue)):
                             continue

--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -15,6 +15,8 @@ from arelle import XmlValidateConst, ModelXbrl
 from arelle.ModelInstanceObject import ModelFact, ModelContext, ModelUnit
 from arelle.ModelValue import DateTime, QName, TypeXValue
 from arelle.ValidateXbrlCalcs import rangeValue, inferredDecimals
+from arelle.typing import TypeGetText
+_: TypeGetText
 
 
 @dataclass(frozen=True)
@@ -475,7 +477,9 @@ def saveDeduplicatedInstance(modelXbrl: ModelXbrl.ModelXbrl, deduplicationType: 
     deduplicatedFacts = frozenset(getDeduplicatedFacts(modelXbrl.facts, deduplicationType))
     duplicateFacts = set(modelXbrl.facts) - deduplicatedFacts
     for fact in duplicateFacts:
-        fact.getparent().remove(fact)
+        parent = fact.getparent()
+        assert parent is not None
+        parent.remove(fact)
         modelXbrl.info(
             "info:deduplicatedFact",
             _("Duplicate fact was excluded from deduplicated instance: %(fact)s, value=%(value)s, decimals=%(decimals)s"),

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -6,6 +6,7 @@
 install
 command_line
 faq
+user_guides/user_guides
 plugins/plugins
 contributing
 build_docs

--- a/docs/source/user_guides/fact_deduplication.md
+++ b/docs/source/user_guides/fact_deduplication.md
@@ -1,0 +1,52 @@
+# Fact Deduplication
+
+:::{index} Fact Deduplication
+:::
+
+Duplicate facts criteria are defined by [the OIM specification][oim].
+Arelle detects duplicate facts by first grouping facts into *duplicate sets*, as defined [here][oim-duplicates].
+From there, Arelle can detect if any, all, or none of the facts contained in each set are of the various *types* of duplicates defined by OIM: inconsistent, consistent, and complete.
+Using this information, Arelle can trigger warnings or remove duplicate facts as described below.
+
+## Duplicate Fact Validation
+### CLI
+To detect and trigger warnings when duplicate facts are encountered, use `--validateDuplicateFacts` in conjunction with `--validate`.
+The valid choices to pass with `--validateDuplicateFacts` are:
+
+| Argument       | Duplicate set fires warning...                    |
+|----------------|---------------------------------------------------|
+| `none`         | Never                                             |
+| `inconsistent` | If any facts in set are NOT consistent duplicates |
+| `consistent`   | If any facts in set are consistent duplicates     |
+| `incomplete`   | If any facts in set are NOT complete duplicates   |
+| `complete`     | If any facts in set are complete duplicates       |
+| `all`          | Always                                            |
+
+
+Example:
+```bash
+python arelleCmdLine.py --file instance.xbrl --validate --validateDuplicateFacts inconsistent
+```
+
+### GUI
+This feature is also available in the GUI by selecting an option under *Tools > Validation > Warn on duplicate facts...*
+
+## Deduplicating Traditional XBRL Instance
+To save a copy of an instance document with duplicate facts removed, use `--saveDeduplicatedInstance`.
+Optionally, provide `--deduplicateFacts` with an argument to specify the logic to use for deduplication.
+The default is `complete`.
+
+| Argument           | Deduplication result                                                                                   |
+|--------------------|--------------------------------------------------------------------------------------------------------|
+| `complete`         | One fact for each complete subset                                                                      |
+| `consistent-pairs` | After `complete` deduplication, excludes any fact that has a consistent duplicate of higher precision  |
+| `consistent-sets`  | If the set is fully consistent, only the highest precision fact is kept. Otherwise, same as `complete` |
+
+
+Example:
+```bash
+python arelleCmdLine.py --file instance.xbrl --deduplicateFacts consistent-pairs --saveDeduplicatedInstance output.xbrl
+```
+
+[oim]: https://www.xbrl.org/Specification/oim/REC-2021-10-13+errata-2023-04-19/oim-REC-2021-10-13+corrected-errata-2023-04-19.html
+[oim-duplicates]: https://www.xbrl.org/Specification/oim/REC-2021-10-13+errata-2023-04-19/oim-REC-2021-10-13+corrected-errata-2023-04-19.html#sec-duplicate-facts

--- a/docs/source/user_guides/user_guides.md
+++ b/docs/source/user_guides/user_guides.md
@@ -1,0 +1,9 @@
+# User Guides
+
+:::{index} User Guides
+:::
+
+:::{toctree}
+:maxdepth: 1
+fact_deduplication
+:::

--- a/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
+++ b/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+import urllib.request
+import zipfile
+from pathlib import Path
+from shutil import rmtree
+
+import regex
+
+from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
+
+errors = []
+this_file = Path(__file__)
+args = parse_args(
+    this_file.stem,
+    "Confirm duplicate facts trigger warnings as expected.",
+)
+arelle_command = args.arelle
+arelle_offline = args.offline
+working_directory = Path(args.working_directory)
+test_directory = Path(args.test_directory)
+
+report_zip_path = test_directory / 'report.zip'
+report_directory = test_directory / 'report'
+report_path = report_directory / "report.xbrl"
+report_zip_url = "https://arelle-public.s3.amazonaws.com/ci/packages/duplicate_facts_deduplication.zip"
+
+print(f"Downloading report: {report_zip_url}")
+urllib.request.urlretrieve(report_zip_url, report_zip_path)
+
+print(f"Extracting report: {report_directory}")
+with zipfile.ZipFile(report_zip_path, "r") as zip_ref:
+    zip_ref.extractall(report_directory)
+
+test_cases: dict[str, dict[regex.Pattern[str], int]] = {
+    'complete': {
+        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE, decimals=\(none\)'): 2,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 1, decimals=\(none\)'): 1,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 2, decimals=\(none\)'): 1,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=INF'): 3,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=200\.000000, decimals=INF'): 1,
+        regex.compile(r'^\[info:deduplicatedInstance].*removing 8 fact'): 1,
+    },
+    'consistent-pairs': {
+        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE, decimals=\(none\)'): 2,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 1, decimals=\(none\)'): 1,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 2, decimals=\(none\)'): 1,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=INF'): 3,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=0'): 2,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.100000, decimals=1'): 2,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=200\.000000, decimals=INF'): 1,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=200\.000000, decimals=0'): 1,
+        regex.compile(r'^\[info:deduplicatedInstance].*removing 13 fact'): 1,
+    },
+    'consistent-sets': {
+        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE, decimals=\(none\)'): 2,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 1, decimals=\(none\)'): 1,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 2, decimals=\(none\)'): 1,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=INF'): 3,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=0'): 1,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.100000, decimals=1'): 1,
+        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=200\.000000, decimals=INF'): 1,
+        regex.compile(r'^\[info:deduplicatedInstance].*removing 10 fact'): 1,
+    },
+}
+for arg, expected_infos in test_cases.items():
+    print(f"Running with argument: {arg}")
+    log_file = prepare_logfile(test_directory, this_file, name=arg)
+    output_path = report_path.with_name(f"deduplicated-{arg}.xbrl")
+    run_arelle(
+        arelle_command,
+        additional_args=[
+            "--file", str(report_path),
+            "--deduplicateFacts", arg,
+            "--saveDeduplicatedInstance", str(output_path),
+        ],
+        offline=arelle_offline,
+        logFile=log_file,
+    )
+    errors += validate_log_file(log_file, expected_results={"info": expected_infos})
+    assert_result(errors)
+
+assert_result(errors)
+
+print("Cleaning up")
+rmtree(working_directory / 'duplicate_facts_deduplication' / 'report')
+os.unlink(working_directory / 'duplicate_facts_deduplication' / 'report.zip')

--- a/tests/integration_tests/scripts/tests/duplicate_facts_validate.py
+++ b/tests/integration_tests/scripts/tests/duplicate_facts_validate.py
@@ -80,5 +80,5 @@ for arg, expected_errors in test_cases.items():
 assert_result(errors)
 
 print("Cleaning up")
-rmtree(working_directory / 'fact_deduplication' / 'report')
-os.unlink(working_directory / 'fact_deduplication' / 'report.zip')
+rmtree(working_directory / 'duplicate_facts_validate' / 'report')
+os.unlink(working_directory / 'duplicate_facts_validate' / 'report.zip')


### PR DESCRIPTION
#### Reason for change
Resolves #1002 

#### Description of change
Reused parts of duplicate fact validation to transform duplicate fact sets into a deduplicated list based on the provided argument. Implemented `complete`, `consistent-set`, and `consistent-pairs` deduplication modes.
Added duplicate fact user guide to documentation.
Added fact deduplication integration test script.

#### Steps to Test
CI

**review**:
@Arelle/arelle
