### PR TITLE
Check that log filter attributes are set before using

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -1019,7 +1019,7 @@ class ModelXbrl:
         return effectiveMessageCode
 
     # isLoggingEffectiveFor( messageCodes= messageCode= level= )
-    def isLoggingEffectiveFor(self, **kwargs: Any) -> QName | str | bool | None:  # args can be messageCode(s) and level
+    def isLoggingEffectiveFor(self, **kwargs: Any) -> bool:  # args can be messageCode(s) and level
         logger = self.logger
         if "messageCodes" in kwargs or "messageCode" in kwargs:
             if "messageCodes" in kwargs:
@@ -1035,7 +1035,7 @@ class ModelXbrl:
             levelEffective = logger.messageLevelFilter.match(kwargs["level"].lower())
         else:
             levelEffective = True
-        return codeEffective and levelEffective
+        return bool(codeEffective and levelEffective)
 
     def logArguments(self, messageCode: str, msg: str, codedArgs: dict[str, str]) -> Any:
         # Prepares arguments for logger function as per info() below.

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -349,7 +349,7 @@ class ModelXbrl:
         self.hasTableIndexing: bool = False
         self.hasFormulae: bool = False
         self.formulaOutputInstance: ModelXbrl | None = None
-        self.logger: Any = logging.getLogger("arelle")
+        self.logger: logging.Logger | None = self.modelManager.cntlr.logger
         self.logRefObjectProperties: bool = getattr(self.logger, "logRefObjectProperties", False)
         self.logRefHasPluginAttrs: bool = any(True for m in pluginClassMethods("Logging.Ref.Attributes"))
         self.logRefHasPluginProperties: bool = any(True for m in pluginClassMethods("Logging.Ref.Properties"))
@@ -1021,6 +1021,10 @@ class ModelXbrl:
     # isLoggingEffectiveFor( messageCodes= messageCode= level= )
     def isLoggingEffectiveFor(self, **kwargs: Any) -> bool:  # args can be messageCode(s) and level
         logger = self.logger
+        if logger is None:
+            return False
+        assert hasattr(logger, 'messageCodeFilter'), 'messageCodeFilter not set on controller logger.'
+        assert hasattr(logger, 'messageLevelFilter'), 'messageLevelFilter not set on controller logger.'
         if "messageCodes" in kwargs or "messageCode" in kwargs:
             if "messageCodes" in kwargs:
                 messageCodes = kwargs["messageCodes"]
@@ -1206,6 +1210,10 @@ class ModelXbrl:
         """Same as error(), but level passed in as argument
         """
         logger = self.logger
+        if logger is None:
+            return
+        assert hasattr(logger, 'messageCodeFilter'), 'messageCodeFilter not set on controller logger.'
+        assert hasattr(logger, 'messageLevelFilter'), 'messageLevelFilter not set on controller logger.'
         # determine logCode
         messageCode = self.effectiveMessageCode(codes)
         if messageCode == "asrtNoLog":


### PR DESCRIPTION
#### Reason for change
Log filter checks assume `messageCodeFilter` and `messageLevelFilter` are set to None or a regex. While this is true for the CLI and GUI, it's not necessarily the case from the Python API. The attributes can be undefined.

#### Description of change
* Reuse cntlr logger (which can be None) from ModelXBRL instead of getLogger().

#### Steps to Test
* CI

**review**:
@Arelle/arelle
