### PR TITLE
ESEF Permit Facts for durationItemTypes Concepts in Hidden Sections

### DIFF
--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -121,6 +121,7 @@ mandatory: set[QName] = set()  # mandatory element qnames
 untransformableTypes = frozenset((
     "anyURI",
     "base64Binary",
+    "duration",
     "hexBinary",
     "NOTATION",
     "QName",


### PR DESCRIPTION
#### Reason for change
Facts for `durationItemType` concepts may be permitted in hidden sections.

From the [filer manual](https://www.esma.europa.eu/sites/default/files/library/esma32-60-254_esef_reporting_manual.pdf):
> Moreover, ESMA is of the opinion that in the ESEF reporting scenario only facts that
are not eligible for transformation can be included in the ix:hidden section (i.e. where
content is not intended for display). Therefore only if there is no transformation rule in
the latest recommended Transformation Rules Registry that can be applied to the fact’s
value (e.g. for enumeration(Set)ItemType or **durationItemType** facts) can such fact be
included in the ix:hidden section.

#### Description of change
* Add duration base type (durationItemType) to `untransformableTypes` set (base types which are permitted in hidden sections).

#### Steps to Test
* Use [p-2024-01-17-en.zip](https://github.com/Arelle/Arelle/files/13968412/p-2024-01-17-en.zip)
* `python arelleCmdLine.py --plugins validate/ESEF --disclosureSystem esef-2023 --validate --file p-2024-01-17-en.zip`
* Confirm `ESEF.2.4.1.transformableElementIncludedInHiddenSection` is not logged for `frs-full:ActuarialAssumptionOfRetirementAge2019`

**review**:
@Arelle/arelle
