### PR TITLE
Increase CI number of cores to 4 for Windows and Linux

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
@@ -257,5 +257,5 @@ config = ConformanceSuiteConfig(
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/EFM', 'inlineXbrlDocumentSet'}),
     public_download_url='https://www.sec.gov/files/edgar/efm-68d-231120.zip',
-    shards=20,
+    shards=40,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
@@ -81,5 +81,5 @@ config = ConformanceSuiteConfig(
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),
     public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2021.zip',
-    shards=4,
+    shards=8,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
@@ -81,5 +81,5 @@ config = ConformanceSuiteConfig(
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),
     public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2021.zip',
-    shards=5,
+    shards=4,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
@@ -86,5 +86,5 @@ config = ConformanceSuiteConfig(
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),
     public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2022.zip',
-    shards=5,
+    shards=4,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
@@ -86,5 +86,5 @@ config = ConformanceSuiteConfig(
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),
     public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2022.zip',
-    shards=4,
+    shards=8,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
@@ -91,5 +91,5 @@ config = ConformanceSuiteConfig(
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),
     public_download_url='https://www.esma.europa.eu/sites/default/files/2023-12/esef_conformance_suite_2023.zip',
-    shards=4,
+    shards=8,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
@@ -91,5 +91,5 @@ config = ConformanceSuiteConfig(
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),
     public_download_url='https://www.esma.europa.eu/sites/default/files/2023-12/esef_conformance_suite_2023.zip',
-    shards=5,
+    shards=4,
 )

--- a/tests/integration_tests/validation/discover_tests.py
+++ b/tests/integration_tests/validation/discover_tests.py
@@ -24,9 +24,9 @@ LATEST_PYTHON_VERSION = '3.12'
 # number of cores on the runners
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
 OS_CORES = {
-    LINUX: 2,
+    LINUX: 4,
     MACOS: 3,
-    WINDOWS: 2,
+    WINDOWS: 4,
 }
 FAST_CONFIG_NAMES = {
     'esef_xhtml_2021',


### PR DESCRIPTION
#### Reason for change
[GitHub increased their CPU count](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/) for Linux and Windows runners to 4.

#### Description of change
* Increase shards per node to 4 for Linux and Windows runners.
* Increase shard counts to align with number of cores in CI (40 for EFM and 8 for ESEF performed the best in my brief testing).

#### Steps to Test
* CI

**review**:
@Arelle/arelle
