### PR TITLE
Support single non-English package names

### DIFF
--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -118,7 +118,7 @@ def parsePackage(cntlr, filesource, metadataFile, fileBase, errors=[]):
                 break # take first entry if several
         for eltName in ("name", "description"):
             closest = ''
-            closestLen = 0
+            closestLen = -1
             for m in root.iterchildren(tag=nsPrefix + eltName):
                 s = (m.text or "").strip()
                 eltLang = xmlLang(m)
@@ -126,7 +126,7 @@ def parsePackage(cntlr, filesource, metadataFile, fileBase, errors=[]):
                 if l > closestLen:
                     closestLen = l
                     closest = s
-                elif closestLen == 0 and eltLang.startswith("en"):
+                elif closestLen <= 0 and eltLang.startswith("en"):
                     closest = s   # pick english if nothing better
             if not closest and eltName == "name":  # assign default name when none in taxonomy package
                 closest = os.path.splitext(os.path.basename(filesource.baseurl))[0]
@@ -233,7 +233,7 @@ def parsePackage(cntlr, filesource, metadataFile, fileBase, errors=[]):
 
     for entryPointSpec in tree.iter(tag=nsPrefix + "entryPoint"):
         name = None
-        closestLen = 0
+        closestLen = -1
 
         # find closest match name node given xml:lang match to current language or no xml:lang
         for nameNode in entryPointSpec.iter(tag=nsPrefix + "name"):
@@ -243,7 +243,7 @@ def parsePackage(cntlr, filesource, metadataFile, fileBase, errors=[]):
             if l > closestLen:
                 closestLen = l
                 name = s
-            elif closestLen == 0 and nameLang.startswith("en"):
+            elif closestLen <= 0 and nameLang.startswith("en"):
                 name = s   # pick english if nothing better
 
         if not name:
@@ -279,7 +279,7 @@ def parsePackage(cntlr, filesource, metadataFile, fileBase, errors=[]):
 
             # find closest language description
             closest = ''
-            closestLen = 0
+            closestLen = -1
             for m in entryPointSpec.iterchildren(tag=nsPrefix + "description"):
                 s = (m.text or "").strip()
                 eltLang = xmlLang(m)
@@ -287,7 +287,7 @@ def parsePackage(cntlr, filesource, metadataFile, fileBase, errors=[]):
                 if l > closestLen:
                     closestLen = l
                     closest = s
-                elif closestLen == 0 and eltLang.startswith("en"):
+                elif closestLen <= 0 and eltLang.startswith("en"):
                     closest = s   # pick english if nothing better
             if not closest and name:  # assign default name when none in taxonomy package
                 closest = name


### PR DESCRIPTION
#### Reason for change
Resolves https://groups.google.com/g/arelle-users/c/QsW-bXffIcA/m/ClWix1IFCQAJ

#### Description of change
Previously package names and descriptions display priority was:
User locale -> English

This PR changes the priority to:
User locale -> English -> first language with content

In the common case of ESEF packages there is no English name or description so the name is displayed as (`<unnamed X>`).

#### Steps to Test
* Test with: https://filings.xbrl.org/filing/549300A0JPRWG1KI7U06-2022-12-31-ESEF-FI-0
* From the GUI open the report package.
* The package name should be listed for the schema entrypoint:
<img width="524" alt="Screenshot 2024-01-26 at 11 43 34 AM" src="https://github.com/Arelle/Arelle/assets/46454775/0b75058c-8d5b-4b26-b77d-7f7cbd96323b">

Current master behavior:
<img width="523" alt="Screenshot 2024-01-26 at 11 44 31 AM" src="https://github.com/Arelle/Arelle/assets/46454775/b9cb28f1-b639-4c2a-a0c5-7828e42fe3ca">

**review**:
@Arelle/arelle
