### PR TITLE
Adding remaining HMRC unaudited company validations

### DIFF
--- a/tests/resources/conformance_suites/HMRC/index.xml
+++ b/tests/resources/conformance_suites/HMRC/index.xml
@@ -2,7 +2,16 @@
 <testcases name="HMRC">
     <testcase uri='jfcvc/3312-testcase.xml' />
     <testcase uri='jfcvc/3315-testcase.xml' />
+    <testcase uri='unaudited_company_abbreviated_accounts/testcase.xml' />
+    <testcase uri='unaudited_company_abridged_accounts/testcase.xml' />
+    <testcase uri='unaudited_company_group_accounts/testcase.xml' />
     <testcase uri='unaudited_dormant_company/testcase.xml' />
     <testcase uri='unaudited_dormant_llp/testcase.xml' />
+    <testcase uri='unaudited_llp_abbreviated_accounts/testcase.xml' />
+    <testcase uri='unaudited_llp_abridged_accounts/testcase.xml' />
+    <testcase uri='unaudited_llp_full_accounts/testcase.xml' />
+    <testcase uri='unaudited_llp_group_accounts/testcase.xml' />
     <testcase uri='unaudited_micro_company/testcase.xml' />
+    <testcase uri='unaudited_micro_llp/testcase.xml' />
+    <testcase uri='unaudited_small_company_full_accounts/testcase.xml' />
 </testcases>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/invalid-co-auditnr.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/invalid-co-auditnr.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbbreviatedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <!-- CAUSE: Text does not match, missing "audit" -->
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/invalid-co-dirresp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/invalid-co-dirresp.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbbreviatedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+         acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <!-- CAUSE: Text does not match, missing "abridged" -->
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an  audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/invalid-co-sec477.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/invalid-co-sec477.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbbreviatedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <!-- CAUSE: Text does not match, missing "477" -->
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/invalid-co-small.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/invalid-co-small.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbbreviatedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <!-- CAUSE: Text does not match, missing "small" -->
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/testcase.xml
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/testcase.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="Unaudited Company Abbreviated Accounts"
+  description="Unaudited company abbreviated account filings must meet certain criteria."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="valid" name="Valid">
+    <description>
+      The document is valid.
+    </description>
+    <data>
+        <instance readMeFirst="true">valid.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="valid-welsh" name="Valid Welsh">
+    <description>
+      The document is valid with Welsh language.
+    </description>
+    <data>
+      <instance readMeFirst="true">valid-welsh.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="co-auditnr" name="Fails Co.AuditNR">
+    <description>
+      StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-auditnr.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.AuditNR</error>
+    </result>
+  </variation>
+  <variation id="co-dirresp" name="Fails Co.DirResp">
+    <description>
+      StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-dirresp.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.DirResp</error>
+    </result>
+  </variation>
+  <variation id="co-small" name="Fails Co.SmCo">
+    <description>
+      StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-small.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.SmCo</error>
+    </result>
+  </variation>
+  <variation id="co-sec477" name="Fails Co.Sec477">
+    <description>
+      StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-sec477.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.Sec477</error>
+    </result>
+  </variation>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/valid-welsh.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/valid-welsh.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="lang">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="lang:LanguagesDimension">lang:Welsh</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ReportPrincipalLanguage contextRef="lang"></bus:ReportPrincipalLanguage>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbbreviatedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Paratowyd yn unol â darpariaethau cwmnïau bach
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Eithriad adran 477 o Ddeddf Cwmnïau 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Cyfarwyddwyr yn cydnabod cyfrifoldebau y ddeddf
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        aelodau heb ei gwneud yn ofynnol i'r cwmni gael archwiliad
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Aelodau wedi cytuno paratoi talfyredig
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/valid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abbreviated_accounts/valid.xbrl
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbbreviatedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-abrid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-abrid.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <!-- CAUSE: Text does not match, missing "abridged" -->
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an  audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-auditnr.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-auditnr.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <!-- CAUSE: Text does not match, missing "audit" -->
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-dirresp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-dirresp.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <!-- CAUSE: Text does not match, missing "acknowledge" -->
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors  their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-sec477.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-sec477.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <!-- CAUSE: Text does not match, missing "477" -->
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-small.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/invalid-co-small.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <!-- CAUSE: Text does not match, missing "small" -->
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/testcase.xml
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/testcase.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="Unaudited Company Abridged Accounts"
+  description="Unaudited company abridged account filings must meet certain criteria."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="valid" name="Valid">
+    <description>
+      The document is valid.
+    </description>
+    <data>
+        <instance readMeFirst="true">valid.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="valid-welsh" name="Valid Welsh">
+    <description>
+      The document is valid with Welsh language.
+    </description>
+    <data>
+      <instance readMeFirst="true">valid-welsh.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="co-abrid" name="Fails Co.Abrid">
+    <description>
+      StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-abrid.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.Abrid</error>
+    </result>
+  </variation>
+  <variation id="co-auditnr" name="Fails Co.AuditNR">
+    <description>
+      StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-auditnr.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.AuditNR</error>
+    </result>
+  </variation>
+  <variation id="co-dirresp" name="Fails Co.DirResp">
+    <description>
+      StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-dirresp.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.DirResp</error>
+    </result>
+  </variation>
+  <variation id="co-small" name="Fails Co.SmCo">
+    <description>
+      StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-small.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.SmCo</error>
+    </result>
+  </variation>
+  <variation id="co-sec477" name="Fails Co.Sec477">
+    <description>
+      StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-sec477.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.Sec477</error>
+    </result>
+  </variation>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/valid-welsh.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/valid-welsh.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="lang">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="lang:LanguagesDimension">lang:Welsh</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ReportPrincipalLanguage contextRef="lang"></bus:ReportPrincipalLanguage>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Paratowyd yn unol â darpariaethau cwmnïau bach
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Eithriad adran 477 o Ddeddf Cwmnïau 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Cyfarwyddwyr yn cydnabod cyfrifoldebau y ddeddf
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        aelodau heb ei gwneud yn ofynnol i'r cwmni gael archwiliad
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Aelodau wedi cytuno paratoi talfyredig
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/valid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_abridged_accounts/valid.xbrl
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/invalid-co-auditnr.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/invalid-co-auditnr.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <!-- CAUSE: Text does not match, missing "audit" -->
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/invalid-co-dirresp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/invalid-co-dirresp.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <!-- CAUSE: Text does not match, missing "acknowledge" -->
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/invalid-co-sec477.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/invalid-co-sec477.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <!-- CAUSE: Text does not match, missing "477" -->
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section  of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/invalid-co-small.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/invalid-co-small.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <!-- CAUSE: Text does not match, missing "small" -->
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions  companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/testcase.xml
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/testcase.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="Unaudited Company Group Accounts"
+  description="Unaudited company group account filings must meet certain criteria."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="valid" name="Valid">
+    <description>
+      The document is valid.
+    </description>
+    <data>
+        <instance readMeFirst="true">valid.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="valid-welsh" name="Valid Welsh">
+    <description>
+      The document is valid with Welsh language.
+    </description>
+    <data>
+      <instance readMeFirst="true">valid-welsh.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="co-auditnr" name="Fails Co.AuditNR">
+    <description>
+      StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-auditnr.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.AuditNR</error>
+    </result>
+  </variation>
+  <variation id="co-dirresp" name="Fails Co.DirResp">
+    <description>
+      StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-dirresp.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.DirResp</error>
+    </result>
+  </variation>
+  <variation id="co-small" name="Fails Co.SmCo">
+    <description>
+      StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-small.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.SmCo</error>
+    </result>
+  </variation>
+  <variation id="co-sec477" name="Fails Co.Sec477">
+    <description>
+      StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-sec477.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.Sec477</error>
+    </result>
+  </variation>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/valid-welsh.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/valid-welsh.xbrl
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="lang">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="lang:LanguagesDimension">lang:Welsh</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ReportPrincipalLanguage contextRef="lang"></bus:ReportPrincipalLanguage>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Paratowyd yn unol â darpariaethau cwmnïau bach
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Eithriad adran 477 o Ddeddf Cwmnïau 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Cyfarwyddwyr yn cydnabod cyfrifoldebau y ddeddf
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        aelodau heb ei gwneud yn ofynnol i'r cwmni gael archwiliad
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Aelodau wedi cytuno paratoi talfyredig
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/valid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_company_group_accounts/valid.xbrl
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/invalid-lp-memresp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/invalid-lp-memresp.xbrl
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbbreviatedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <!-- CAUSE: Text does not match, missing "Members" -->
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+         acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/invalid-lp-sec477.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/invalid-lp-sec477.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbbreviatedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <!-- CAUSE: Text does not match, missing "477" -->
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/invalid-lp-smlp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/invalid-lp-smlp.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbbreviatedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <!-- CAUSE: Text does not match, missing "LLP" -->
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small 
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/testcase.xml
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/testcase.xml
@@ -1,0 +1,66 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="Unaudited LLP Abbreviated Accounts"
+  description="Unaudited LLP abbreviated account filings must meet certain criteria."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="valid" name="Valid">
+    <description>
+      The document is valid.
+    </description>
+    <data>
+        <instance readMeFirst="true">valid.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="valid-welsh" name="Valid Welsh">
+    <description>
+      The document is valid with Welsh language.
+    </description>
+    <data>
+      <instance readMeFirst="true">valid-welsh.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="lp-memresp" name="Fails Lp.MemResp">
+    <description>
+      StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-memresp.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.MemResp</error>
+    </result>
+  </variation>
+  <variation id="lp-smlp" name="Fails Lp.SmLp">
+    <description>
+      StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-smlp.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.SmLp</error>
+    </result>
+  </variation>
+  <variation id="lp-sec477" name="Fails Lp.Sec477">
+    <description>
+      StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-sec477.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.Sec477</error>
+    </result>
+  </variation>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/valid-welsh.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/valid-welsh.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="lang">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="lang:LanguagesDimension">lang:Welsh</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ReportPrincipalLanguage contextRef="lang"></bus:ReportPrincipalLanguage>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Paratowyd yn unol â y darpariaethau cwmnïau PAC bach
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Eithriad adran 477 o Ddeddf Cwmnïau 2006 PAC
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Aelodau'n cydnabod cyfrifoldebau y Ddeddf PAC
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        aelodau heb ei gwneud yn ofynnol i'r cwmni gael archwiliad
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Aelodau wedi cytuno paratoi talfyredig
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/valid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abbreviated_accounts/valid.xbrl
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/invalid-lp-abrid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/invalid-lp-abrid.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <!-- CAUSE: Text does not match, missing "abridged" -->
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an  audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/invalid-lp-memresp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/invalid-lp-memresp.xbrl
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <!-- CAUSE: Text does not match, missing "Members" -->
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+         acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/invalid-lp-sec477.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/invalid-lp-sec477.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <!-- CAUSE: Text does not match, missing "477" -->
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/invalid-lp-smlp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/invalid-lp-smlp.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <!-- CAUSE: Text does not match, missing "LLP" -->
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small 
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/testcase.xml
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/testcase.xml
@@ -1,0 +1,77 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="Unaudited LLP Abridged Accounts"
+  description="Unaudited LLP abridged account filings must meet certain criteria."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="valid" name="Valid">
+    <description>
+      The document is valid.
+    </description>
+    <data>
+        <instance readMeFirst="true">valid.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="valid-welsh" name="Valid Welsh">
+    <description>
+      The document is valid with Welsh language.
+    </description>
+    <data>
+      <instance readMeFirst="true">valid-welsh.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="lp-abrid" name="Fails Lp.Abrid">
+    <description>
+      StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-abrid.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.Abrid</error>
+    </result>
+  </variation>
+  <variation id="lp-memresp" name="Fails Lp.MemResp">
+    <description>
+      StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-memresp.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.MemResp</error>
+    </result>
+  </variation>
+  <variation id="lp-smlp" name="Fails Lp.SmLp">
+    <description>
+      StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-smlp.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.SmLp</error>
+    </result>
+  </variation>
+  <variation id="lp-sec477" name="Fails Lp.Sec477">
+    <description>
+      StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-sec477.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.Sec477</error>
+    </result>
+  </variation>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/valid-welsh.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/valid-welsh.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="lang">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="lang:LanguagesDimension">lang:Welsh</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ReportPrincipalLanguage contextRef="lang"></bus:ReportPrincipalLanguage>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Paratowyd yn unol â y darpariaethau cwmnïau PAC bach
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Eithriad adran 477 o Ddeddf Cwmnïau 2006 PAC
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Aelodau'n cydnabod cyfrifoldebau y Ddeddf PAC
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        aelodau heb ei gwneud yn ofynnol i'r cwmni gael archwiliad
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Aelodau wedi cytuno paratoi talfyredig
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/valid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_abridged_accounts/valid.xbrl
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:AbridgedAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/invalid-lp-memresp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/invalid-lp-memresp.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <!-- CAUSE: Text does not match, missing "acknowledge" -->
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members  their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/invalid-lp-sec477.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/invalid-lp-sec477.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <!-- CAUSE: Text does not match, missing "477" -->
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section  of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/invalid-lp-smlp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/invalid-lp-smlp.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <!-- CAUSE: Text does not match, missing "small LLP" -->
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/testcase.xml
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/testcase.xml
@@ -1,0 +1,66 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="Unaudited LLP Full Accounts"
+  description="Unaudited LLP full account filings must meet certain criteria."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="valid" name="Valid">
+    <description>
+      The document is valid.
+    </description>
+    <data>
+        <instance readMeFirst="true">valid.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="valid-welsh" name="Valid Welsh">
+    <description>
+      The document is valid with Welsh language.
+    </description>
+    <data>
+      <instance readMeFirst="true">valid-welsh.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="lp-memresp" name="Fails Lp.MemResp">
+    <description>
+      StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-memresp.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.MemResp</error>
+    </result>
+  </variation>
+  <variation id="lp-smlp" name="Fails Lp.SmLp">
+    <description>
+      StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-smlp.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.SmLp</error>
+    </result>
+  </variation>
+  <variation id="lp-sec477" name="Fails Lp.Sec477">
+    <description>
+      StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-sec477.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.Sec477</error>
+    </result>
+  </variation>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/valid-welsh.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/valid-welsh.xbrl
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="lang">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="lang:LanguagesDimension">lang:Welsh</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ReportPrincipalLanguage contextRef="lang"></bus:ReportPrincipalLanguage>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Paratowyd yn unol â y darpariaethau cwmnïau PAC bach
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Eithriad adran 477 o Ddeddf Cwmnïau 2006 PAC
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Aelodau'n cydnabod cyfrifoldebau y Ddeddf PAC
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        aelodau heb ei gwneud yn ofynnol i'r cwmni gael archwiliad
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Aelodau wedi cytuno paratoi talfyredig
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/valid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_full_accounts/valid.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/invalid-lp-memresp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/invalid-lp-memresp.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <!-- CAUSE: Text does not match, missing "Members" -->
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+         acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit LLP
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/invalid-lp-sec477.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/invalid-lp-sec477.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <!-- CAUSE: Text does not match, missing "477" -->
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section  of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit LLP
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/invalid-lp-smlp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/invalid-lp-smlp.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <!-- CAUSE: Text does not match, missing "small" -->
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit LLP
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/testcase.xml
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/testcase.xml
@@ -1,0 +1,66 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="Unaudited LLP Group Accounts"
+  description="Unaudited LLP group account filings must meet certain criteria."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="valid" name="Valid">
+    <description>
+      The document is valid.
+    </description>
+    <data>
+        <instance readMeFirst="true">valid.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="valid-welsh" name="Valid Welsh">
+    <description>
+      The document is valid with Welsh language.
+    </description>
+    <data>
+      <instance readMeFirst="true">valid-welsh.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="lp-memresp" name="Fails Lp.MemResp">
+    <description>
+      StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-memresp.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.MemResp</error>
+    </result>
+  </variation>
+  <variation id="lp-smlp" name="Fails Lp.SmLp">
+    <description>
+      StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-smlp.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.SmLp</error>
+    </result>
+  </variation>
+  <variation id="lp-sec477" name="Fails Lp.Sec477">
+    <description>
+      StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-sec477.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.Sec477</error>
+    </result>
+  </variation>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/valid-welsh.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/valid-welsh.xbrl
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="lang">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="lang:LanguagesDimension">lang:Welsh</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ReportPrincipalLanguage contextRef="lang"></bus:ReportPrincipalLanguage>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Paratowyd yn unol â y darpariaethau cwmnïau PAC bach
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Eithriad adran 477 o Ddeddf Cwmnïau 2006 PAC
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Aelodau'n cydnabod cyfrifoldebau y Ddeddf PAC
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        aelodau heb ei gwneud yn ofynnol i'r cwmni gael archwiliad
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Aelodau wedi cytuno paratoi talfyredig
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/valid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_llp_group_accounts/valid.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="scope-accounts">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ScopeAccountsDimension">bus:GroupAccountsOnly</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ScopeAccounts contextRef="scope-accounts"></bus:ScopeAccounts>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Members acknowledge their responsibilities under Companies Act 2006 LLP
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit LLP
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/invalid-lp-memresp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/invalid-lp-memresp.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:Micro-entities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions micro small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+        <!-- CAUSE: Text does not match, missing "LLP" -->
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Member acknowledges responsibilities of the Act of forming a thing of sorts
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members agreed to the preparation abridged
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/invalid-lp-micro.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/invalid-lp-micro.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:Micro-entities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+            <!-- CAUSE: Text does not match, missing "micro" -->
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions  LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Member acknowledges responsibilities of the Act of forming Limited Liability Partnership
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members agreed to the preparation abridged
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/invalid-lp-sec477.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/invalid-lp-sec477.xbrl
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:Micro-entities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExemptWithAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+     <!-- CAUSE: Text does not match, missing "477" -->
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section  of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions micro small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Member acknowledges responsibilities of the Act of forming Limited Liability Partnership
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members agreed to the preparation abridged
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/testcase.xml
+++ b/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/testcase.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="Unaudited Micro Company"
+  description="Unaudited Micro LLP filings must meet certain criteria."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="valid" name="Valid">
+    <description>
+      The document is valid.
+    </description>
+    <data>
+        <instance readMeFirst="true">valid.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="valid-welsh" name="Valid Welsh">
+    <description>
+      The document is valid with Welsh language.
+    </description>
+    <data>
+      <instance readMeFirst="true">valid-welsh.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="lp-memresp" name="Fails Lp.MemResp">
+    <description>
+      StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-memresp.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.MemResp</error>
+    </result>
+  </variation>
+  <variation id="lp-micro" name="Fails Lp.Micro">
+    <description>
+      StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-micro.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.Micro</error>
+    </result>
+  </variation>
+  <variation id="lp-sec477" name="Fails Lp.Sec477">
+    <description>
+      StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-lp-sec477.xbrl</instance>
+    </data>
+    <result>
+      <error>Lp.Sec477</error>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/valid-welsh.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/valid-welsh.xbrl
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="lang">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="lang:LanguagesDimension">lang:Welsh</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ReportPrincipalLanguage contextRef="lang"></bus:ReportPrincipalLanguage>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:Micro-entities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+         Eithriad adran 477 o Ddeddf Cwmnïau 2006 PAC micro
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        wedi eu paratoi yn unol â y darpariaethau micro
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection480CompaniesAct2006RelatingToDormantCompanies contextRef="duration">
+        Eithriad adran 480 o Ddeddf Cwmnïau 2006 PAC
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection480CompaniesAct2006RelatingToDormantCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Aelodau'n cydnabodcyfrifoldebau y Ddeddf PAC
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        aelodau heb ei gwneud yn ofynnol i'r cwmni gael archwiliad
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+            Aelod wedi cytuno paratoi talfyredig
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/valid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_micro_llp/valid.xbrl
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2023-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2023-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2023-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2023-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2023-01-01/FRS-101-2023-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:Micro-entities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsType contextRef="accounts-type"></bus:AccountsType>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006 LLP
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions micro small LLP
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Member acknowledges responsibilities of the Act of forming Limited Liability Partnership
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members agreed to the preparation abridged
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:LimitedLiabilityPartnershipLLP</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/invalid-co-auditnr.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/invalid-co-auditnr.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <!-- CAUSE: Text does not match, missing "audit" -->
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/invalid-co-dirresp.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/invalid-co-dirresp.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <!-- CAUSE: Text does not match, missing "acknowledge" -->
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors  their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/invalid-co-sec477.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/invalid-co-sec477.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <!-- CAUSE: Text does not match, missing "477" -->
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section  of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/invalid-co-small.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/invalid-co-small.xbrl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <!-- CAUSE: Text does not match, missing "small" -->
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions  companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/testcase.xml
+++ b/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/testcase.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="Unaudited Small Company Full Accounts"
+  description="Unaudited small company full account filings must meet certain criteria."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="valid" name="Valid">
+    <description>
+      The document is valid.
+    </description>
+    <data>
+        <instance readMeFirst="true">valid.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="valid-welsh" name="Valid Welsh">
+    <description>
+      The document is valid with Welsh language.
+    </description>
+    <data>
+      <instance readMeFirst="true">valid-welsh.xbrl</instance>
+    </data>
+    <result>
+    </result>
+  </variation>
+  <variation id="co-auditnr" name="Fails Co.AuditNR">
+    <description>
+      StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-auditnr.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.AuditNR</error>
+    </result>
+  </variation>
+  <variation id="co-dirresp" name="Fails Co.DirResp">
+    <description>
+      StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-dirresp.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.DirResp</error>
+    </result>
+  </variation>
+  <variation id="co-small" name="Fails Co.SmCo">
+    <description>
+      StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-small.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.SmCo</error>
+    </result>
+  </variation>
+  <variation id="co-sec477" name="Fails Co.Sec477">
+    <description>
+      StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies fact is missing required text.
+    </description>
+    <data>
+      <instance readMeFirst="true">invalid-co-sec477.xbrl</instance>
+    </data>
+    <result>
+      <error>Co.Sec477</error>
+    </result>
+  </variation>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/valid-welsh.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/valid-welsh.xbrl
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="lang">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="lang:LanguagesDimension">lang:Welsh</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ReportPrincipalLanguage contextRef="lang"></bus:ReportPrincipalLanguage>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Paratowyd yn unol â darpariaethau cwmnïau bach
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Eithriad adran 477 o Ddeddf Cwmnïau 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Cyfarwyddwyr yn cydnabod cyfrifoldebau y ddeddf
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        aelodau heb ei gwneud yn ofynnol i'r cwmni gael archwiliad
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Aelodau wedi cytuno paratoi talfyredig
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>

--- a/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/valid.xbrl
+++ b/tests/resources/conformance_suites/HMRC/unaudited_small_company_full_accounts/valid.xbrl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl
+        xmlns="http://www.xbrl.org/2003/instance"
+        xmlns:bus="http://xbrl.frc.org.uk/cd/2021-01-01/business"
+        xmlns:core="http://xbrl.frc.org.uk/fr/2021-01-01/core"
+        xmlns:direp="http://xbrl.frc.org.uk/reports/2021-01-01/direp"
+        xmlns:lang="http://xbrl.frc.org.uk/cd/2021-01-01/languages"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xbrldi="http://xbrl.org/2006/xbrldi">
+    <link:schemaRef
+            xlink:href="https://xbrl.frc.org.uk/FRS-101/2021-01-01/FRS-101-2021-01-01.xsd"
+            xlink:type="simple"/>
+
+    <context id="accounting-standards">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountingStandardsDimension">bus:SmallEntities</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountingStandardsApplied contextRef="accounting-standards"></bus:AccountingStandardsApplied>
+
+    <context id="accounts-status">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsStatusDimension">bus:AuditExempt-NoAccountantsReport</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsStatusAuditedOrUnaudited contextRef="accounts-status"></bus:AccountsStatusAuditedOrUnaudited>
+
+    <context id="accounts-type">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:AccountsTypeDimension">bus:FullAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:AccountsTypeFullOrAbbreviated contextRef="accounts-type"></bus:AccountsTypeFullOrAbbreviated>
+
+    <context id="applicable-legislation">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:ApplicableLegislationDimension">bus:SmallCompaniesRegimeForAccounts</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:ApplicableLegislation contextRef="applicable-legislation"></bus:ApplicableLegislation>
+
+    <context id="duration">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:DescriptionPrincipalActivities contextRef="duration">text</bus:DescriptionPrincipalActivities>
+    <bus:EntityCurrentLegalOrRegisteredName contextRef="duration">text</bus:EntityCurrentLegalOrRegisteredName>
+    <bus:EntityDormantTruefalse contextRef="duration">false</bus:EntityDormantTruefalse>
+    <bus:EntityTradingStatus contextRef="duration"></bus:EntityTradingStatus>
+    <core:DirectorSigningFinancialStatements contextRef="duration"></core:DirectorSigningFinancialStatements>
+    <direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime contextRef="duration">
+        Prepared in accordance with provisions small companies
+    </direp:StatementThatAccountsHaveBeenPreparedInAccordanceWithProvisionsSmallCompaniesRegime>
+    <direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies contextRef="duration">
+        Exempt from audit under section 477 of the Companies Act 2006
+    </direp:StatementThatCompanyEntitledToExemptionFromAuditUnderSection477CompaniesAct2006RelatingToSmallCompanies>
+    <direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct contextRef="duration">
+        Directors acknowledge their responsibilities under Companies Act 2006
+    </direp:StatementThatDirectorsAcknowledgeTheirResponsibilitiesUnderCompaniesAct>
+    <direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006 contextRef="duration">
+        Members have not agreed the company to preparation of an abridged audit
+    </direp:StatementThatMembersHaveAgreedToPreparationAbridgedAccountsUnderSection444CompaniesAct2006>
+    <direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit contextRef="duration">
+        Members have not required the company to obtain an audit
+    </direp:StatementThatMembersHaveNotRequiredCompanyToObtainAnAudit>
+
+    <context id="instant">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-12-30</instant>
+        </period>
+    </context>
+    <bus:BalanceSheetDate contextRef="instant">2021-01-01</bus:BalanceSheetDate>
+    <bus:EndDateForPeriodCoveredByReport contextRef="instant">2021-01-01</bus:EndDateForPeriodCoveredByReport>
+    <bus:StartDateForPeriodCoveredByReport contextRef="instant">2020-01-01</bus:StartDateForPeriodCoveredByReport>
+    <core:DateAuthorisationFinancialStatementsForIssue contextRef="instant">2021-01-01</core:DateAuthorisationFinancialStatementsForIssue>
+
+    <context id="legal-form-entity">
+        <entity>
+            <identifier scheme="http://www.gooog">12345678</identifier>
+            <segment>
+                <xbrldi:explicitMember dimension="bus:LegalFormEntityDimension">bus:UnlimitedCompany</xbrldi:explicitMember>
+            </segment>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2021-12-30</endDate>
+        </period>
+    </context>
+    <bus:LegalFormEntity contextRef="legal-form-entity"></bus:LegalFormEntity>
+</xbrl>


### PR DESCRIPTION

#### Description of change

Added validations: 
Unaudited Micro-LLP, 
Unaudited Company Abridged Accounts, 
Unaudited LLP Abridged Accounts, 
Unaudited Company Abbreviated Accounts, 
Unaudited LLP Abbreviated Accounts, 
Unaudited Company Group Accounts, 
Unaudited LLP Group Accounts, 
Unaudited Small Company Full Accounts, 
Unaudited LLP Full Accounts

#### Steps to Test

CI.  Conformance suite has been updated for each validation.

**review**:
@Arelle/arelle
