### PR TITLE
Use larger set of safe path chars in url escaping

### DIFF
--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -476,7 +476,13 @@ class WebCache:
         :return: `url` with scheme-specific-part quoted except for parameter separators
         """
         urlScheme, schemeSep, urlSchemeSpecificPart = url.partition("://")
-        return urlScheme + schemeSep + quote(urlSchemeSpecificPart, '/?=&')
+        urlPath, querySep, query = urlSchemeSpecificPart.partition("?")
+        # RFC 3986: https://www.ietf.org/rfc/rfc3986.txt
+        querySafeChars = ';/?'
+        pathSafeChars = querySafeChars + ':@&=+$,'
+        quotedUrlPath = quote(urlPath, safe=pathSafeChars)
+        quotedQuery = quote(query, safe=querySafeChars)
+        return urlScheme + schemeSep + quotedUrlPath + querySep + quotedQuery
 
     def _downloadFile(
             self,


### PR DESCRIPTION
#### Reason for change
URL escaping is overly aggressive and breaks some URLs including the CDN URLs for the ixbrl-viewer.

#### Description of change
Handle path and query string escaping separately with their own sets of safe characters.

#### Steps to Test
Verify the following command doesn't rise a `[webCache:retrievalError] Bad Request` error:
`python arelleCmdLine.py --file https://filings.xbrl.org/549300D2K6PKKKXVNN73/2022-12-31/ESEF/DK/1/APMM-2022-12-31-en.zip --plugins ixbrl-viewer --save-viewer ixbrlviewer.html --viewer-url https://cdn.jsdelivr.net/npm/ixbrl-viewer@1.4.18/iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js`

**review**:
@Arelle/arelle
