### PR TITLE
Use prefixedNamespaces to determine taxonomy instead of targetNamespaces

### DIFF
--- a/arelle/plugin/validate/HMRC/__init__.py
+++ b/arelle/plugin/validate/HMRC/__init__.py
@@ -165,10 +165,7 @@ def validateXbrlStart(val, parameters=None, *args, **kwargs):
         val.isAccounts = not val.isComputation
 
     val.txmyType = None
-    for doc in val.modelXbrl.modelDocument.referencesDocument:
-        ns = doc.targetNamespace
-        if not ns:
-            continue
+    for ns in val.modelXbrl.prefixedNamespaces.values():
         if ns.startswith("http://www.xbrl.org/uk/char/") or ns.startswith("http://xbrl.frc.org.uk/char/"):
             val.txmyType = "charities"
         elif ns.startswith("http://www.xbrl.org/uk/gaap/"):


### PR DESCRIPTION
#### Reason for change
HMRC plugin can not determine taxonomy used if document is loaded via IXDS.

#### Description of change
Use prefixed namespaces off model instead of referenced doc target namespaces to determine taxonomy for HMRC validation plugin.

#### Steps to Test
Run the attached [document](https://github.com/Arelle/Arelle/files/14336279/HMRC-TBD.zip) against validation. It should not fire an `HMRC.TBD` error.

**review**:
@Arelle/arelle
