### PR TITLE
Use version IDs in S3 downloads

### DIFF
--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -72,10 +72,7 @@ jobs:
       - name: Download conformance suites from S3
         run: aws s3 sync s3://arelle/conformance_suites tests/resources/conformance_suites
       - name: Run integration tests with pytest
-        run: |
-          pytest -s --disable-warnings --offline --log-to-file --download-cache \
-          --name=${{ matrix.test.name }}${{ matrix.test.shard && format(' --shard={0}', matrix.test.shard) || '' }} \
-          tests/integration_tests/validation/test_conformance_suites.py
+        run: pytest -s --disable-warnings --offline --log-to-file --download-cache --name=${{ matrix.test.name }}${{ matrix.test.shard && format(' --shard={0}', matrix.test.shard) || '' }} tests/integration_tests/validation/test_conformance_suites.py
       - name: Cat logs
         if: always()
         shell: bash

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -69,13 +69,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements-dev.txt
-      - name: Download cache from S3
-        if: ${{ matrix.test.cache }}
-        run: python tests/integration_tests/download_cache.py --name "conformance_suites/${{ matrix.test.name }}.zip"
       - name: Download conformance suites from S3
         run: aws s3 sync s3://arelle/conformance_suites tests/resources/conformance_suites
       - name: Run integration tests with pytest
-        run: pytest -s --disable-warnings --offline --log-to-file --name=${{ matrix.test.name }}${{ matrix.test.shard && format(' --shard={0}', matrix.test.shard) || '' }} tests/integration_tests/validation/test_conformance_suites.py
+        run: |
+          pytest -s --disable-warnings --offline --log-to-file --download-cache \
+          --name=${{ matrix.test.name }}${{ matrix.test.shard && format(' --shard={0}', matrix.test.shard) || '' }} \
+          tests/integration_tests/validation/test_conformance_suites.py
       - name: Cat logs
         if: always()
         shell: bash

--- a/tests/integration_tests/download_cache.py
+++ b/tests/integration_tests/download_cache.py
@@ -22,11 +22,14 @@ def download_and_apply_cache(name: str, cache_directory: str | None = None, vers
         f'ci/caches/{name}',
         version_id=version_id
     )
-    urllib.request.urlretrieve(uri, TEMP_ZIP_NAME)
-    # Unzip into cache directory
-    with zipfile.ZipFile(TEMP_ZIP_NAME, 'r') as zip_ref:
-        zip_ref.extractall(cache_directory)
-    os.remove(TEMP_ZIP_NAME)
+    try:
+        urllib.request.urlretrieve(uri, TEMP_ZIP_NAME)
+        # Unzip into cache directory
+        with zipfile.ZipFile(TEMP_ZIP_NAME, 'r') as zip_ref:
+            zip_ref.extractall(cache_directory)
+        os.remove(TEMP_ZIP_NAME)
+    except Exception as exc:
+        raise Exception(f'Failed to download cache from {uri} and extract to {cache_directory}.') from exc
 
 
 def download_program() -> None:

--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -38,7 +38,7 @@ def get_document_id(doc: ModelDocument.ModelDocument) -> str:
 
 
 def get_s3_uri(path: str, version_id: str | None = None) -> str:
-    uri = os.path.join(f'https://arelle-public.s3.amazonaws.com', path)
+    uri = f'https://arelle-public.s3.amazonaws.com/{path}'
     if version_id is not None:
         uri += f'?versionId={version_id}'
     return uri

--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -37,6 +37,13 @@ def get_document_id(doc: ModelDocument.ModelDocument) -> str:
     return PurePath(doc.filepath).relative_to(basepath).as_posix()
 
 
+def get_s3_uri(path: str, version_id: str | None = None) -> str:
+    uri = os.path.join(f'https://arelle-public.s3.amazonaws.com', path)
+    if version_id is not None:
+        uri += f'?versionId={version_id}'
+    return uri
+
+
 def get_test_data(
         args: list[str],
         expected_failure_ids: frozenset[str] = frozenset(),

--- a/tests/integration_tests/scripts/run_scripts.py
+++ b/tests/integration_tests/scripts/run_scripts.py
@@ -68,7 +68,10 @@ def run_script_options(options: Namespace) -> list[ParameterSet]:
     if options.all:
         scripts = all_scripts
         if options.download_cache:
-            download_and_apply_cache(ALL_SCRIPTS_ZIP)
+            download_and_apply_cache(
+                ALL_SCRIPTS_ZIP,
+                version_id='RMN9iin8l7Fqz7E4qfq_1uTuVMc8524U'
+            )
     else:
         names = options.name
         assert names, '--name or --all is required'

--- a/tests/integration_tests/scripts/script_util.py
+++ b/tests/integration_tests/scripts/script_util.py
@@ -25,6 +25,7 @@ def parse_args(
     description: str,
     arelle: bool = True,
     cache: str | None = None,
+    cache_version_id: str | None = None,
     working_directory: bool = True,
 ) -> argparse.Namespace:
     """
@@ -34,6 +35,7 @@ def parse_args(
     :param description: Human-readable description of the test.
     :param arelle: Whether '--arelle' argument is required.
     :param cache: Name of the cache that will be downloaded if `--download-cache` is provided.
+    :param cache_version_id: Version of the cache that will be downloaded if `--download-cache` is provided.
     :param working_directory: Whether a working directory should be configured.
     :return: Parsed argument Namespace.
     """
@@ -48,7 +50,7 @@ def parse_args(
                         help="Directory to place temporary files and log output.")
     parsed_args = parser.parse_args()
     if cache and parsed_args.download_cache:
-        download_and_apply_cache(f"scripts/{cache}")
+        download_and_apply_cache(f"scripts/{cache}", version_id=cache_version_id)
         print(f"Downloaded and applied cache: {cache}")
     if working_directory:
         test_directory = Path(parsed_args.working_directory).joinpath(name).absolute()

--- a/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
+++ b/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
@@ -8,6 +8,7 @@ from shutil import rmtree
 
 import regex
 
+from tests.integration_tests.integration_test_util import get_s3_uri
 from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
@@ -24,7 +25,10 @@ test_directory = Path(args.test_directory)
 report_zip_path = test_directory / 'report.zip'
 report_directory = test_directory / 'report'
 report_path = report_directory / "report.xbrl"
-report_zip_url = "https://arelle-public.s3.amazonaws.com/ci/packages/duplicate_facts_deduplication.zip"
+report_zip_url = get_s3_uri(
+    'ci/packages/duplicate_facts_deduplication.zip',
+    version_id='c7OCNP1vk_KJ_WOqE54M3bGtUsRHwJMI'
+)
 
 print(f"Downloading report: {report_zip_url}")
 urllib.request.urlretrieve(report_zip_url, report_zip_path)

--- a/tests/integration_tests/scripts/tests/duplicate_facts_validate.py
+++ b/tests/integration_tests/scripts/tests/duplicate_facts_validate.py
@@ -8,6 +8,7 @@ from shutil import rmtree
 
 import regex
 
+from tests.integration_tests.integration_test_util import get_s3_uri
 from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
@@ -24,7 +25,10 @@ test_directory = Path(args.test_directory)
 report_zip_path = test_directory / 'report.zip'
 report_directory = test_directory / 'report'
 report_path = report_directory / "report.xbrl"
-report_zip_url = "https://arelle-public.s3.amazonaws.com/ci/packages/fact_deduplication.zip"
+report_zip_url = get_s3_uri(
+    'ci/packages/fact_deduplication.zip',
+    version_id='.KKcbsQZQx5jLzXilkFZlQ3OdwTuFaoe'
+)
 
 print(f"Downloading report: {report_zip_url}")
 urllib.request.urlretrieve(report_zip_url, report_zip_path)

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
@@ -14,6 +14,7 @@ args = parse_args(
     this_file.stem,
     "Confirm ixbrl-viewer plugin runs successfully from the command line.",
     cache=this_file.with_suffix(".zip").name,
+    cache_version_id='P.uruiqpYrdNHGzX.XuJPGS3QS6_qY9g',
 )
 arelle_command = args.arelle
 arelle_offline = args.offline

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
@@ -5,6 +5,7 @@ import zipfile
 from pathlib import Path
 from shutil import rmtree
 
+from tests.integration_tests.integration_test_util import get_s3_uri
 from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
@@ -23,10 +24,13 @@ samples_zip_path = test_directory / 'samples.zip'
 samples_directory = test_directory / 'samples'
 target_path = samples_directory / "samples/src/ixds-test/document1.html"
 viewer_path = test_directory / "viewer.html"
-
+report_zip_url = get_s3_uri(
+    'ci/packages/IXBRLViewerSamples.zip',
+    version_id='6eS7qUUoWLeM9JSSTXOfANkHoLz1Zv5o'
+)
 
 print(f"Downloading samples: {samples_zip_path}")
-urllib.request.urlretrieve("https://arelle-public.s3.amazonaws.com/ci/packages/IXBRLViewerSamples.zip", samples_zip_path)
+urllib.request.urlretrieve(report_zip_url, samples_zip_path)
 
 print(f"Extracting samples: {samples_directory}")
 with zipfile.ZipFile(samples_zip_path, "r") as zip_ref:

--- a/tests/integration_tests/scripts/tests/japan_ixds.py
+++ b/tests/integration_tests/scripts/tests/japan_ixds.py
@@ -5,6 +5,7 @@ import zipfile
 from pathlib import Path
 from shutil import rmtree
 
+from tests.integration_tests.integration_test_util import get_s3_uri
 from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
@@ -24,7 +25,10 @@ report_zip_path = test_directory / 'report.zip'
 report_directory = test_directory / 'report'
 manifest_path = report_directory / "manifest.xml"
 extracted_path = report_directory / "tse-acedjpfr-19990-2023-06-30-01-2023-08-18_extracted.xbrl"
-report_zip_url = "https://arelle-public.s3.amazonaws.com/ci/packages/JapaneseXBRLReport.zip"
+report_zip_url = get_s3_uri(
+    'ci/packages/JapaneseXBRLReport.zip',
+    version_id='M7vTPhHhir1rOm7nSMPiCGcbCA0ksObh'
+)
 
 print(f"Downloading report: {report_zip_url}")
 urllib.request.urlretrieve(report_zip_url, report_zip_path)

--- a/tests/integration_tests/scripts/tests/japan_ixds.py
+++ b/tests/integration_tests/scripts/tests/japan_ixds.py
@@ -14,6 +14,7 @@ args = parse_args(
     this_file.stem,
     "Extract and validate Japanese IXDS instance.",
     cache=this_file.with_suffix(".zip").name,
+    cache_version_id='PiPwS2lDqbtid8K3dbUlF0m.KIa5Jm8E',
 )
 arelle_command = args.arelle
 arelle_offline = args.offline

--- a/tests/integration_tests/validation/README.md
+++ b/tests/integration_tests/validation/README.md
@@ -7,6 +7,7 @@ python -m tests.integration_tests.validation.run_conformance_suites --help
 
   -h, --help            show this help message and exit
   --all                 Select all configured conformance suites
+  --download-cache      Download and apply pre-built cache package
   --download-overwrite  Download (and overwrite) selected conformance suite
                         files
   --download-missing    Download missing selected conformance suite files

--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -19,6 +19,7 @@ class ConformanceSuiteConfig:
     additional_plugins_by_prefix: list[tuple[str, frozenset[str]]] = field(default_factory=list)
     approximate_relative_timing: dict[str, float] = field(default_factory=dict)  # by uri
     args: list[str] = field(default_factory=list)
+    cache_version_id: str | None = None
     capture_warnings: bool = True
     expected_empty_testcases: frozenset[str] = frozenset()
     expected_failure_ids: frozenset[str] = frozenset()
@@ -54,6 +55,8 @@ class ConformanceSuiteConfig:
         overlapping_expected_testcase_ids = self.expected_failure_ids.intersection(self.required_locale_by_ids)
         assert not overlapping_expected_testcase_ids, \
             f'Testcase IDs in both expected failures and required locales: {sorted(overlapping_expected_testcase_ids)}'
+        assert not self.network_or_cache_required or self.cache_version_id, \
+            'If network or cache is required, a cache version ID must be provided.'
 
     @property
     def prefixed_extract_filepath(self) -> str | None:

--- a/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
@@ -406,6 +406,7 @@ config = ConformanceSuiteConfig(
         '--disclosureSystem', 'efm-pragmatic',
         '--formula', 'run',
     ],
+    cache_version_id='EVHW_hgNxuwBw4aiKfksIBuqWJypQEZh',
     expected_empty_testcases=frozenset(f'conf/{s}' for s in [
         '605-instance-syntax/605-45-cover-page-facts-general-case/605-45-cover-page-facts-general-case-testcase.xml',
         '609-linkbase-syntax/609-10-general-namespace-specific-custom-arc-restrictions/609-10-general-namespace-specific-custom-arc-restrictions-testcase.xml',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
@@ -75,6 +75,7 @@ config = ConformanceSuiteConfig(
         '--disclosureSystem', 'esef-2021',
         '--formula', 'run',
     ],
+    cache_version_id='RHyZFLHe3de9PM._A4y125qBI63Al17Z',
     file='esef_conformance_suite_2021/esef_conformance_suite_2021/index_inline_xbrl.xml',
     info_url='https://www.esma.europa.eu/document/conformance-suite-2021',
     local_filepath='esef_conformance_suite_2021.zip',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
@@ -74,6 +74,7 @@ config = ConformanceSuiteConfig(
         '--disclosureSystem', 'esef-2022',
         '--formula', 'run',
     ],
+    cache_version_id='CSFFHD5xlJF.AklNscrzwwPGRVLO3ome',
     expected_failure_ids=frozenset(f'esef_conformance_suite_2022/tests/{s}' for s in [
         # The following test cases fail because of the `tech_duplicated_facts1` formula which fires
         # incorrectly because it does not take into account the language attribute on the fact.

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
@@ -74,6 +74,7 @@ config = ConformanceSuiteConfig(
         '--disclosureSystem', 'esef-2023',
         '--formula', 'run',
     ],
+    cache_version_id='yBVmKR4WMHVcHEp.SDUNO1zxTwQwkRhD',
     expected_failure_ids=frozenset(f'tests/inline_xbrl/{s}' for s in [
         # Test report uses older domain item type (http://www.xbrl.org/dtr/type/non-numeric) forbidden by ESEF.3.2.2.
         'G3-1-2/index.xml:TC2_valid',

--- a/tests/integration_tests/validation/conformance_suite_configurations/hmrc_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/hmrc_current.py
@@ -29,6 +29,7 @@ config = ConformanceSuiteConfig(
     args=[
         '--hmrc',
     ],
+    cache_version_id='qFZpmbM3qqKf4xA3EQued7ek83cBCSiz',
     file='index.xml',
     info_url='https://www.gov.uk/government/organisations/hm-revenue-customs',
     local_filepath='HMRC',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt16.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt16.py
@@ -48,6 +48,7 @@ config = ConformanceSuiteConfig(
     args=[
         '--disclosureSystem', 'NT16-preview',
     ],
+    cache_version_id='ODcN7yG7UJb_W2ItTUCacjKNtwZc1oh6',
     file='index.xml',
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT16%20-%2020210301_0.pdf',
     local_filepath='nl_nt16',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt17.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt17.py
@@ -48,6 +48,7 @@ config = ConformanceSuiteConfig(
     args=[
         '--disclosureSystem', 'NT17-preview',
     ],
+    cache_version_id='eOz6hLM64QEXb4MloAAx_kxm.iIkxb9L',
     file='index.xml',
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT17%20-%2020220301__.pdf',
     local_filepath='nl_nt17',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt18.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt18.py
@@ -27,6 +27,7 @@ config = ConformanceSuiteConfig(
     args=[
         '--disclosureSystem', 'NT18-preview',
     ],
+    cache_version_id='5FqxcEUcRYnqmuAVPDH1qOrdECSnoXgD',
     file='index.xml',
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT18%20-%2020230301_.pdf',
     local_filepath='nl_nt18',

--- a/tests/integration_tests/validation/discover_tests.py
+++ b/tests/integration_tests/validation/discover_tests.py
@@ -51,17 +51,15 @@ FAST_CONFIG_NAMES = {
 class Entry(TypedDict, total=False):
     name: str
     short_name: str
-    cache: bool
     os: str
     python_version: str
     shard: str
 
 
-def generate_config_entry(name: str, short_name: str, network_or_cache_required: bool, os: str, python_version: str, shard: str | None) -> Entry:
+def generate_config_entry(name: str, short_name: str, os: str, python_version: str, shard: str | None) -> Entry:
     e: Entry = {
         'name': name,
         'short_name': short_name,
-        'cache': network_or_cache_required,
         'os': os,
         'python_version': python_version,
     }
@@ -75,7 +73,6 @@ def generate_config_entries(config: ConformanceSuiteConfig, os: str, python_vers
         yield generate_config_entry(
             name=config.name,
             short_name=config.name,
-            network_or_cache_required=config.network_or_cache_required,
             os=os,
             python_version=python_version,
             shard=None,
@@ -88,7 +85,6 @@ def generate_config_entries(config: ConformanceSuiteConfig, os: str, python_vers
             yield generate_config_entry(
                 name=config.name,
                 short_name=config.name,
-                network_or_cache_required=config.network_or_cache_required,
                 os=os,
                 python_version=python_version,
                 shard=f'{start}-{end}',
@@ -109,7 +105,6 @@ def main() -> None:
         output.append(generate_config_entry(
             name=','.join(sorted(FAST_CONFIG_NAMES)),
             short_name='miscellaneous suites',
-            network_or_cache_required=False,
             os=os,
             python_version=LATEST_PYTHON_VERSION,
             shard=None,


### PR DESCRIPTION
#### Reason for change
Without using versioned S3 objects, any changes we need to make to test documents hosted on S3 will potentially break tests while master/PR branches attempt tests against the same documents.

[Info on S3 versioned buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RetrievingObjectVersions.html)

#### Description of change
Provide the option to specify version ID wherever S3 downloads are configured.
Set up initial version IDs for conformance suite and integration test script caches/packages.

#### Steps to Test
CI will fail due to running master's version of the workflow, but a successful workflow dispatch run can be seen [here](https://github.com/Arelle/Arelle/actions/runs/7981890932).

**review**:
@Arelle/arelle
