### PR TITLE
Fix typo in schema remapping

### DIFF
--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -716,7 +716,7 @@ standardNamespaceSchemaLocations: dict[str, str] = {
     xbrli: "http://www.xbrl.org/2003/xbrl-instance-2003-12-31.xsd",
     link: "http://www.xbrl.org/2003/xbrl-linkbase-2003-12-31.xsd",
     xl: "http://www.xbrl.org/2003/xl-2003-12-31.xsd",
-    xlink: "http://www.w3.org/1999/xlink",
+    xlink: "http://www.xbrl.org/2003/xlink-2003-12-31.xsd",
     xbrldt: "http://www.xbrl.org/2005/xbrldt-2005.xsd",
     xbrldi: "http://www.xbrl.org/2006/xbrldi-2006.xsd",
     gen: "http://www.xbrl.org/2008/generic-link.xsd",


### PR DESCRIPTION
#### Reason for change
The `standardNamespaceSchemaLocations` namespace to schema map points to the xlink namespace instead of its schema.

#### Description of change
One entry in the namespace > schema map was a namespace > namespace. This updates the value to point to the correct schema instead of the namespace which doesn't exist as a file.

#### Steps to Test
[xlink-remap.zip](https://github.com/Arelle/Arelle/files/14366070/xlink-remap.zip)
Open empty-instance.xml from the attached zip and confirm no xmlSchema:syntax errors are raised.

**review**:
@Arelle/arelle
