### PR TITLE
Add other language regions as fall backs for labels

### DIFF
--- a/arelle/ModelRelationshipSet.py
+++ b/arelle/ModelRelationshipSet.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
-from arelle import ModelDtsObject, XbrlConst, ModelValue
+from arelle import Locale, XbrlConst, ModelValue
 from arelle.ModelObject import ModelObject
 from arelle.ModelDtsObject import ModelRelationship, ModelResource
 from arelle.PrototypeDtsObject import LocPrototype, PrototypeObject
@@ -361,6 +361,8 @@ class ModelRelationshipSet:
             labels = sorted(labels, key=lambda rel: rel.priority, reverse=True)
         shorter: _LangLabels | None = None
         longer: _LangLabels | None = None
+        regionalVariant: _LangLabels | None = None
+        baseLang = _lang.partition(Locale.BCP47_LANGUAGE_REGION_SEPARATOR)[0] if _lang else None
         for modelLabelRel in labels:
             label = modelLabelRel.toModelObject
             if wildRole or role == label.role:
@@ -383,6 +385,11 @@ class ModelRelationshipSet:
                             shorter = _LangLabels(labelLang, [text])
                         else:
                             shorter.labels.append(text)
+                    elif baseLang and labelLang.startswith(baseLang):
+                        if not regionalVariant:
+                            regionalVariant = _LangLabels(labelLang, [text])
+                        else:
+                            regionalVariant.labels.append(text)
         if langLabels:
             if returnMultiple: return langLabels
             else: return langLabels[0]
@@ -392,4 +399,7 @@ class ModelRelationshipSet:
         if longer:
             if returnMultiple: return longer.labels
             else: return longer.labels[0]
+        if regionalVariant:
+            if returnMultiple: return regionalVariant.labels
+            else: return regionalVariant.labels[0]
         return None


### PR DESCRIPTION
#### Reason for change
Resolves #1089

Recent locale detection improvements (#1023) have caused the system detected label setting for some users to become more specific (previously en and now en-GB). If a user with a regional language setting (such as en-GB) opens a taxonomy with labels of a different region of the same language (en-US) they will not see any english labels.

#### Description of change
Continue to prioritize regional labels, but provide additional reasonable fall backs.
en-GB -> en -> en-US -> QName

#### Steps to Test
1. Set `Labels` to the UK variant of english in the GUI "Tools" -> "Language..." menu.
2. Close and reopen Arelle.
3. Load an SEC (en-US) taxonomy.
4. Confirm en-US labels are displayed in the fact table.

**review**:
@Arelle/arelle
