### PR TITLE
Add date types to deduplication test

### DIFF
--- a/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
+++ b/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
@@ -27,7 +27,7 @@ report_directory = test_directory / 'report'
 report_path = report_directory / "report.xbrl"
 report_zip_url = get_s3_uri(
     'ci/packages/duplicate_facts_deduplication.zip',
-    version_id='c7OCNP1vk_KJ_WOqE54M3bGtUsRHwJMI'
+    version_id='1NplyThuJkNOmSNITHdVuqE4MYtvDGOq'
 )
 
 print(f"Downloading report: {report_zip_url}")

--- a/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
+++ b/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
@@ -37,35 +37,40 @@ print(f"Extracting report: {report_directory}")
 with zipfile.ZipFile(report_zip_path, "r") as zip_ref:
     zip_ref.extractall(report_directory)
 
+ALL_TESTCASES = {
+    regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE, decimals=\(none\)'): 2,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 1, decimals=\(none\)'): 1,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 2, decimals=\(none\)'): 1,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=INF'): 3,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=200\.000000, decimals=INF'): 1,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Date, value=2001-01-01, decimals=\(none\)'): 2,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Date, value=2001-02-01, decimals=\(none\)'): 1,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Day, value=---01, decimals=\(none\)'): 2,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Day, value=---02, decimals=\(none\)'): 1,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Month, value=--01, decimals=\(none\)'): 2,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Month, value=--02, decimals=\(none\)'): 1,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Year, value=2001, decimals=\(none\)'): 2,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:Year, value=2002, decimals=\(none\)'): 1,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:MonthDay, value=--01-01, decimals=\(none\)'): 2,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:MonthDay, value=--02-01, decimals=\(none\)'): 1,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:YearMonth, value=2001-01, decimals=\(none\)'): 2,
+    regex.compile(r'^\[info:deduplicatedFact].*mock:YearMonth, value=2002-01, decimals=\(none\)'): 1,
+}
+
 test_cases: dict[str, dict[regex.Pattern[str], int]] = {
     'complete': {
-        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE, decimals=\(none\)'): 2,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 1, decimals=\(none\)'): 1,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 2, decimals=\(none\)'): 1,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=INF'): 3,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=200\.000000, decimals=INF'): 1,
-        regex.compile(r'^\[info:deduplicatedInstance].*removing 8 fact'): 1,
+        regex.compile(r'^\[info:deduplicatedInstance].*removing 26 fact'): 1,
     },
     'consistent-pairs': {
-        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE, decimals=\(none\)'): 2,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 1, decimals=\(none\)'): 1,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 2, decimals=\(none\)'): 1,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=INF'): 3,
         regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=0'): 2,
         regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.100000, decimals=1'): 2,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=200\.000000, decimals=INF'): 1,
         regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=200\.000000, decimals=0'): 1,
-        regex.compile(r'^\[info:deduplicatedInstance].*removing 13 fact'): 1,
+        regex.compile(r'^\[info:deduplicatedInstance].*removing 31 fact'): 1,
     },
     'consistent-sets': {
-        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE, decimals=\(none\)'): 2,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 1, decimals=\(none\)'): 1,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:NonNumeric, value=COMPLETE 2, decimals=\(none\)'): 1,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=INF'): 3,
         regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.000000, decimals=0'): 1,
         regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=100\.100000, decimals=1'): 1,
-        regex.compile(r'^\[info:deduplicatedFact].*mock:Numeric, value=200\.000000, decimals=INF'): 1,
-        regex.compile(r'^\[info:deduplicatedInstance].*removing 10 fact'): 1,
+        regex.compile(r'^\[info:deduplicatedInstance].*removing 28 fact'): 1,
     },
 }
 for arg, expected_infos in test_cases.items():
@@ -82,6 +87,8 @@ for arg, expected_infos in test_cases.items():
         offline=arelle_offline,
         logFile=log_file,
     )
+    for pattern, count in ALL_TESTCASES.items():
+        expected_infos[pattern] = expected_infos.get(pattern, 0) + count
     errors += validate_log_file(log_file, expected_results={"info": expected_infos})
     assert_result(errors)
 


### PR DESCRIPTION
#### Reason for change
Some date types encountered unique errors when encountered during deduplication. Add them to the deduplication integration test script.

#### Steps to Test
CI

**review**:
@Arelle/arelle
