### PR TITLE
Add default to `deduplicateIxbrlFacts` arg `getattr`

### DIFF
--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -704,7 +704,7 @@ def saveTargetInstanceOverriden(deduplicationType: DeduplicationType | None) -> 
 
 
 def commandLineXbrlRun(cntlr, options: RuntimeOptions, modelXbrl, *args, **kwargs):
-    deduplicationTypeArg = getattr(options, "deduplicateIxbrlFacts")
+    deduplicationTypeArg = getattr(options, "deduplicateIxbrlFacts", None)
     deduplicationType = None if deduplicationTypeArg is None else DeduplicationType(deduplicationTypeArg)
     # skip if another class handles saving (e.g., EdgarRenderer)
     if saveTargetInstanceOverriden(deduplicationType):


### PR DESCRIPTION
#### Reason for change
Recent addition of `deduplicateIxbrlFacts` arg did not consider the use of third-party alternatives to the `RuntimeOptions` class which may not define `deduplicateIxbrlFacts` as an attribute.

#### Description of change
Default to `None` for `deduplicateIxbrlFacts` if the attribute is not on the options object.

#### Steps to Test
CI

**review**:
@Arelle/arelle
