### PR TITLE
Update macOS runners

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -54,7 +54,7 @@ permissions: {}
 jobs:
   build-macos:
     environment: release
-    runs-on: macos-12
+    runs-on: macos-13
     outputs:
       artifact_versioned_name: ${{ steps.define-artifact-names.outputs.artifact_versioned_name }}
       uploaded_artifact_name: ${{ steps.define-artifact-names.outputs.uploaded_artifact_name }}

--- a/.github/workflows/test-scripts-parallel.yml
+++ b/.github/workflows/test-scripts-parallel.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         name: ${{ fromJson(needs.find-tests.outputs.names) }}
         os:
-          - macos-12
+          - macos-13
           - ubuntu-22.04
           - windows-2022
         python-version:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-13
           - ubuntu-22.04
           - windows-2022
         python-version:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-13
           - ubuntu-22.04
           - windows-2022
         python-version:

--- a/tests/integration_tests/validation/discover_tests.py
+++ b/tests/integration_tests/validation/discover_tests.py
@@ -11,7 +11,7 @@ from .conformance_suite_configurations.xbrl_2_1 import config as xbrl_2_1
 
 
 LINUX = 'ubuntu-22.04'
-MACOS = 'macos-12'
+MACOS = 'macos-13'
 WINDOWS = 'windows-2022'
 ALL_PYTHON_VERSIONS = (
     '3.8',
@@ -25,7 +25,7 @@ LATEST_PYTHON_VERSION = '3.12'
 # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
 OS_CORES = {
     LINUX: 4,
-    MACOS: 3,
+    MACOS: 4,
     WINDOWS: 4,
 }
 FAST_CONFIG_NAMES = {


### PR DESCRIPTION
#### Reason for change
New larger macOS runners are available. I'm also looking at a followup ticket to produce both Intel (macos-13) and Apple silicon (beta macos-14) builds.

#### Description of change
Update CI macOS runners.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
