### PR TITLE
Update XBRL 2.1 calc arc tests for calc 1.1

### DIFF
--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -195,7 +195,7 @@ class ValidateXbrl:
                         break
 
             # check calculation arcs for weight issues (note calc arc is an "any" cycles)
-            if arcrole == XbrlConst.summationItem:
+            if arcrole in XbrlConst.summationItems:
                 for modelRel in relsSet.modelRelationships:
                     weight = modelRel.weight
                     fromConcept = modelRel.fromModelObject


### PR DESCRIPTION
#### Reason for change
XBRL 2.1 tests in 5.1.1.2 and 5.2.5.2 were not using the new calc arcroles

#### Description of change
Add calc 1.1 arcrole.

#### Steps to Test
https://gitlab.xbrl.org/base-spec/base-spec/-/merge_requests/159

**review**:
@Arelle/arelle
