### PR TITLE
[FIX] Fix the xpath matches when the element checked doesn't have a value

### DIFF
--- a/arelle/FunctionUtil.py
+++ b/arelle/FunctionUtil.py
@@ -30,7 +30,7 @@ def stringArg(xc, args, i, type, missingArgFallback=None, emptyFallback=''):
     item = anytypeArg(xc, args, i, type, missingArgFallback)
     if item == (): return emptyFallback
     if isinstance(item, (ModelObject,ModelAttribute)):
-        return item.text
+        return item.text or emptyFallback
     return str(item)
 
 def numericArg(xc, p, args, i=0, missingArgFallback=None, emptyFallback=0, convertFallback=None):


### PR DESCRIPTION
#### Reason for change

In the EIOPA Solvency taxonomy, there is the possibility to have optional open column in table linkbase. 
Following the [EIOPA filing rules](https://dev.eiopa.europa.eu/Taxonomy/Full/2.8.0_Hotfix/Common/EIOPA_XBRL_Filing_Rules_2.8.0_Hotfix.pdf) (section S.22, p19) in the xbrl report, the typed dimension are saved as:
```
<xbrldi:typedMember dimension="s2c_dim:CV">
    <s2c_typ:ID xsi:nil="true"/>
 </xbrldi:typedMember>
```

Those dimension can be used in a validation, for example BV1231, which does this (problemetic part of the formula):
`matches(xfi:fact-typed-dimension-value($v0, QName('http://eiopa.europa.eu/xbrl/s2c/dict/dim','CV'))/s2c_typ:ID,&quot;^LEI/[A-Z0-9]{18}[0-9]{2}$&quot;)`
They want to validate the text of the dimension with a `matches` (regex), and verify that the value is a LEI.

On master, the validation fails because the `item.text` on the empty dimension return None, which is then used in a regex [here](https://github.com/Arelle/Arelle/blob/master/arelle/FunctionFn.py#L291), which only handle string values.

#### Description of change

The change make sure that the return value of `stringArg` is a string and not None

#### Steps to Test


With the [Solvency 2.8 taxonomy](https://dev.eiopa.europa.eu/Taxonomy/Full/2.8.0_Hotfix/S2/EIOPA_SolvencyII_XBRL_Taxonomy_2.8.0_Hotfix.zip), open the unzipped [solvency_optional_column.zip](https://github.com/Arelle/Arelle/files/14599078/solvency_optional_column.zip) file and validate it.

**review**:
@Arelle/arelle
