### PR TITLE
Add FG-NL-03 validation

### DIFF
--- a/tests/resources/conformance_suites/nl_nt16/fg_nl/03-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt16/fg_nl/03-invalid.xbrl
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- CAUSE: The default prefix for the nl-common-data namespace is nl-cd-->
+<xbrl
+  xml:lang="en"
+  xmlns="http://www.xbrl.org/2003/instance"
+  xmlns:iso4217="http://www.xbrl.org/2003/iso4217"
+  xmlns:jenv-bw2-i="http://www.nltaxonomie.nl/nt16/jenv/20211208/dictionary/jenv-bw2-data"
+  xmlns:kvk-i="http://www.nltaxonomie.nl/nt16/kvk/20211208/dictionary/kvk-data"
+  xmlns:link="http://www.xbrl.org/2003/linkbase"
+  xmlns:nl-cd-invalid="http://www.nltaxonomie.nl/nt16/sbr/20210301/dictionary/nl-common-data"
+  xmlns:xbrli="http://www.xbrl.org/2003/instance"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+    <link:schemaRef
+      xlink:href="http://www.nltaxonomie.nl/nt16/kvk/20211208/entrypoints/kvk-rpt-jaarverantwoording-2021-nlgaap-klein-publicatiestukken.xsd"
+      xlink:type="simple"/>
+    <context id="ctx-1">
+        <entity>
+            <identifier scheme="http://www.kvk.nl/kvk-id">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2022-01-01</endDate>
+        </period>
+    </context>
+    <context id="ctx-2">
+        <entity>
+            <identifier scheme="http://www.kvk.nl/kvk-id">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-01-01</instant>
+        </period>
+    </context>
+    <xbrli:unit id="usd">
+        <xbrli:measure>iso4217:USD</xbrli:measure>
+    </xbrli:unit>
+    <xbrli:unit id="pure">
+        <xbrli:measure>xbrli:pure</xbrli:measure>
+    </xbrli:unit>
+    <nl-cd-invalid:LegalEntityName contextRef="ctx-1" xml:lang="en">Testing Entity Name</nl-cd-invalid:LegalEntityName>
+    <jenv-bw2-i:LegalEntityRegisteredOffice contextRef="ctx-1" xml:lang="en">Address</jenv-bw2-i:LegalEntityRegisteredOffice>
+    <nl-cd-invalid:ChamberOfCommerceRegistrationNumber contextRef="ctx-1" xml:lang="en">12345678</nl-cd-invalid:ChamberOfCommerceRegistrationNumber>
+    <kvk-i:BusinessNames contextRef="ctx-1" xml:lang="en">Testing Entity Name</kvk-i:BusinessNames>
+    <kvk-i:LegalSizeCriteriaClassificationSmall contextRef="ctx-1" xml:lang="en">Klein</kvk-i:LegalSizeCriteriaClassificationSmall>
+    <jenv-bw2-i:FinancialReportingPeriodCurrentStartDate contextRef="ctx-1">2021-01-01</jenv-bw2-i:FinancialReportingPeriodCurrentStartDate>
+    <jenv-bw2-i:FinancialReportingPeriodCurrentEndDate contextRef="ctx-1">2021-12-31</jenv-bw2-i:FinancialReportingPeriodCurrentEndDate>
+    <jenv-bw2-i:FinancialReportingPeriodPreviousStartDate contextRef="ctx-1">2020-01-01</jenv-bw2-i:FinancialReportingPeriodPreviousStartDate>
+    <jenv-bw2-i:FinancialReportingPeriodPreviousEndDate contextRef="ctx-1">2020-12-31</jenv-bw2-i:FinancialReportingPeriodPreviousEndDate>
+    <jenv-bw2-i:DocumentAdoptionDate contextRef="ctx-1">2022-01-01</jenv-bw2-i:DocumentAdoptionDate>
+    <jenv-bw2-i:DocumentAdoptionStatus contextRef="ctx-1">Ja</jenv-bw2-i:DocumentAdoptionStatus>
+    <kvk-i:DocumentResubmissionDueToUnsurmountableInaccuracies contextRef="ctx-1">Ja</kvk-i:DocumentResubmissionDueToUnsurmountableInaccuracies>
+    <kvk-i:DocumentResubmissionDueToUnsurmountableInaccuraciesExplanation contextRef="ctx-1">
+        Explanation
+    </kvk-i:DocumentResubmissionDueToUnsurmountableInaccuraciesExplanation>
+    <jenv-bw2-i:RightsGrantedExercisePrice contextRef="ctx-2" xml:lang="en" decimals="2" unitRef="usd">100.00</jenv-bw2-i:RightsGrantedExercisePrice>
+    <jenv-bw2-i:ShareCapitalInTheCurrencyOfDenominationWhenDifferentPresentationCurrencyExchangeRateUsed contextRef="ctx-2" xml:lang="en" decimals="INF" unitRef="pure">1.1</jenv-bw2-i:ShareCapitalInTheCurrencyOfDenominationWhenDifferentPresentationCurrencyExchangeRateUsed>
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt16/fg_nl/03-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt16/fg_nl/03-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="NL.FG-NL-03"
+  description="An XBRL instance document SHOULD use the recommended default namespace prefixes for all namespaces."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="invalid-prefix" name="Invalid Prefix">
+    <description>
+        The instance uses a prefix for a namespace that does not match the taxonomy-defined prefix for that namespace.
+    </description>
+    <data>
+        <instance readMeFirst="true">03-invalid.xbrl</instance>
+    </data>
+    <result>
+      <error>NL.FG-NL-03</error>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt16/index.xml
+++ b/tests/resources/conformance_suites/nl_nt16/index.xml
@@ -13,6 +13,7 @@
     <testcase uri='br_kvk/4-16-testcase.xml' />
     <testcase uri='br_kvk/4-17-testcase.xml' />
     <testcase uri='br_kvk/4-20-testcase.xml' />
+    <testcase uri='fg_nl/03-testcase.xml' />
     <testcase uri='fg_nl/04-testcase.xml' />
     <testcase uri='fg_nl/05-testcase.xml' />
     <testcase uri='fg_nl/09-testcase.xml' />

--- a/tests/resources/conformance_suites/nl_nt17/fg_nl/03-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt17/fg_nl/03-invalid.xbrl
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- CAUSE: The default prefix for the nl-common-data namespace is nl-cd-->
+<xbrl
+  xml:lang="en"
+  xmlns="http://www.xbrl.org/2003/instance"
+  xmlns:iso4217="http://www.xbrl.org/2003/iso4217"
+  xmlns:jenv-bw2-i="http://www.nltaxonomie.nl/nt17/jenv/20221214/dictionary/jenv-bw2-data"
+  xmlns:kvk-i="http://www.nltaxonomie.nl/nt17/kvk/20221214/dictionary/kvk-data"
+  xmlns:link="http://www.xbrl.org/2003/linkbase"
+  xmlns:nl-cd-invalid="http://www.nltaxonomie.nl/nt17/sbr/20220301/dictionary/nl-common-data"
+  xmlns:xbrli="http://www.xbrl.org/2003/instance"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+    <link:schemaRef
+      xlink:href="http://www.nltaxonomie.nl/nt17/kvk/20221214/entrypoints/kvk-rpt-jaarverantwoording-2022-nlgaap-klein-publicatiestukken.xsd"
+      xlink:type="simple"/>
+    <context id="ctx-1">
+        <entity>
+            <identifier scheme="http://www.kvk.nl/kvk-id">12345678</identifier>
+        </entity>
+        <period>
+            <startDate>2021-01-01</startDate>
+            <endDate>2022-01-01</endDate>
+        </period>
+    </context>
+    <context id="ctx-2">
+        <entity>
+            <identifier scheme="http://www.kvk.nl/kvk-id">12345678</identifier>
+        </entity>
+        <period>
+            <instant>2021-01-01</instant>
+        </period>
+    </context>
+    <xbrli:unit id="usd">
+        <xbrli:measure>iso4217:USD</xbrli:measure>
+    </xbrli:unit>
+    <xbrli:unit id="pure">
+        <xbrli:measure>xbrli:pure</xbrli:measure>
+    </xbrli:unit>
+    <nl-cd-invalid:LegalEntityName contextRef="ctx-1" xml:lang="en">Testing Entity Name</nl-cd-invalid:LegalEntityName>
+    <jenv-bw2-i:LegalEntityRegisteredOffice contextRef="ctx-1" xml:lang="en">Address</jenv-bw2-i:LegalEntityRegisteredOffice>
+    <nl-cd-invalid:ChamberOfCommerceRegistrationNumber contextRef="ctx-1" xml:lang="en">12345678</nl-cd-invalid:ChamberOfCommerceRegistrationNumber>
+    <kvk-i:BusinessNames contextRef="ctx-1" xml:lang="en">Testing Entity Name</kvk-i:BusinessNames>
+    <kvk-i:LegalSizeCriteriaClassificationSmall contextRef="ctx-1" xml:lang="en">Klein</kvk-i:LegalSizeCriteriaClassificationSmall>
+    <jenv-bw2-i:FinancialReportingPeriodCurrentStartDate contextRef="ctx-1">2021-01-01</jenv-bw2-i:FinancialReportingPeriodCurrentStartDate>
+    <jenv-bw2-i:FinancialReportingPeriodCurrentEndDate contextRef="ctx-1">2021-12-31</jenv-bw2-i:FinancialReportingPeriodCurrentEndDate>
+    <jenv-bw2-i:FinancialReportingPeriodPreviousStartDate contextRef="ctx-1">2020-01-01</jenv-bw2-i:FinancialReportingPeriodPreviousStartDate>
+    <jenv-bw2-i:FinancialReportingPeriodPreviousEndDate contextRef="ctx-1">2020-12-31</jenv-bw2-i:FinancialReportingPeriodPreviousEndDate>
+    <jenv-bw2-i:DocumentAdoptionDate contextRef="ctx-1">2022-01-01</jenv-bw2-i:DocumentAdoptionDate>
+    <jenv-bw2-i:DocumentAdoptionStatus contextRef="ctx-1">Ja</jenv-bw2-i:DocumentAdoptionStatus>
+    <kvk-i:DocumentResubmissionDueToUnsurmountableInaccuracies contextRef="ctx-1">Ja</kvk-i:DocumentResubmissionDueToUnsurmountableInaccuracies>
+    <kvk-i:DocumentResubmissionDueToUnsurmountableInaccuraciesExplanation contextRef="ctx-1">
+        Explanation
+    </kvk-i:DocumentResubmissionDueToUnsurmountableInaccuraciesExplanation>
+    <jenv-bw2-i:RightsGrantedExercisePrice contextRef="ctx-2" xml:lang="en" decimals="2" unitRef="usd">100.00</jenv-bw2-i:RightsGrantedExercisePrice>
+    <jenv-bw2-i:ShareCapitalInTheCurrencyOfDenominationWhenDifferentPresentationCurrencyExchangeRateUsed contextRef="ctx-2" xml:lang="en" decimals="INF" unitRef="pure">1.1</jenv-bw2-i:ShareCapitalInTheCurrencyOfDenominationWhenDifferentPresentationCurrencyExchangeRateUsed>
+</xbrl>

--- a/tests/resources/conformance_suites/nl_nt17/fg_nl/03-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt17/fg_nl/03-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="NL.FG-NL-03"
+  description="An XBRL instance document SHOULD use the recommended default namespace prefixes for all namespaces."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="invalid-prefix" name="Invalid Prefix">
+    <description>
+        The instance uses a prefix for a namespace that does not match the taxonomy-defined prefix for that namespace.
+    </description>
+    <data>
+        <instance readMeFirst="true">03-invalid.xbrl</instance>
+    </data>
+    <result>
+      <error>NL.FG-NL-03</error>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt17/index.xml
+++ b/tests/resources/conformance_suites/nl_nt17/index.xml
@@ -13,6 +13,7 @@
     <testcase uri='br_kvk/4-16-testcase.xml' />
     <testcase uri='br_kvk/4-17-testcase.xml' />
     <testcase uri='br_kvk/4-20-testcase.xml' />
+    <testcase uri='fg_nl/03-testcase.xml' />
     <testcase uri='fg_nl/04-testcase.xml' />
     <testcase uri='fg_nl/05-testcase.xml' />
     <testcase uri='fg_nl/09-testcase.xml' />

--- a/tests/resources/conformance_suites/nl_nt18/fg_nl/03-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt18/fg_nl/03-invalid.xbrl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- CAUSE: The default prefix for the jenv-bw2-data namespace is jenv-bw2-i-->
+<xbrli:xbrl
+        xmlns:xbrli="http://www.xbrl.org/2003/instance"
+        xmlns:jenv-bw2-x="http://www.nltaxonomie.nl/nt18/jenv/20231213.b/dictionary/jenv-bw2-data"
+        xmlns:link="http://www.xbrl.org/2003/linkbase"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xml="http://www.w3.org/XML/1998/namespace"
+        xml:lang="nl">
+    <link:schemaRef xlink:href="http://www.nltaxonomie.nl/nt18/jenv/20231213.b/dictionary/jenv-bw2-data.xsd" xlink:type="simple"/>
+    <xbrli:context id="c-1">
+        <xbrli:entity>
+            <xbrli:identifier scheme="http://www.kvk.nl/kvk-id/">32123456</xbrli:identifier>
+        </xbrli:entity>
+        <xbrli:period>
+            <xbrli:startDate>2021-01-01</xbrli:startDate>
+            <xbrli:endDate>2021-12-31</xbrli:endDate>
+        </xbrli:period>
+    </xbrli:context>
+    <jenv-bw2-x:FinancialReportingPeriodCurrentStartDate contextRef="c-1">2021-01-01</jenv-bw2-x:FinancialReportingPeriodCurrentStartDate>
+</xbrli:xbrl>

--- a/tests/resources/conformance_suites/nl_nt18/fg_nl/03-testcase.xml
+++ b/tests/resources/conformance_suites/nl_nt18/fg_nl/03-testcase.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://xbrl.org/2005/conformance"
+  name="NL.FG-NL-03"
+  description="An XBRL instance document SHOULD use the recommended default namespace prefixes for all namespaces."
+  outpath=''
+  owner="support@arelle.org"
+  xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+  <variation id="invalid-prefix" name="Invalid Prefix">
+    <description>
+        The instance uses a prefix for a namespace that does not match the taxonomy-defined prefix for that namespace.
+    </description>
+    <data>
+        <instance readMeFirst="true">03-invalid.xbrl</instance>
+    </data>
+    <result>
+      <error>NL.FG-NL-03</error>
+    </result>
+  </variation>
+</testcase>

--- a/tests/resources/conformance_suites/nl_nt18/index.xml
+++ b/tests/resources/conformance_suites/nl_nt18/index.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <testcases name="NL-NT18">
+    <testcase uri='fg_nl/03-testcase.xml' />
     <testcase uri='fg_nl/04-testcase.xml' />
     <testcase uri='fg_nl/05-testcase.xml' />
     <testcase uri='fg_nl/09-testcase.xml' />


### PR DESCRIPTION
#### Description of change
"An XBRL instance document SHOULD use the recommended default namespace prefixes for all namespaces"

Generate full mapping of namespaces to prefixes from the taxonomy.
Compare to mapping of namespaces to prefixes from the instance.
If there are differences, generate a warning.

#### Steps to Test
CI, verify FG-NL-03 included in relevant results:
* kvk_nt16
  * testcase-kvk-rpt-jaarverantwoording-2021-nlgaap-micro.xml:V5
  * testcase-kvk-rpt-jaarverantwoording-2021-nlgaap-klein.xml:V5
* nl_nt16
  * fg_nl/03-invalid.xml:invalid-prefix
* nl_nt17
  * fg_nl/03-invalid.xml:invalid-prefix
* nl_nt18
  * fg_nl/03-invalid.xml:invalid-prefix

**review**:
@Arelle/arelle
