### PR TITLE
FG-NL-03: Inline namespace declarations

### DIFF
--- a/tests/resources/conformance_suites/nl_nt16/fg_nl/03-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt16/fg_nl/03-invalid.xbrl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- CAUSE: The default prefix for the nl-common-data namespace is nl-cd-->
+<!-- CAUSE: The standard prefix for the nl-common-data namespace is nl-cd-->
 <xbrl
   xml:lang="en"
   xmlns="http://www.xbrl.org/2003/instance"
@@ -38,7 +38,8 @@
     </xbrli:unit>
     <nl-cd-invalid:LegalEntityName contextRef="ctx-1" xml:lang="en">Testing Entity Name</nl-cd-invalid:LegalEntityName>
     <jenv-bw2-i:LegalEntityRegisteredOffice contextRef="ctx-1" xml:lang="en">Address</jenv-bw2-i:LegalEntityRegisteredOffice>
-    <nl-cd-invalid:ChamberOfCommerceRegistrationNumber contextRef="ctx-1" xml:lang="en">12345678</nl-cd-invalid:ChamberOfCommerceRegistrationNumber>
+    <!-- CAUSE: The standard prefix for the nl-common-data namespace is nl-cd-->
+    <nl-cd-invalid2:ChamberOfCommerceRegistrationNumber xmlns:nl-cd-invalid2="http://www.nltaxonomie.nl/nt16/sbr/20210301/dictionary/nl-common-data" contextRef="ctx-1" xml:lang="en">12345678</nl-cd-invalid2:ChamberOfCommerceRegistrationNumber>
     <kvk-i:BusinessNames contextRef="ctx-1" xml:lang="en">Testing Entity Name</kvk-i:BusinessNames>
     <kvk-i:LegalSizeCriteriaClassificationSmall contextRef="ctx-1" xml:lang="en">Klein</kvk-i:LegalSizeCriteriaClassificationSmall>
     <jenv-bw2-i:FinancialReportingPeriodCurrentStartDate contextRef="ctx-1">2021-01-01</jenv-bw2-i:FinancialReportingPeriodCurrentStartDate>

--- a/tests/resources/conformance_suites/nl_nt17/fg_nl/03-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt17/fg_nl/03-invalid.xbrl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- CAUSE: The default prefix for the nl-common-data namespace is nl-cd-->
+<!-- CAUSE: The standard prefix for the nl-common-data namespace is nl-cd-->
 <xbrl
   xml:lang="en"
   xmlns="http://www.xbrl.org/2003/instance"
@@ -38,7 +38,8 @@
     </xbrli:unit>
     <nl-cd-invalid:LegalEntityName contextRef="ctx-1" xml:lang="en">Testing Entity Name</nl-cd-invalid:LegalEntityName>
     <jenv-bw2-i:LegalEntityRegisteredOffice contextRef="ctx-1" xml:lang="en">Address</jenv-bw2-i:LegalEntityRegisteredOffice>
-    <nl-cd-invalid:ChamberOfCommerceRegistrationNumber contextRef="ctx-1" xml:lang="en">12345678</nl-cd-invalid:ChamberOfCommerceRegistrationNumber>
+    <!-- CAUSE: The standard prefix for the nl-common-data namespace is nl-cd-->
+    <nl-cd-invalid2:ChamberOfCommerceRegistrationNumber xmlns:nl-cd-invalid2="http://www.nltaxonomie.nl/nt17/sbr/20220301/dictionary/nl-common-data" contextRef="ctx-1" xml:lang="en">12345678</nl-cd-invalid2:ChamberOfCommerceRegistrationNumber>
     <kvk-i:BusinessNames contextRef="ctx-1" xml:lang="en">Testing Entity Name</kvk-i:BusinessNames>
     <kvk-i:LegalSizeCriteriaClassificationSmall contextRef="ctx-1" xml:lang="en">Klein</kvk-i:LegalSizeCriteriaClassificationSmall>
     <jenv-bw2-i:FinancialReportingPeriodCurrentStartDate contextRef="ctx-1">2021-01-01</jenv-bw2-i:FinancialReportingPeriodCurrentStartDate>

--- a/tests/resources/conformance_suites/nl_nt18/fg_nl/03-invalid.xbrl
+++ b/tests/resources/conformance_suites/nl_nt18/fg_nl/03-invalid.xbrl
@@ -17,5 +17,6 @@
             <xbrli:endDate>2021-12-31</xbrli:endDate>
         </xbrli:period>
     </xbrli:context>
-    <jenv-bw2-x:FinancialReportingPeriodCurrentStartDate contextRef="c-1">2021-01-01</jenv-bw2-x:FinancialReportingPeriodCurrentStartDate>
+    <!-- CAUSE: The default prefix for the jenv-bw2-data namespace is jenv-bw2-i-->
+    <jenv-bw2-x2:FinancialReportingPeriodCurrentStartDate xmlns:jenv-bw2-x2="http://www.nltaxonomie.nl/nt18/jenv/20231213.b/dictionary/jenv-bw2-data" contextRef="c-1">2021-01-01</jenv-bw2-x2:FinancialReportingPeriodCurrentStartDate>
 </xbrli:xbrl>


### PR DESCRIPTION
#### Reason for change
Initial implementation of the validation wasn't accounting for namespace declarations that weren't on the document's root node.

#### Description of change
Collect namespace declarations from all elements to validate for standard prefixes.

#### Steps to Test
CI

**review**:
@Arelle/arelle
