### PR TITLE
Run individual conformance suites via `workflow_dispatch`

### DIFF
--- a/.github/actions/test_conformance_suite/action.yml
+++ b/.github/actions/test_conformance_suite/action.yml
@@ -1,0 +1,58 @@
+name: Test Conformance Suite
+description: Runs pytest against conformance suite runner using given inputs. Adds logs to workflow run.
+inputs:
+  name:
+    description: Name of the conformance suite to run
+    required: true
+  python_version:
+    description: Python version to use
+    required: true
+  shard:
+    description: Optional selection of shards to run (e.g. "0", "0-3")
+    required: false
+  short_name:
+    description: Optional shortened version of name for compact display (defaults to `name`)
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout EdgarRenderer
+      if: ${{ inputs.name == 'efm_current' }}
+      uses: actions/checkout@v4.1.2
+      with:
+        repository: Arelle/EdgarRenderer
+        path: arelle/plugin/EdgarRenderer
+    - name: Install Python 3
+      uses: actions/setup-python@v5.0.0
+      with:
+        cache: 'pip'
+        check-latest: true
+        python-version: ${{ inputs.python_version }}
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install -r requirements-dev.txt
+    - name: Download conformance suites from S3
+      shell: bash
+      run: aws s3 sync s3://arelle/conformance_suites tests/resources/conformance_suites
+    - name: Run integration tests with pytest
+      shell: bash
+      run: pytest -s --disable-warnings --offline --log-to-file --download-cache --name=${{ inputs.name }}${{ inputs.shard && format(' --shard={0}', inputs.shard) || '' }} tests/integration_tests/validation/test_conformance_suites.py
+    - name: Cat logs
+      if: always()
+      shell: bash
+      run: tail -n+1 conf-*log.txt
+    - id: build-artifact-name
+      if: always()
+      shell: bash
+      run: |
+        printf 'artifact-name=%s%s %s %s logs' "${{ inputs.short_name || inputs.name }}" "${{ inputs.shard && format(' {0}', inputs.shard) || '' }}" "${{ runner.os }}" "${{ inputs.python_version }}" >> $GITHUB_OUTPUT
+    - name: Upload logs and reports
+      if: always()
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: ${{ steps.build-artifact-name.outputs.artifact-name }}
+        if-no-files-found: error
+        path: 'conf-*'

--- a/.github/workflows/conformance-suite.yml
+++ b/.github/workflows/conformance-suite.yml
@@ -1,0 +1,45 @@
+name: Run Xbrl Conformance Suite
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: Name of the conformance suite to run
+        required: true
+        type: string
+      os:
+        default: ubuntu-22.04
+        description: Operating system to use
+        required: true
+        type: string
+      python_version:
+        default: 3.12
+        description: Python version to use
+        required: true
+        type: string
+      shard:
+        description: Optional selection of shards to run (e.g. "0", "0-3")
+        required: false
+        type: string
+
+jobs:
+  run-conformance-suite:
+    name: ${{ inputs.name }}${{ inputs.shard && format(':{0}', inputs.shard) || '' }} - ${{ inputs.os }} - ${{ inputs.python_version }}
+    runs-on: ${{ inputs.os }}
+    environment: integration-tests
+    steps:
+      - uses: actions/checkout@v4.1.2
+        with:
+          persist-credentials: false
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-east-1
+      - name: Test Conformance Suite
+        uses: ./.github/actions/test_conformance_suite
+        with:
+          name: ${{ inputs.name }}
+          python_version: ${{ inputs.python_version }}
+          shard: ${{ inputs.shard }}

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -38,53 +38,23 @@ jobs:
       fail-fast: false
       matrix:
         test: ${{ fromJson(needs.find-tests.outputs.matrix) }}
-
     environment: integration-tests
     steps:
+      - uses: actions/checkout@v4.1.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: us-east-1
-      - uses: actions/checkout@v4.1.2
+      - name: Test Conformance Suite
+        uses: ./.github/actions/test_conformance_suite
         with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Checkout EdgarRenderer
-        if: ${{ matrix.test.name == 'efm_current' }}
-        uses: actions/checkout@v4.1.2
-        with:
-          repository: Arelle/EdgarRenderer
-          path: arelle/plugin/EdgarRenderer
-      - name: Install Python 3
-        uses: actions/setup-python@v5.0.0
-        with:
-          cache: 'pip'
-          check-latest: true
-          python-version: ${{ matrix.test.python_version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install -r requirements-dev.txt
-      - name: Download conformance suites from S3
-        run: aws s3 sync s3://arelle/conformance_suites tests/resources/conformance_suites
-      - name: Run integration tests with pytest
-        run: pytest -s --disable-warnings --offline --log-to-file --download-cache --name=${{ matrix.test.name }}${{ matrix.test.shard && format(' --shard={0}', matrix.test.shard) || '' }} tests/integration_tests/validation/test_conformance_suites.py
-      - name: Cat logs
-        if: always()
-        shell: bash
-        run: tail -n+1 conf-*log.txt
-      - id: build-artifact-name
-        if: always()
-        shell: bash
-        run: |
-          printf 'artifact-name=%s%s %s %s logs' "${{ matrix.test.short_name }}" "${{ matrix.test.shard && format(' {0}', matrix.test.shard) || '' }}" "${{ matrix.test.os }}" "${{ matrix.test.python_version }}" >> $GITHUB_OUTPUT
-      - name: Upload logs and reports
-        if: always()
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name: ${{ steps.build-artifact-name.outputs.artifact-name }}
-          if-no-files-found: error
-          path: 'conf-*'
+          name: ${{ matrix.test.name }}
+          python_version: ${{ matrix.test.python_version }}
+          shard: ${{ matrix.test.shard }}
+          short_name: ${{ matrix.test.short_name }}

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -4,6 +4,7 @@ See COPYRIGHT.md for copyright information.
 import fnmatch
 import os, sys, traceback, logging
 import time
+from urllib.parse import unquote
 
 import regex as re
 from collections import defaultdict, OrderedDict
@@ -59,7 +60,7 @@ class Validate:
         patterns = self.modelXbrl.modelManager.formulaOptions.testcaseFilters
         if not patterns:
             return True
-        variationIdPath = f'{modelTestcaseVariation.base}:{modelTestcaseVariation.id}'
+        variationIdPath = f'{unquote(modelTestcaseVariation.base)}:{modelTestcaseVariation.id}'
         for pattern in patterns:
             if fnmatch.fnmatch(variationIdPath, pattern):
                 return True

--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -123,7 +123,7 @@ def get_test_data(
                     if isExpectedFailure(test_id, expected_failure_ids, required_locale_by_ids, system_locale):
                         marks.append(pytest.mark.xfail())
                     elif mv.status == 'skip':
-                        marks.append(pytest.mark.skip())
+                        continue  # don't report variations skipped due to shards
                     param = pytest.param(
                         {
                             'status': mv.status,

--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -21,6 +21,7 @@ class ConformanceSuiteConfig:
     args: list[str] = field(default_factory=list)
     cache_version_id: str | None = None
     capture_warnings: bool = True
+    ci_enabled: bool = True
     expected_failure_ids: frozenset[str] = frozenset()
     expected_model_errors: frozenset[str] = frozenset()
     extract_path: str | None = None

--- a/tests/integration_tests/validation/conformance_suite_configs.py
+++ b/tests/integration_tests/validation/conformance_suite_configs.py
@@ -71,5 +71,5 @@ ALL_CONFORMANCE_SUITE_CONFIGS: tuple[ConformanceSuiteConfig, ...] = (
     xbrl_utr_registry_1_0,
     xbrl_utr_structure_1_0,
 )
-
+CI_CONFORMANCE_SUITE_CONFIGS = tuple(c for c in ALL_CONFORMANCE_SUITE_CONFIGS if c.ci_enabled)
 PUBLIC_CONFORMANCE_SUITE_CONFIGS = tuple(c for c in ALL_CONFORMANCE_SUITE_CONFIGS if c.public_download_url)

--- a/tests/integration_tests/validation/discover_tests.py
+++ b/tests/integration_tests/validation/discover_tests.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from typing import TypedDict
 
 from .conformance_suite_config import ConformanceSuiteConfig
-from .conformance_suite_configs import ALL_CONFORMANCE_SUITE_CONFIGS
+from .conformance_suite_configs import CI_CONFORMANCE_SUITE_CONFIGS
 from .conformance_suite_configurations.efm_current import config as efm_current
 from .conformance_suite_configurations.xbrl_2_1 import config as xbrl_2_1
 
@@ -95,7 +95,7 @@ def generate_config_entries(config: ConformanceSuiteConfig, os: str, python_vers
 def main() -> None:
     output: list[Entry] = []
     config_names_seen: set[str] = set()
-    for config in ALL_CONFORMANCE_SUITE_CONFIGS:
+    for config in CI_CONFORMANCE_SUITE_CONFIGS:
         if config.name in FAST_CONFIG_NAMES:
             assert not config.network_or_cache_required
             assert config.shards == 1
@@ -111,7 +111,7 @@ def main() -> None:
             shard=None,
         ))
 
-    for config in ALL_CONFORMANCE_SUITE_CONFIGS:
+    for config in CI_CONFORMANCE_SUITE_CONFIGS:
         # configurations don't necessarily have unique names, e.g. malformed UTR
         if config.name in config_names_seen:
             continue


### PR DESCRIPTION
#### Reason for change
Preparation for long-running conformance suites that we don't need to run against every PR

#### Description of change
Move core conformance suite workflow steps to composite action. `conformance-suite` and `conformance-suites` then call the same action.

Also fixed some tangentially related errors I encountered:

1. The new filter-based approach to shards had a flaw where the IDs being compared were URL-encoded and thus getting errantly filtered out. Made a fix and added a check to confirm the number of filter args being passed matches the number of non-skipped results from the shard.
1. The testcase discovery process for shards was only grabbing the first `testcases` element found in testcase index files, meaning testcase index files where testcases are grouped into multiple `testcases` elements were not being ran completely. This may have only recently effected `xbrl_formula_1_0`.

#### Steps to Test
CI. May not be able to run via `workflow_dispatch` until after merge.

**review**:
@Arelle/arelle