### PR TITLE
Hook up all KVK validations to NT-18

### DIFF
--- a/arelle/plugin/validate/NL/rules/br_kvk.py
+++ b/arelle/plugin/validate/NL/rules/br_kvk.py
@@ -20,6 +20,7 @@ from arelle.utils.validate.Validation import Validation
 from ..DisclosureSystems import (
     DISCLOSURE_SYSTEM_NT16,
     DISCLOSURE_SYSTEM_NT17,
+    DISCLOSURE_SYSTEM_NT18
 )
 from ..PluginValidationDataExtension import PluginValidationDataExtension
 
@@ -44,6 +45,7 @@ def _getReportingPeriodDateValue(modelXbrl: ModelXbrl, qname: QName) -> date | N
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_br_kvk_2_04(
@@ -120,6 +122,7 @@ def rule_br_kvk_2_04(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_br_kvk_3_01(
@@ -159,6 +162,7 @@ def rule_br_kvk_3_01(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_br_kvk_4_07(
@@ -190,6 +194,7 @@ def rule_br_kvk_4_07(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_br_kvk_4_10(
@@ -221,6 +226,7 @@ def rule_br_kvk_4_10(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_br_kvk_4_12(
@@ -257,6 +263,7 @@ def rule_br_kvk_4_12(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_br_kvk_4_16(
@@ -297,6 +304,7 @@ def rule_br_kvk_4_16(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_br_kvk_4_17(
@@ -328,6 +336,7 @@ def rule_br_kvk_4_17(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_br_kvk_4_20(

--- a/arelle/plugin/validate/NL/rules/fr_kvk.py
+++ b/arelle/plugin/validate/NL/rules/fr_kvk.py
@@ -18,6 +18,7 @@ from lxml.etree import _Element
 from ..DisclosureSystems import (
     DISCLOSURE_SYSTEM_NT16,
     DISCLOSURE_SYSTEM_NT17,
+    DISCLOSURE_SYSTEM_NT18
 )
 from ..PluginValidationDataExtension import PluginValidationDataExtension
 
@@ -33,6 +34,7 @@ ACCEPTED_DECIMAL_VALUES = ('INF', '-9', '-6', '-3', '0', '2')
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_fr_kvk_1_01(
@@ -61,6 +63,7 @@ def rule_fr_kvk_1_01(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_fr_kvk_2_01(
@@ -91,6 +94,7 @@ def rule_fr_kvk_2_01(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_fr_kvk_2_02(
@@ -125,6 +129,7 @@ def rule_fr_kvk_2_02(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_fr_kvk_2_03(
@@ -163,6 +168,7 @@ def rule_fr_kvk_2_03(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_fr_kvk_5_01(
@@ -194,6 +200,7 @@ def rule_fr_kvk_5_01(
     disclosureSystems=[
         DISCLOSURE_SYSTEM_NT16,
         DISCLOSURE_SYSTEM_NT17,
+        DISCLOSURE_SYSTEM_NT18
     ],
 )
 def rule_fr_kvk_5_02(


### PR DESCRIPTION
#### Reason for change
Some validations in the NL validation plugin were not hooked up to the NT-18 disclosure system.

#### Description of change
Hooked all NL KVK validations up to the NT-18 disclosure system

#### Steps to Test
CI

**review**:
@Arelle/arelle
