### PR TITLE
Support writing DTS view to XML

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -189,7 +189,7 @@ def parseArgs(args):
     parser.add_option("--labelRole", "--labelrole", action="store", dest="labelRole",
                       help=_("Label role for labels in following file options (instead of standard label)"))
     parser.add_option("--DTS", "--csvDTS", action="store", dest="DTSFile",
-                      help=_("Write DTS tree into FILE (may be .csv or .html)"))
+                      help=_("Write DTS tree into FILE"))
     parser.add_option("--facts", "--csvFacts", action="store", dest="factsFile",
                       help=_("Write fact list into FILE"))
     parser.add_option("--factListCols", action="store", dest="factListCols",

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -51,6 +51,7 @@ from arelle import (DialogURL, DialogLanguage,
                     ViewWinFactList, ViewFileFactList, ViewWinFactTable, ViewWinRenderedGrid, ViewWinXml,
                     ViewWinRoleTypes, ViewFileRoleTypes, ViewFileConcepts,
                     ViewWinTests, ViewWinTree, ViewWinVersReport, ViewWinRssFeed,
+                    ViewFileDTS,
                     ViewFileFactTable,
                     ViewFileFormulae,
                     ViewFileTests,
@@ -661,6 +662,8 @@ class CntlrWinMain (Cntlr.Cntlr):
                         ViewFileFactTable.viewFacts(modelXbrl, filename, arcrole=view.arcrole, linkrole=view.linkrole, linkqname=view.linkqname, arcqname=view.arcqname, labelrole=view.labelrole, lang=view.lang)
                     elif isinstance(view, ViewWinFormulae.ViewFormulae):
                         ViewFileFormulae.viewFormulae(modelXbrl, filename, "Formulae", lang=view.lang)
+                    elif isinstance(view, ViewWinDTS.ViewDTS):
+                        ViewFileDTS.viewDTS(modelXbrl, filename)
                     else:
                         ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, filename, view.tabTitle, view.arcrole, labelrole=view.labelrole, lang=view.lang)
                 except (IOError, EnvironmentError) as err:

--- a/arelle/ViewFileDTS.py
+++ b/arelle/ViewFileDTS.py
@@ -27,11 +27,16 @@ class ViewDTS(ViewFile.View):
     def viewDtsElement(self, modelDocument, referenceTypes, indent, visited):
         visited.add(modelDocument)
         dtsObjectType = modelDocument.gettype()
-        attr = {"file": modelDocument.basename, "referenceTypes": sorted(referenceTypes)}
+        xmlRowElementName = dtsObjectType
+        referenceTypes = sorted(referenceTypes)
+        if self.type == ViewFile.XML:
+            xmlRowElementName = xmlRowElementName.replace(" ", "-")
+            referenceTypes = " ".join(referenceTypes)
+        attr = {"file": modelDocument.basename, "referenceTypes": referenceTypes}
         if not modelDocument.inDTS:
             attr["inDTS"] = "false"
         self.addRow(["{0} - {1}".format(modelDocument.basename, dtsObjectType)], treeIndent=indent,
-                    xmlRowElementName=dtsObjectType, xmlRowEltAttr=attr, xmlCol0skipElt=True)
+                    xmlRowElementName=xmlRowElementName, xmlRowEltAttr=attr, xmlCol0skipElt=True)
         for referencedDocument, ref in modelDocument.referencesDocument.items():
             if referencedDocument not in visited:
                 self.viewDtsElement(referencedDocument, ref.referenceTypes, indent + 1, visited)


### PR DESCRIPTION
#### Reason for change
Resolves #885  

#### Description of change
Previously, the DTS view did not support the XML format, resulting in an exception rather than prompting users to save to a different file format. Additionally, attempting to save the DTS view from the GUI in any format type caused an exception.

#### Steps to Test
* Verify that an exception is not raised for the following:
	`python arelleCmdLine.py -f https://filings.xbrl.org/529900GSTEOHKA0R1M59/2023-12-31/ESEF/LT/0/invlbalticrealestate-2023-12-31-en.zip --DTS dts.xml`

**review**:
@Arelle/arelle
