### PR TITLE
[FIX] Avoid using id() for the fact aspect cache

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -32,6 +32,8 @@
     measure sets.
 """
 from __future__ import annotations
+
+import uuid
 from collections import defaultdict
 from typing import Any, TYPE_CHECKING
 from lxml import etree
@@ -141,10 +143,12 @@ class ModelFact(ModelObject):
         ([ModelFact]) - List of child facts in source document order
     """
     modelTupleFacts: list['ModelFact']
+    uniqueUUID: uuid.UUID
 
     def init(self, modelDocument):
         super(ModelFact, self).init(modelDocument)
         self.modelTupleFacts = []
+        self.uniqueUUID = uuid.uuid4()
 
     @property
     def concept(self):

--- a/arelle/PrototypeInstanceObject.py
+++ b/arelle/PrototypeInstanceObject.py
@@ -3,6 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 
+import uuid
 from arelle import XmlUtil
 from arelle.ModelDtsObject import ModelConcept
 from arelle.ModelValue import QName
@@ -44,6 +45,7 @@ class FactPrototype():      # behaves like a fact for dimensional validity testi
         else:
             self.unit = None
         self.factObjectId = None
+        self.uniqueUUID = uuid.uuid4()
 
     def clear(self):
         if self.context is not None:

--- a/arelle/formula/FactAspectsCache.py
+++ b/arelle/formula/FactAspectsCache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -8,6 +9,8 @@ from arelle.ModelValue import QName
 if TYPE_CHECKING:
     from arelle.ModelInstanceObject import ModelFact
 
+
+noneUUID = uuid.uuid4()
 
 class FactAspectsCache:
     def __init__(self, maxSize: int) -> None:
@@ -19,7 +22,7 @@ class FactAspectsCache:
         self._size = 0
         self._prioritizedAspects: set[int | QName] = set()
         self._matchingAspects: defaultdict[
-            tuple[int, int],
+            tuple[uuid.UUID, uuid.UUID],
             defaultdict[int | QName, bool | None]
         ] = defaultdict(lambda: defaultdict(lambda: None))
 
@@ -48,9 +51,9 @@ class FactAspectsCache:
         factsCacheKey = self._buildFactKey(fact1, fact2)
         self._matchingAspects[factsCacheKey][aspect] = value
 
-    def _buildFactKey(self, fact1: ModelFact, fact2: ModelFact) -> tuple[int, int]:
-        fact1Id = id(fact1)
-        fact2Id = id(fact2)
+    def _buildFactKey(self, fact1: ModelFact, fact2: ModelFact) -> tuple[uuid.UUID, uuid.UUID]:
+        fact1Id = fact1.uniqueUUID if fact1 is not None else noneUUID
+        fact2Id = fact2.uniqueUUID if fact2 is not None else noneUUID
         return min(fact1Id, fact2Id), max(fact1Id, fact2Id)
 
     def __repr__(self) -> str:

--- a/tests/unit_tests/arelle/formula/test_fact_aspects_cache.py
+++ b/tests/unit_tests/arelle/formula/test_fact_aspects_cache.py
@@ -1,26 +1,37 @@
+import uuid
+
 from arelle.formula.FactAspectsCache import FactAspectsCache
 
+
+class FactTest:
+    def __init__(self, name):
+        self.name = name
+        self.uniqueUUID = uuid.uuid4()
 
 class TestFactAspectsCache:
     def test_match(self):
         cache = FactAspectsCache(10)
-        cache.cacheMatch("fact1", "fact2", "aspect")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        cache.cacheMatch(fact1, fact2, "aspect")
 
-        fact1_evaluations = cache.evaluations("fact1", "fact2")
-        fact2_evaluations = cache.evaluations("fact2", "fact1")
+        fact1_evaluations = cache.evaluations(fact1, fact2)
+        fact2_evaluations = cache.evaluations(fact2, fact1)
 
         assert all(evaluations == {"aspect": True} for evaluations in (fact1_evaluations, fact2_evaluations))
 
     def test_cache_none_values(self):
         cache = FactAspectsCache(10)
 
-        cache.cacheNotMatch(None, "fact2", "aspect")
-        cache.cacheNotMatch("fact1", None, "aspect")
-        cache.cacheNotMatch("fact1", "fact2", None)
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        cache.cacheNotMatch(None, fact2, "aspect")
+        cache.cacheNotMatch(fact1, None, "aspect")
+        cache.cacheNotMatch(fact1, fact2, None)
 
-        fact1_2_evaluations = cache.evaluations("fact1", "fact2")
-        fact1_none_evaluations = cache.evaluations("fact1", None)
-        fact2_none_evaluations = cache.evaluations(None, "fact2")
+        fact1_2_evaluations = cache.evaluations(fact1, fact2)
+        fact1_none_evaluations = cache.evaluations(fact1, None)
+        fact2_none_evaluations = cache.evaluations(None, fact2)
 
         assert fact1_2_evaluations == {
             None: False,
@@ -36,19 +47,23 @@ class TestFactAspectsCache:
 
     def test_non_match(self):
         cache = FactAspectsCache(10)
-        cache.cacheNotMatch("fact1", "fact2", "aspect")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        cache.cacheNotMatch(fact1, fact2, "aspect")
 
-        fact1_evaluations = cache.evaluations("fact1", "fact2")
-        fact2_evaluations = cache.evaluations("fact2", "fact1")
+        fact1_evaluations = cache.evaluations(fact1, fact2)
+        fact2_evaluations = cache.evaluations(fact2, fact1)
 
         assert all(evaluations == {"aspect": False} for evaluations in (fact1_evaluations, fact2_evaluations))
 
     def test_mixed_evaluations(self):
         cache = FactAspectsCache(10)
-        cache.cacheMatch("fact1", "fact2", "aspect1")
-        cache.cacheNotMatch("fact1", "fact2", "aspect2")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        cache.cacheMatch(fact1, fact2, "aspect1")
+        cache.cacheNotMatch(fact1, fact2, "aspect2")
 
-        evaluations = cache.evaluations("fact1", "fact2")
+        evaluations = cache.evaluations(fact1, fact2)
 
         assert evaluations == {
             "aspect1": True,
@@ -58,23 +73,28 @@ class TestFactAspectsCache:
     def test_empty_cache(self):
         cache = FactAspectsCache(10)
 
-        evaluations = cache.evaluations("fact1", "fact2")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        evaluations = cache.evaluations(fact1, fact2)
 
         assert evaluations is None
 
     def test_additional_facts(self):
         cache = FactAspectsCache(10)
 
-        cache.cacheMatch("fact1", "fact2", "aspect1")
-        cache.cacheNotMatch("fact1", "fact2", "aspect2")
-        cache.cacheMatch("fact1", "fact2", "aspect3")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        fact3 = FactTest("fact3")
+        cache.cacheMatch(fact1, fact2, "aspect1")
+        cache.cacheNotMatch(fact1, fact2, "aspect2")
+        cache.cacheMatch(fact1, fact2, "aspect3")
 
-        cache.cacheNotMatch("fact1", "fact3", "aspect1")
-        cache.cacheMatch("fact1", "fact3", "aspect2")
+        cache.cacheNotMatch(fact1, fact3, "aspect1")
+        cache.cacheMatch(fact1, fact3, "aspect2")
 
-        cache.cacheNotMatch("fact2", "fact3", "aspect1")
+        cache.cacheNotMatch(fact2, fact3, "aspect1")
 
-        evaluations = cache.evaluations("fact1", "fact2")
+        evaluations = cache.evaluations(fact1, fact2)
 
         assert evaluations == {
             "aspect1": True,
@@ -84,10 +104,12 @@ class TestFactAspectsCache:
 
     def test_max_size_reached(self):
         cache = FactAspectsCache(2)
-        cache.cacheNotMatch("fact1", "fact2", "aspect1")
-        cache.cacheMatch("fact1", "fact2", "aspect2")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        cache.cacheNotMatch(fact1, fact2, "aspect1")
+        cache.cacheMatch(fact1, fact2, "aspect2")
 
-        evaluations = cache.evaluations("fact1", "fact2")
+        evaluations = cache.evaluations(fact1, fact2)
 
         assert evaluations == {
             "aspect1": False,
@@ -95,9 +117,9 @@ class TestFactAspectsCache:
         }
         assert cache.prioritizedAspects == {"aspect1"}
 
-        cache.cacheNotMatch("fact1", "fact2", "aspect3")
+        cache.cacheNotMatch(fact1, fact2, "aspect3")
 
-        evaluations = cache.evaluations("fact1", "fact2")
+        evaluations = cache.evaluations(fact1, fact2)
 
         assert evaluations == {
             "aspect1": False,
@@ -107,10 +129,12 @@ class TestFactAspectsCache:
 
     def test_negative_max_size(self):
         cache = FactAspectsCache(-1)
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
         for i in range(100):
-            cache.cacheNotMatch("fact1", "fact2", f"aspect{i}")
+            cache.cacheNotMatch(fact1, fact2, f"aspect{i}")
 
-        evaluations = cache.evaluations("fact1", "fact2")
+        evaluations = cache.evaluations(fact1, fact2)
 
         assert evaluations == {
             f"aspect{i}": False
@@ -123,41 +147,51 @@ class TestFactAspectsCache:
 
     def test_zero_max_size(self):
         cache = FactAspectsCache(0)
-        cache.cacheNotMatch("fact1", "fact2", "aspect")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        cache.cacheNotMatch(fact1, fact2, "aspect")
 
-        evaluations = cache.evaluations("fact1", "fact2")
+        evaluations = cache.evaluations(fact1, fact2)
 
         assert evaluations is None
         assert cache.prioritizedAspects == {"aspect"}
 
     def test_clear(self):
         cache = FactAspectsCache(10)
-        cache.cacheMatch("fact1", "fact2", "aspect")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        cache.cacheMatch(fact1, fact2, "aspect")
 
-        evaluations = cache.evaluations("fact1", "fact2")
+        evaluations = cache.evaluations(fact1, fact2)
 
         assert evaluations == {
             "aspect": True,
         }
 
         cache.clear()
-        evaluations = cache.evaluations("fact1", "fact2")
+        evaluations = cache.evaluations(fact1, fact2)
 
         assert evaluations is None
 
     def test_prioritized_aspects(self):
         cache = FactAspectsCache(10)
-        cache.cacheNotMatch("fact1", "fact2", "aspect1")
-        cache.cacheNotMatch("fact1", "fact2", "aspect2")
-        cache.cacheMatch("fact1", "fact2", "aspect3")
-        cache.cacheMatch("fact1", "fact2", "aspect4")
-        cache.cacheNotMatch("fact3", "fact4", "aspect5")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        fact3 = FactTest("fact3")
+        fact4 = FactTest("fact4")
+        cache.cacheNotMatch(fact1, fact2, "aspect1")
+        cache.cacheNotMatch(fact1, fact2, "aspect2")
+        cache.cacheMatch(fact1, fact2, "aspect3")
+        cache.cacheMatch(fact1, fact2, "aspect4")
+        cache.cacheNotMatch(fact3, fact4, "aspect5")
 
         assert cache.prioritizedAspects == {"aspect1", "aspect2", "aspect5"}
 
     def test_prioritized_aspects_clear(self):
         cache = FactAspectsCache(10)
-        cache.cacheNotMatch("fact1", "fact2", "aspect1")
+        fact1 = FactTest("fact1")
+        fact2 = FactTest("fact2")
+        cache.cacheNotMatch(fact1, fact2, "aspect1")
 
         assert cache.prioritizedAspects == {"aspect1"}
 
@@ -165,6 +199,6 @@ class TestFactAspectsCache:
 
         assert cache.prioritizedAspects == set()
 
-        cache.cacheNotMatch("fact1", "fact2", "aspect1")
+        cache.cacheNotMatch(fact1, fact2, "aspect1")
 
         assert cache.prioritizedAspects == {"aspect1"}


### PR DESCRIPTION
#### Reason for change

The `id()` function used in the fact aspect cache can return the same value for different objects, when the first object is freed.
It can be tested with this code:
```
class Test:
    pass

know_ids = []
new_id = id(Test())
while new_id not in know_ids:
    know_ids.append(new_id)
    new_id = id(Test())

print(know_ids)
```
Since the test object is freed as soon as the `id()` function is finished, the second time that a test object is initialized, it will usually take the same memory address, which will give the same output for `id()` 

It might be linked to the OS, I am on Ubuntu 22.04

#### Description of change

The change removed the usage of `id()` in favor of an uuid stored in the ModelFact and FactPrototype.
There might be a better way to do it, but I didn't find an existing attribute that seems to be usable as a unique identifier.

#### Steps to Test

The random behavior is really visible in the table linkbase conformance pr (https://github.com/Arelle/Arelle/pull/1111) where there is a few conformances that will fail randomly. Running the conformance multiple time will make it vary from 6 to 10 from my tests. (6 tests really fails the conformance suite at the moment)
The reason that it's more visible in that branch is because a lot of FactPrototype are created than freed in the new tableLayout. 


**review**:
@Arelle/arelle
