### PR TITLE
Restrict lxml versions that don't throw on absolute paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
           - "*"
     ignore:
       - dependency-name: "cx_Freeze"
+      - dependency-name: "lxml"
+        versions:
+          - ">5.1.0"
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/arelle/XhtmlValidate.py
+++ b/arelle/XhtmlValidate.py
@@ -85,7 +85,7 @@ def xhtmlValidate(modelXbrl: ModelXbrl, elt: ModelObject) -> None:
     XmlValidate.lxmlSchemaValidate(elt.modelDocument, inlineSchema)
 
     # lxml bug: doesn't detect: class="" (min length 1)
-    for e in elt.getroottree().iterfind("//{http://www.w3.org/1999/xhtml}*[@class='']"):
+    for e in elt.getroottree().iterfind(".//{http://www.w3.org/1999/xhtml}*[@class='']"):
         modelXbrl.error("arelle:xhtmlClassError",
             _("Attribute class must not be empty on element ix:%(element)s"),
             modelObject=e, element=e.localName)
@@ -100,7 +100,7 @@ def xhtmlValidate(modelXbrl: ModelXbrl, elt: ModelObject) -> None:
 
 
 def containsNamespacedElements(elt: etree.ElementBase, namespace: str) -> bool:
-    return elt.getroottree().find("//ns:*", {"ns": namespace}) is not None
+    return elt.getroottree().find(".//ns:*", {"ns": namespace}) is not None
 
 
 def resolveHtmlUri(elt, name, value):

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -1073,7 +1073,7 @@ def xpointerElement(modelDocument: ModelDocument, fragmentIdentifier: str) -> et
             if scheme in modelDocument.idObjects:
                 node = modelDocument.idObjects.get(scheme)
             else:
-                node = modelDocument.xmlDocument.find("//*[@id='{0}']".format(scheme))
+                node = modelDocument.xmlDocument.find(".//*[@id='{0}']".format(scheme))
             if node is not None:
                 return node    # this scheme fails
         elif scheme == "element" and parenPart and path:
@@ -1083,7 +1083,7 @@ def xpointerElement(modelDocument: ModelDocument, fragmentIdentifier: str) -> et
                 if id in modelDocument.idObjects:
                     node = modelDocument.idObjects.get(id)
                 else:
-                    node = modelDocument.xmlDocument.find("//*[@id='{0}']".format(id))
+                    node = modelDocument.xmlDocument.find(".//*[@id='{0}']".format(id))
                 if node is None:
                     continue    # this scheme fails
                 elif len(pathParts) > 1:

--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -3018,7 +3018,7 @@ def validateFinally(val, *args, **kwargs):
                                     _("Footnotes MUST have standard footnote resource role, %(role)s is disallowed, %(label)s: %(value)s"),
                                     modelObject=elt, role=elt.role, label=elt.xlinkLabel, value=elt.xValue[:100])
         # xml base on anything
-        for elt in modelXbrl.modelDocument.xmlRootElement.getroottree().iterfind("//{*}*[@{http://www.w3.org/XML/1998/namespace}base]"):
+        for elt in modelXbrl.modelDocument.xmlRootElement.getroottree().iterfind(".//{*}*[@{http://www.w3.org/XML/1998/namespace}base]"):
             modelXbrl.error("xbrlxe:unsupportedXmlBase",
                             _("Instance MUST NOT contain xml:base attributes: element %(qname)s, xml:base %(base)s"),
                             modelObject=elt, qname=elt.qname if isinstance(elt, ModelObject) else elt.tag,

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -2999,7 +2999,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
         unexpectedRedactElts = []
         docTypeAllowsRedact = deiDocumentType in docTypesAllowingRedact
         for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
-            for ixElt in ixdsHtmlRootElt.getroottree().iterfind("//{http://www.w3.org/1999/xhtml}*[@style]"):
+            for ixElt in ixdsHtmlRootElt.getroottree().iterfind(".//{http://www.w3.org/1999/xhtml}*[@style]"):
                 style = ixElt.get("style","")
                 hiddenFactRefMatch = styleIxHiddenPattern.match(style)
                 if hiddenFactRefMatch:

--- a/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
@@ -424,7 +424,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                 hiddenEltIds[ixElt.id] = ixElt
                             ixHiddenFacts.add(ixElt)
                 # maliciously hidden facts
-                for cssHiddenElt in ixdsHtmlRootElt.getroottree().iterfind("//{http://www.w3.org/1999/xhtml}*[@style]"):
+                for cssHiddenElt in ixdsHtmlRootElt.getroottree().iterfind(".//{http://www.w3.org/1999/xhtml}*[@style]"):
                     if styleCssHiddenPattern.match(cssHiddenElt.get("style","")):
                         for tag in (ixNStag + "nonNumeric", ixNStag+"nonFraction"):
                             for ixElt in cssHiddenElt.iterdescendants(tag=tag):
@@ -447,7 +447,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     countEligible=len(eligibleForTransformHiddenFacts),
                     elements=", ".join(sorted(set(str(f.qname) for f in eligibleForTransformHiddenFacts))))
             for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
-                for ixElt in ixdsHtmlRootElt.getroottree().iterfind("//{http://www.w3.org/1999/xhtml}*[@style]"):
+                for ixElt in ixdsHtmlRootElt.getroottree().iterfind(".//{http://www.w3.org/1999/xhtml}*[@style]"):
                     hiddenFactRefMatch = styleIxHiddenPattern.match(ixElt.get("style",""))
                     if hiddenFactRefMatch:
                         hiddenFactRef = hiddenFactRefMatch.group(2)

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -462,7 +462,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                 hiddenEltIds[ixElt.id] = ixElt
                             ixHiddenFacts.add(ixElt)
                 # maliciously hidden facts
-                for cssHiddenElt in ixdsHtmlRootElt.getroottree().iterfind("//{http://www.w3.org/1999/xhtml}*[@style]"):
+                for cssHiddenElt in ixdsHtmlRootElt.getroottree().iterfind(".//{http://www.w3.org/1999/xhtml}*[@style]"):
                     if styleCssHiddenPattern.match(cssHiddenElt.get("style","")):
                         for tag in (ixNStag + "nonNumeric", ixNStag+"nonFraction"):
                             for ixElt in cssHiddenElt.iterdescendants(tag=tag):
@@ -485,7 +485,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     countEligible=len(eligibleForTransformHiddenFacts),
                     elements=", ".join(sorted(set(str(f.qname) for f in eligibleForTransformHiddenFacts))))
             for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
-                for ixElt in ixdsHtmlRootElt.getroottree().iterfind("//{http://www.w3.org/1999/xhtml}*[@style]"):
+                for ixElt in ixdsHtmlRootElt.getroottree().iterfind(".//{http://www.w3.org/1999/xhtml}*[@style]"):
                     styleValue = ixElt.get("style","")
                     hiddenFactRefMatch = styleIxHiddenPattern.match(styleValue)
 

--- a/arelle/plugin/xbrlDB/XbrlSemanticJsonDB.py
+++ b/arelle/plugin/xbrlDB/XbrlSemanticJsonDB.py
@@ -215,7 +215,7 @@ class XbrlSemanticJsonDatabaseConnection():
         if isinstance(results, str) and query is not None:
             parser = etree.HTMLParser()
             htmlDoc = etree.parse(io.StringIO(results), parser)
-            body = htmlDoc.find("//body")
+            body = htmlDoc.find(".//body")
             if body is not None:
                 error = "".join(text for text in body.itertext())
             else:

--- a/arelle/plugin/xbrlDB/XbrlSemanticRdfDB.py
+++ b/arelle/plugin/xbrlDB/XbrlSemanticRdfDB.py
@@ -282,7 +282,7 @@ class XbrlSemanticRdfDatabaseConnection():
         if isinstance(results, str) and query is not None:
             parser = etree.HTMLParser()
             htmlDoc = etree.parse(io.StringIO(results), parser)
-            body = htmlDoc.find("//body")
+            body = htmlDoc.find(".//body")
             if body is not None:
                 error = "".join(text for text in body.itertext())
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.8"
 dependencies = [
     'certifi',
     'isodate==0.*',
-    'lxml>=4,<6',
+    'lxml>=4,<=5.1.0',
     'numpy==1.*',
     'openpyxl==3.*',
     'pyparsing==3.*',


### PR DESCRIPTION
#### Reason for change
This PR addresses an issue identified with the use of absolute paths in lxml versions prior to 5.1.1, which can lead to misleading search paths when using ElementTree.iterfind, ElementTree.find, and ElementTree.findall. For more context, refer to the [lxml bug #2059977](https://bugs.launchpad.net/lxml/+bug/2059977).

In versions of lxml prior to 5.1.1, using absolute paths with the mentioned methods would only match child elements, not including the root element, which could lead to misleading element matching. Starting with version 5.1.1, an attempt was made to issue a warning for such usage, but due to a bug, a SyntaxError is thrown instead.

Example demonstrating the issue:

```python
from lxml import etree

xml_string = """
<concept>
    <concept>Content 1</concept>
    <concept>Content 2</concept>
</concept>
"""

root_tree = etree.fromstring(xml_string).getroottree()
concept_iterator = root_tree.iterfind("//concept")
print(len(list(concept_iterator)))

```

1. With lxml version 5.1.0, the script outputs 2, indicating it only finds child elements.
2. With lxml version 5.1.1, a SyntaxError is raised when executing root_tree.iterfind("//concept").

#### Description of change
* This PR modifies the code to use relative paths when utilizing ElementTree methods, ensuring that searches are explicitly limited to child elements.
* It also introduces version constraints on lxml to prevent the use of versions that throw syntax exceptions due to the aforementioned bug. This is a temporary measure until dependent plugins, such as EdgarRenderer, are also updated.

#### Steps to Test
* CI 

**review**:
@Arelle/arelle
