### PR TITLE
Update to lxml version with iterfind fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,6 @@ updates:
           - "*"
     ignore:
       - dependency-name: "cx_Freeze"
-      - dependency-name: "lxml"
-        versions:
-          - ">5.1.0"
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.8"
 dependencies = [
     'certifi',
     'isodate==0.*',
-    'lxml>=4,<=5.1.0',
+    'lxml>=4,<6',
     'numpy==1.*',
     'openpyxl==3.*',
     'pyparsing==3.*',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core modules
 certifi==2024.2.2
-lxml==5.1.0
+lxml==5.2.1
 OpenPyXL==3.1.2
 pyparsing==3.1.2
 regex==2023.12.25


### PR DESCRIPTION
#### Reason for change
5.2.1 [release notes](https://github.com/lxml/lxml/releases/tag/lxml-5.2.1):
> LP#2059977: Element.iterfind("//absolute_path") failed with a SyntaxError where it should have issued a warning.

#### Description of change
lxml 5.2.1 was just released with a patch for our reported issue.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
