### PR TITLE
Add plugin data to cntlr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tests/resources/conformance_suites/*
 !tests/resources/conformance_suites/dba/
 !tests/resources/conformance_suites/hmrc/
 !tests/resources/conformance_suites/nl_*/
+tests/resources/packages/
 
 ### IDE-specific ignores
 

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -28,6 +28,7 @@ from arelle.BetaFeatures import BETA_FEATURES_AND_DESCRIPTIONS
 from arelle.SystemInfo import PlatformOS, getSystemWordSize, hasFileSystem, hasWebServer, isCGI, isGAE
 from arelle.WebCache import WebCache
 from arelle.typing import TypeGetText
+from arelle.utils.PluginData import PluginData
 
 _: TypeGetText
 
@@ -177,6 +178,7 @@ class Cntlr:
         self.imagesDir = os.path.join(_resourcesDir, "images")
         self.localeDir = os.path.join(_resourcesDir, "locale")
         self.pluginDir = os.path.join(_resourcesDir, "plugin")
+        self.__pluginData: dict[str, PluginData] = {}
         if cxFrozen:
             # some cx_freeze versions set this variable, which is incompatible with matplotlib after v3.1
             os.environ.pop("MATPLOTLIBDATA", None)
@@ -628,6 +630,17 @@ class Cntlr:
                 # The file exists in cache, we can proceed despite working offline
                 return True
         return False
+
+    def getPluginData(self, pluginName: str) -> PluginData | None:
+        return self.__pluginData.get(pluginName)
+
+    def setPluginData(self, pluginData: PluginData) -> None:
+        if pluginData.name in self.__pluginData:
+            raise RuntimeError(f"PluginData already set on Cntlr for {pluginData.name}.")
+        self.__pluginData[pluginData.name] = pluginData
+
+    def _clearPluginData(self) -> None:
+        self.__pluginData.clear()
 
 
 def logRefsFileLines(refs: list[dict[str, Any]]) -> str:

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -6,15 +6,14 @@ This module is Arelle's controller in command line non-interactive mode
 See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
-from arelle import PythonUtil, ValidateDuplicateFacts  # define 2.x or 3.x string types
+from arelle import ValidateDuplicateFacts
 import gettext, time, datetime, os, shlex, sys, traceback, fnmatch, threading, json, logging, platform
 from optparse import OptionGroup, OptionParser, SUPPRESS_HELP
 import regex as re
 from arelle import (Cntlr, FileSource, ModelDocument, RenderingEvaluator, XmlUtil, XbrlConst, Version,
                     ViewFileDTS, ViewFileFactList, ViewFileFactTable, ViewFileConcepts,
                     ViewFileFormulae, ViewFileRelationshipSet, ViewFileTests, ViewFileRssFeed,
-                    ViewFileRoleTypes,
-                    ModelManager)
+                    ViewFileRoleTypes)
 from arelle.RuntimeOptions import RuntimeOptions, RuntimeOptionsException
 from arelle.BetaFeatures import BETA_FEATURES_AND_DESCRIPTIONS
 from arelle.ModelValue import qname
@@ -32,6 +31,7 @@ from pprint import pprint
 import logging
 from lxml import etree
 import glob
+
 win32file = win32api = win32process = pywintypes = None
 STILL_ACTIVE = 259 # MS Windows process status constants
 PROCESS_QUERY_INFORMATION = 0x400
@@ -1154,6 +1154,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
             for pluginXbrlMethod in pluginClassMethods("CntlrCmdLine.Filing.End"):
                 pluginXbrlMethod(self, options, filesource, _entrypointFiles, sourceZipStream=sourceZipStream, responseZipStream=responseZipStream)
         self.username = self.password = None #dereference password
+        self._clearPluginData()
 
         if options.statusPipe and getattr(self, "statusPipe", None) is not None:
             win32file.WriteFile(self.statusPipe, b" ")  # clear status

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -1026,6 +1026,8 @@ class CntlrWinMain (Cntlr.Cntlr):
         if not self.okayToContinue():
             return
         self.modelManager.close()
+        if not self.modelManager.loadedModelXbrls:
+            self._clearPluginData()
         self.parent.title(_("arelle - Unnamed"))
         self.setValidateTooltipText()
         self.currentView = None

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -1132,7 +1132,7 @@ class ValidateXbrl:
         allPluginData = getattr(self, "_pluginData", None)
         if allPluginData is None:
             raise RuntimeError("PluginData can't be retrieved until validation has begun.")
-        pluginData: PluginValidationData = allPluginData.get(pluginName)
+        pluginData: PluginValidationData | None = allPluginData.get(pluginName)
         return pluginData
 
     def setPluginData(self, pluginData: PluginValidationData) -> None:

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -24,7 +24,7 @@ from arelle.XhtmlValidate import ixMsgCode
 from arelle.XmlValidateConst import VALID
 from collections import defaultdict
 from arelle.typing import TypeGetText
-from arelle.utils.validate.PluginValidationData import PluginValidationData
+from arelle.utils.PluginData import PluginData
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelDtsObject import ModelRelationship
 from arelle.ModelFormulaObject import ModelCustomFunctionSignature
@@ -119,7 +119,7 @@ class ValidateXbrl:
         self.validateIXDS = False # set when any inline document found
         self.validateEnum = bool(XbrlConst.enums & modelXbrl.namespaceDocs.keys())
         self.validateDuplicateFacts = modelXbrl.modelManager.validateDuplicateFacts
-        self._pluginData: dict[str, PluginValidationData] = {}
+        self._pluginData: dict[str, PluginData] = {}
 
         for pluginXbrlMethod in pluginClassMethods("Validate.XBRL.Start"):
             pluginXbrlMethod(self, parameters)
@@ -1128,14 +1128,14 @@ class ValidateXbrl:
         self.modelXbrl = modelXbrl
         ValidateFormula.executeCallTest(self, name, callTuple, testTuple)
 
-    def getPluginData(self, pluginName: str) -> PluginValidationData | None:
+    def getPluginData(self, pluginName: str) -> PluginData | None:
         allPluginData = getattr(self, "_pluginData", None)
         if allPluginData is None:
             raise RuntimeError("PluginData can't be retrieved until validation has begun.")
-        pluginData: PluginValidationData | None = allPluginData.get(pluginName)
+        pluginData: PluginData | None = allPluginData.get(pluginName)
         return pluginData
 
-    def setPluginData(self, pluginData: PluginValidationData) -> None:
+    def setPluginData(self, pluginData: PluginData) -> None:
         allPluginData = getattr(self, "_pluginData", None)
         if allPluginData is None:
             raise RuntimeError("PluginData can't be set until validation has begun.")

--- a/arelle/examples/plugin/validate/XYZ/PluginValidationDataExtension.py
+++ b/arelle/examples/plugin/validate/XYZ/PluginValidationDataExtension.py
@@ -3,8 +3,8 @@ See COPYRIGHT.md for copyright information.
 """
 from __future__ import annotations
 
-from arelle.utils.validate.PluginValidationData import PluginValidationData
+from arelle.utils.PluginData import PluginData
 
 
-class PluginValidationDataExtension(PluginValidationData):
+class PluginValidationDataExtension(PluginData):
     positiveFactConcepts: set[str] | None = None

--- a/arelle/plugin/validate/DBA/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/DBA/PluginValidationDataExtension.py
@@ -4,12 +4,12 @@ See COPYRIGHT.md for copyright information.
 from __future__ import annotations
 
 from arelle.ModelValue import qname, QName
-from arelle.utils.validate.PluginValidationData import PluginValidationData
+from arelle.utils.PluginData import PluginData
 
 
 NAMESPACE_GSD = 'http://xbrl.dcca.dk/gsd'
 
 
-class PluginValidationDataExtension(PluginValidationData):
+class PluginValidationDataExtension(PluginData):
     reportingPeriodEndDateQn: QName = qname(f'{{{NAMESPACE_GSD}}}ReportingPeriodEndDate')
     reportingPeriodStartDateQn: QName = qname(f'{{{NAMESPACE_GSD}}}ReportingPeriodStartDate')

--- a/arelle/plugin/validate/NL/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/NL/PluginValidationDataExtension.py
@@ -9,11 +9,11 @@ from dataclasses import dataclass
 from arelle.ModelInstanceObject import ModelUnit, ModelContext, ModelFact
 from arelle.ModelValue import QName
 from arelle.ModelXbrl import ModelXbrl
-from arelle.utils.validate.PluginValidationData import PluginValidationData
+from arelle.utils.PluginData import PluginData
 
 
 @dataclass
-class PluginValidationDataExtension(PluginValidationData):
+class PluginValidationDataExtension(PluginData):
     financialReportingPeriodCurrentStartDateQn: QName
     financialReportingPeriodCurrentEndDateQn: QName
     financialReportingPeriodPreviousStartDateQn: QName

--- a/arelle/utils/PluginData.py
+++ b/arelle/utils/PluginData.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class PluginData:
+    """
+    Base dataclass which should be extended with fields by plugins that need to cache data while processing a report.
+    """
+    name: str

--- a/arelle/utils/validate/PluginValidationData.py
+++ b/arelle/utils/validate/PluginValidationData.py
@@ -1,9 +1,0 @@
-from dataclasses import dataclass
-
-
-@dataclass
-class PluginValidationData:
-    """
-    Base dataclass which should be extended with fields by plugins that need to cache data between validation rules.
-    """
-    name: str

--- a/arelle/utils/validate/ValidationPlugin.py
+++ b/arelle/utils/validate/ValidationPlugin.py
@@ -18,7 +18,7 @@ from arelle.utils.validate.Decorator import (
     ValidationFunction,
     getValidationAttributes,
 )
-from arelle.utils.validate.PluginValidationData import PluginValidationData
+from arelle.utils.PluginData import PluginData
 
 
 class ValidationPlugin:
@@ -33,7 +33,7 @@ class ValidationPlugin:
         Base validation plugin class. Can be initialized directly, or extended if you require additional plugin hooks.
         This class is intended to be used in conjunction with the [@validation](#arelle.utils.validate.Decorator.validation) decorator.
 
-        If you need to cache or store data between rules, you should implement a dataclass that extends [PluginValidationData](#arelle.utils.validate.PluginValidationData.PluginValidationData)
+        If you need to cache or store data between rules, you should implement a dataclass that extends [PluginData](#arelle.utils.PluginData.PluginData)
         and override the [newPluginData](#newPluginData) method to return your dataclass.
 
         :param disclosureSystemConfigUrl: A path to the plugin disclosure system xml config file.
@@ -55,14 +55,14 @@ class ValidationPlugin:
             ValidationHook, dict[ValidationFunction, set[str]]
         ] = {}
 
-    def newPluginData(self, validateXbrl: ValidateXbrl) -> PluginValidationData:
+    def newPluginData(self, validateXbrl: ValidateXbrl) -> PluginData:
         """
         Returns a dataclass intended to be overriden by plugins to facilitate caching and passing data between rule functions.
         The default implementation doesn't provide any fields other than the plugin name.
 
-        :return: An instance of PluginValidationData.
+        :return: An instance of PluginData.
         """
-        return PluginValidationData(self.name)
+        return PluginData(self.name)
 
     @property
     def validationTypes(self) -> tuple[str, ...]:


### PR DESCRIPTION
#### Reason for change
The Arelle viewer currently keeps models open for ixds support (see Arelle/ixbrl-viewer/issues/653). When used with the webserver this causes models to not be closed.

#### Description of change
* Rename validation plugin data to more generic plugin data.
* Allow plugins to access their own data beyond the life of validations (validation data still works the same way).
* Make sure plugin data is cleared after processing.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
