### PR TITLE
Configure relevant conformance suites with public assets

### DIFF
--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import locale
 import os.path
 import re
+import urllib.parse
 from collections import Counter
 from pathlib import PurePath
 from typing import TYPE_CHECKING, cast
@@ -64,6 +65,7 @@ def get_document_id_from_basepath(doc: ModelDocument.ModelDocument, basepath: st
 
 
 def get_s3_uri(path: str, version_id: str | None = None) -> str:
+    path = urllib.parse.quote(path)
     uri = f'https://arelle-public.s3.amazonaws.com/{path}'
     if version_id is not None:
         uri += f'?versionId={version_id}'

--- a/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath, Path
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
     additional_plugins_by_prefix=[(f'conf/{t}', frozenset({'EdgarRenderer'})) for t in [
@@ -15,6 +15,7 @@ config = ConformanceSuiteConfig(
             Path('efm-69-240318.zip'),
             entry_point=Path('conf/testcases.xml'),
             public_download_url='https://www.sec.gov/files/edgar/efm-69-240318.zip',
+            source=AssetSource.S3_PUBLIC,
         )
     ],
     cache_version_id='p7LKRmAEYKJ8jIxUUWMpYFzZjH2DD78u',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
@@ -2,7 +2,7 @@ from pathlib import PurePath, Path
 
 from tests.integration_tests.validation.assets import ESEF_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import (
-    ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+    ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
 
 config = ConformanceSuiteConfig(
@@ -15,6 +15,7 @@ config = ConformanceSuiteConfig(
             Path('esef_conformance_suite_2021.zip'),
             entry_point=Path('esef_conformance_suite_2021/esef_conformance_suite_2021/index_inline_xbrl.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2021.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ] + [
         package for year in [2017, 2019, 2020, 2021] for package in ESEF_PACKAGES[year]

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
@@ -2,7 +2,7 @@ from pathlib import PurePath, Path
 
 from tests.integration_tests.validation.assets import ESEF_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import (
-    ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+    ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
 config = ConformanceSuiteConfig(
     args=[
@@ -14,6 +14,7 @@ config = ConformanceSuiteConfig(
             Path('esef_conformance_suite_2022.zip'),
             entry_point=Path('esef_conformance_suite_2022/index_inline_xbrl.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2022.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ] + [
         package for year in [2017, 2019, 2020, 2021, 2022] for package in ESEF_PACKAGES[year]

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
@@ -2,7 +2,7 @@ from pathlib import PurePath, Path
 
 from tests.integration_tests.validation.assets import ESEF_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import (
-    ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+    ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
 config = ConformanceSuiteConfig(
     args=[
@@ -14,6 +14,7 @@ config = ConformanceSuiteConfig(
             Path('esef_conformance_suite_2023.zip'),
             entry_point=Path('index_inline_xbrl.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/2023-12/esef_conformance_suite_2023.zip',
+            source=AssetSource.S3_PUBLIC,
         )
     ] + [
         package for year in [2017, 2019, 2020, 2021, 2022] for package in ESEF_PACKAGES[year]

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2021.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath, Path
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
     args=[
@@ -11,6 +11,7 @@ config = ConformanceSuiteConfig(
             Path('esef_conformance_suite_2021.zip'),
             entry_point=Path('esef_conformance_suite_2021/esef_conformance_suite_2021/index_pure_xhtml.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2021.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ],
     info_url='https://www.esma.europa.eu/document/conformance-suite-2021',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath, Path
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
     args=[
@@ -11,6 +11,7 @@ config = ConformanceSuiteConfig(
             Path('esef_conformance_suite_2022.zip'),
             entry_point=Path('esef_conformance_suite_2022/index_pure_xhtml.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2022.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ],
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2022',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2023.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath, Path
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
     args=[
@@ -11,6 +11,7 @@ config = ConformanceSuiteConfig(
             Path('esef_conformance_suite_2023.zip'),
             entry_point=Path('index_pure_xhtml.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/2023-12/esef_conformance_suite_2023.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ],
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2023',

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt16.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt16.py
@@ -1,7 +1,7 @@
 from pathlib import PurePath, Path
 
 from tests.integration_tests.validation.assets import NL_PACKAGES
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 ZIP_PATH = Path('NT16_KVK_20211208 Berichten_0.zip')
 # needs to be extracted because arelle can't load a taxonomy package ZIP from within a ZIP
@@ -17,6 +17,7 @@ config = ConformanceSuiteConfig(
             entry_point_root=EXTRACTED_PATH / 'berichten' / 'NT16_KVK_20211208 - Testsuite.zip',
             entry_point=Path('testcases.xml'),
             public_download_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/NT16_KVK_20211208%20Berichten_0.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
         *NL_PACKAGES['NT16'],
     ],

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt17.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt17.py
@@ -1,7 +1,7 @@
 from pathlib import PurePath, Path
 
 from tests.integration_tests.validation.assets import NL_PACKAGES
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 ZIP_PATH = Path('NT17_KVK_20221214 Berichten.zip')
 # needs to be extracted because arelle can't load a taxonomy package ZIP from within a ZIP
@@ -17,6 +17,7 @@ config = ConformanceSuiteConfig(
             entry_point_root=EXTRACTED_PATH / 'berichten' / 'NT17_KVK_20221214 - Testsuite.zip',
             entry_point=Path('testcases.xml'),
             public_download_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/NT17_KVK_20221214%20Berichten.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
         *NL_PACKAGES['NT17'],
     ],

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt18.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt18.py
@@ -1,7 +1,7 @@
 from pathlib import PurePath, Path
 
 from tests.integration_tests.validation.assets import NL_PACKAGES
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 ZIP_PATH = Path('NT18_KVK_20231213 Berichten.zip')
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
@@ -16,6 +16,7 @@ config = ConformanceSuiteConfig(
             entry_point_root=EXTRACTED_PATH / 'berichten' / 'NT18_KVK_20231213 - Test-suite.zip',
             entry_point=Path('testcases.xml'),
             public_download_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/NT18_KVK_20231213%20Berichten.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
         *NL_PACKAGES['NT18'],
     ],

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_2_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_2_1.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath, Path
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
     args=[
@@ -11,6 +11,7 @@ config = ConformanceSuiteConfig(
             Path('XBRL-CONF-2014-12-10.zip'),
             entry_point=Path('XBRL-CONF-2014-12-10/xbrl.xml'),
             public_download_url='https://www.xbrl.org/2014/XBRL-CONF-2014-12-10.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ],
     expected_failure_ids=frozenset(f'XBRL-CONF-2014-12-10/Common/{s}' for s in [

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_dimensions_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_dimensions_1_0.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath, Path
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
     assets=[
@@ -7,6 +7,7 @@ config = ConformanceSuiteConfig(
             Path('xdt-conf-cr4-2009-10-06.zip'),
             entry_point=Path('xdt.xml'),
             public_download_url='https://www.xbrl.org/2009/xdt-conf-cr4-2009-10-06.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ],
     args=[

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_extensible_enumerations_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_extensible_enumerations_1_0.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath, Path
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
     assets=[
@@ -7,6 +7,7 @@ config = ConformanceSuiteConfig(
             Path('extensible-enumerations-CONF-2014-10-29.zip'),
             entry_point=Path('extensible-enumerations-CONF-2014-10-29/enumerations-index.xml'),
             public_download_url='https://www.xbrl.org/2014/extensible-enumerations-CONF-2014-10-29.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ],
     info_url='https://specifications.xbrl.org/work-product-index-extensible-enumerations-extensible-enumerations-1.0.html',

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_ixbrl_1_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_ixbrl_1_1.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import (
-    CONFORMANCE_SUITE_PATH_PREFIX, ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+    CONFORMANCE_SUITE_PATH_PREFIX, ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
 
 ZIP_PATH = Path('inlineXBRL-1.1-conformanceSuite-2020-04-08.zip')
@@ -18,6 +18,7 @@ config = ConformanceSuiteConfig(
             entry_point_root=EXTRACTED_PATH,
             entry_point=Path('inlineXBRL-1.1-conformanceSuite-2020-04-08/index.xml'),
             public_download_url='https://www.xbrl.org/2020/inlineXBRL-1.1-conformanceSuite-2020-04-08.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ],
     capture_warnings=False,

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_table_linkbase_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_table_linkbase_1_0.py
@@ -1,5 +1,5 @@
 from pathlib import PurePath, Path
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
     assets=[
@@ -7,6 +7,7 @@ config = ConformanceSuiteConfig(
             Path('table-linkbase-conf-2015-08-12.zip'),
             entry_point=Path('table-linkbase-conf-2015-08-12/conf/testcases-index.xml'),
             public_download_url='https://www.xbrl.org/2015/table-linkbase-conf-2015-08-12.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ],
     expected_failure_ids=frozenset(f'table-linkbase-conf-2015-08-12/conf/tests/{s}' for s in [

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_malformed_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_malformed_1_0.py
@@ -1,6 +1,6 @@
 from pathlib import PurePath, Path
 
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 from tests.integration_tests.validation.conformance_suite_configurations.xbrl_utr_structure_1_0 import config as structure_config
 
 ENTRY_POINT_ROOT = structure_config.entry_point_asset.entry_point_root
@@ -27,6 +27,7 @@ configs = [
                 ENTRY_POINT_ROOT,
                 entry_point=Path('conf/utr-structure/tests/01-simple/simpleValid.xml'),
                 public_download_url=structure_config.entry_point_asset.public_download_url,
+                source=AssetSource.S3_PUBLIC,
             ),
         ],
         expected_model_errors=frozenset(expected_model_errors),

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_registry_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_registry_1_0.py
@@ -14,10 +14,11 @@ config = ConformanceSuiteConfig(
             Path('utr/registry/utr-conf-cr-2013-05-17.zip'),
             entry_point=Path('utr-conf-cr-2013-05-17/2013-05-17/index.xml'),
             public_download_url='https://www.xbrl.org/utr/utr-conf-cr-2013-05-17.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
         ConformanceSuiteAssetConfig(
             local_filename=Path('utr/registry/utr.xml'),
-            source=AssetSource.S3_PRIVATE,
+            source=AssetSource.S3_PUBLIC,
             type=AssetType.CONFORMANCE_SUITE,
             public_download_url='https://www.xbrl.org/utr/utr.xml',
             s3_key='utr/registry/utr.xml',

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_structure_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_structure_1_0.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import (
-    CONFORMANCE_SUITE_PATH_PREFIX, ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+    CONFORMANCE_SUITE_PATH_PREFIX, ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
 
 ZIP_PATH = 'utr/structure/utr-structure-conf-cr-2013-11-18.zip'
@@ -15,6 +15,7 @@ config = ConformanceSuiteConfig(
             Path(ZIP_PATH),
             entry_point=Path('conf/utr-structure/index.xml'),
             public_download_url='https://www.xbrl.org/2013/utr-structure-conf-cr-2013-11-18.zip',
+            source=AssetSource.S3_PUBLIC,
         ),
     ],
     info_url='https://specifications.xbrl.org/work-product-index-registries-units-registry-1.0.html',

--- a/tests/integration_tests/validation/download_assets.py
+++ b/tests/integration_tests/validation/download_assets.py
@@ -72,7 +72,9 @@ def _download_public_s3_asset(asset: ConformanceSuiteAssetConfig) -> None:
     """
     key = asset.s3_key
     assert key is not None
-    if asset.type == AssetType.CACHE_PACKAGE:
+    if asset.type == AssetType.CONFORMANCE_SUITE:
+        key = f'ci/conformance_suites/{key}'
+    elif asset.type == AssetType.CACHE_PACKAGE:
         key = f'ci/caches/conformance_suites/{key}'
     elif asset.type == AssetType.TAXONOMY_PACKAGE:
         key = f'ci/taxonomy_packages/{key}'


### PR DESCRIPTION
#### Reason for change
Some of the conformance suite assets currently downloaded from our private S3 bucket do not actually need to be private. By downloading from the public S3 bucket, we don't need to approve runs of these conformance suites.

#### Steps to Test
CI (affected suites should run and pass without approval)

**review**:
@Arelle/arelle
