### PR TITLE
Limit EFM severity releveler to EFM disclosure systems active

### DIFF
--- a/arelle/plugin/validate/EFM/__init__.py
+++ b/arelle/plugin/validate/EFM/__init__.py
@@ -310,18 +310,19 @@ def validateXbrlStart(val, parameters=None, *args, **kwargs):
         efmFiling.attachmentDocumentType = val.params.get("attachmentDocumentType")
 
 def severityReleveler(modelXbrl, level, messageCode, args, **kwargs):
-    if messageCode and feeTagMessageCodesRelevelable.match(messageCode) and level == "ERROR":
-        if not hasattr(modelXbrl, "isFeeTagging"):
-            modelXbrl.isFeeTagging = any(ns.startswith("http://xbrl.sec.gov/ffd") for ns in modelXbrl.namespaceDocs)
-        if modelXbrl.isFeeTagging:
-            modelObject = args.get("modelObject")
-            if (isinstance(modelObject, ModelFact) and
-                str(modelObject.qname) not in feeTagEltsNotRelevelable):
-                    level = "WARNING"
-    # add message number
-    messageCode, msgNum = messageNumericId(modelXbrl, level, messageCode, args)
-    if msgNum:
-        args["edgarMessageNumericId"] = msgNum
+    if getattr(modelXbrl.modelManager.disclosureSystem, "EFMplugin", False):
+        if messageCode and feeTagMessageCodesRelevelable.match(messageCode) and level == "ERROR":
+            if not hasattr(modelXbrl, "isFeeTagging"):
+                modelXbrl.isFeeTagging = any(ns.startswith("http://xbrl.sec.gov/ffd") for ns in modelXbrl.namespaceDocs)
+            if modelXbrl.isFeeTagging:
+                modelObject = args.get("modelObject")
+                if (isinstance(modelObject, ModelFact) and
+                    str(modelObject.qname) not in feeTagEltsNotRelevelable):
+                        level = "WARNING"
+        # add message number
+        messageCode, msgNum = messageNumericId(modelXbrl, level, messageCode, args)
+        if msgNum:
+            args["edgarMessageNumericId"] = msgNum
     return level, messageCode
 
 def isolateSeparateIXDSes(modelXbrl, *args, **kwargs):


### PR DESCRIPTION
#### Reason for change
EFM severity releveler was pumping out edgar message numbers when no edgar disclosure system was active.

#### Description of change
Check disclosure system on this method

#### Steps to Test
Check log when running ESEF or other non-Edgar disclosure system with Edgar plugins active.

**review**:
@Arelle/arelle
