### PR TITLE
Correctly validate maxInclusive datatypes

### DIFF
--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -473,10 +473,10 @@ def validateValue(
                          and xValue < 0) or
                         (baseXsdType == "nonPositiveInteger" and xValue > 0) or
                         (baseXsdType == "positiveInteger" and xValue <= 0) or
-                        (baseXsdType == "byte" and not -128 <= xValue < 127) or
-                        (baseXsdType == "unsignedByte" and not 0 <= xValue < 255) or
-                        (baseXsdType == "short" and not -32768 <= xValue < 32767) or
-                        (baseXsdType == "unsignedShort" and not 0 <= xValue < 65535) or
+                        (baseXsdType == "byte" and not -128 <= xValue <= 127) or
+                        (baseXsdType == "unsignedByte" and not 0 <= xValue <= 255) or
+                        (baseXsdType == "short" and not -32768 <= xValue <= 32767) or
+                        (baseXsdType == "unsignedShort" and not 0 <= xValue <= 65535) or
                         (baseXsdType == "positiveInteger" and xValue <= 0)):
                         raise ValueError("{0} is not {1}".format(value, baseXsdType))
                     if facets:

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -86,8 +86,8 @@ BASE_XSD_TYPES = {
         {"value": "-129", "expected": ("=", None, INVALID)},
         {"value": "-128", "expected": (-128, -128, VALID)},
         {"value": "0", "expected": (0, 0, VALID)},
-        {"value": "126", "expected": (126, 126, VALID)},
-        {"value": "127", "expected": ("=", None, INVALID)},  # TODO: This and other integer ranges seem to incorrectly exclude the maximum value
+        {"value": "127", "expected": (127, 127, VALID)},
+        {"value": "128", "expected": ("=", None, INVALID)},
     ],
     "date": [
         {"value": "2025-01-02", "expected": ("=", DateTime(2025, 1, 2), VALID)},
@@ -339,8 +339,8 @@ BASE_XSD_TYPES = {
         {"value": "-32769", "expected": ("=", None, INVALID)},
         {"value": "-32768", "expected": (-32768, -32768, VALID)},
         {"value": "0", "expected": (0, 0, VALID)},
-        {"value": "32766", "expected": (32766, 32766, VALID)},
-        {"value": "32767", "expected": ("=", None, INVALID)},
+        {"value": "32767", "expected": (32767, 32767, VALID)},
+        {"value": "32768", "expected": ("=", None, INVALID)},
     ],
     "string": [
         {"value": "*", "expected": ("=", "=", VALID)},
@@ -367,8 +367,8 @@ BASE_XSD_TYPES = {
         {"value": "-1", "expected": ("=", None, INVALID)},
         {"value": "0", "expected": (0, 0, VALID)},
         {"value": "1", "expected": (1, 1, VALID)},
-        {"value": "254", "expected": (254, 254, VALID)},
-        {"value": "255", "expected": ("=", None, INVALID)},
+        {"value": "255", "expected": (255, 255, VALID)},
+        {"value": "256", "expected": ("=", None, INVALID)},
     ],
     "unsignedInt": [
         {"value": "-1", "expected": ("=", None, INVALID)},
@@ -384,8 +384,8 @@ BASE_XSD_TYPES = {
         {"value": "-1", "expected": ("=", None, INVALID)},
         {"value": "0", "expected": (0, 0, VALID)},
         {"value": "1", "expected": (1, 1, VALID)},
-        {"value": "65534", "expected": (65534, 65534, VALID)},
-        {"value": "65535", "expected": ("=", None, INVALID)},
+        {"value": "65535", "expected": (65535, 65535, VALID)},
+        {"value": "65536", "expected": ("=", None, INVALID)},
     ],
     "XBRLI_DATEUNION": [
         {"value": "2025-01-02", "expected": ("=", DateTime(2025, 1, 2), VALID)},


### PR DESCRIPTION
#### Reason for change
The max values used for `byte`, `unsignedByte`, `short`, `unsignedShort` datatypes were all one too low. The facets for these datatypes are maxInclusive not maxExclusive.

[byte](https://www.w3.org/TR/xmlschema-2/#byte)
> byte is ·derived· from short by setting the value of ·maxInclusive· to be 127 and ·minInclusive· to be -128. The ·base type· of byte is short.

[unsignedByte](https://www.w3.org/TR/xmlschema-2/#unsignedByte)
> unsignedByte is ·derived· from unsignedShort by setting the value of ·maxInclusive· to be 255. The ·base type· of unsignedByte is unsignedShort.

[short](https://www.w3.org/TR/xmlschema-2/#short)
> short is ·derived· from int by setting the value of ·maxInclusive· to be 32767 and ·minInclusive· to be -32768. The ·base type· of short is int.

[unsignedShort](https://www.w3.org/TR/xmlschema-2/#unsignedShort)
> unsignedShort is ·derived· from unsignedInt by setting the value of ·maxInclusive· to be 65535. The ·base type· of unsignedShort is unsignedInt.

#### Description of change
Use maxInclusive checks for `byte`, `unsignedByte`, `short`, and `unsignedShort`.

#### Steps to Test
CI

**review**:
@Arelle/arelle
