### PR TITLE
Quick fix: add option to filter integration test scripts for frozen builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -127,7 +127,7 @@ jobs:
           mkdir .test_build
           tar -xvzf "${{ env.BUILD_ARTIFACT_PATH }}" -C .test_build
           pip install -r requirements-dev.txt
-          pytest -s --disable-warnings --all --download-cache --offline --arelle=".test_build/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
+          pytest -s --disable-warnings --all-frozen-builds --download-cache --offline --arelle=".test_build/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
       - name: "[Test] Upload test artifacts"
         if: always()
         uses: actions/upload-artifact@v4.3.3

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -188,7 +188,7 @@ jobs:
       - name: "[Test] Test build artifact"
         run : |
           pip install -r requirements-dev.txt
-          pytest -s --disable-warnings --all --download-cache --offline --arelle="build/Arelle.app/Contents/MacOS/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
+          pytest -s --disable-warnings --all-frozen-builds --download-cache --offline --arelle="build/Arelle.app/Contents/MacOS/arelleCmdLine" tests/integration_tests/scripts/test_scripts.py
       - name: "[Test] Upload test artifacts"
         if: always()
         uses: actions/upload-artifact@v4.3.3

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -138,7 +138,7 @@ jobs:
     - name: "[Test] Test build"
       run: |
         pip install -r requirements-dev.txt
-        pytest -s --disable-warnings --all --download-cache --offline --arelle="${{ env.BUILD_PATH }}\arelleCmdLine.exe" tests/integration_tests/scripts/test_scripts.py
+        pytest -s --disable-warnings --all-frozen-builds --download-cache --offline --arelle="${{ env.BUILD_PATH }}\arelleCmdLine.exe" tests/integration_tests/scripts/test_scripts.py
     - name: "[Test] Upload test artifacts"
       if: always()
       uses: actions/upload-artifact@v4.3.3

--- a/tests/integration_tests/scripts/README.md
+++ b/tests/integration_tests/scripts/README.md
@@ -10,6 +10,8 @@ python -m tests.integration_tests.scripts.run_scripts --help
 
   -h, --help            show this help message and exit
   --all                 Select all configured integration tests.
+  --all-frozen-builds   Select all configured integration tests that should run 
+                        against frozen builds.
   --arelle ARELLE       CLI command to run Arelle
   --download-cache      Whether or not to download and apply cache.
   --list                List names of all integration tests.

--- a/tests/integration_tests/scripts/run_scripts.py
+++ b/tests/integration_tests/scripts/run_scripts.py
@@ -21,6 +21,11 @@ ARGUMENTS: list[dict[str, Any]] = [
         "help": "Select all configured integration tests."
     },
     {
+        "name": "--all-frozen-builds",
+        "action": "store_true",
+        "help": "Select all configured integration tests that should run against frozen builds."
+    },
+    {
         "name": "--arelle",
         "action": "store",
         "help": "CLI command to run Arelle"
@@ -54,6 +59,12 @@ ARGUMENTS: list[dict[str, Any]] = [
 TESTS_PATH = './tests/integration_tests/scripts/tests'
 
 
+def _for_frozen_build(name: Path) -> bool:
+    if name.stem.startswith("python_api_"):
+        return False
+    return True
+
+
 def _get_all_scripts() -> list[Path]:
     """
     Returns absolute paths of runnable scripts based on the operating system.
@@ -72,6 +83,8 @@ def run_script_options(options: Namespace) -> list[ParameterSet]:
                 ALL_SCRIPTS_ZIP,
                 version_id='RMN9iin8l7Fqz7E4qfq_1uTuVMc8524U'
             )
+    elif options.all_frozen_builds:
+        scripts = [s for s in all_scripts if _for_frozen_build(s)]
     else:
         names = options.name
         assert names, '--name or --all is required'


### PR DESCRIPTION
#### Reason for change
Python API integration test scripts fail against frozen builds: https://github.com/Arelle/Arelle/actions/runs/8898179822/job/24434754929
This could be resolved by making some changes to how these scripts are run against the frozen builds, but testing Python API usage against frozen builds might be more trouble than it's worth.

Either way, this is a quick fix to unblock releases.

#### Description of change
Add CLI option to integration test script runner that allows a subset of tests to be run that excludes scripts we don't want to run against frozen builds.

#### Steps to Test
CI

**review**:
@Arelle/arelle
