### PR TITLE
Table Linkbase save as Excel

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -594,6 +594,12 @@ class CntlrWinMain (Cntlr.Cntlr):
                                 initialdir=initialdir,
                                 filetypes=[(_("HTML file .html"), "*.html"), (_("HTML file .htm"), "*.htm"), (_("XML file .xml"), "*.xml"), (_("JSON file .xml"), "*.json")],
                                 defaultextension=f".{fileType}")
+                    elif fileType == "xlsx" and filename is None:
+                        filename = self.uiFileDialog("save",
+                                title=caption,
+                                initialdir=initialdir,
+                                filetypes=[(_("Excel file .xlsx"), "*.xlsx")],
+                                defaultextension=f".{fileType}")
                     else: # ask file type
                         if filename is None:
                             filename = self.uiFileDialog("save",

--- a/arelle/ViewFile.py
+++ b/arelle/ViewFile.py
@@ -85,6 +85,7 @@ class View:
             self.xlsxWs = self.xlsxWb.create_sheet(title=rootElementName)
             self.xlsxRow = 0
             self.xlsxColWrapText = [] # bool true if col is always wrap text
+            self.autoFilter = True # auto-filter table
         elif self.type == HTML:
             if style == "rendering":
                 html = io.StringIO(
@@ -172,6 +173,11 @@ class View:
         # list with True for columns to be word wrapped in every row including heading
         if self.type == XLSX:
             self.xlsxColWrapText = colColWrapText
+
+    def setAutoFilter(self, autoFilter):
+        # list with True for columns to be word wrapped in every row including heading
+        if self.type == XLSX:
+            self.autoFilter = autoFilter
 
     def addRow(self, cols, asHeader=False, treeIndent=0, colSpan=1, xmlRowElementName=None, xmlRowEltAttr=None, xmlRowText=None, xmlCol0skipElt=False, xmlColElementNames=None, lastColSpan=None, arcRole=None):
         if asHeader and len(cols) > self.numHdrCols:
@@ -322,8 +328,9 @@ class View:
             if not isinstance(self.outfile, FileNamedStringIO):
                 self.csvFile.close()
         elif self.type == XLSX:
-            # add filtering
-            self.xlsxWs.auto_filter.ref = 'A1:{}{}'.format(utils.get_column_letter(self.xlsxWs.max_column), len(self.xlsxWs['A']))
+            if self.autoFilter:
+                # add filtering
+                self.xlsxWs.auto_filter.ref = 'A1:{}{}'.format(utils.get_column_letter(self.xlsxWs.max_column), len(self.xlsxWs['A']))
             self.xlsxWb.save(self.outfile)
         elif self.type != NOOUT and not noWrite:
             fileType = TYPENAMES[self.type]

--- a/arelle/ViewFileRenderedGrid.py
+++ b/arelle/ViewFileRenderedGrid.py
@@ -18,7 +18,12 @@ from arelle.ModelRenderingObject import (StrctMdlBreakdown, StrctMdlStructuralNo
 from arelle.rendering.RenderingResolution import resolveTableStructure, RENDER_UNITS_PER_CHAR
 from arelle.ModelValue import QName
 from arelle.ModelXbrl import DEFAULT
-from arelle.ViewFile import HTML, XML
+from arelle.ViewFile import HTML, XLSX
+
+# deferred opening of openpyxl so it's not needed in site-packages unless it is used
+Workbook = cell = utils = Font = PatternFill = Border = Alignment = Color = fills = Side = Comment = None
+
+
 # change tableModel for namespace needed for consistency suite
 '''
 from arelle.XbrlConst import (tableModelMMDD as tableModelNamespace,
@@ -51,13 +56,16 @@ def viewRenderedGrid(modelXbrl, outfile, lang=None, viewTblELR=None, sourceView=
     else:
         layoutTable(view)
         lytMdlTblMdl = view.lytMdlTblMdl
-    if view.tblElt is not None: # may be None if there is no table
-        view.view(lytMdlTblMdl)
+    if view.type == HTML and view.tblElt is not None: # may be None if there is no table
+        view.viewHTML(lytMdlTblMdl)
+    elif view.type == XLSX:
+        view.viewXLSX(lytMdlTblMdl)
     view.close()
     modelXbrl.modelManager.showStatus(_("rendered table saved to {0}").format(outfile), clearAfter=5000)
 
 class ViewRenderedGrid(ViewFile.View):
     def __init__(self, modelXbrl, outfile, lang, cssExtras):
+        global Workbook, cell, utils, Font, PatternFill, Border, Alignment, Color, fills, Side, Comment
         # find table model namespace based on table namespace
         self.tableModelNamespace = XbrlConst.tableModel
         for xsdNs in modelXbrl.namespaceDocs.keys():
@@ -69,6 +77,12 @@ class ViewRenderedGrid(ViewFile.View):
                                                lang,
                                                style="rendering",
                                                cssExtras=cssExtras)
+        if self.type == XLSX:
+            if Workbook is None:
+                from openpyxl import Workbook, cell, utils
+                from openpyxl.styles import Font, PatternFill, Border, Alignment, Color, fills, Side
+                from openpyxl.comments import Comment
+
         class nonTkBooleanVar():
             def __init__(self, value=True):
                 self.value = value
@@ -83,7 +97,12 @@ class ViewRenderedGrid(ViewFile.View):
         self.view()
 
     def view(self, lytMdlTblMdl):
+        if self.type == HTML:
+            self.viewHTML(lytMdlTblMdl)
+        elif self.type == XLSX:
+            self.viewXLSX(lytMdlTblMdl)
 
+    def viewHTML(self, lytMdlTblMdl):
         for lytMdlTableSet in lytMdlTblMdl.lytMdlTableSets:
             self.tblElt.append(etree.Comment(f"TableSet linkbase file: {lytMdlTableSet.srcFile}, line {lytMdlTableSet.srcLine}"))
             self.tblElt.append(etree.Comment(f"TableSet linkrole: {lytMdlTableSet.srcLinkrole}"))
@@ -210,5 +229,119 @@ class ViewRenderedGrid(ViewFile.View):
                                                                   "style":f"text-align:{justify};width:8em;"}
                                                  ).text = "\n".join(v for f, v, justify in lytMdlCell.facts)
                             yRowNum += 1
+                    if zTbl < len(lytMdlZBodyCell.lytMdlBodyChildren) - 1:
+                        zTbl += 1
+
+    def viewXLSX(self, lytMdlTblMdl):
+        for lytMdlTableSet in lytMdlTblMdl.lytMdlTableSets:
+            self.xlsxWs.cell(row=self.xlsxRow+1, column=1).comment = Comment(
+                f"TableSet linkbase file: {lytMdlTableSet.srcFile}, line {lytMdlTableSet.srcLine} \n"
+                f"TableSet linkrole: {lytMdlTableSet.srcLinkrole}",
+                "Arelle")
+            self.xlsxWs.cell(row=self.xlsxRow+1, column=1).value = lytMdlTableSet.label
+            # left align and merger to width of table
+            self.xlsxRow += 1
+            for lytMdlTable in lytMdlTableSet.lytMdlTables:
+                if lytMdlTable.strctMdlTable.tblParamValues:
+                    # show any parameters
+                    params = ["parameter = value"]
+                    for name, value in lytMdlTable.strctMdlTable.tblParamValues.items():
+                        params.append(f"{name} = {value}")
+                    self.xlsxWs.cell(row=self.xlsxRow+1, column=iCol+1).value = "\n".join(params)
+                    self.xlsxRow += 1
+                # each Z is a separate table in the outer table
+                lytMdlZHdrs = lytMdlTable.lytMdlAxisHeaders("z")
+                if lytMdlZHdrs is not None:
+                    lytMdlZHdrGroups = lytMdlZHdrs.lytMdlGroups
+                    numZtbls = lytMdlTable.numBodyCells("z") or 1 # must have at least 1 z entry
+                    zHdrElts = [[] for i in range(numZtbls)]
+                    for lytMdlZGrp in lytMdlZHdrs.lytMdlGroups:
+                        for lytMdlZHdr in lytMdlZGrp.lytMdlHeaders:
+                            zRow = 0
+                            if all(lytMdlCell.isOpenAspectEntrySurrogate for lytMdlCell in lytMdlZHdr.lytMdlCells):
+                                continue # skip header with only open aspect entry surrogate
+                            for lytMdlZCell in lytMdlZHdr.lytMdlCells:
+                                for iSpan in range(lytMdlZCell.span):
+                                    zHdrElts[zRow].append([lbl[0] for lbl in lytMdlZCell.labels])
+                                    zRow += 1
+                else:
+                    zHdrElts = [[]]
+                    numZtbls = 1
+                zTbl = 0
+                lytMdlZBodyCell = lytMdlTable.lytMdlBodyChildren[0] # examples only show one z cell despite number of tables
+                for lytMdlYBodyCell in lytMdlZBodyCell.lytMdlBodyChildren:
+                    lytMdlXHdrs = lytMdlTable.lytMdlAxisHeaders("x")
+                    lytMdlYHdrs = lytMdlTable.lytMdlAxisHeaders("y")
+                    nbrXcolHdrs = lytMdlTable.headerDepth("x")
+                    nbrYrowHdrs = lytMdlTable.headerDepth("y")
+                    # build y row headers
+                    numYrows = lytMdlTable.numBodyCells("y")
+                    yRowHdrs = [[] for i in range(numYrows)] # list of list of row header elements for each row
+                    for lytMdlYGrp in lytMdlYHdrs.lytMdlGroups:
+                        for lytMdlYHdr in lytMdlYGrp.lytMdlHeaders:
+                            yRow = 0
+                            if all(lytMdlCell.isOpenAspectEntrySurrogate for lytMdlCell in lytMdlYHdr.lytMdlCells):
+                                continue # skip header with only open aspect entry surrogate
+                            for lytMdlYCell in lytMdlYHdr.lytMdlCells:
+                                for iLabel in range(lytMdlYHdr.maxNumLabels):
+                                    if lytMdlYCell.isOpenAspectEntrySurrogate:
+                                        continue # strip all open aspect entry surrogates from layout model file
+                                    rowHdrElt = {"align": "left"}
+                                    if lytMdlYCell.rollup:
+                                        rowHdrElt["class"] = "yAxisTopSpanLeg"
+                                    else:
+                                        rowHdrElt["class"] = "yAxisHdr"
+                                    if lytMdlYCell.span > 1:
+                                        rowHdrElt["rowspan"] = lytMdlYCell.span
+                                    rowHdrElt["text"] = lytMdlYCell.labelXmlText(iLabel,"\u00a0")
+                                    yRowHdrs[yRow].append(rowHdrElt)
+                                yRow += lytMdlYCell.span
+                    firstColHdr = True
+                    for lytMdlGroup in lytMdlXHdrs.lytMdlGroups:
+                        for lytMdlHeader in lytMdlGroup.lytMdlHeaders:
+                            if all(lytMdlCell.isOpenAspectEntrySurrogate for lytMdlCell in lytMdlHeader.lytMdlCells):
+                                continue # skip header with only open aspect entry surrogate
+                            for iLabel in range(lytMdlHeader.maxNumLabels):
+                                rowElts = []
+                                if firstColHdr:
+                                    zHdrElts = []
+                                    if zHdrElts[zTbl]:
+                                        zHdrTblElt = etree.SubElement(zHdrElt,"{http://www.w3.org/1999/xhtml}table",
+                                                                      attrib={"style":"border-top:none;border-left:none;border-right:none;border-bottom:none;"})
+                                        for zHdrLblRow in zHdrElts[zTbl]:
+                                            for lbl in zHdrLblRow:
+                                                zHdrRowElt = {"class":"tableHdr", "align": "left", "text": lbl}
+                                                zHdrElts.append(zHdrRowElt)
+                                    else:
+                                        zHdrRowElt = {"class":"tableHdr"}
+                                        zHdrElts.append(zHdrRowElt)
+                                    firstColHdr = False
+                                for lytMdlCell in lytMdlHeader.lytMdlCells:
+                                    if lytMdlCell.isOpenAspectEntrySurrogate:
+                                        continue # strip all open aspect entry surrogates from layout model file
+                                    rowElt = {"style":"max-width:100em;"}
+                                    if lytMdlCell.rollup:
+                                        rowElt["class"] = "xAxisSpanLeg"
+                                    else:
+                                        rowElt["class"] = "xAxisHdr"
+                                    if lytMdlCell.span > 1:
+                                        rowElt["colspan"] = lytMdlCell.span
+                                    rowElt.text = lytMdlCell.labelXmlText(iLabel,"\u00a0")
+                                    rowElts.append(rowElt)
+                    yRowNum = 0
+                    for lytMdlXBodyCell in lytMdlYBodyCell.lytMdlBodyChildren:
+                        if True: # not any(lytMdlCell.isOpenAspectEntrySurrogate for lytMdlCell in lytMdlXBodyCell.lytMdlBodyChildren):
+                            cols = []
+                            if yRowNum < len(yRowHdrs):
+                                for rowHdrElt in yRowHdrs[yRowNum]:
+                                    cols.append(rowHdrElt.get("text"))
+                            for lytMdlCell in lytMdlXBodyCell.lytMdlBodyChildren:
+                                if lytMdlCell.isOpenAspectEntrySurrogate:
+                                    continue
+                                justify = "left"
+                                for f, v, justify in lytMdlCell.facts:
+                                    break;
+                                cols.append("\n".join(v for f, v, justify in lytMdlCell.facts))
+                            self.addRow(cols)
                     if zTbl < len(lytMdlZBodyCell.lytMdlBodyChildren) - 1:
                         zTbl += 1

--- a/arelle/ViewFileRenderedGrid.py
+++ b/arelle/ViewFileRenderedGrid.py
@@ -233,12 +233,21 @@ class ViewRenderedGrid(ViewFile.View):
                         zTbl += 1
 
     def viewXLSX(self, lytMdlTblMdl):
+        self.setAutoFilter(False) # filtering not comfortable with grid of tables
+        thinBorder = Border(left=Side(style='thin'), right=Side(style='thin'), top=Side(style='thin'), bottom=Side(style='thin'))
+        xColHdrBorder = Border(left=Side(style='thin'), top=Side(style='thin'), right=Side(style='thin'))
+        yRowHdrBorder = Border(left=Side(style='thin'), top=Side(style='thin'), bottom=Side(style='thin'))
         for lytMdlTableSet in lytMdlTblMdl.lytMdlTableSets:
-            self.xlsxWs.cell(row=self.xlsxRow+1, column=1).comment = Comment(
+            numCols = 1
+            titleXlsRow = self.xlsxRow + 1
+            titleCell = self.xlsxWs.cell(row=self.xlsxRow+1, column=1)
+            titleCell.comment = Comment(
                 f"TableSet linkbase file: {lytMdlTableSet.srcFile}, line {lytMdlTableSet.srcLine} \n"
                 f"TableSet linkrole: {lytMdlTableSet.srcLinkrole}",
                 "Arelle")
-            self.xlsxWs.cell(row=self.xlsxRow+1, column=1).value = lytMdlTableSet.label
+            titleCell.value = lytMdlTableSet.label
+            titleCell.alignment = Alignment(wrap_text=True)
+            titleCell.border = thinBorder
             # left align and merger to width of table
             self.xlsxRow += 1
             for lytMdlTable in lytMdlTableSet.lytMdlTables:
@@ -254,7 +263,7 @@ class ViewRenderedGrid(ViewFile.View):
                 if lytMdlZHdrs is not None:
                     lytMdlZHdrGroups = lytMdlZHdrs.lytMdlGroups
                     numZtbls = lytMdlTable.numBodyCells("z") or 1 # must have at least 1 z entry
-                    zHdrElts = [[] for i in range(numZtbls)]
+                    zHdrLbls = [[] for i in range(numZtbls)]
                     for lytMdlZGrp in lytMdlZHdrs.lytMdlGroups:
                         for lytMdlZHdr in lytMdlZGrp.lytMdlHeaders:
                             zRow = 0
@@ -262,10 +271,10 @@ class ViewRenderedGrid(ViewFile.View):
                                 continue # skip header with only open aspect entry surrogate
                             for lytMdlZCell in lytMdlZHdr.lytMdlCells:
                                 for iSpan in range(lytMdlZCell.span):
-                                    zHdrElts[zRow].append([lbl[0] for lbl in lytMdlZCell.labels])
+                                    zHdrLbls[zRow].append([lbl[0] for lbl in lytMdlZCell.labels])
                                     zRow += 1
                 else:
-                    zHdrElts = [[]]
+                    zHdrLbls = [[]]
                     numZtbls = 1
                 zTbl = 0
                 lytMdlZBodyCell = lytMdlTable.lytMdlBodyChildren[0] # examples only show one z cell despite number of tables
@@ -296,52 +305,87 @@ class ViewRenderedGrid(ViewFile.View):
                                     rowHdrElt["text"] = lytMdlYCell.labelXmlText(iLabel,"\u00a0")
                                     yRowHdrs[yRow].append(rowHdrElt)
                                 yRow += lytMdlYCell.span
-                    firstColHdr = True
+                    yHdrCols = max(len(yRowHdrs[y]) for y in range(len(yRowHdrs)))
+                    yFirstHdrRow = self.xlsxRow + 1
+                    # upper left row/col hdr col, contains z axis labels, if any
+                    zHdrCell = self.xlsxWs.cell(row=yFirstHdrRow, column=1)
+                    zHdrCell.fill = PatternFill(patternType=fills.FILL_SOLID, fgColor=Color("EEEEEE"))
+                    zHdrCell.border = thinBorder
+                    v = "\n".join(((" ".join(lbl for lbl in zHdrRowLbls))
+                                   for zHdrRowLbls in zHdrLbls[zTbl]
+                                   if zHdrRowLbls))
+                    if v:
+                        zHdrCell.value = v
+                        zHdrCell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
                     for lytMdlGroup in lytMdlXHdrs.lytMdlGroups:
                         for lytMdlHeader in lytMdlGroup.lytMdlHeaders:
                             if all(lytMdlCell.isOpenAspectEntrySurrogate for lytMdlCell in lytMdlHeader.lytMdlCells):
                                 continue # skip header with only open aspect entry surrogate
                             for iLabel in range(lytMdlHeader.maxNumLabels):
-                                rowElts = []
-                                if firstColHdr:
-                                    zHdrElts = []
-                                    if zHdrElts[zTbl]:
-                                        zHdrTblElt = etree.SubElement(zHdrElt,"{http://www.w3.org/1999/xhtml}table",
-                                                                      attrib={"style":"border-top:none;border-left:none;border-right:none;border-bottom:none;"})
-                                        for zHdrLblRow in zHdrElts[zTbl]:
-                                            for lbl in zHdrLblRow:
-                                                zHdrRowElt = {"class":"tableHdr", "align": "left", "text": lbl}
-                                                zHdrElts.append(zHdrRowElt)
-                                    else:
-                                        zHdrRowElt = {"class":"tableHdr"}
-                                        zHdrElts.append(zHdrRowElt)
-                                    firstColHdr = False
-                                for lytMdlCell in lytMdlHeader.lytMdlCells:
+                                xlsxCol = yHdrCols + 1
+                                self.xlsxRow += 1
+                                for i, lytMdlCell in enumerate(lytMdlHeader.lytMdlCells):
                                     if lytMdlCell.isOpenAspectEntrySurrogate:
                                         continue # strip all open aspect entry surrogates from layout model file
-                                    rowElt = {"style":"max-width:100em;"}
-                                    if lytMdlCell.rollup:
-                                        rowElt["class"] = "xAxisSpanLeg"
-                                    else:
-                                        rowElt["class"] = "xAxisHdr"
+                                    c = self.xlsxWs.cell(row=self.xlsxRow, column=xlsxCol)
+                                    c.value = lytMdlCell.labelXmlText(iLabel, None)
+                                    c.alignment = Alignment(horizontal="center", vertical="center")
+                                    c.fill = PatternFill(patternType=fills.FILL_SOLID, fgColor=Color("EEEEEE"))
+                                    c.border = xColHdrBorder
                                     if lytMdlCell.span > 1:
-                                        rowElt["colspan"] = lytMdlCell.span
-                                    rowElt.text = lytMdlCell.labelXmlText(iLabel,"\u00a0")
-                                    rowElts.append(rowElt)
+                                        self.xlsxWs.merge_cells(range_string='%s%s:%s%s' % (utils.get_column_letter(xlsxCol), self.xlsxRow, utils.get_column_letter(xlsxCol + lytMdlCell.span - 1), self.xlsxRow))
+                                        xlsxCol += lytMdlCell.span
+                                    else:
+                                        xlsxCol += 1
+                    # upper left row/col hdr col
+                    if yHdrCols > 1:
+                        self.xlsxWs.merge_cells(range_string='%s%s:%s%s' % (utils.get_column_letter(1), yFirstHdrRow, utils.get_column_letter(yHdrCols), self.xlsxRow))
                     yRowNum = 0
+                    rowspans = len(yRowHdrs[yRowNum]) * [0] # remaining rowspan per row col
                     for lytMdlXBodyCell in lytMdlYBodyCell.lytMdlBodyChildren:
                         if True: # not any(lytMdlCell.isOpenAspectEntrySurrogate for lytMdlCell in lytMdlXBodyCell.lytMdlBodyChildren):
-                            cols = []
+                            self.xlsxRow += 1
+                            xlsxCol = 1
                             if yRowNum < len(yRowHdrs):
-                                for rowHdrElt in yRowHdrs[yRowNum]:
-                                    cols.append(rowHdrElt.get("text"))
+                                for i, rowHdrElt in enumerate(yRowHdrs[yRowNum]):
+                                    while xlsxCol-1 < len(rowspans) and rowspans[xlsxCol-1] > 0:
+                                        rowspans[xlsxCol-1] -= 1
+                                        xlsxCol += 1
+                                    rowspan = rowHdrElt.get("rowspan", 1)
+                                    c = self.xlsxWs.cell(row=self.xlsxRow, column=xlsxCol)
+                                    v = rowHdrElt.get("text")
+                                    c.value = v
+                                    c.alignment = Alignment(horizontal=rowHdrElt.get("align", "left" if xlsxCol == 1 or not v.isnumeric() else "center"),
+                                                            vertical="center")
+                                    c.fill = PatternFill(patternType=fills.FILL_SOLID, fgColor=Color("EEEEEE"))
+                                    c.border = yRowHdrBorder
+                                    if rowspan > 1:
+                                        rowspans[xlsxCol-1] = rowspan - 1
+                                        self.xlsxWs.merge_cells(range_string='%s%s:%s%s' % (utils.get_column_letter(xlsxCol), self.xlsxRow, utils.get_column_letter(xlsxCol), self.xlsxRow + rowspan - 1))
+                                    xlsxCol += 1
                             for lytMdlCell in lytMdlXBodyCell.lytMdlBodyChildren:
                                 if lytMdlCell.isOpenAspectEntrySurrogate:
+                                    xlsxCol += 1
                                     continue
                                 justify = "left"
                                 for f, v, justify in lytMdlCell.facts:
-                                    break;
-                                cols.append("\n".join(v for f, v, justify in lytMdlCell.facts))
-                            self.addRow(cols)
+                                    break; # sets justify to first fact
+                                if len(lytMdlCell.facts) == 0:
+                                    v = None
+                                elif len(lytMdlCell.facts) == 1:
+                                    v = lytMdlCell.facts[0][1]
+                                else:
+                                    v = "\n".join(v for f, v, justify in lytMdlCell.facts)
+                                c = self.xlsxWs.cell(row=self.xlsxRow, column=xlsxCol)
+                                if v is not None:
+                                    c.value = v
+                                    c.alignment = Alignment(horizontal=justify, vertical="top")
+                                c.border = thinBorder
+                                xlsxCol += 1
+                            if xlsxCol > numCols:
+                                numCols = xlsxCol
+                        yRowNum += 1
                     if zTbl < len(lytMdlZBodyCell.lytMdlBodyChildren) - 1:
                         zTbl += 1
+            self.setColWidths((numCols) * [12])
+            self.xlsxWs.merge_cells(range_string='%s%s:%s%s' % (utils.get_column_letter(1), titleXlsRow, utils.get_column_letter(numCols - 1), titleXlsRow))

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -77,6 +77,8 @@ def viewRenderedGrid(modelXbrl, tabWin, lang=None):
     saveMenu = Menu(view.viewFrame, tearoff=0)
     saveMenu.add_command(label=_("HTML table"), underline=0, command=lambda: view.modelXbrl.modelManager.cntlr.fileSave(
         view=view, fileType="html", method=ViewFileRenderedGrid.viewRenderedGrid, caption=_("arelle - Save HTML-rendered Table")))
+    saveMenu.add_command(label=_("Excel table"), underline=0, command=lambda: view.modelXbrl.modelManager.cntlr.fileSave(
+        view=view, fileType="xlsx", method=ViewFileRenderedGrid.viewRenderedGrid, caption=_("arelle - Save Excel-rendered Table")))
     saveMenu.add_command(label=_("Layout model"), underline=0, command=lambda: view.modelXbrl.modelManager.cntlr.fileSave(
         view=view, fileType="xml", method=ViewFileRenderedLayout.viewRenderedLayout, caption=_("arelle - Save Table Layout Model")))
     saveMenu.add_command(label=_("Structural model"), underline=0, command=lambda: view.modelXbrl.modelManager.cntlr.fileSave(


### PR DESCRIPTION
#### Reason for change
Table linkbase saves as HTML, this change adds a capability to save as Excel/

#### Description of change
Add save as Excel to output formats supported by ViewFileRenderedGrid.
Add right-btn menu option to save Excel to table pane menu.

#### Steps to Test
Save table examples in HTML and Excel and compare results.

**review**:
@Arelle/arelle
