### PR TITLE
Updated download_assets to use boto3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+boto3==1.34.100
+boto3-stubs==1.34.100
 flake8==7.0.0
 flake8-noqa==1.4.0
 


### PR DESCRIPTION
#### Description of change

Updated download_cache to use boto3 instead of aws


#### Steps to Test

CI

**review**:
@Arelle/arelle
