### PR TITLE
Updated download_assets to use boto3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,11 @@
+boto3==1.34.100
 flake8==7.0.0
 flake8-noqa==1.4.0
 
 mypy==1.10.0
 pytest==8.2.0
 
+boto3-stubs==1.34.100
 typing-extensions==4.11.0
 lxml-stubs==0.5.1
 types-PyMySQL==1.1.0.20240425

--- a/tests/integration_tests/validation/download_assets.py
+++ b/tests/integration_tests/validation/download_assets.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import boto3
 import os
-import subprocess
 import urllib.request
 import zipfile
 from pathlib import Path
-from shutil import which
 
 from tests.integration_tests.download_cache import apply_cache
 from tests.integration_tests.integration_test_util import get_s3_uri
@@ -44,7 +43,7 @@ def _download_asset(asset: ConformanceSuiteAssetConfig, download_private: bool) 
 def _download_private_s3_asset(asset: ConformanceSuiteAssetConfig) -> None:
     """
     Downloads given asset from private S3 bucket.
-    Will raise an error if AWS CLI is not installed or required AWS
+    Will raise an error if the required AWS
     environment variables are not set.
     """
     key = asset.s3_key
@@ -54,16 +53,11 @@ def _download_private_s3_asset(asset: ConformanceSuiteAssetConfig) -> None:
     asset.full_local_path.parent.mkdir(parents=True, exist_ok=True)
     assert 'AWS_ACCESS_KEY_ID' in os.environ.keys(), 'Must have AWS_ACCESS_KEY_ID environment variable set.'
     assert 'AWS_SECRET_ACCESS_KEY' in os.environ.keys(), 'Must have AWS_SECRET_ACCESS_KEY environment variable set.'
-    assert which('aws'), 'AWS CLI must be installed.'
-    args = [
-        'aws', 's3api', 'get-object',
-        '--bucket', 'arelle',
-        '--key', key,
-    ]
+    s3 = boto3.client('s3')
     if asset.s3_version_id:
-        args.extend(['--version-id', asset.s3_version_id])
-    args.append(str(asset.full_local_path))
-    subprocess.run(args, check=True)
+        s3.download_file('arelle', Key=key, Filename=str(asset.full_local_path), ExtraArgs={'VersionId': asset.s3_version_id})
+    else:
+        s3.download_file('arelle', Key=key, Filename=str(asset.full_local_path))
 
 
 def _download_public_s3_asset(asset: ConformanceSuiteAssetConfig) -> None:


### PR DESCRIPTION
#### Reason for change

Removing aws and reducing system dependencies

#### Description of change

Changed download_private_s3_asset to use boto3 instead  of aws

#### Steps to Test

CI

**review**:
@Arelle/arelle
