### PR TITLE
EDGAR 24.1.1.u2 preview

### DIFF
--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -4590,7 +4590,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                 for dimConcept in modelXbrl.nameConcepts.get(rule["axis"], ()):
                     reportedItems = rule["reported-items"]
                     dependentItems = rule["dependent-items"]
-                    for b in factBindings(modelXbrl, flattenToSet( (reportedItems, dependentItems)), alignDims=(dimConcept.qname,), coverUnit=True, nils=False).values():
+                    for b in factBindings(modelXbrl, flattenToSet( (reportedItems, dependentItems)), alignDims=(dimConcept.qname,), coverUnit=True, nils=True).values():
                         for name in reportedItems:
                             if name in b:
                                 f = b[name]


### PR DESCRIPTION
### Reason for change
 * Correct DQC 0076 to allow nils
#### In [EdgarRenderer PR ](https://github.com/Arelle/EdgarRenderer/pull/105)
 * Wrong class in validation caused exception.
 * Nested facts with transformation missing on outer (invalid) fact corrupted inner (valid) fact
 * Redaction of initial segment of continuation chain corrected


### Description of change
 * See above

### Steps to Test
 * Code inspection
 * Private test filings
 * Test suite, regression tests

review:
@Arelle/arelle