### PR TITLE
Add calculation views for calc 1.1 arc

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1091,7 +1091,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         if options.tableFile:
                             ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.tableFile, "Table Linkbase", "Table-rendering", labelrole=options.labelRole, lang=options.labelLang)
                         if options.calFile:
-                            ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.calFile, "Calculation Linkbase", XbrlConst.summationItem, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
+                            ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.calFile, "Calculation Linkbase", XbrlConst.summationItems, labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
                         if options.dimFile:
                             ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, options.dimFile, "Dimensions", "XBRL-dimensions", labelrole=options.labelRole, lang=options.labelLang, cols=options.relationshipCols)
                         if options.anchFile:

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -2064,7 +2064,7 @@ class ModelRelationship(ModelObject):
     def propertyView(self):
         return self.toModelObject.propertyView + \
                (("arcrole", self.arcrole),
-                ("weight", self.weight) if self.arcrole == XbrlConst.summationItem else (),
+                ("weight", self.weight) if self.arcrole in XbrlConst.summationItems else (),
                 ("preferredLabel", self.preferredLabel)  if self.arcrole == XbrlConst.parentChild and self.preferredLabel else (),
                 ("contextElement", self.contextElement)  if self.arcrole in (XbrlConst.all, XbrlConst.notAll)  else (),
                 ("typedDomain", self.toModelObject.typedDomainElement.qname)

--- a/arelle/ViewFileFactTable.py
+++ b/arelle/ViewFileFactTable.py
@@ -302,7 +302,7 @@ class ViewFacts(ViewFile.View):
             for i, modelRel in enumerate(relationshipSet.fromModelObject(concept)):
                 nestedRelationshipSet = relationshipSet
                 targetRole = modelRel.targetRole
-                if self.arcrole == XbrlConst.summationItem:
+                if self.arcrole in XbrlConst.summationItems:
                     childPrefix = "({:0g}) ".format(modelRel.weight) # format without .0 on integer weights
                 elif targetRole is None or len(targetRole) == 0:
                     targetRole = relationshipSet.linkrole

--- a/arelle/ViewWinFactTable.py
+++ b/arelle/ViewWinFactTable.py
@@ -204,7 +204,7 @@ class ViewFactTable(ViewWinTree.ViewTree):
             for i, modelRel in enumerate(relationshipSet.fromModelObject(concept)):
                 nestedRelationshipSet = relationshipSet
                 targetRole = modelRel.targetRole
-                if self.arcrole == XbrlConst.summationItem:
+                if self.arcrole in XbrlConst.summationItems:
                     childPrefix = "({:0g}) ".format(modelRel.weight) # format without .0 on integer weights
                 elif targetRole is None or len(targetRole) == 0:
                     targetRole = relationshipSet.linkrole

--- a/arelle/ViewWinRelationshipSet.py
+++ b/arelle/ViewWinRelationshipSet.py
@@ -89,7 +89,7 @@ class ViewRelationshipSet(ViewWinTree.ViewTree):
                     self.treeView.heading("type", text=_("Type"))
                     self.treeView.column("references", width=200, anchor="w", stretch=False)
                     self.treeView.heading("references", text=_("References"))
-                elif self.arcrole == XbrlConst.summationItem: # extra columns
+                elif self.arcrole in XbrlConst.summationItems: # extra columns
                     self.treeView.column("#0", width=300, anchor="w")
                     self.treeView["columns"] = ("weight", "balance")
                     self.treeView.column("weight", width=48, anchor="w", stretch=False)
@@ -253,7 +253,7 @@ class ViewRelationshipSet(ViewWinTree.ViewTree):
                     self.treeView.set(childnode, "preferredLabel", preferredLabel)
                 self.treeView.set(childnode, "type", concept.niceType)
                 self.treeView.set(childnode, "references", viewReferences(concept))
-            elif self.arcrole == XbrlConst.summationItem:
+            elif self.arcrole in XbrlConst.summationItems:
                 if isRelation:
                     self.treeView.set(childnode, "weight", "{:+0g} ".format(modelObject.weight))
                 self.treeView.set(childnode, "balance", concept.balance)
@@ -313,7 +313,7 @@ class ViewRelationshipSet(ViewWinTree.ViewTree):
                 for modelRel in childRelationshipSet.fromModelObject(concept):
                     nestedRelationshipSet = childRelationshipSet
                     targetRole = modelRel.targetRole
-                    if self.arcrole == XbrlConst.summationItem:
+                    if self.arcrole in XbrlConst.summationItems:
                         childPrefix = "({:0g}) ".format(modelRel.weight) # format without .0 on integer weights
                     elif targetRole is None or len(targetRole) == 0:
                         targetRole = relationshipSet.linkrole


### PR DESCRIPTION
#### Reason for change
Calculation views don't display 1.1 summation arcs.

#### Description of change
Updates calculation views to handle both calc 1.1 and xbrl 2.1 spec summation arcs.

#### Steps to Test
CLI:
1. Use [filing_documents.zip](https://github.com/Arelle/Arelle/files/15328530/filing_documents.zip)
2. Run `python arelleCmdLine.py --cal out.csv --file filing_documents.zip`
3. Confirm calculation is displayed in csv report

GUI:
1. Open the same filing in the GUI and verify that the calculation tab is populated


**review**:
@Arelle/arelle
