### PR TITLE
[FIX] Fixes table linkbase (EBA)

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -596,16 +596,6 @@ class CntlrWinMain (Cntlr.Cntlr):
                                 initialdir=initialdir,
                                 filetypes=[(_("HTML file .html"), "*.html"), (_("HTML file .htm"), "*.htm"), (_("XML file .xml"), "*.xml"), (_("JSON file .xml"), "*.json")],
                                 defaultextension=f".{fileType}")
-                    else: # ask file type
-                        if filename is None:
-                            filename = self.uiFileDialog("save",
-                                    title=_caption,
-                                    initialdir=initialdir,
-                                    filetypes=[(_("XBRL instance .xbrl"), "*.xbrl"), (_("XBRL instance .xml"), "*.xml"), (_("HTML table .html"), "*.html"), (_("HTML table .htm"), "*.htm")],
-                                    defaultextension=".html")
-                        if filename and (filename.endswith(".xbrl") or filename.endswith(".xml")):
-                            view.saveInstance(filename)
-                            return True
                     if not filename:
                         return False
                     try:
@@ -622,6 +612,16 @@ class CntlrWinMain (Cntlr.Cntlr):
                             initialdir=initialdir,
                             filetypes=[(_("XBRL instance .xbrl"), "*.xbrl"), (_("XBRL instance .xml"), "*.xml")],
                             defaultextension=".xbrl")
+                else: # ask file type
+                    if filename is None:
+                        filename = self.uiFileDialog("save",
+                                                     title=caption,
+                                                     initialdir=initialdir,
+                                                     filetypes=[(_("XBRL instance .xbrl"), "*.xbrl"), (_("XBRL instance .xml"), "*.xml"), (_("HTML table .html"), "*.html"), (_("HTML table .htm"), "*.htm")],
+                                                     defaultextension=".html")
+                    if filename and (filename.endswith(".xbrl") or filename.endswith(".xml")):
+                        view.saveInstance(filename)
+                        return True
             elif isinstance(view, ViewWinTests.ViewTests) and modelXbrl.modelDocument.type in (ModelDocument.Type.TESTCASESINDEX, ModelDocument.Type.TESTCASE):
                 filename = self.uiFileDialog("save",
                         title=_("arelle - Save Test Results"),

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -628,8 +628,8 @@ class ViewRenderedGrid(ViewWinTkTable.ViewTkTable):
                 else:
                     self.aspectEntryObjectIdsNode[yStrctNode.aspectEntryObjectId] = yStrctNode
                     if TRACE_TK: print(f"yAxis hdr combobox x {leftCol-1} y {row-1} values {self.aspectEntryValues(yStrctNode)}")
-                    self.aspectEntryObjectIdsCell[yStrctNode.aspectEntryObjectId] = self.table.initHeaderCombobox(leftCol-1,
-                                                                                                                       row-1,
+                    self.aspectEntryObjectIdsCell[yStrctNode.aspectEntryObjectId] = self.table.initHeaderCombobox(leftCol,
+                                                                                                                       row,
                                                                                                                        values=self.aspectEntryValues(yStrctNode),
                                                                                                                        objectId=yStrctNode.aspectEntryObjectId,
                                                                                                                        comboboxselected=self.onAspectComboboxSelection)
@@ -813,8 +813,8 @@ class ViewRenderedGrid(ViewWinTkTable.ViewTkTable):
                                 except ValueError:
                                     effectiveValue = enumerationValues[0]
                                     selectedIdx = 0
-                                xValue = self.dataFirstCol + i-1
-                                yValue = row-1
+                                xValue = self.dataFirstCol + i
+                                yValue = row
                                 if TRACE_TK: print(f"body comboBox enums x {xValue} y {yValue} values {effectiveValue} value {enumerationValues}")
                                 self.table.initCellCombobox(effectiveValue,
                                                             enumerationValues,

--- a/arelle/rendering/RenderingEvaluator.py
+++ b/arelle/rendering/RenderingEvaluator.py
@@ -92,7 +92,7 @@ def init(modelXbrl):
         if instance is not None: # no instance was provided, check for context-dependent XPath expressions
             for paramQname, modelParameter in modelXbrl.qnameParameters.items():
                 if isinstance(modelParameter, ModelParameter):
-                    if any(p.name in XPathContext.PATH_OPS for p in modelParameter.selectProg):
+                    if any(hasattr(p, "name") and p.name in XPathContext.PATH_OPS for p in modelParameter.selectProg):
                         modelXbrl.error("arelle:tableParameterRequiresInstance",
                             _("Parameter %(qname)s requires an instance as a context item for the XPath expression but no instance was provided."),
                             modelObject=modelParameter, qname=paramQname)


### PR DESCRIPTION
* Fix the opening of EBA .xsd files
* Fix the position of the combobox
* Fix the save of table linkbase instance

#### Reason for change
Opening some table linkbase taxonomies (such as EBA) cause a stacktrace. 

#### Description of change
Loading fix:
While testing the "arelle:tableParameterRequiresInstance" error, arelle tries to access the "name" attribute from the elements of the modelParameter.selectProg list. This list is composed of object from [formula/XPathParser.py](https://github.com/Arelle/Arelle/blob/master/arelle/formula/XPathParser.py) like ProgHeader, OperationDef... In the EBA case, there is also QNameDef, which doesn't have the name attribute. 

Combobox position:
Combo boxes were misaligned by one row and one column. It was probably an oversight from the table linkbase update

Save Table linkbase.
The save was never done with tables linkbase, as the filename was never asked.

#### Steps to Test
Open an EBA entrypoint (I tested with corep_LE).
Without this PR, the entrypoint won't load, and if you correct the loading, combobox are misaligned and the save doesn't work.

#### Reason of draft PR
There is still one issue in table linkbase, related to open axes. When there are 2 breakdowns with open axis, only one is handled.
It seems that the issue is located in the RenderingResolution, so it's trickier to fix, I am still looking for the correction.

Old (and correct) behavior:
![image](https://github.com/Arelle/Arelle/assets/29726174/d761e64f-e1b1-4471-b50d-a2e77c3300f8)

New behavior (missing an open typed dimention):
![image](https://github.com/Arelle/Arelle/assets/29726174/d3db3780-cc84-4d20-ab6d-dcb244d82a03)

**review**:
@Arelle/arelle
