### PR TITLE
Example RSS Feed Save OIM

### DIFF
--- a/arelle/ViewWinRssFeed.py
+++ b/arelle/ViewWinRssFeed.py
@@ -8,6 +8,7 @@ except ImportError:
     from ttk import *
 import os
 from arelle import (ViewWinTree, ModelDocument)
+from arelle.PluginManager import pluginClassMethods
 
 def viewRssFeed(modelXbrl, tabWin):
     view = ViewRssFeed(modelXbrl, tabWin)
@@ -79,6 +80,9 @@ class ViewRssFeed(ViewWinTree.ViewTree):
         import webbrowser
         filingMenu = Menu(self.viewFrame, tearoff=0)
         filingMenu.add_command(label=_("Open Instance Document"), underline=0, command=self.openInstance)
+        for pluginMenuExtender in pluginClassMethods("RssFeed.Menu.Filing"):
+            pluginMenuExtender(self, filingMenu)
+
         if event is not None:
             self.menu.delete(0, 0) # remove old filings
             menuRow = self.treeView.identify_row(event.y) # this is the object ID

--- a/arelle/examples/plugin/rssSaveOim.py
+++ b/arelle/examples/plugin/rssSaveOim.py
@@ -1,5 +1,5 @@
 '''
-Rss Save OIM is a plug-in to the RSS GUI menu that will load an RSS filing's 
+Rss Save OIM is a plug-in to the RSS GUI menu that will load an RSS filing's
 instances and save them as OIM files.
 
 See COPYRIGHT.md for copyright information.
@@ -12,14 +12,13 @@ and each (of possibly multiple) instances are saved to OIM JSON files.
 
 If there is only one instance it saves to the file name provided by the Save Dialog.
 If there are multiple instances (such as a multi-IXDS inline filing), the additional
-instances are saved under their base file name with replaced suffix json, in the 
+instances are saved under their base file name with replaced suffix json, in the
 directory chosen by the Save Dialog.
 
 This plug-in imports the following plug-ins:
   saveLoadableOIM to save the xBRL-JSON instances
   inlineXbrlDocumentSet for multi-doc or multi-IXDS filings
   validate/EFM for isolation of multi-IXDS filings into primary and supplemental modelXbrl objects
-  
 '''
 
 import os
@@ -47,7 +46,7 @@ def saveFilingOim(cntlr, zippedUrl, oimFile):
                     modelXbrl.info("arelle:savedOIM",_("Saved OIM File {}").format(supplementalOimFile))
                 supplementalModelXbrl.close()
         modelXbrl.close()
-        
+
 
 def rssFeedFilingMenuExtender(viewRssFeed, menu, *args, **kwargs):
     # Extend menu with an item for the savedts plugin

--- a/arelle/examples/plugin/rssSaveOim.py
+++ b/arelle/examples/plugin/rssSaveOim.py
@@ -1,0 +1,97 @@
+'''
+Rss Save OIM is a plug-in to the RSS GUI menu that will load an RSS filing's 
+instances and save them as OIM files.
+
+See COPYRIGHT.md for copyright information.
+
+ViewWinRssFeed allows the GUI user to right-click on a filing.  This plugin
+adds a menu item to save the filing as OIM Json files.
+
+The identified filing is loaded in a separate thread (so the GUI is not blocked)
+and each (of possibly multiple) instances are saved to OIM JSON files.
+
+If there is only one instance it saves to the file name provided by the Save Dialog.
+If there are multiple instances (such as a multi-IXDS inline filing), the additional
+instances are saved under their base file name with replaced suffix json, in the 
+directory chosen by the Save Dialog.
+
+This plug-in imports the following plug-ins:
+  saveLoadableOIM to save the xBRL-JSON instances
+  inlineXbrlDocumentSet for multi-doc or multi-IXDS filings
+  validate/EFM for isolation of multi-IXDS filings into primary and supplemental modelXbrl objects
+  
+'''
+
+import os
+from arelle import ModelXbrl
+from arelle.FileSource import openFileSource
+from arelle.PluginManager import pluginClassMethods
+from arelle.Version import authorLabel, copyrightLabel
+
+def saveFilingOim(cntlr, zippedUrl, oimFile):
+    # load filing
+    modelXbrl = ModelXbrl.load(cntlr.modelManager,
+                               openFileSource(zippedUrl, cntlr))
+    if modelXbrl is not None:
+        for saveLoadableOIM in pluginClassMethods("SaveLoadableOim.Save"):
+            saveLoadableOIM(modelXbrl, oimFile)
+            modelXbrl.info("arelle:savedOIM", _("Saved OIM File {}").format(oimFile))
+        # check for supplemental instances
+        if hasattr(modelXbrl, "supplementalModelXbrls"):
+            oimFileDir = os.path.dirname(oimFile)
+            for supplementalModelXbrl in modelXbrl.supplementalModelXbrls:
+                # use basename for the json file
+                supplementalOimFile = os.path.join(oimFileDir, os.path.splitext(supplementalModelXbrl.basename)[0] + ".json")
+                for saveLoadableOIM in pluginClassMethods("SaveLoadableOim.Save"):
+                    saveLoadableOIM(supplementalModelXbrl, supplementalOimFile)
+                    modelXbrl.info("arelle:savedOIM",_("Saved OIM File {}").format(supplementalOimFile))
+                supplementalModelXbrl.close()
+        modelXbrl.close()
+        
+
+def rssFeedFilingMenuExtender(viewRssFeed, menu, *args, **kwargs):
+    # Extend menu with an item for the savedts plugin
+    menu.add_command(label="Save Filing OIM",
+                     underline=0,
+                     command=lambda: saveFilingOimMenuCommand(viewRssFeed) )
+
+def saveFilingOimMenuCommand(viewRssFeed):
+    # save DTS menu item has been invoked
+    cntlr = viewRssFeed.modelXbrl.modelManager.cntlr
+    # get rssItemObj for the currently active row (if any)
+    rssItemObj = viewRssFeed.modelXbrl.modelObject(viewRssFeed.menuRow)
+    if rssItemObj is None:
+        return
+    # get file name into which to save log file while in foreground thread
+    oimFile = cntlr.uiFileDialog("save",
+            title=_("arelle - Save Filing OIM JSON file"),
+            initialdir=cntlr.config.setdefault("loadableExcelFileDir","."),
+            filetypes=[(_("JSON file .json"), "*.json")],
+            defaultextension=".json")
+    if not oimFile:
+        return False
+    import os
+    cntlr.config["loadableOIMFileDir"] = os.path.dirname(oimFile)
+    cntlr.saveConfig()
+
+    import threading
+    thread = threading.Thread(target=lambda
+                                  _cntlr=cntlr,
+                                  _zippedUrl=rssItemObj.zippedUrl,
+                                  _oimFile=oimFile:
+                                        saveFilingOim(_cntlr, _zippedUrl, _oimFile))
+    thread.daemon = True
+    thread.start()
+
+
+__pluginInfo__ = {
+    'name': 'Load RSS item and save OIM file',
+    'version': '1.0',
+    'description': "This plug-in saves an RSS-identified XBRL filing in OIM JSON files, for each instance of the filing.",
+    'license': 'Apache-2',
+    'author': authorLabel,
+    'copyright': copyrightLabel,
+    'import': ('saveLoadableOIM', 'inlineXbrlDocumentSet', 'validate/EFM'), # import dependent modules
+    # classes of mount points (required)
+    'RssFeed.Menu.Filing': rssFeedFilingMenuExtender
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,6 +290,7 @@ module = [
     'arelle.examples.plugin.formulaSuiteConverter',
     'arelle.examples.plugin.functionsCustom',
     'arelle.examples.plugin.hello_dolly',
+    'arelle.examples.plugin.rssSaveOim',
     'arelle.formula.FormulaConsisAsser',
     'arelle.formula.FormulaEvaluator',
     'arelle.formula.ValidateFormula',


### PR DESCRIPTION
#### Reason for change
Provide a plugin for RSS Feed GUI which adds a menu option to selected Filing, to save OIM JSON files for the instances in the filing.

#### Description of change
New plugin is examples/rssSaveOim.  Select plugin with the Plugin Manager Browse button.

A plugin call is made from the RSS Filing Selection menu to "RssFeed.Menu.Filing"

Plugin rssSaveOim creates a menu entry to save the OIM, which in turn utilizes these other plugins:

  * inlineDocumentSet - handles multiple-document and multiple-IXDS filings, sorts the zip htm files into proper IXDSes
  * validate/EFM - provides EDGAR-specific htm-to-IXDS allotment rules.

#### Steps to Test

 * Start the RSS Feed
 * Right-click and select Filing -> Save Filing OIM

**review**:
@Arelle/arelle
