### PR TITLE
Python 3.12 Builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.11.8'
+        default: '3.12.4'
         description: 'Python version to use'
         required: false
         type: string
@@ -40,7 +40,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.11.8'
+        default: '3.12.4'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.11'
+        default: '3.12'
         description: 'Python version to use'
         required: false
         type: string
@@ -40,7 +40,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.11'
+        default: '3.12'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.11'
+        default: '3.12'
         description: 'Python version to use'
         required: false
         type: string
@@ -36,7 +36,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.11'
+        default: '3.12'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.11'
+        default: '3.12'
         description: 'Python version to use'
         required: false
         type: string
@@ -82,7 +82,7 @@ jobs:
         with:
           cache: 'pip'
           check-latest: true
-          python-version: ${{ github.event_name == 'workflow_dispatch' && inputs.python_version || '3.11' }}
+          python-version: ${{ github.event_name == 'workflow_dispatch' && inputs.python_version || '3.12' }}
       - name: Install Python dependencies
         if: matrix.build-type == 'source'
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,12 +68,12 @@ Here's how to set up your environment:
   2. Install a supported version of Python.
     For example, 
     
-    pyenv install 3.12.2
+    pyenv install 3.12.4
 
   3. Create a virtual env using the Python version you just installed.
     For example, 
 
-    PYENV_VERSION=3.12.2 pyenv exec python -m venv venv
+    PYENV_VERSION=3.12.4 pyenv exec python -m venv venv
   4. Activate your environment: 
     
     source venv/bin/activate

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,4 @@
-cx-Freeze==6.15.12
+cx-Freeze==7.1.0.post0
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
 -r requirements-plugins.txt


### PR DESCRIPTION
#### Reason for change
cx-Freeze now supports Python 3.12, so lets update release builds and documentation to 3.12

#### Description of change
Python 3.12 removed `imp` package which was used in `pygettext.py`. Fortunately, most of the use of `imp` is not actually invoked by our build pipeline, the exception being easily replaced by `importlib`.

#### Steps to Test
- CI
- Test builds ([Windows](https://github.com/Arelle/Arelle/actions/runs/9503302600), [macOS](https://github.com/Arelle/Arelle/actions/runs/9503303552), [Linux](https://github.com/Arelle/Arelle/actions/runs/9503304803))
- I confirmed that `messages.pot` had no functional changes caused by `pygettext.py` changes. (Used build from [this run](https://github.com/Arelle/Arelle/actions/runs/9489396070) and compared extracted messages file to that in the latest release build)

**review**:
@Arelle/arelle
