### PR TITLE
Making XML dictionary logging truncation configurable

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -338,7 +338,8 @@ class Cntlr:
         logHandler: logging.Handler | None = None,
         logToBuffer: bool = False,
         logTextMaxLength: int | None = None,
-        logRefObjectProperties: bool = True
+        logRefObjectProperties: bool = True,
+        logXmlMaxAttributeLength: int | None = None
     ) -> None:
         # add additional logging levels (for python 2.7, all of these are ints)
         logging.addLevelName(logging.INFO - 1, "INFO-RESULT") # result data, has @name, @value, optional href to source and readable message
@@ -364,7 +365,11 @@ class Cntlr:
                 self.logHandler = StructuredMessageLogHandler()
                 setattr(self.logger, "logRefObjectProperties", logRefObjectProperties)
             elif logFileName.endswith(".xml") or logFileName.endswith(".json") or logToBuffer:
-                self.logHandler = LogToXmlHandler(filename=logFileName, mode=logFileMode or "a")  # should this be "w" mode??
+                self.logHandler = LogToXmlHandler(
+                    filename=logFileName,
+                    mode=logFileMode or "a",
+                    logXmlMaxAttributeLength=logXmlMaxAttributeLength
+                )  # should this be "w" mode??
                 setattr(self.logger, "logRefObjectProperties", logRefObjectProperties)
                 if not logFormat:
                     logFormat = "%(message)s"

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -256,6 +256,8 @@ def parseArgs(args):
                       help=_("Log reference object properties (default)."), default=True)
     parser.add_option("--logNoRefObjectProperties", "--lognorefobjectproperties", action="store_false", dest="logRefObjectProperties",
                       help=_("Do not log reference object properties."))
+    parser.add_option("--logXmlMaxAttributeLength", "--logxmlmaxattributelength", action="store", dest="logXmlMaxAttributeLength", type="int",
+                      help=_("Truncate XML log file attribute values at length. The default is 4096000 for JSON content and 128 for everything else."))
     parser.add_option("--statusPipe", action="store", dest="statusPipe", help=SUPPRESS_HELP)
     parser.add_option("--monitorParentProcess", action="store", dest="monitorParentProcess", help=SUPPRESS_HELP)
     parser.add_option("--outputAttribution", "--outputattribution", action="store", dest="outputAttribution", help=SUPPRESS_HELP)
@@ -518,7 +520,8 @@ def configAndRunCntlr(options, arellePluginModules):
                            logLevel=(options.logLevel or "DEBUG"),
                            logToBuffer=getattr(options, "logToBuffer", False),
                            logTextMaxLength=options.logTextMaxLength,  # e.g., used by EdgarRenderer to require buffered logging
-                           logRefObjectProperties=options.logRefObjectProperties)
+                           logRefObjectProperties=options.logRefObjectProperties,
+                           logXmlMaxAttributeLength=options.logXmlMaxAttributeLength)
         cntlr.postLoggingInit()  # Cntlr options after logging is started
         cntlr.run(options)
         return cntlr

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -100,6 +100,7 @@ class RuntimeOptions:
     logLevelFilter: Optional[str] = None
     logRefObjectProperties: Optional[bool] = None
     logTextMaxLength: Optional[int] = None
+    logXmlMaxAttributeLength: Optional[int] = None
     monitorParentProcess: Optional[bool] = None
     noCertificateCheck: Optional[bool] = None
     outputAttribution: Optional[str] = None

--- a/arelle/api/Session.py
+++ b/arelle/api/Session.py
@@ -101,7 +101,8 @@ class Session:
                     logLevel=(options.logLevel or "DEBUG"),
                     logToBuffer=options.logFile == 'logToBuffer',
                     logTextMaxLength=options.logTextMaxLength,  # e.g., used by EdgarRenderer to require buffered logging
-                    logRefObjectProperties=options.logRefObjectProperties or True
+                    logRefObjectProperties=options.logRefObjectProperties or True,
+                    logXmlMaxAttributeLength=options.logXmlMaxAttributeLength
                 )
                 self._cntlr.postLoggingInit()  # Cntlr options after logging is started
             return self._cntlr.run(options)

--- a/arelle/logging/handlers/LogToXmlHandler.py
+++ b/arelle/logging/handlers/LogToXmlHandler.py
@@ -22,8 +22,13 @@ class LogToXmlHandler(LogHandlerWithXml):
     filemode: str
     htmlTitle: str = "Arelle Message Log" # may be customized in plugin startup
 
-    def __init__(self, filename: str | None = None, mode: str = 'w') -> None:
-        super(LogToXmlHandler, self).__init__()
+    def __init__(
+            self,
+            filename: str | None = None,
+            mode: str = 'w',
+            logXmlMaxAttributeLength: int | None = None
+    ) -> None:
+        super(LogToXmlHandler, self).__init__(logXmlMaxAttributeLength=logXmlMaxAttributeLength)
         self.filename = filename # may be none if buffer is retrieved by get methods below and not written anywhere
         self.logRecordBuffer = []
         self.filemode = mode


### PR DESCRIPTION
#### Reason for change

[GitHub issue](https://github.com/Arelle/Arelle/issues/1187)


#### Description of change

Added logXmlMaxLength as a user configurable option


#### Steps to Test

Testing steps outlined in the issue

**review**:
@Arelle/arelle
