### PR TITLE
Update liberal EFM disclosure systems so that they allow EFM 6.22.00 errors for all-years

### DIFF
--- a/arelle/DisclosureSystem.py
+++ b/arelle/DisclosureSystem.py
@@ -72,6 +72,7 @@ class DisclosureSystem:
         self.xmlLangIsInheritable = True # for label and footnote, spec sections 4.11.1.2.1 and 5.2.2.2.1
         self.defaultLanguage = None
         self.language = None
+        self.validTaxonomiesUrl = None
         self.standardTaxonomiesUrl = None
         self.mappingsUrl = os.path.join(self.modelManager.cntlr.configDir, "mappings.xml")
         self.mappedFiles = {}
@@ -198,6 +199,10 @@ class DisclosureSystem:
                                     self.standardTaxonomiesUrl = self.modelManager.cntlr.webCache.normalizeUrl(
                                                      dsElt.get("standardTaxonomiesUrl"),
                                                      url)
+                                if dsElt.get("validTaxonomiesUrl"):
+                                    self.validTaxonomiesUrl = self.modelManager.cntlr.webCache.normalizeUrl(
+                                        dsElt.get("validTaxonomiesUrl"),
+                                        url)
                                 if dsElt.get("mappingsUrl"):
                                     self.mappingsUrl = self.modelManager.cntlr.webCache.normalizeUrl(
                                                  dsElt.get("mappingsUrl"),
@@ -235,6 +240,7 @@ class DisclosureSystem:
             self.loadMappings()
             self.utrUrl = [self.mappedUrl(u) for u in self.utrUrl] # utr may be mapped, change to its mapped entry
             self.loadStandardTaxonomiesDict()
+            self.loadValidTaxonomiesDict()
             self.utrTypeEntries = None # clear any prior loaded entries
             # set log level filters (including resetting prior disclosure systems values if no such filter)
             self.modelManager.cntlr.setLogLevelFilter(self.logLevelFilter)  # None or "" clears out prior filter if any
@@ -335,6 +341,45 @@ class DisclosureSystem:
                                                  level=logging.ERROR)
                 etree.clear_error_log()
 
+    def loadValidTaxonomiesDict(self):
+        if self.selection:
+            self.validTaxonomiesDict = defaultdict(set)
+            if not self.validTaxonomiesUrl:
+                return
+            basename = os.path.basename(self.validTaxonomiesUrl)
+            self.modelManager.cntlr.showStatus(_("parsing {0}").format(basename))
+            try:
+                from arelle.FileSource import openXmlFileStream
+                for filepath in (self.validTaxonomiesUrl,
+                                 os.path.join(self.modelManager.cntlr.configDir,"xbrlschemafiles.xml")):
+                    xmldoc = etree.parse(filepath) # must open with file path for xinclude to know base of file
+                    xmldoc.xinclude() # to include elements below root use xpointer(/*/*)
+                    for locElt in xmldoc.iter(tag="Loc"):
+                        href = None
+                        namespaceUri = None
+                        attType = None
+                        for childElt in locElt.iterchildren():
+                            ln = childElt.tag
+                            value = childElt.text.strip()
+                            if ln == "Href":
+                                href = value
+                            elif ln == "Namespace":
+                                namespaceUri = value
+                            elif ln == "AttType":
+                                attType = value
+                        if href:
+                            if namespaceUri and (attType == "SCH" or attType == "ENT"):
+                                self.validTaxonomiesDict[namespaceUri].add(href)
+                            if href not in self.validTaxonomiesDict:
+                                self.validTaxonomiesDict[href] = "Allowed" + attType
+            except (EnvironmentError,
+                    etree.LxmlError) as err:
+                self.modelManager.cntlr.addToLog(_("Disclosure System \"%(name)s\" import %(importFile)s, error: %(error)s"),
+                                                 messageCode="arelle:disclosureSystemImportError",
+                                                 messageArgs={"error": str(err), "name": self.name, "importFile": basename},
+                                                 level=logging.ERROR)
+                etree.clear_error_log()
+
     def loadMappings(self):
         basename = os.path.basename(self.mappingsUrl)
         self.modelManager.cntlr.showStatus(_("parsing {0}").format(basename))
@@ -383,5 +428,12 @@ class DisclosureSystem:
 
     def hrefValid(self, href):
         if self.standardTaxonomiesUrl:
+            return href in self.standardTaxonomiesDict
+        return True # no standard taxonomies to test
+
+    def hrefValidForValidTaxonomy(self, href):
+        if self.validTaxonomiesUrl:
+            return href in self.validTaxonomiesDict
+        elif self.standardTaxonomiesUrl: # fallback to standard taxonomies dict
             return href in self.standardTaxonomiesDict
         return True # no standard taxonomies to test

--- a/arelle/DisclosureSystem.py
+++ b/arelle/DisclosureSystem.py
@@ -431,7 +431,7 @@ class DisclosureSystem:
             return href in self.standardTaxonomiesDict
         return True # no standard taxonomies to test
 
-    def hrefValidForValidTaxonomy(self, href):
+    def hrefValidForDisclosureSystem(self, href):
         if self.validTaxonomiesUrl:
             return href in self.validTaxonomiesDict
         elif self.standardTaxonomiesUrl: # fallback to standard taxonomies dict

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -72,7 +72,7 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
             modelXbrl.uriDir = os.path.dirname(modelXbrl.uriDir)
     if modelXbrl.modelManager.validateDisclosureSystem and \
        not normalizedUri.startswith(modelXbrl.uriDir) and \
-       not modelXbrl.modelManager.disclosureSystem.hrefValid(normalizedUri):
+       not modelXbrl.modelManager.disclosureSystem.hrefValidForValidTaxonomy(normalizedUri):
         blocked = modelXbrl.modelManager.disclosureSystem.blockDisallowedReferences
         if normalizedUri not in modelXbrl.urlUnloadableDocs:
             # HMRC note, HMRC.blockedFile should be in this list if uk-taxonomies.xml is maintained an dup to date

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -72,7 +72,7 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
             modelXbrl.uriDir = os.path.dirname(modelXbrl.uriDir)
     if modelXbrl.modelManager.validateDisclosureSystem and \
        not normalizedUri.startswith(modelXbrl.uriDir) and \
-       not modelXbrl.modelManager.disclosureSystem.hrefValidForValidTaxonomy(normalizedUri):
+       not modelXbrl.modelManager.disclosureSystem.hrefValidForDisclosureSystem(normalizedUri):
         blocked = modelXbrl.modelManager.disclosureSystem.blockDisallowedReferences
         if normalizedUri not in modelXbrl.urlUnloadableDocs:
             # HMRC note, HMRC.blockedFile should be in this list if uk-taxonomies.xml is maintained an dup to date

--- a/arelle/config/disclosuresystems.xsd
+++ b/arelle/config/disclosuresystems.xsd
@@ -59,6 +59,7 @@
       <xs:attribute name="names" use="required"/>
       <xs:attribute name="roleDefinitionPattern" use="optional"/>
       <xs:attribute name="standardTaxonomiesUrl" use="optional" />
+      <xs:attribute name="validTaxonomiesUrl" use="optional" />
       <xs:attribute name="mappingsUrl" />
       <xs:attribute name="utrUrl" />
       <xs:attribute name="utrStatusFilters" />

--- a/arelle/plugin/validate/EFM/config.xml
+++ b/arelle/plugin/validate/EFM/config.xml
@@ -96,7 +96,7 @@
       blockDisallowedReferences="false"
       defaultXmlLang="en-US"
       defaultLanguage="English"
-      standardTaxonomiesUrl="resources/edgartaxonomies/edgartaxonomies-all-years.xml"
+      standardTaxonomiesUrl="resources/edgartaxonomies/edgartaxonomies-24-1.xml"
       utrUrl="http://www.xbrl.org/utr/2022-02-16/utr.xml"
       validateFileText="true"
       validateEntryText="true"
@@ -120,8 +120,6 @@
       deiDocumentPeriodEndDateElement="DocumentPeriodEndDate"
       deiFilerIdentifierElement="EntityCentralIndexKey"
       deiFilerNameElement="EntityRegistrantName"
-      logLevelFilter="(?!.*-semantic$)"
-      logCodeFilter="(?!EFM.6.03.03.matchInstance|EFM.6.05.28.linkrole|EFM.6.07.06|EFM.6.10.01.missingLabelLinkbase)"
    />
   <DisclosureSystem
      names="US SEC (Edgar Filing Manual, Strict, all years)|efm-all-years|efm-strict-all-years"
@@ -204,6 +202,45 @@
      logCodeFilter="(?!EFM.6.05.28.linkrole|EFM.6.07.06|EFM.6.10.01.missingLabelLinkbase)"
      standardTaxonomyDatabase="efmStandardTaxonomies.db"
      standardTaxonomyUrlPattern="http://www.fasb.org|http://xbrl.sec.gov|http://www.xbrl.org|http://taxonomies.xbrl.us|http://xbrl.us/us-gaap|http://xbrl.ici.org/rr|http://xbrl.ifrs.org/taxonomy"
+     />
+  <DisclosureSystem
+     names="US SEC (Edgar Filing Manual, Liberal, All Years)|efm-nonblocking-all-years|efm-liberal-all-years"
+     description="US SEC Edgar Filing Manual, all years\n
+     Default language en-US (en allowed in some cases per EFM)\n
+     CIK identifier patterns\n
+     Allowed references http://www.sec.gov/info/edgar/edgartaxonomies.shtml\n
+     Disallowed references are processed\n
+     No content (semantic) tests are reported"
+     validationType="EFM"
+     exclusiveTypesPattern="EFM|GFM|HMRC|SBR.NL|FERC"
+     blockDisallowedReferences="false"
+     defaultXmlLang="en-US"
+     defaultLanguage="English"
+     standardTaxonomiesUrl="resources/edgartaxonomies/extendedtaxonomies-all-years.xml"
+     validTaxonomiesUrl="resources/edgartaxonomies/edgartaxonomies-24-1.xml"
+     utrUrl="http://www.xbrl.org/utr/2022-02-16/utr.xml"
+     validateFileText="true"
+     validateEntryText="true"
+     allowedExternalHrefPattern="https?://www.sec.gov/(ix[?]doc=/)?Archives/edgar/data/"
+     allowedImageTypes = '{
+        "data-scheme": false,
+        "img-file-extensions": ["gif", "jpg"],
+        "mime-types": []
+        }'
+     identifierSchemePattern="^http://www\.sec\.gov/CIK$"
+     identifierValuePattern="^[0-9]{10}$"
+     identifierValueName="CIK"
+     contextElement="segment"
+     roleDefinitionPattern="^[0-9]+ - (Statement|Disclosure|Schedule|Document) - [^\n]*\S$"
+     labelCheckPattern="[ \n\r\t]{2,}|&lt;|&amp;lt;|&amp;#60;|&amp;#x3C"
+     labelTrimPattern="[ \n\r\t]"
+     deiNamespacePattern="^http://xbrl\.us/dei/|^http://xbrl\.sec\.gov/dei"
+     deiAmendmentFlagElement="AmendmentFlag"
+     deiCurrentFiscalYearEndDateElement="CurrentFiscalYearEndDate"
+     deiDocumentFiscalYearFocusElement="DocumentFiscalYearFocus"
+     deiDocumentPeriodEndDateElement="DocumentPeriodEndDate"
+     deiFilerIdentifierElement="EntityCentralIndexKey"
+     deiFilerNameElement="EntityRegistrantName"
      />
   <DisclosureSystem
      names="US SEC extended with IFRS (Edgar Filing Manual, Pragmatic, all years)|efm-extended-pragmatic-all-years"

--- a/arelle/plugin/validate/EFM/config.xml
+++ b/arelle/plugin/validate/EFM/config.xml
@@ -84,7 +84,7 @@
      standardTaxonomyUrlPattern="http://www.fasb.org|http://xbrl.sec.gov|http://www.xbrl.org|http://taxonomies.xbrl.us|http://xbrl.us/us-gaap|http://xbrl.ici.org/rr|http://xbrl.ifrs.org/taxonomy"
      />
    <DisclosureSystem
-      names="US SEC (Edgar Filing Manual, Liberal, All Years)|efm-nonblocking|efm-liberal"
+      names="US SEC (Edgar Filing Manual, Liberal)|efm-nonblocking|efm-liberal"
       description="US SEC Edgar Filing Manual, all years\n
       Default language en-US (en allowed in some cases per EFM)\n
       CIK identifier patterns\n


### PR DESCRIPTION
#### Reason for change
Need more flexibility between currently existing disclosure systems in the EFM validation plugin

#### Description of change
- Updated `efm-liberal` to use up-to-date edgartaxonomies file
- Added `efm-liberal-all-years` which utilizes a new field on the disclosure system config to determine which taxonomies are valida but allow all taxonomies to be validated with.

#### Steps to Test
CI

**review**:
@Arelle/arelle
