### PR TITLE
Reduce concurrency issues with web cache downloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     'certifi',
+    'filelock',
     'isodate==0.*',
     'lxml>=4,<6',
     'numpy==1.*',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # core modules
 certifi==2024.6.2
+filelock==3.15.1
 lxml==5.2.2
 OpenPyXL==3.1.4
 pyparsing==3.1.2


### PR DESCRIPTION
#### Reason for change
Previous implementation of temporary file usage for web cache downloads was potentially problematic (concurrent downloads of the same file would conflict).
Previous implementations of other web cache file management introduced TOCTOU issues.

#### Description of change
* Use FileLock so no two WebCache instances will download the same file concurrently
* Use operations that either combine the file system check + operation or simply perform the operation and ignore the error.

#### Steps to Test
Web cache downloading isn't covered by our CI. Run two CLI commands locally that both attempt download of the same large file concurrently.

**review**:
@Arelle/arelle
