### PR TITLE
OIM optimization: prevent unnecessary root element replacement

### DIFF
--- a/arelle/plugin/loadFromOIM.py
+++ b/arelle/plugin/loadFromOIM.py
@@ -1836,6 +1836,14 @@ def loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                 initialComment="extracted from OIM {}".format(mappedUri),
                 base=documentBase)
             _return = modelXbrl.modelDocument
+
+        # Add any prefix/namespace combinations we are already aware of
+        # to the document, in order to prevent the costly `setXmlns` operation
+        # that involves copying all child elements from the existing root
+        # to a new root.
+        for prefix, namespace in namespaces.items():
+            setXmlns(modelXbrl.modelDocument, prefix, namespace)
+
         if len(modelXbrl.errors) > prevErrLen:
             error("oime:invalidTaxonomy",
                   _("Unable to obtain a valid taxonomy from URLs provided"),


### PR DESCRIPTION
#### Reason for change
The approach Arelle [currently uses](https://github.com/Arelle/Arelle/blob/cc8d600ab14a1ce0b8ca17f145ed4290f4c1615e/arelle/XmlUtil.py#L909) to add individual namespaces to a document's `nsmap` is to essentially create a new root element and copy over all child elements from the original root to the new root, and then use that new root as the document going forward. This method is understandably slower the larger the document is.

OIM parsing creates an empty document and progressively writes data to it as it reads source data. It will trigger the above process whenever a new prefix/namespace is encountered, which is quick when the document is small but can take more than a minute once the document has reached considerable size.

#### Description of change
A perfect solution would involve improving the efficiency of `nsmap` updates, but I did not find any potential solutions in my investigation. Instead, an effective solution may involve simply avoiding the need for `nsmap` updates on large documents.

`loadFromOIM` is aware of many prefix/namespace combinations very early on in the parsing process. If we assign these namespaces to the empty initialized document, we won't need to do the costly transferring between roots as described above since that process doesn't run if the prefix/namespace already exists.

#### Steps to Test
I used a 5,000 line CSV recently provided to our support email inbox. Initially, it was taking over 11 minutes to run. With this change it runs in just under a minute, a 92% reduction.

**review**:
@Arelle/arelle
