### PR TITLE
Support for stream input/output via Session API

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -606,6 +606,9 @@ class CntlrCmdLine(Cntlr.Cntlr):
         :param options: OptionParser options from parse_args of main argv arguments (when called from command line) or corresponding arguments from web service (REST) request.
         :type options: optparse.Values
         """
+        sourceZipStream = sourceZipStream or options.sourceZipStream
+        responseZipStream = responseZipStream or options.responseZipStream
+
         for b in BETA_FEATURES_AND_DESCRIPTIONS.keys():
             self.betaFeatures[b] = getattr(options, b)
         if options.statusPipe or options.monitorParentProcess:

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -4,7 +4,7 @@ See COPYRIGHT.md for copyright information.
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass
-from typing import Any, Optional, Union, Pattern
+from typing import Any, Optional, Union, Pattern, BinaryIO
 
 from arelle.FileSource import FileNamedStringIO
 from arelle.SystemInfo import hasWebServer
@@ -114,6 +114,7 @@ class RuntimeOptions:
     proxy: Optional[str] = None
     redirectFallbacks: Optional[dict[Pattern[str], str]] = None
     relationshipCols: Optional[int] = None
+    responseZipStream: Optional[BinaryIO] = None
     roleTypesFile: Optional[str] = None
     rssReport: Optional[str] = None
     rssReportCols: Optional[int] = None
@@ -123,6 +124,7 @@ class RuntimeOptions:
     showOptions: Optional[bool] = None
     skipDTS: Optional[bool] = None
     skipLoading: Optional[bool] = None
+    sourceZipStream: Optional[BinaryIO] = None
     statusPipe: Optional[str] = None
     tableFile: Optional[str] = None
     testReport: Optional[str] = None

--- a/arelle/api/Session.py
+++ b/arelle/api/Session.py
@@ -81,12 +81,15 @@ class Session:
             if self._cntlr.uiLang != options.uiLang:
                 self._cntlr.setUiLanguage(options.uiLang)
             self._cntlr.disablePersistentConfig = options.disablePersistentConfig or False
+        logRefObjectProperties = True
+        if options.logRefObjectProperties is not None:
+            logRefObjectProperties = options.logRefObjectProperties
         if options.webserver:
             if not self._cntlr.logger:
                 self._cntlr.startLogging(
                     logFileName='logToBuffer',
                     logTextMaxLength=options.logTextMaxLength,
-                    logRefObjectProperties=options.logRefObjectProperties or True
+                    logRefObjectProperties=logRefObjectProperties,
                 )
                 self._cntlr.postLoggingInit()
             from arelle import CntlrWebMain
@@ -101,7 +104,7 @@ class Session:
                     logLevel=(options.logLevel or "DEBUG"),
                     logToBuffer=options.logFile == 'logToBuffer',
                     logTextMaxLength=options.logTextMaxLength,  # e.g., used by EdgarRenderer to require buffered logging
-                    logRefObjectProperties=options.logRefObjectProperties or True,
+                    logRefObjectProperties=logRefObjectProperties,
                     logXmlMaxAttributeLength=options.logXmlMaxAttributeLength
                 )
                 self._cntlr.postLoggingInit()  # Cntlr options after logging is started

--- a/arelle/api/Session.py
+++ b/arelle/api/Session.py
@@ -35,6 +35,14 @@ class Session:
         if self._cntlr is not None:
             self._cntlr.close()
 
+    def get_log_messages(self) -> list[dict[str, Any]]:
+        """
+        :return: Raw log records (messages) from the session.
+        """
+        if not self._cntlr or not self._cntlr.logHandler:
+            return []
+        return getattr(self._cntlr.logHandler, 'messages', [])
+
     def get_logs(self, log_format: str, clear_logs: bool = False) -> str:
         """
         Retrieve logs as a string in the configured format.


### PR DESCRIPTION
#### Reason for change
Some API users will be using in-memory streams for input/output rather than using the file system. Add ability to support this as well as some ancillary features.

#### Steps to Test
CI. An integration test script has been updated to use the stream approach.

**review**:
@Arelle/arelle
