### PR TITLE
Add unitName to utrEntry

### DIFF
--- a/arelle/ValidateUtr.py
+++ b/arelle/ValidateUtr.py
@@ -10,7 +10,7 @@ from arelle.ModelXbrl import ModelXbrl
 DIVISOR = "*DIV*"
 
 class UtrEntry(): # use slotted class for execution efficiency
-    __slots__ = ("id", "unitId", "nsUnit", "itemType", "nsItemType", "isSimple",
+    __slots__ = ("id", "unitId", "unitName", "nsUnit", "itemType", "nsItemType", "isSimple",
                  "numeratorItemType", "nsNumeratorItemType",
                  "denominatorItemType", "nsDenominatorItemType", "symbol",
                  "status")
@@ -52,6 +52,7 @@ def loadUtr(modelXbrl, statusFilters=None): # Build a dictionary of item types t
                 u = UtrEntry()
                 u.id = unitElt.get("id")
                 u.unitId = unitElt.findtext("{http://www.xbrl.org/2009/utr}unitId")
+                u.unitName = unitElt.findtext("{http://www.xbrl.org/2009/utr}unitName")
                 u.nsUnit = (unitElt.findtext("{http://www.xbrl.org/2009/utr}nsUnit") or None) # None if empty entry
                 u.itemType = unitElt.findtext("{http://www.xbrl.org/2009/utr}itemType")
                 u.nsItemType = unitElt.findtext("{http://www.xbrl.org/2009/utr}nsItemType")


### PR DESCRIPTION
#### Reason for change

The [UTR](https://www.xbrl.org/utr/utr.xml) provides various metadata about units.  Arelle currently exposes some elements of this via the `UtrEntry` class, but this doesn't include the `unitName` field.

I want to show this in the iXBRL viewer.

#### Description of change

Adds an additional slot (`unitName`) to `UtrEntry` and populates it from the UTR.

#### Steps to Test

This change is not visible through the UI or command line.  In Python, on a numeric fact object you should be able to call:

```
    next(iter(fact.utrEntries)).unitName
```

and it should give you a human readable description like "Pound Sterling" for `iso4217:GBP`.

(there will be a viewer PR that makes use of this shortly)


**review**:
@Arelle/arelle
