### PR TITLE
Move DQCRT Exception traceback into args on log message.

### DIFF
--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -4932,7 +4932,11 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
             modelXbrl.warning(f"{dqcRuleName}.{id}",
                               f"Validation was unable to complete rule {dqcRuleName} due to an internal error.  This is not considered an error in the filing.",
                               modelObject=modelXbrl)
-            modelXbrl.debug("arelle:dqcrtException", _("DQCRT Exception traceback: {}").format(traceback.format_exception(*sys.exc_info())))
+            modelXbrl.debug(
+                "arelle:dqcrtException",
+                _("An unexpected exception occurred in DQCRT"),
+                traceback=traceback.format_exception(*sys.exc_info())
+            )
 
     val.modelXbrl.profileActivity("... DQCRT checks", minTimeToShow=0.1)
     del val.summationItemRelsSetAllELRs


### PR DESCRIPTION
Restore #1204, reverted in #1213, noted [here](https://github.com/Arelle/Arelle/pull/1213#discussion_r1622406948).

#### Steps to Test
CI

**review**:
@Arelle/arelle
