### PR TITLE
Edgar validation update 1

### DIFF
--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -159,7 +159,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
     # efmSubmissionType and efmIxdsType are already set when re-validating after redaction/redline removal
     submissionType = getattr(modelXbrl,'efmSubmissionType', val.params.get("submissionType", ""))
     attachmentDocumentType = getattr(modelXbrl,'efmIxdsType', val.params.get("attachmentDocumentType", "")) # this is different from dei:documentType
-    isFeeTagging = feeTaggingAttachmentDocumentTypePattern.match(attachmentDocumentType)
+    isFeeTagging = feeTaggingAttachmentDocumentTypePattern.match(attachmentDocumentType or "")
     requiredFactLang = disclosureSystem.defaultXmlLang.lower() if disclosureSystem.defaultXmlLang else disclosureSystem.defaultXmlLang
     hasSubmissionType = bool(submissionType)
     hasAttachmentDocumentType = bool(attachmentDocumentType)


### PR DESCRIPTION
 * fix arelle edgar cmd line operation with flat zip of multi-doc single-IXDS with no json file argument, was raising exception, found by Ram

#### Reason for change
 * exception with flat zip of multi-doc single-IXDS without json file argument

#### Description of change
 * assume no attachmentDocumentType

#### Steps to Test
 * try with -f of multi-doc zip

**review**:
@Arelle/arelle
