### PR TITLE
Use correct file for standard taxonomies dict for efm-liberal-all-years

### DIFF
--- a/arelle/plugin/validate/EFM/config.xml
+++ b/arelle/plugin/validate/EFM/config.xml
@@ -216,7 +216,7 @@
      blockDisallowedReferences="false"
      defaultXmlLang="en-US"
      defaultLanguage="English"
-     standardTaxonomiesUrl="resources/edgartaxonomies/extendedtaxonomies-all-years.xml"
+     standardTaxonomiesUrl="resources/edgartaxonomies/edgartaxonomies-all-years.xml"
      validTaxonomiesUrl="resources/edgartaxonomies/edgartaxonomies-24-2.xml"
      utrUrl="http://www.xbrl.org/utr/2022-02-16/utr.xml"
      validateFileText="true"


### PR DESCRIPTION
#### Reason for change
The `efm-liberal-all-years` disclosure system is using the wrong file for the standard taxonomies dict. It is currently using extendedtaxonomies-all-years.xml. This file incorrectly sets the efm version to 34 which causes old validations to fire.

#### Description of change
Updated the standardTaxonomiesUrl from `extendedtaxonomies-all-years.xml` to `edgartaxonomies-all-years.xml`

#### Steps to Test
CI

**review**:
@Arelle/arelle
