### PR TITLE
Include calc 1.1 arcroles when looking up model rels

### DIFF
--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -159,7 +159,7 @@ class ValidateXbrl:
             else:
                 cyclesAllowed = "any"
                 specSect = None
-            if cyclesAllowed != "any" or arcrole in (XbrlConst.summationItem,) \
+            if cyclesAllowed != "any" or arcrole in XbrlConst.summationItems \
                                       or arcrole in self.genericArcArcroles  \
                                       or arcrole.startswith(XbrlConst.formulaStartsWith) \
                                       or (modelXbrl.hasXDT and arcrole.startswith(XbrlConst.dimStartsWith)):


### PR DESCRIPTION
#### Reason for change
resolves #1265

Calc 1.1 arcroles were not included in relationship set lookup for calculation arc validation. Additionally, because assignment of the relationship set occurred in a separate conditional, validation was applied to a relationship set from a previous iteration triggering an attribute exception.

#### Description of change
* Include calc 1.1 arcrole in relationship set lookup for calc arc validation.
* Move usage of the relationship set under the same conditional as the lookup and assignment to make sure validation is never performed on the wrong set.

#### Steps to Test
* Contact for private testing doc

**review**:
@Arelle/arelle
