### PR TITLE
EDGAR 24.2 attachmentDocumentType inconsistencies

### DIFF
--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -158,7 +158,7 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
     deiDocumentType = None # needed for non-instance validation too
     # efmSubmissionType and efmIxdsType are already set when re-validating after redaction/redline removal
     submissionType = getattr(modelXbrl,'efmSubmissionType', val.params.get("submissionType", ""))
-    attachmentDocumentType = getattr(modelXbrl,'efmIxdsType', val.params.get("attachmentDocumentType", "")) # this is different from dei:documentType
+    attachmentDocumentType = getattr(modelXbrl,'efmIxdsType', val.params.get("attachmentDocumentType")) # this is different from dei:documentType, None if absent
     isFeeTagging = feeTaggingAttachmentDocumentTypePattern.match(attachmentDocumentType or "")
     requiredFactLang = disclosureSystem.defaultXmlLang.lower() if disclosureSystem.defaultXmlLang else disclosureSystem.defaultXmlLang
     hasSubmissionType = bool(submissionType)


### PR DESCRIPTION
#### Reason for change
Apply consistent treatment to attachmentDocumentType to allow None when absent or when null in entrypoint objects (which may be from --file parameter).

[EdgarRenderer PR](https://github.com/Arelle/EdgarRenderer/pull/111)

#### Description of change
Pattern matches or "" to tolerate None value.  Log message of any stripped files apply "(none)" when no attachmentDocumentType was available.

#### Steps to Test
Suggest simple argument such as python3 arelleCmdLine.py --plugin EdgarRenderer --disclosureSystem efm-pragmatic -v -f 'path to any multi-doc or multi-ixds filing such as IBM accession 0000051143-24-000012-xbrl.zip'

**review**:
@Arelle/arelle
