### PR TITLE
Guard UK member validation against incomplete contexts

### DIFF
--- a/arelle/plugin/validate/UK/__init__.py
+++ b/arelle/plugin/validate/UK/__init__.py
@@ -223,7 +223,7 @@ def validateXbrlFinally(val, *args, **kwargs):
         contextsWithScenario = []
         for cntx in contextsUsed:
             for dim in cntx.qnameDims.values():
-                if dim.isExplicit:
+                if dim.isExplicit and dim.memberQname is not None:
                     _memName = dim.memberQname.localName
                     m = memNameNumPattern.match(_memName)
                     if m:


### PR DESCRIPTION
#### Reason for change
An attribute exception is raised when a report that contains a context with a dimension but no member is validated with the validate/UK plugin and HMRC disclosure system.

#### Description of change
Check that the context dimension has a member before preceding with HMRC validation of the context member. 

#### Steps to Test
1. Use [wk-2024-07-08-ixbrl.zip](https://github.com/user-attachments/files/16142526/wk-2024-07-08-ixbrl.zip)
2. On master confirm that a `exception:AttributeError` is raised with the following command:
  * `python arelleCmdLine.py --plugins validate/UK --disclosureSystem hmrc --validate --file wk-2024-07-08-ixbrl.zip`
3. On this branch confirm that the attribute error is no longer raised and that both a `xmlSchema:valueError` and `xbrldie:PrimaryItemDimensionallyInvalidError` are raised.

**review**:
@Arelle/arelle
