### PR TITLE
Pass data streams to Session instead of RuntimeOptions

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -611,9 +611,6 @@ class CntlrCmdLine(Cntlr.Cntlr):
         :param options: OptionParser options from parse_args of main argv arguments (when called from command line) or corresponding arguments from web service (REST) request.
         :type options: optparse.Values
         """
-        sourceZipStream = sourceZipStream or options.sourceZipStream
-        responseZipStream = responseZipStream or options.responseZipStream
-
         for b in BETA_FEATURES_AND_DESCRIPTIONS.keys():
             self.betaFeatures[b] = getattr(options, b)
         if options.statusPipe or options.monitorParentProcess:

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -4,7 +4,7 @@ See COPYRIGHT.md for copyright information.
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass
-from typing import Any, Optional, Union, Pattern, BinaryIO
+from typing import Any, Optional, Union, Pattern
 
 from arelle.FileSource import FileNamedStringIO
 from arelle.SystemInfo import hasWebServer
@@ -114,7 +114,6 @@ class RuntimeOptions:
     proxy: Optional[str] = None
     redirectFallbacks: Optional[dict[Pattern[str], str]] = None
     relationshipCols: Optional[int] = None
-    responseZipStream: Optional[BinaryIO] = None
     roleTypesFile: Optional[str] = None
     rssReport: Optional[str] = None
     rssReportCols: Optional[int] = None
@@ -124,7 +123,6 @@ class RuntimeOptions:
     showOptions: Optional[bool] = None
     skipDTS: Optional[bool] = None
     skipLoading: Optional[bool] = None
-    sourceZipStream: Optional[BinaryIO] = None
     statusPipe: Optional[str] = None
     tableFile: Optional[str] = None
     testReport: Optional[str] = None

--- a/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
+++ b/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
@@ -40,7 +40,6 @@ print(f"Generating IXBRL viewer: {viewer_path}")
 # include start
 with open(samples_zip_path, 'rb') as stream:
     options = RuntimeOptions(
-        sourceZipStream=stream,
         entrypointFile=str(target_path),
         internetConnectivity='offline' if arelle_offline else 'online',
         keepOpen=True,
@@ -54,7 +53,7 @@ with open(samples_zip_path, 'rb') as stream:
         strictOptions=False,
     )
     with Session() as session:
-        session.run(options)
+        session.run(options, sourceZipStream=stream)
         log_xml = session.get_logs('xml')
 # include end
 


### PR DESCRIPTION
#### Reason for change
[Recent addition](https://github.com/Arelle/Arelle/pull/1239) of streams to `RuntimeOptions` prevents the object from being pickled/deep-copied. FERC renderer [relies](https://github.com/Workiva/xule-all/blob/008bc2cf0bf4594b07acee0eb4892dac27bf5f32/plugin/FERC/render.py#L2181) on this ability, but in general it would be preferred to maintain the ability to pickle `RuntimeOptions`.

#### Description of change
Rather than passing actual data source/destination streams as options, we can pass them to `Session.run` instead.


#### Steps to Test
CI

**review**:
@Arelle/arelle
