### PR TITLE
Add map of UTR entries by QName to ModelXbrl

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -1345,3 +1345,19 @@ class ModelXbrl:
                   _("DTS of %(entryFile)s has %(numberOfFiles)s files packaged into %(packageOutputFile)s"),
                 modelObject=self,
                 entryFile=os.path.basename(entryFilename), packageOutputFile=pkgFilename, numberOfFiles=numFiles)
+
+    @property
+    def qnameUtrUnits(self):
+        try:
+            return self._qnameUtrUnits
+        except AttributeError:
+            from arelle.ValidateUtr import ValidateUtr
+            utrEntries = ValidateUtr(self).utrItemTypeEntries
+            qnameUtrUnits = {}
+            for unitType, unitMap in utrEntries.items():
+                for unitId, unit in unitMap.items():
+                    unitQName = unit.qname()
+                    if unitQName:
+                        qnameUtrUnits[unitQName] = unit
+            self._qnameUtrUnits = qnameUtrUnits
+            return self._qnameUtrUnits

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from arelle.ModelValue import QName
     from arelle.PrototypeDtsObject import LinkPrototype
     from arelle.typing import EmptyTuple, TypeGetText, LocaleDict
+    from arelle.ValidateUtr import UtrEntry
 
     _: TypeGetText  # Handle gettext
 else:
@@ -307,6 +308,7 @@ class ModelXbrl:
     _nonNilFactsInInstance: set[ModelFact]
     _startedProfiledActivity: float
     _startedTimeStat: float
+    _qnameUtrUnits: dict[QName, UtrEntry]
 
     def __init__(self,  modelManager: ModelManager, errorCaptureLevel: str | None = None) -> None:
         self.modelManager = modelManager
@@ -1347,7 +1349,7 @@ class ModelXbrl:
                 entryFile=os.path.basename(entryFilename), packageOutputFile=pkgFilename, numberOfFiles=numFiles)
 
     @property
-    def qnameUtrUnits(self):
+    def qnameUtrUnits(self) -> dict[QName, UtrEntry]:
         try:
             return self._qnameUtrUnits
         except AttributeError:

--- a/arelle/ValidateUtr.py
+++ b/arelle/ValidateUtr.py
@@ -5,6 +5,7 @@ from lxml import etree
 from arelle import ModelDocument
 from collections import defaultdict
 
+from arelle.ModelValue import QName
 from arelle.ModelXbrl import ModelXbrl
 
 DIVISOR = "*DIV*"
@@ -14,6 +15,12 @@ class UtrEntry(): # use slotted class for execution efficiency
                  "numeratorItemType", "nsNumeratorItemType", "definition",
                  "denominatorItemType", "nsDenominatorItemType", "symbol",
                  "status")
+
+    def qname(self) -> QName | None:
+        if not self.nsUnit:
+            return None
+        prefix = self.nsUnit.split('/')[-1]
+        return QName(prefix=prefix, namespaceURI=self.nsUnit, localName=self.unitId)
 
     def __repr__(self):
         return "utrEntry({})".format(', '.join("{}={}".format(n, getattr(self,n))

--- a/arelle/ValidateUtr.py
+++ b/arelle/ValidateUtr.py
@@ -4,6 +4,7 @@ See COPYRIGHT.md for copyright information.
 from lxml import etree
 from arelle import ModelDocument
 from collections import defaultdict
+from typing import Optional
 
 from arelle.ModelValue import QName
 from arelle.ModelXbrl import ModelXbrl
@@ -16,7 +17,7 @@ class UtrEntry(): # use slotted class for execution efficiency
                  "denominatorItemType", "nsDenominatorItemType", "symbol",
                  "status")
 
-    def qname(self) -> QName | None:
+    def qname(self) -> Optional[QName]:
         if not self.nsUnit:
             return None
         prefix = self.nsUnit.split('/')[-1]

--- a/arelle/ValidateUtr.py
+++ b/arelle/ValidateUtr.py
@@ -11,7 +11,7 @@ DIVISOR = "*DIV*"
 
 class UtrEntry(): # use slotted class for execution efficiency
     __slots__ = ("id", "unitId", "unitName", "nsUnit", "itemType", "nsItemType", "isSimple",
-                 "numeratorItemType", "nsNumeratorItemType",
+                 "numeratorItemType", "nsNumeratorItemType", "definition",
                  "denominatorItemType", "nsDenominatorItemType", "symbol",
                  "status")
 
@@ -62,6 +62,7 @@ def loadUtr(modelXbrl, statusFilters=None): # Build a dictionary of item types t
                 u.nsDenominatorItemType = unitElt.findtext("{http://www.xbrl.org/2009/utr}nsDenominatorItemType")
                 u.isSimple = all(e is None for e in (u.numeratorItemType, u.nsNumeratorItemType, u.denominatorItemType, u.nsDenominatorItemType))
                 u.symbol = unitElt.findtext("{http://www.xbrl.org/2009/utr}symbol")
+                u.definition = unitElt.findtext("{http://www.xbrl.org/2009/utr}definition")
                 u.status = unitElt.findtext("{http://www.xbrl.org/2009/utr}status")
                 if u.status in statusFilters:
                     # TO DO: This indexing scheme assumes that there are no name clashes in item types of the registry.

--- a/arelle/ValidateUtr.py
+++ b/arelle/ValidateUtr.py
@@ -118,6 +118,9 @@ def utrSymbol(modelType, unitMeasures):
     return ValidateUtr(modelType.modelXbrl).utrSymbol(unitMeasures[0], unitMeasures[1])
 
 class ValidateUtr:
+
+    utrItemTypeEntries: dict[str, dict[str, UtrEntry]]
+
     def __init__(self, modelXbrl: ModelXbrl, messageLevel: str="ERROR", messageCode: str="utre:error-NumericFactUtrInvalid") -> None:
         self.modelXbrl = modelXbrl
         self.messageLevel = messageLevel

--- a/arelle/ValidateUtr.py
+++ b/arelle/ValidateUtr.py
@@ -1,6 +1,8 @@
 '''
 See COPYRIGHT.md for copyright information.
 '''
+from __future__ import annotations
+
 from lxml import etree
 from arelle import ModelDocument
 from collections import defaultdict
@@ -12,6 +14,21 @@ from arelle.ModelXbrl import ModelXbrl
 DIVISOR = "*DIV*"
 
 class UtrEntry(): # use slotted class for execution efficiency
+    id: str | None
+    unitId: str | None
+    unitName: str | None
+    nsUnit: str | None
+    itemType: str | None
+    nsItemType: str | None
+    numeratorItemType: str | None
+    nsNumeratorItemType: str | None
+    denominatorItemType: str | None
+    nsDenominatorItemType: str | None
+    isSimple: bool
+    symbol: str | None
+    definition: str | None
+    status: str | None
+
     __slots__ = ("id", "unitId", "unitName", "nsUnit", "itemType", "nsItemType", "isSimple",
                  "numeratorItemType", "nsNumeratorItemType", "definition",
                  "denominatorItemType", "nsDenominatorItemType", "symbol",
@@ -119,15 +136,13 @@ def utrSymbol(modelType, unitMeasures):
 
 class ValidateUtr:
 
-    utrItemTypeEntries: dict[str, dict[str, UtrEntry]]
-
     def __init__(self, modelXbrl: ModelXbrl, messageLevel: str="ERROR", messageCode: str="utre:error-NumericFactUtrInvalid") -> None:
         self.modelXbrl = modelXbrl
         self.messageLevel = messageLevel
         self.messageCode = messageCode
         if getattr(modelXbrl.modelManager.disclosureSystem, "utrItemTypeEntries", None) is None:
             loadUtr(modelXbrl)
-        self.utrItemTypeEntries = modelXbrl.modelManager.disclosureSystem.utrItemTypeEntries
+        self.utrItemTypeEntries: dict[str, dict[str, UtrEntry]] = modelXbrl.modelManager.disclosureSystem.utrItemTypeEntries
 
     def validateFacts(self):
         modelXbrl = self.modelXbrl


### PR DESCRIPTION
#### Reason for change

To support display of units in iXBRL viewer.

#### Description of change

Adds a map of UTR entries by QName to `ModelXbrl`.

Also adds the `definition` field from UTR to each UTR entry.

Original implementation by @aaroncameron-wk (https://github.com/aaroncameron-wk/arelle-public/tree/utr-entries)

#### Steps to Test

Calling `qnameUtrUnits` on a `ModelXbrl` object should return a dict mapping QNames to UTR entries.

**review**:
@Arelle/arelle
