### PR TITLE
Resolve Python exceptions raised by broken document

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -806,7 +806,7 @@ class ModelXbrl:
             self._factsByDatatype[notStrict, typeQname] = fbdt = set()
             for f in self.factsInInstance:
                 c = f.concept
-                if c is not None and (c.typeQname == typeQname or (notStrict and c.type.isDerivedFrom(typeQname))):
+                if c is not None and (c.typeQname == typeQname or (notStrict and c.type is not None and c.type.isDerivedFrom(typeQname))):
                     fbdt.add(f)
             return fbdt
 

--- a/arelle/plugin/validate/EFM/Filing.py
+++ b/arelle/plugin/validate/EFM/Filing.py
@@ -3782,12 +3782,12 @@ def validateFiling(val, modelXbrl, isEFM=False, isGFM=False):
                         def r6facts():
                             for n in rule["names"]:
                                 for f in modelXbrl.factsByLocalName.get(n,()):
-                                    if f.context is not None:
+                                    if f.context is not None and f.context.endDatetime is not None and f.context.startDatetime is not None:
                                         yield f
                             for n in ("{http://www.xbrl.org/dtr/type/non-numeric}textBlockItemType",
                                       "{http://www.xbrl.org/dtr/type/2020-01-21}textBlockItemType"):
                                 for f in modelXbrl.factsByDatatype(True, qname(n)):
-                                    if f.context is not None:
+                                    if f.context is not None and f.context.endDatetime is not None and f.context.startDatetime is not None:
                                         yield f
                         for f in r6facts():
                             durationDays = (f.context.endDatetime - f.context.startDatetime).days


### PR DESCRIPTION
#### Reason for change
Broken document raised Python exceptions.

#### Description of change
* Guard against concepts without a item type.
* Guard against contexts without a start or end date.

#### Steps to Test
* CI
* Internal testing doc

**review**:
@Arelle/arelle
