### PR TITLE
Add ModelXbrl ixdsTarget property/setter that handles (default) value

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -309,6 +309,7 @@ class ModelXbrl:
     _startedProfiledActivity: float
     _startedTimeStat: float
     _qnameUtrUnits: dict[QName, UtrEntry]
+    _ixdsTarget: str | None
 
     def __init__(self,  modelManager: ModelManager, errorCaptureLevel: str | None = None) -> None:
         self.modelManager = modelManager
@@ -1000,6 +1001,16 @@ class ModelXbrl:
             self.modelManager.addToLog(_("Exception viewing properties {0} {1} at {2}").format(
                             modelObject,
                             err, traceback.format_tb(sys.exc_info()[2])))
+
+    @property
+    def ixdsTarget(self) -> str | None:
+        if self._ixdsTarget == '(default)':
+            return None
+        return self._ixdsTarget
+
+    @ixdsTarget.setter
+    def ixdsTarget(self, value: str | None) -> None:
+        self._ixdsTarget = value
 
     def effectiveMessageCode(self, messageCodes: tuple[Any] | str) -> str | None:
         """


### PR DESCRIPTION
#### Reason for change
Arelle inconsistently handles the "(default)" IXDS target value.
For example:
In the IXDS plugin, the "(default)" value [translates](https://github.com/Arelle/Arelle/blob/948d3ea67940b3bd9b0d12714e50f9d8685e0e11/arelle/plugin/inlineXbrlDocumentSet.py#L155) to `None`.
But where the `arelle:ixdsTargetNotDefined` error code [fires](https://github.com/Arelle/Arelle/blob/948d3ea67940b3bd9b0d12714e50f9d8685e0e11/arelle/ModelDocument.py#L1995), there is no consideration for the "(default)" value.

#### Description of change
Ensure that whenever `modelXbrl.ixdsTarget` is retrieved, it returns `None` if the underlying value is "(default)".

#### Steps to Test
CI

**review**:
@Arelle/arelle
