### PR TITLE
Added validations DBA.FR74a and DBA.FR74b and related conformance tests.

### DIFF
--- a/arelle/plugin/validate/DBA/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/DBA/PluginValidationDataExtension.py
@@ -42,6 +42,7 @@ class PluginValidationDataExtension(PluginData):
     precedingReportingPeriodStartDateQn: QName
     profitLossQn: QName
     proposedDividendRecognisedInEquityQn: QName
+    provisionsQn: QName
     reportingPeriodEndDateQn: QName
     reportingPeriodStartDateQn: QName
     shorttermLiabilitiesOtherThanProvisionsQn: QName

--- a/arelle/plugin/validate/DBA/ValidationPluginExtension.py
+++ b/arelle/plugin/validate/DBA/ValidationPluginExtension.py
@@ -11,11 +11,13 @@ from .PluginValidationDataExtension import PluginValidationDataExtension
 
 _: TypeGetText
 
+DANISH_CURRENCY_ID = 'DKK'
 NAMESPACE_ARR = 'http://xbrl.dcca.dk/arr'
 NAMESPACE_CMN = 'http://xbrl.dcca.dk/cmn'
 NAMESPACE_FSA = 'http://xbrl.dcca.dk/fsa'
 NAMESPACE_GSD = 'http://xbrl.dcca.dk/gsd'
 NAMESPACE_SOB = 'http://xbrl.dcca.dk/sob'
+ROUNDING_MARGIN = 1000
 
 
 class ValidationPluginExtension(ValidationPlugin):
@@ -75,6 +77,7 @@ class ValidationPluginExtension(ValidationPlugin):
             precedingReportingPeriodStartDateQn=qname(f'{{{NAMESPACE_GSD}}}PrecedingReportingPeriodStartDate'),
             profitLossQn=qname(f'{{{NAMESPACE_FSA}}}ProfitLoss'),
             proposedDividendRecognisedInEquityQn=qname(f'{{{NAMESPACE_FSA}}}ProposedDividendRecognisedInEquity'),
+            provisionsQn=qname(f'{{{NAMESPACE_FSA}}}Provisions'),
             reportingPeriodEndDateQn=qname(f'{{{NAMESPACE_GSD}}}ReportingPeriodEndDate'),
             reportingPeriodStartDateQn=qname(f'{{{NAMESPACE_GSD}}}ReportingPeriodStartDate'),
             shorttermLiabilitiesOtherThanProvisionsQn=qname(f'{{{NAMESPACE_FSA}}}ShorttermLiabilitiesOtherThanProvisions'),

--- a/arelle/plugin/validate/DBA/rules/__init__.py
+++ b/arelle/plugin/validate/DBA/rules/__init__.py
@@ -177,7 +177,10 @@ def getFactsGroupedByContextId(modelXbrl: ModelXbrl, *conceptQns: QName) -> dict
     facts: set[ModelFact] = set()
     for conceptQn in conceptQns:
         facts.update(modelXbrl.factsByQname.get(conceptQn, set()))
-    return {
-        k: sorted(v, key=lambda f: f.objectIndex)
-        for k, v in itertools.groupby(facts, key=lambda f: f.contextID)
-    }
+    grouped_facts: dict[str, list[ModelFact]] = {}
+    for fact in facts:
+        context_id = fact.contextID
+        if context_id not in grouped_facts:
+            grouped_facts[context_id] = []
+        grouped_facts[context_id].append(fact)
+    return grouped_facts

--- a/tests/resources/conformance_suites/dba/fr/fr74-testcase.xml
+++ b/tests/resources/conformance_suites/dba/fr/fr74-testcase.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="../testcase.xsl"?>
+<testcase
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xbrl.org/2005/conformance"
+        name="DBA.FR81"
+        description=" DBA.FR74a:Provisions [hierarchy:fsa:Provisions] and underlying fields must each be less than or equal to the balance
+        sheet total (fsa:LiabilitiesAndEquity) minus equity (fsa:Equity)."
+        outpath=''
+        owner="support@arelle.org"
+        xsi:schemaLocation="http://xbrl.org/2005/conformance https://www.xbrl.org/2005/conformance.xsd">
+    <variation id="invalid-74a" name="Invalid-74a">
+        <description>
+            Provisions is NOT less than or equal to LiabilitiesAndEquity minus Equity.
+        </description>
+        <data>
+            <instance readMeFirst="true">fr74a-invalid.xbrl</instance>
+        </data>
+        <result>
+            <error>DBA.FR74a</error>
+        </result>
+    </variation>
+    <variation id="invalid-74b" name="Invalid-74b">
+        <description>
+            LiabilitiesOtherThanProvisions is NOT less than or equal to LiabilitiesAndEquity minus Equity.
+        </description>
+        <data>
+            <instance readMeFirst="true">fr74b-invalid.xbrl</instance>
+        </data>
+        <result>
+            <error>DBA.FR74b</error>
+        </result>
+    </variation>
+</testcase>

--- a/tests/resources/conformance_suites/dba/fr/fr74a-invalid.xbrl
+++ b/tests/resources/conformance_suites/dba/fr/fr74a-invalid.xbrl
@@ -456,7 +456,7 @@
     <fsa:PropertyPlantAndEquipmentInProgressAndPrepaymentsForPropertyPlantAndEquipment contextRef="ID_9" xml:lang="da" unitRef="DKK" decimals="-3">0000</fsa:PropertyPlantAndEquipmentInProgressAndPrepaymentsForPropertyPlantAndEquipment>
     <fsa:ProposedDividendRecognisedInEquity contextRef="ID_8" xml:lang="da" unitRef="DKK" decimals="-3">180000000</fsa:ProposedDividendRecognisedInEquity>
     <fsa:ProposedDividendRecognisedInEquity contextRef="ID_9" xml:lang="da" unitRef="DKK" decimals="-3">0000</fsa:ProposedDividendRecognisedInEquity>
-    <fsa:Provisions contextRef="ID_8" xml:lang="da" unitRef="DKK" decimals="-3">1013196000</fsa:Provisions>
+    <fsa:Provisions contextRef="ID_8" xml:lang="da" unitRef="DKK" decimals="-3">101319600000000000</fsa:Provisions>
     <fsa:Provisions contextRef="ID_9" xml:lang="da" unitRef="DKK" decimals="-3">872674000</fsa:Provisions>
     <fsa:ProvisionsForDeferredTax contextRef="ID_8" xml:lang="da" unitRef="DKK" decimals="-3">1013196000</fsa:ProvisionsForDeferredTax>
     <fsa:ProvisionsForDeferredTax contextRef="ID_9" xml:lang="da" unitRef="DKK" decimals="-3">872674000</fsa:ProvisionsForDeferredTax>

--- a/tests/resources/conformance_suites/dba/fr/fr74b-invalid.xbrl
+++ b/tests/resources/conformance_suites/dba/fr/fr74b-invalid.xbrl
@@ -407,7 +407,7 @@
     <fsa:LeaseholdImprovements contextRef="ID_9" xml:lang="da" unitRef="DKK" decimals="-3">26141000</fsa:LeaseholdImprovements>
     <fsa:LiabilitiesAndEquity contextRef="ID_8" xml:lang="da" unitRef="DKK" decimals="-3">8858363000</fsa:LiabilitiesAndEquity>
     <fsa:LiabilitiesAndEquity contextRef="ID_9" xml:lang="da" unitRef="DKK" decimals="-3">8160805000</fsa:LiabilitiesAndEquity>
-    <fsa:LiabilitiesOtherThanProvisions contextRef="ID_8" xml:lang="da" unitRef="DKK" decimals="-3">4299840000</fsa:LiabilitiesOtherThanProvisions>
+    <fsa:LiabilitiesOtherThanProvisions contextRef="ID_8" xml:lang="da" unitRef="DKK" decimals="-3">429984000000</fsa:LiabilitiesOtherThanProvisions>
     <fsa:LiabilitiesOtherThanProvisions contextRef="ID_9" xml:lang="da" unitRef="DKK" decimals="-3">4272778000</fsa:LiabilitiesOtherThanProvisions>
     <fsa:LongtermDebtToBanks contextRef="ID_8" xml:lang="da" unitRef="DKK" decimals="-3">0000</fsa:LongtermDebtToBanks>
     <fsa:LongtermDebtToBanks contextRef="ID_9" xml:lang="da" unitRef="DKK" decimals="-3">269269000</fsa:LongtermDebtToBanks>

--- a/tests/resources/conformance_suites/dba/index.xml
+++ b/tests/resources/conformance_suites/dba/index.xml
@@ -6,6 +6,7 @@
     <testcase uri='fr/fr41-testcase.xml' />
     <testcase uri='fr/fr48-testcase.xml' />
     <testcase uri='fr/fr56-testcase.xml' />
+    <testcase uri='fr/fr74-testcase.xml' />
     <testcase uri='fr/fr81-testcase.xml' />
     <testcase uri='fr/valid-testcase.xml' />
 </testcases>


### PR DESCRIPTION
#### Reason for change

>DBA.FR74a: Provisions (fsa:Provisions) must be less than or equal to the balance sheet total (fsa:LiabilitiesAndEquity) minus equity (fsa:Equity).

>DBA.FR74b: Liabilities (fsa:LiabilitiesOtherThanProvisions) and must be less than or equal to total assets (fsa:LiabilitiesAndEquity) minus equity (fsa:Equity).

#### Description of change

Added validations and conformance tests.

Anonymized the valid-001 test case.

Fixed a bug in getFactsGroupedByContextId that was causing some facts to be missed.


#### Steps to Test

**review**:
@Arelle/arelle
