### PR TITLE
Detect xbrli Namespace Prefix When Loading OIM Reports

### DIFF
--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -1737,6 +1737,11 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
             if not UrlUtil.isAbsolute(tUrl) and os.path.isabs(tUrl) and not UrlUtil.isAbsolute(txBase) and os.path.isabs(txBase):
                 taxonomyRefs[i] = os.path.relpath(tUrl, txBase)
         prevErrLen = len(modelXbrl.errors) # track any xbrl validation errors
+        xbrliNamespacePrefix = None
+        for prefix, ns in namespaces.items():
+            if ns == XbrlConst.xbrli:
+                xbrliNamespacePrefix = prefix
+                break
         if modelXbrl: # pull loader implementation
             modelXbrl.blockDpmDBrecursion = True
             modelXbrl.modelDocument = _return = ModelDocument.create(
@@ -1746,6 +1751,7 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                   schemaRefs=taxonomyRefs,
                   isEntry=True,
                   initialComment="extracted from OIM {}".format(mappedUri),
+                  xbrliNamespacePrefix=xbrliNamespacePrefix,
                   documentEncoding="utf-8",
                   base=documentBase or modelXbrl.entryLoadingUrl)
             modelXbrl.modelDocument.inDTS = True
@@ -1757,6 +1763,7 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                 schemaRefs=taxonomyRefs,
                 isEntry=True,
                 initialComment="extracted from OIM {}".format(mappedUri),
+                xbrliNamespacePrefix=xbrliNamespacePrefix,
                 base=documentBase)
             _return = modelXbrl.modelDocument
 


### PR DESCRIPTION
#### Reason for change
The root xbrl element is written with the expectation that the default namespace is xbrli, but if the report includes xbrli in the namespaces dict it's written to the converted doc and the default namespace is removed.

Resolves #1294

#### Description of change
* Detect if xbrli is in the parsed OIM namespaces dict.
* If present, use the prefix for the root xbrl element when creating the XML instance.

#### Steps to Test
* internal testing doc

**review**:
@Arelle/arelle
