### PR TITLE
Move dev import behind TYPE_CHECKING

### DIFF
--- a/arelle/utils/validate/Decorator.py
+++ b/arelle/utils/validate/Decorator.py
@@ -4,12 +4,13 @@ See COPYRIGHT.md for copyright information.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Optional
-
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
 
 from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Validation import Validation
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 ValidationFunction: TypeAlias = Callable[..., Optional[Iterable[Validation]]]
 


### PR DESCRIPTION
#### Reason for change
Resolves https://groups.google.com/g/arelle-users/c/K-GMxt2S-nk

#### Description of change
Move type checking dev dependency behind `TYPE_CHECKING` guard.
`typing_extensions` is a dev dependency and not included for users who only install dependencies from requirements.txt.

#### Steps to Test
`python arelleCmdLine.py --file https://www.sec.gov/Archives/edgar/data/1445305/000144530524000071/0001445305-24-000071-xbrl.zip --plugins validate/ROS`

```shell
Traceback (most recent call last):
  File "/.../Arelle/arelle/PluginManager.py", line 605, in pluginClassMethods
    pluginMethodsForClass = pluginMethodsForClasses[className]
                            ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'DisclosureSystem.Types'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/.../Arelle/arelle/PluginManager.py", line 555, in loadModule
    module = _find_and_load_module(moduleDir=moduleDir, moduleName=moduleName)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../Arelle/arelle/PluginManager.py", line 536, in _find_and_load_module
    spec.loader.exec_module(sys.modules[moduleName])
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/.../Arelle/arelle/plugin/validate/ROS/__init__.py", line 14, in <module>
    from .ValidationPluginExtension import ValidationPluginExtension
  File "/.../Arelle/arelle/plugin/validate/ROS/ValidationPluginExtension.py", line 7, in <module>
    from arelle.utils.validate.ValidationPlugin import ValidationPlugin
  File "/.../Arelle/arelle/utils/validate/ValidationPlugin.py", line 16, in <module>
    from arelle.utils.validate.Decorator import (
  File "/.../Arelle/arelle/utils/validate/Decorator.py", line 9, in <module>
    from typing_extensions import TypeAlias
ModuleNotFoundError: No module named 'typing_extensions'
```
**review**:
@Arelle/arelle
