### PR TITLE
Updating ROS.19 validation to make it more robust

### DIFF
--- a/arelle/plugin/validate/ROS/rules/ros.py
+++ b/arelle/plugin/validate/ROS/rules/ros.py
@@ -354,7 +354,7 @@ def rule_ros19(
     message: str | None = None
     modelObjects = set()
     monetaryFacts = val.modelXbrl.factsByDatatype(False, qnXbrliMonetaryItemType)
-    monetaryUnits = set(fact.unit.value for fact in monetaryFacts)
+    monetaryUnits = set(fact.unit.value for fact in monetaryFacts if fact.unit)
     pricipalCurrencyFacts = val.modelXbrl.factsByLocalName.get(PRINCIPAL_CURRENCY, set())
     principalCurrencyValues = set(fact.text for fact in pricipalCurrencyFacts)
     if len(principalCurrencyValues) != 1:


### PR DESCRIPTION
#### Reason for change

ROS.19 was having an issue for facts without units.

#### Description of change

Checks for existence of units before inspecting them.

#### Steps to Test

Validate a ROS document that has monetary facts without units.

**review**:
@Arelle/arelle
