### PR TITLE
Update Python Version Specific Dependencies

### DIFF
--- a/arelle/webserver/bottle.py
+++ b/arelle/webserver/bottle.py
@@ -314,7 +314,8 @@ class Router(object):
         and details on the matching order are described in docs:`routing`.
     """
 
-    default_pattern = '[^/]+'
+    # Workaround for a bug in myst 4 that parses these brackets as a footnote ref.
+    default_pattern = '[^' + '/]+'
     default_filter = 're'
 
     #: The current CPython regexp implementation does not allow more

--- a/distro.py
+++ b/distro.py
@@ -66,7 +66,7 @@ includeLibs = [
     "lxml.etree",
     "lxml.html",
     "lxml",
-    "numpy.core._methods",
+    "numpy._core._methods",
     "numpy.lib.format",
     "numpy",
     "openpyxl",
@@ -161,7 +161,7 @@ else:
 setup(
     executables=[guiExecutable, cliExecutable],
     options=options,
-    setup_requires=["setuptools_scm~=8.0"],
+    setup_requires=["setuptools_scm~=8.1"],
     use_scm_version={
         "tag_regex": r"^(?:[\w-]+-?)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
         "write_to": os.path.normcase("arelle/_version.py"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=69.0", "wheel~=0.42", "setuptools_scm[toml]~=8.0"]
+requires = ["setuptools~=73.0", "wheel~=0.44", "setuptools_scm[toml]~=8.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -33,7 +33,7 @@ dependencies = [
     'filelock',
     'isodate==0.*',
     'lxml>=4,<6',
-    'numpy==1.*',
+    'numpy>=1,<3',
     'openpyxl==3.*',
     'pyparsing==3.*',
     'python-dateutil==2.*',

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,4 @@
-cx-Freeze==7.1.0.post0
+cx-Freeze==7.2.0
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
 -r requirements-plugins.txt

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,9 @@
 furo==2024.8.6
-myst-parser==3.0.1
+myst-parser==3.0.1 ; python_version <= "3.9"
+myst-parser==4.0.0 ; python_version > "3.9"
 sphinx==7.1.2 ; python_version <= "3.8"
-sphinx==7.2.6 ; python_version > "3.8"
+sphinx==7.4.7 ; python_version == "3.9"
+sphinx==8.0.2 ; python_version > "3.9"
 sphinx-autobuild==2021.3.14
 sphinx-autodoc2==0.5.0
 sphinx-copybutton==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,10 @@ pycountry==24.6.1
 # plugins
 # EdgarRenderer plugin
 NumPy==1.24.4 ; python_version <= "3.8"
-NumPy==1.26.2 ; python_version > "3.8"
-Matplotlib==3.7.4 ; python_version <= "3.8"
-Matplotlib==3.8.2 ; python_version > "3.8"
+NumPy==2.0.1 ; python_version == "3.9"
+NumPy==2.1.0 ; python_version > "3.9"
+Matplotlib==3.7.5 ; python_version <= "3.8"
+Matplotlib==3.9.2 ; python_version > "3.8"
 holidays==0.54
 pytz==2024.1
 Tornado==6.4.1


### PR DESCRIPTION
#### Reason for change
Resolves #1325 by supporting NumPy 2.*

#### Description of change
Update NumPy and other dependencies that are Python version specific.

#### Steps to Test
- [ ] CI
- [x] Regression test documentation build
- [x] Regression test frozen builds ([Linux](https://github.com/Arelle/Arelle/actions/runs/10524853956), [macOS](https://github.com/Arelle/Arelle/actions/runs/10524852546), [Windows](https://github.com/Arelle/Arelle/actions/runs/10524851040))
- [x] Regression test XULE and SEC plugins 

**review**:
@Arelle/arelle
