### PR TITLE
Add cipc-ca-enum:DescriptionOfNatureOfFinancialStatements to mustNotBeHiddenFacts

### DIFF
--- a/arelle/plugin/validate/CIPC/Const.py
+++ b/arelle/plugin/validate/CIPC/Const.py
@@ -20,6 +20,7 @@ mustNotBeHiddenElements = [
     "cipc-ca:DisclosureOfDirectorsResponsibilityExplanatory",
     "cipc-ca:FullRegisteredNameOfCompany",
     "cipc-ca:RegistrationNumberOfCompany",
+    "cipc-ca-enum:DescriptionOfNatureOfFinancialStatements",
     "ifrs-full:DateOfEndOfReportingPeriod2013",
     "ifrs-full:DescriptionOfNatureOfFinancialStatements",
     "ifrs-full:DescriptionOfPresentationCurrency",

--- a/arelle/plugin/validate/CIPC/__init__.py
+++ b/arelle/plugin/validate/CIPC/__init__.py
@@ -193,7 +193,7 @@ def validateXbrlFinally(val, *args, **kwargs):
         mustNotBeHiddenQnames = set()
         for prefixedName in mustNotBeHiddenElements:
             prefix, _sep, name = prefixedName.rpartition(":")
-            mustNotBeHiddenQnames.add(qname(nsMap.get(prefix),name))
+            mustNotBeHiddenQnames.add(qname(nsMap.get(prefix), name))
         for concept in mustNotBeHiddenQnames:
             facts = val.modelXbrl.factsByQname.get(concept, ())
             for fact in facts:
@@ -203,7 +203,7 @@ def validateXbrlFinally(val, *args, **kwargs):
             modelXbrl.error("CIPC.MandatoryElementInHiddenSection",
                             _("These mandatory concepts can not appear in a hidden section: %(facts)s."),
                             modelObject=foundHiddenFacts,
-                            facts=", ".join(sorted(str(fact.qname.localName) for fact in foundHiddenFacts))
+                            facts=", ".join(sorted(set(str(fact.qname.localName) for fact in foundHiddenFacts)))
                             )
 
         ''' checked by CIPC formula


### PR DESCRIPTION
#### Reason for change
CIPC HiddenFact check was not catching `cipc-ca-enum:DescriptionOfNatureOfFinancialStatements`

#### Description of change
Added `cipc-ca-enum:DescriptionOfNatureOfFinancialStatements` to mustNotBeHiddentFacts in CIPC validation plugin

#### Steps to Test
CI

**review**:
@Arelle/arelle
