### PR TITLE
ROS.19 fires if principle currency is not majority of monetary facts

### DIFF
--- a/arelle/plugin/validate/ROS/rules/__init__.py
+++ b/arelle/plugin/validate/ROS/rules/__init__.py
@@ -50,7 +50,6 @@ def errorOnNegativeFact(
     if errorModelFacts:
         yield Validation.error(
             codes=code,
-            conceptLn=conceptLn,
             modelObject=errorModelFacts,
             msg=message,
         )

--- a/arelle/plugin/validate/ROS/rules/ros.py
+++ b/arelle/plugin/validate/ROS/rules/ros.py
@@ -337,7 +337,7 @@ def rule_ros18(
             val.modelXbrl,
             conceptLn=TURNOVER_REVENUE,
             code='ROS.18',
-            message=_("'%(conceptLn)s' cannot have a negative value.")
+            message=_("Turnover / Revenue cannot be a negative value.")
         )
 
 

--- a/tests/resources/conformance_suites/ros/main/ros18-invalid.htm
+++ b/tests/resources/conformance_suites/ros/main/ros18-invalid.htm
@@ -97,7 +97,7 @@
 <div><span><br/></span></div>
 <div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%">-<ix:nonFraction unitRef="u-1" contextRef="c-1" decimals="0" sign="-" name="core:ProfitLossBeforeTax" id="f-15">1111</ix:nonFraction>  ProfitLossBeforeTax</span>
 </div>
-<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-1116">EUR</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
+<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-1116">Euro</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
 </div>
 <div style="height:72pt;position:relative;width:100%">
     <div style="bottom:0;position:absolute;width:100%">

--- a/tests/resources/conformance_suites/ros/main/ros6-invalid-101.htm
+++ b/tests/resources/conformance_suites/ros/main/ros6-invalid-101.htm
@@ -79,7 +79,7 @@
 <div><span><br/></span></div>
 <div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonFraction unitRef="u-1" contextRef="c-1" decimals="0" name="ie-dpl:DPLGrossProfitLoss" id="f-13">1111</ix:nonFraction> DPLGrossProfitLoss</span>
 </div>
-<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-11115">EUR</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
+<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-11115">Euro</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
 </div>
 <div style="height:72pt;position:relative;width:100%">
     <div style="bottom:0;position:absolute;width:100%">

--- a/tests/resources/conformance_suites/ros/main/ros6-invalid-ifrs.htm
+++ b/tests/resources/conformance_suites/ros/main/ros6-invalid-ifrs.htm
@@ -80,7 +80,7 @@
 <div><span><br/></span></div>
 <div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonFraction unitRef="u-1" contextRef="c-1" decimals="0" name="ie-dpl:DPLGrossProfitLoss" id="f-13">1111</ix:nonFraction> DPLGrossProfitLoss</span>
 </div>
-<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-1115">EUR</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
+<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-1115">Euro</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
 </div>
 <div><span><br/></span></div>
 <div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%">ProfitLossBeforeTax</span></div>

--- a/tests/resources/conformance_suites/ros/main/valid-101.htm
+++ b/tests/resources/conformance_suites/ros/main/valid-101.htm
@@ -79,7 +79,7 @@
 <div><span><br/></span></div>
 <div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonFraction unitRef="u-1" contextRef="c-1" decimals="0" name="ie-dpl:DPLGrossProfitLoss" id="f-13">1111</ix:nonFraction> DPLGrossProfitLoss</span>
 </div>
-<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-1115">EUR</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
+<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-1115">Euro</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
 </div>
 <div style="height:72pt;position:relative;width:100%">
     <div style="bottom:0;position:absolute;width:100%">

--- a/tests/resources/conformance_suites/ros/main/valid-ifrs.htm
+++ b/tests/resources/conformance_suites/ros/main/valid-ifrs.htm
@@ -95,7 +95,7 @@
                                                                                                                                 name="ie-dpl:DPLGrossProfitLoss" id="f-13">1111</ix:nonFraction> DPLGrossProfitLoss</span>
 </div>
 <div><span><br/></span></div>
-<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-14">EUR</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
+<div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%"><ix:nonNumeric contextRef="c-1" name="bus:PrincipalCurrencyUsedInBusinessReport" format="ixt:nocontent" id="f-14">Euro</ix:nonNumeric> PrincipalCurrencyUsedInBusinessReport</span>
 </div>
 <div><span><br/></span></div>
 <div><span style="color:#000000;font-family:'Arial',sans-serif;font-size:12pt;font-weight:400;line-height:120%">-<ix:nonFraction unitRef="u-1" contextRef="c-1" decimals="0" sign="-"


### PR DESCRIPTION
#### Reason for change
ROS.19 was firing if even one fact did not match the principle currency.

#### Description of change
ROS.19 was updated to only fire if principle currency is not the majority of monetary facts.

#### Steps to Test
CI

**review**:
@Arelle/arelle
