### PR TITLE
Fix relativeUri for web-based references

### DIFF
--- a/arelle/UrlUtil.py
+++ b/arelle/UrlUtil.py
@@ -379,7 +379,8 @@ def parseRfcDatetime(rfc2822date: str) -> datetime | None:
 
 zipRelativeFilePattern = re.compile(r".*[.]zip[/\\](.*)$")
 def relativeUri(baseUri: str, relativeUri: str) -> str: # return uri relative to this modelDocument uri
-    if isHttpUrl(relativeUri):
+    if ((isAbsolute(relativeUri) or isAbsolute(baseUri)) and
+        (authority(relativeUri) != authority(baseUri))):
         return relativeUri
     # check if base is zip-relative and relativeUri is not
     mBaseUri = zipRelativeFilePattern.match(baseUri)


### PR DESCRIPTION
#### Reason for change
Extracted instances from web-loaded filings had ix11 spec-invalid schemaRef (does not affect filings loaded from local storage).

Loading any web instance, such as [example here](https://www.sec.gov/Archives/edgar/data/1434588/000155837024011082/lope-20240630x10q.htm) produces an extracted instance with schemaRef having the full http path to its extension xsd, which conflicts with [Inline Spec 12.2 Mapping of schemaRef](https://www.xbrl.org/specification/inlinexbrl-part1/rec-2013-11-18/inlinexbrl-part1-rec-2013-11-18.html#d1e7549)

#### Description of change
relativeUrl change to provide relative URL for web references from same scheme and authority.

#### Steps to Test
Loading an inline report from a full https source, examine extracted instance schemaRef before change (in extracted instance) where it has absolute full path and after change, where the schemaRef is same as source, relative local file name.

**review**:
@Arelle/arelle
