### PR TITLE
[ESEF] Implement the 2024 rules

### DIFF
--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -90,6 +90,10 @@ qnDomainItemTypes2023 = frozenset((
     qname("{http://www.xbrl.org/dtr/type/2020-01-21}nonnum:domainItemType"),
 ))
 
+qnDomainItemTypes2024 = frozenset((
+    qname("{http://www.xbrl.org/dtr/type/2022-03-31}nonnum:domainItemType"),
+))
+
 
 linkbaseRefTypes = {
     "http://www.xbrl.org/2003/role/calculationLinkbaseRef": "cal",

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -164,7 +164,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                         extMonetaryConceptsWithoutBalance.append(modelConcept)
                     widerConcept = widerNarrowerRelSet.fromModelObject(modelConcept)
                     narrowerConcept = widerNarrowerRelSet.toModelObject(modelConcept)
-                    if getDisclosureSystemYear(val.modelXbrl) >= 2024 and (widerConcept and all(modelConcept.baseXbrliType != r.toModelObject.baseXbrliType for r in widerConcept)) or (narrowerConcept and all(modelConcept.baseXbrliType != r.fromModelObject.baseXbrliType for r in narrowerConcept)):
+                    if getDisclosureSystemYear(val.modelXbrl) >= 2024 and ((widerConcept and all(modelConcept.baseXbrliType != r.toModelObject.baseXbrliType for r in widerConcept)) or (narrowerConcept and all(modelConcept.baseXbrliType != r.fromModelObject.baseXbrliType for r in narrowerConcept))):
                         val.modelXbrl.warning("ESEF.1.4.1.differentExtensionDataType",
                                             _("Issuers should anchor their extension elements to ESEF core taxonomy elements sharing the same data type. %(qname)s"),
                                             modelObject=modelConcept, qname=modelConcept.qname)

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -51,7 +51,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
             return word[0].upper() + word[1:]
         return word
 
-    esefYear = None
+    esefYear = getDisclosureSystemYear(val.modelXbrl) # if the taxonomy isn't recognised, take the disclosure system
     for url in val.modelXbrl.namespaceDocs.keys():
         match = re.match("http[s]?://www.esma.europa.eu/taxonomy/([0-9]{4}-[0-9]{2}-[0-9]{2})/.*", url)
         if match:

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -315,7 +315,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                 if linkEltName == "calculationLink":
                     val.hasExtensionCal = True
                     linkbasesFound.add(linkEltName)
-                    if esefTaxonomyYear >= 2024:
+                    if esefDisclosureSystemYear >= 2024:
                         for arc in linkElt.iterdescendants(tag="{http://www.xbrl.org/2003/linkbase}calculationArc"):
                             if arc.get("{http://www.w3.org/1999/xlink}arcrole") != "https://www.xbrl.org/2023/arcrole/summation-item":
                                 val.modelXbrl.error("ESEF.3.4.1.IncorrectSummationItemArcroleUsed",

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -168,17 +168,18 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                         widerConcept = widerNarrowerRelSet.fromModelObject(modelConcept)
                         narrowerConcept = widerNarrowerRelSet.toModelObject(modelConcept)
 
-                        widerTypes = set(r.toModelObject.baseXbrliType for r in widerConcept)
-                        narrowerTypes = set(r.fromModelObject.baseXbrliType for r in narrowerConcept)
+                        # Transform the qname to str for the later join()
+                        widerTypes = set(str(r.toModelObject.typeQname) for r in widerConcept)
+                        narrowerTypes = set(str(r.fromModelObject.typeQname) for r in narrowerConcept)
 
-                        if (narrowerTypes and modelConcept.baseXbrliType not in narrowerTypes) or (widerTypes and modelConcept.baseXbrliType not in widerTypes):
+                        if (narrowerTypes and narrowerTypes != {str(modelConcept.typeQname)}) or (widerTypes and widerTypes != {str(modelConcept.typeQname)}):
                             widerNarrowerType = "{} {}".format(
                                 "Wider: {}".format(", ".join(widerTypes)) if widerTypes else "",
                                 "Narrower: {}".format(", ".join(narrowerTypes)) if narrowerTypes else ""
                             )
                             val.modelXbrl.warning("ESEF.1.4.1.differentExtensionDataType",
                                                 _("Issuers should anchor their extension elements to ESEF core taxonomy elements sharing the same data type. Concept: %(qname)s type: %(type)s %(widerNarrowerType)s"),
-                                                modelObject=modelConcept, qname=modelConcept.qname, type=modelConcept.baseXbrliType, widerNarrowerType=widerNarrowerType)
+                                                modelObject=modelConcept, qname=modelConcept.qname, type=modelConcept.typeQname, widerNarrowerType=widerNarrowerType)
 
                     # check all lang's of standard label
                     hasLc3Match = False

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -664,7 +664,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     if not f.id:
                         factsMissingId.append(f)
                     escaped = f.get("escape") in ("true", "1")
-                    if (f.concept.type.isTextBlock and not escaped) or (not f.concept.type.isTextBlock and escaped):
+                    if escaped != f.concept.type.isTextBlock:
                         modelXbrl.error("ESEF.2.2.7.improperApplicationOfEscapeAttribute",
                                           _("Facts with datatype 'dtr-types:textBlockItemType' MUST use the 'escape' attribute set to 'true'. Facts with any other datatype MUST use the 'escape' attribute set to 'false' - fact %(conceptName)s"),
                                           modelObject=f, conceptName=f.concept.qname)

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -656,17 +656,17 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     escaped = f.get("escape") in ("true", "1")
                     if (f.concept.type.isTextBlock and not escaped) or (not f.concept.type.isTextBlock and escaped):
                         modelXbrl.error("ESEF.2.2.7.improperApplicationOfEscapeAttribute",
-                                          _("Facts with datatype 'dtr-types:textBlockItemType' MUST use the 'escape' attribute set to 'true'. Facts with any other datatype MUST use the 'escape' attribute set to 'false'"),
-                                          modelObject=f)
+                                          _("Facts with datatype 'dtr-types:textBlockItemType' MUST use the 'escape' attribute set to 'true'. Facts with any other datatype MUST use the 'escape' attribute set to 'false' - fact %(conceptName)s"),
+                                          modelObject=f, conceptName=f.concept.qname)
                     if f.effectiveValue == "0" and f.xValue != 0:
                         modelXbrl.warning("ESEF.2.2.5.roundedValueBelowScaleNotNull",
-                                          _("A value that has been rounded and is below the scale should show a value of zero. It has been found to have the value %(value)s"),
-                                          modelObject=f, value=f.value)
+                                          _("A value that has been rounded and is below the scale should show a value of zero. It has been found to have the value %(value)s - fact %(conceptName)s"),
+                                          modelObject=f, value=f.value, conceptName=f.concept.qname)
                     if f.concept.periodType == "instant":
                         if f.context.instantDate.day == 1 and f.context.instantDate.month == 1:
                             modelXbrl.error("ESEF.2.1.2.inappropriateInstantDate",
-                                              _("Instant date %(actualValue)s shall be replaced by %(expectedValue)s to ensure a better comparability between the facts."),
-                                              modelObject=f, actualValue=f.context.instantDate, expectedValue=f.context.instantDate - timedelta(days=1))
+                                              _("Instant date %(actualValue)s in context %(contextID)s shall be replaced by %(expectedValue)s to ensure a better comparability between the facts."),
+                                              modelObject=f, actualValue=f.context.instantDate, expectedValue=f.context.instantDate - timedelta(days=1), contextID=f.context.id)
                             pass
                 if f.precision is not None:
                     precisionFacts.add(f)

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -175,7 +175,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     if ifrs_year != esef_year:
                         # this check isn't precise enough, but the list of available concept isn't available in esef_cor
                         modelXbrl.warning("ESEF.1.2.IFRSNotYetIncluded",
-                                        _("Elements available in the IFRS Taxonomy that were not yet included in the ESEF taxonomy sould not be used."),
+                                        _("Elements available in the IFRS Taxonomy that were not yet included in the ESEF taxonomy should not be used."),
                                         modelObject=modelXbrl)
 
     if val.consolidated and not (val.hasExtensionSchema and val.hasExtensionPre and val.hasExtensionCal and val.hasExtensionDef and val.hasExtensionLbl):
@@ -656,7 +656,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     escaped = f.get("escape") in ("true", "1")
                     if (f.concept.type.isTextBlock and not escaped) or (not f.concept.type.isTextBlock and escaped):
                         modelXbrl.error("ESEF.2.2.7.improperApplicationOfEscapeAttribute",
-                                          _("Facts with datatype 'dtr-types:textBlockItemType' MUST use the 'escape' attribute set to 'true'. Facts with any other datatype MUST use the 'escape' attribute set to true 'false'"),
+                                          _("Facts with datatype 'dtr-types:textBlockItemType' MUST use the 'escape' attribute set to 'true'. Facts with any other datatype MUST use the 'escape' attribute set to 'false'"),
                                           modelObject=f)
                     if f.effectiveValue == "0" and f.xValue != 0:
                         modelXbrl.warning("ESEF.2.2.5.roundedValueBelowScaleNotNull",

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -146,7 +146,8 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
     checkFilingDTS(val, modelXbrl.modelDocument, esefNotesConcepts, [], ifrsNses=_ifrsNses)
     modelXbrl.profileActivity("... filer DTS checks", minTimeToShow=1.0)
 
-    if getDisclosureSystemYear(modelXbrl) >= 2023:
+    esefDisclosureSystemYear = getDisclosureSystemYear(modelXbrl)
+    if esefDisclosureSystemYear >= 2023:
         if val.unconsolidated and modelXbrl.fileSource.dir:
             instanceNumber = 0
             for file in modelXbrl.fileSource.dir:
@@ -283,7 +284,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                 modelObject=doc, doctype=docinfo.doctype)
 
         reportIncorrectlyPlacedInPackageRef = "https://www.xbrl.org/Specification/report-package/CR-2023-05-03/report-package-CR-2023-05-03.html"
-        if getDisclosureSystemYear(modelXbrl) < 2023:
+        if esefDisclosureSystemYear < 2023:
             reportIncorrectlyPlacedInPackageRef = "http://www.xbrl.org/WGN/report-packages/WGN-2018-08-14/report-packages-WGN-2018-08-14.html"
 
         if len(ixdsDocDirs) > 1 and val.consolidated:
@@ -411,7 +412,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                     modelObject=elt, qname=elt.qname)
                         elif any(character in elt.stringValue for character in ['&lt;', '&amp;', '&', '<']):
                             if not (hasattr(elt, 'attrib')) or ('escape' not in elt.attrib or elt.attrib.get('escape').lower() != 'true'):
-                                modelXbrl.error("ESEF.2.2.6.escapedHTMLUsedInBlockTagWithSpecialCharacters" if getDisclosureSystemYear(modelXbrl) < 2023 else "ESEF.2.2.7.escapedHTMLUsedInBlockTagWithSpecialCharacters",
+                                modelXbrl.error("ESEF.2.2.6.escapedHTMLUsedInBlockTagWithSpecialCharacters" if esefDisclosureSystemYear < 2023 else "ESEF.2.2.7.escapedHTMLUsedInBlockTagWithSpecialCharacters",
                                         _("A text block containing '&' or '<' character MUST have an 'escape' attribute: %(qname)s."),
                                         modelObject=elt, qname=elt.qname)
                         # Check that continuation elements are in the order of html text as rendered to user
@@ -534,6 +535,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
         contextsWithDisallowedOCEcontent = []
         contextsWithPeriodTime: list[ModelContext] = []
         contextsWithPeriodTimeZone: list[ModelContext] = []
+        contextsWithWrongInstantDate: list[ModelContext] = []
         contextIdentifiers = defaultdict(list)
         nonStandardTypedDimensions: dict[Any, Any] = defaultdict(set)
         for context in modelXbrl.contexts.values():
@@ -548,6 +550,9 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                         contextsWithPeriodTime.append(context)
                     if m.group(3):
                         contextsWithPeriodTimeZone.append(context)
+
+            if esefDisclosureSystemYear >= 2024 and context.instantDate and context.instantDate.day == 1 and context.instantDate.month == 1:
+                contextsWithWrongInstantDate.append(context)
             for elt in context.iterdescendants("{http://www.xbrl.org/2003/instance}segment"):
                 contextsWithDisallowedOCEs.append(context)
                 break
@@ -597,6 +602,11 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
             modelXbrl.error("ESEF.2.1.2.periodWithTimeZone",
                 _("The xbrli:startDate, xbrli:endDate and xbrli:instant elements MUST identify periods using whole days (i.e. specified without a time zone): %(contextIds)s"),
                 modelObject=contextsWithPeriodTimeZone, contextIds=", ".join(c.id for c in contextsWithPeriodTimeZone if c.id))
+        if contextsWithWrongInstantDate:
+            for context in contextsWithWrongInstantDate:
+                modelXbrl.error("ESEF.2.1.2.inappropriateInstantDate",
+                                _("Instant date %(actualValue)s in context %(contextID)s shall be replaced by %(expectedValue)s to ensure a better comparability between the facts."),
+                                modelObject=contextsWithWrongInstantDate, actualValue=context.instantDate, expectedValue=context.instantDate - timedelta(days=1), contextID=context.id)
 
         # identify unique contexts and units
         mapContext = {}
@@ -650,7 +660,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
             if qn in mandatory:
                 reportedMandatory.add(qn)
             for f in facts:
-                if getDisclosureSystemYear(modelXbrl) >= 2024:
+                if esefDisclosureSystemYear >= 2024:
                     if not f.id:
                         factsMissingId.append(f)
                     escaped = f.get("escape") in ("true", "1")
@@ -662,12 +672,6 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                         modelXbrl.warning("ESEF.2.2.5.roundedValueBelowScaleNotNull",
                                           _("A value that has been rounded and is below the scale should show a value of zero. It has been found to have the value %(value)s - fact %(conceptName)s"),
                                           modelObject=f, value=f.value, conceptName=f.concept.qname)
-                    if f.concept.periodType == "instant":
-                        if f.context.instantDate.day == 1 and f.context.instantDate.month == 1:
-                            modelXbrl.error("ESEF.2.1.2.inappropriateInstantDate",
-                                              _("Instant date %(actualValue)s in context %(contextID)s shall be replaced by %(expectedValue)s to ensure a better comparability between the facts."),
-                                              modelObject=f, actualValue=f.context.instantDate, expectedValue=f.context.instantDate - timedelta(days=1), contextID=f.context.id)
-                            pass
                 if f.precision is not None:
                     precisionFacts.add(f)
                 if f.isNumeric and f.concept is not None and getattr(f, "xValid", 0) >= VALID:
@@ -699,7 +703,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                         #    conceptsUsed.add(dim.typedMember)
                 '''
 
-        if getDisclosureSystemYear(modelXbrl) >= 2024 and factsMissingId:
+        if esefDisclosureSystemYear >= 2024 and factsMissingId:
             modelXbrl.warning("ESEF.2.2.8.missingFactID",
                               _("All facts should have a unique identifier. Facts %(elements)s have no identifier."),
                               modelObject=f, elements=", ".join([str(f.qname) for f in factsMissingId]), )

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -369,7 +369,7 @@ __pluginInfo__ = {
         "Validate ESMA ESEF-2022",
         "validate/ESEF_2022",
     ],
-    "version": "1.2023.00",
+    "version": "1.2024.00",
     "description": """ESMA ESEF Filer Manual and RTS Validations.""",
     "license": "Apache-2",
     "author": authorLabel,

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -130,6 +130,22 @@
             "https://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd"
         ]
     },
+    "ESEF-2024": {
+        "outdatedTaxonomyURLs": [
+            "http://www.esma.europa.eu/taxonomy/2017-03-31/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2017-03-31/esef_cor.xsd",
+            "http://www.esma.europa.eu/taxonomy/2019-03-27/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2019-03-27/esef_cor.xsd",
+            "http://www.esma.europa.eu/taxonomy/2020-03-16/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2020-03-16/esef_cor.xsd",
+            "http://www.esma.europa.eu/taxonomy/2021-03-24/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2021-03-24/esef_cor.xsd"
+        ],
+        "effectiveTaxonomyURLs": [
+            "http://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd"
+        ]
+    },
     "AT": {
         "name": "Austria",
         "reportPackageMaxMB": "100",

--- a/arelle/plugin/validate/ESEF/resources/config.xml
+++ b/arelle/plugin/validate/ESEF/resources/config.xml
@@ -5,6 +5,27 @@
     <!-- see ../../../../config/disclosuresystem.xml for full comments -->
 
     <DisclosureSystem
+        names="ESMA RTS on ESEF-2024|ESEF-2024|esef-2024"
+        description="ESMA RTS on ESEF-2024 Validation Checks for Consolidated Financial Statements"
+        validationType="ESEF"
+        exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
+        blockDisallowedReferences="false"
+        validateFileText="false"
+        contextElement="scenario"
+    />
+
+    <DisclosureSystem
+        names="ESMA RTS on ESEF-2024 Unconsolidated|ESEF-Unconsolidated-2024|esef-unconsolidated-2024"
+        description="ESMA RTS on ESEF-2024 Validation Checks for Unconsolidated Financial Statements"
+        validationType="ESEF"
+        exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
+        blockDisallowedReferences="false"
+        validateFileText="false"
+        contextElement="scenario"
+     />
+
+
+    <DisclosureSystem
          names="ESMA RTS on ESEF-2023|ESEF-2023|esef-2023|ESEF|esef"
          description="ESMA RTS on ESEF-2023 Validation Checks for Consolidated Financial Statements"
          validationType="ESEF"


### PR DESCRIPTION
#### Reason for change
The ESMA published the 2024 reporting manual.

#### Description of change
Implement the new rules defined for ESEF 2024.

#### Steps to Test
Use the ESEF 2024 disclosure system and validate an instance.

#### Caveats
* Since the ESEF 2024 taxonomy isn't published, some rules cannot be tested yet. They are activated based in the taxonomy used and not the disclosure system. 
* The conformance suite isn't published yet, so there might still have a few changes later.
* The default esef in the disclosure system isn't updated yet, it should be done when the ESMA published the taxonomy and the conformance suite.

**review**:
@Arelle/arelle
@gmongelli 