### PR TITLE
Remove RuntimeOptions attr Overrides

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -607,7 +607,7 @@ class ParserForDynamicPlugins:
         if 'dest' in kwargs:
             _dest = kwargs['dest']
             if not hasattr(self.options, _dest):
-                setattr(self.options, _dest, kwargs.get('default',None))
+                setattr(self.options, _dest, kwargs.get('default'))
 
     def add_option_group(self, *args, **kwargs):
         pass

--- a/arelle/CntlrWebMain.py
+++ b/arelle/CntlrWebMain.py
@@ -63,7 +63,6 @@ def getRuntimeOptions() -> RuntimeOptions:
     if _RUNTIME_OPTIONS is None:
         raise ValueError(_('_RUNTIME_OPTIONS accessed before it was set.'))
     options = deepcopy(_RUNTIME_OPTIONS)
-    options.strictOptions = False
     return options
 
 def setRuntimeOptions(runtimeOptions: RuntimeOptions) -> None:

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -25,9 +25,7 @@ class RuntimeOptions:
         using the pluginOptions InitVar and applied to the class using setattr() in __post_init
         RuntimeOptionsException is raised if an improper combination of options are specified.
     """
-    _initialized: bool = False
     pluginOptions: InitVar[Optional[dict[str, RuntimeOptionValue]]] = None
-    strictOptions: bool = True  # Accessing options that are not defined will raise an AttributeError
 
     abortOnMajorError: Optional[bool] = None
     about: Optional[str] = None
@@ -150,34 +148,11 @@ class RuntimeOptions:
     webserver: Optional[str] = None
     xdgConfigHome: Optional[str] = None
 
-    def __delattr__(self, name: str) -> Any:
-        """
-        Delete attribute while silencing AttributeError if it does not exist and `strictOptions` is False.
-        :param name:
-        :return: None
-        """
-        try:
-            object.__delattr__(self, name)
-        except AttributeError as exc:
-            if self.strictOptions:
-                raise exc
-
     def __eq__(self, other: Any) -> bool:
         """ Default dataclass implementation doesn't consider plugin applied options. """
         if isinstance(other, RuntimeOptions):
             return vars(self) == vars(other)
         return NotImplemented
-
-    def __getattr__(self, name: str) -> Any:
-        """
-        If an attribute isn't found, it may be an unspecified plugin option.
-        Return None for any attributes not found on the class.
-        :param name:
-        :return: None
-        """
-        if self._initialized and not self.strictOptions:
-            return None
-        raise AttributeError(name)
 
     def __repr__(self) -> str:
         """ Default dataclass implementation doesn't consider plugin applied options. """
@@ -219,4 +194,3 @@ class RuntimeOptions:
                 self.roleTypesFile, self.arcroleTypesFile
         )):
             raise RuntimeOptionsException('Incorrect arguments with webserver')
-        self._initialized = True

--- a/tests/integration_tests/scripts/tests/python_api_instance_extraction.py
+++ b/tests/integration_tests/scripts/tests/python_api_instance_extraction.py
@@ -57,7 +57,6 @@ with io.BytesIO() as extracted_stream:
                 'saveTargetInstance': True,
             },
             plugins='inlineXbrlDocumentSet',
-            strictOptions=False,
         )
         with Session() as session:
             session.run(
@@ -87,7 +86,6 @@ with open(report_zip_path, 'rb') as stream:
         keepOpen=True,
         logFile=str(arelle_log_file2),
         logFormat="[%(messageCode)s] %(message)s - %(file)s",
-        strictOptions=False,
         validate=True,
         validateDuplicateFacts='consistent',
     )

--- a/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
+++ b/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
@@ -63,7 +63,6 @@ with open(samples_zip_path, 'rb') as stream:
             'viewer_feature_review': True,
         },
         plugins='ixbrl-viewer',
-        strictOptions=False,
     )
     with Session() as session:
         session.run(

--- a/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
+++ b/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
@@ -64,6 +64,8 @@ with open(samples_zip_path, 'rb') as stream:
         },
         plugins='ixbrl-viewer',
     )
+    # Plugin default options haven't been applied yet.
+    assert not hasattr(options, 'viewerURL')
     with Session() as session:
         session.run(
             options,
@@ -71,6 +73,9 @@ with open(samples_zip_path, 'rb') as stream:
             logHandler=log_handler,
             logFilters=[log_filter],
         )
+        # Plugin default options were applied.
+        assert hasattr(options, "viewerURL")
+        assert options.viewerURL.endswith("ixbrlviewer.js")
         log_xml = session.get_logs('xml')
 # include end
 

--- a/tests/integration_tests/scripts/tests/python_api_query_model.py
+++ b/tests/integration_tests/scripts/tests/python_api_query_model.py
@@ -57,7 +57,6 @@ options = RuntimeOptions(
     logFormat="[%(messageCode)s] %(message)s - %(file)s",
     packages=package_paths,
     plugins='validate/ESEF',
-    strictOptions=False,
     validate=True,
 )
 target_qname = qname('https://xbrl.ifrs.org/taxonomy/2022-03-24/ifrs-full', 'Equity')

--- a/tests/integration_tests/scripts/tests/python_api_taxonomy_service.py
+++ b/tests/integration_tests/scripts/tests/python_api_taxonomy_service.py
@@ -48,7 +48,6 @@ options = RuntimeOptions(
     logLevel='DEBUG',
     logRefObjectProperties=True,
     plugins=FERC.__file__,
-    strictOptions=False,
     utrValidate=True,
     validate=True,
 )

--- a/tests/integration_tests/scripts/tests/python_api_validate_esef.py
+++ b/tests/integration_tests/scripts/tests/python_api_validate_esef.py
@@ -56,7 +56,6 @@ options = RuntimeOptions(
     logFormat="[%(messageCode)s] %(message)s - %(file)s",
     packages=package_paths,
     plugins='validate/ESEF',
-    strictOptions=False,
     validate=True,
 )
 with Session() as session:


### PR DESCRIPTION
#### Reason for change
This addresses the issue reported in [this thread](https://groups.google.com/g/arelle-users/c/5GIW9bqYdlU).

#### Description of change
- Removed `RuntimeOptions` attribute overrides that prevented options from being set for any plugin loaded from the web server. This issue occurred because `hasattr(options, "any_value")` always returned true when strict options was set to `False`.
- Ensured that plugin default options are also set for the Python library interface, not just the web server. Plugins from the CLI interface are "preloaded" and not reloaded as part of this change.

#### Steps to Test
1. CI
2. Test Web Server with XULE:
   - Copy `validate/DQC` and `xule` plugins into the plugin directory.
   - Run the command: `python arelleCmdLine.py --webserver=0.0.0.0:8080`
   - Execute the following `curl` command:
     ```sh
     curl 'http://localhost:8080/rest/xbrl/validation?plugins=validate/DQC&file=https://www.sec.gov/Archives/edgar/data/1445305/000144530524000107/0001445305-24-000107-xbrl.zip'
     ```
   - Verify that the following error is not raised:
     ```plaintext
     File "arelle/plugin/xule/__init__.py", line 711, in xuleCmdUtilityRun
         if getattr(options, 'xule_max_excel_files') < 1:
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     TypeError: '<' not supported between instances of 'NoneType' and 'int'
     ```

**review**:
@Arelle/arelle
