### PR TITLE
Don't run filesystem path normalization on URIs.

### DIFF
--- a/arelle/XhtmlValidate.py
+++ b/arelle/XhtmlValidate.py
@@ -110,6 +110,6 @@ def resolveHtmlUri(elt, name, value):
     if elt.localName == "object" and name in ("classid", "data", "archiveListElement") and elt.get("codebase"):
         base = elt.get("codebase") + "/"
     else:
-        base = getattr(elt.modelDocument, "htmlBase") # None if no htmlBase, empty string if it's not set
+        base = getattr(elt.modelDocument, "htmlBase", "") # None if no htmlBase, empty string if it's not set
     _uri = urljoin(base, value)
     return _uri

--- a/tests/unit_tests/arelle/test_xhtmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xhtmlvalidate.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock, patch
+
+from arelle.ModelObject import ModelObject
+from arelle.ModelValue import qname
+from arelle.XhtmlValidate import (
+    resolveHtmlUri,
+)
+
+
+def test_opaque_uris_not_path_normed():
+    uri = 'data:image/png;base64,iVBORw0K//a'
+    elt_attrs = {'src': uri}
+    elt = Mock(
+        spec=ModelObject,
+
+        localName='img',
+        namespaceURI='http://www.w3.org/1999/xhtml',
+        modelDocument=Mock(htmlBase=None),
+        prefix=None,
+
+        get=elt_attrs.get,
+        items=elt_attrs.items,
+    )
+    elt.qname = qname(elt)
+    resolved_uri = resolveHtmlUri(elt, 'src', uri)
+    assert resolved_uri == uri

--- a/tests/unit_tests/arelle/test_xmlutil.py
+++ b/tests/unit_tests/arelle/test_xmlutil.py
@@ -1,0 +1,32 @@
+from unittest.mock import Mock, patch
+
+from arelle.ModelObject import ModelObject
+from arelle.ModelValue import qname
+from arelle.XmlUtil import (
+    escapedNode,
+)
+from arelle.XhtmlValidate import (
+    htmlEltUriAttrs,
+    resolveHtmlUri,
+)
+
+
+@patch('arelle.XmlUtil.htmlEltUriAttrs', new=htmlEltUriAttrs)
+@patch('arelle.XmlUtil.resolveHtmlUri', new=resolveHtmlUri)
+def test_opaque_uris_not_path_normed():
+    uri = 'data:image/png;base64,iVBORw0K//a'
+    elt_attrs = {'src': uri}
+    elt = Mock(
+        spec=ModelObject,
+
+        localName='img',
+        namespaceURI='http://www.w3.org/1999/xhtml',
+        modelDocument=Mock(htmlBase=None),
+        prefix=None,
+
+        get=elt_attrs.get,
+        items=elt_attrs.items,
+    )
+    elt.qname = qname(elt)
+    node = escapedNode(elt, start=True, empty=True, ixEscape=True, ixResolveUris=True)
+    assert node == f'<img src="{uri}">'


### PR DESCRIPTION
#### Reason for change
The slash collapsing behavior of filesystem path normalization isn't appropriate for URLs in general, and specifically breaks base64 encoded data URIs that contain repeated slashes.  Use urljoin instead.

#### Steps to Test
CI

**review**:
@Arelle/arelle
