### PR TITLE
Add pillow to python package dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     'lxml>=4,<6',
     'numpy>=1,<3',
     'openpyxl==3.*',
+    'pillow==10.*',
     'pyparsing==3.*',
     'python-dateutil==2.*',
     'regex',


### PR DESCRIPTION
#### Reason for change
[CI is failing](https://github.com/Arelle/ixbrl-viewer/actions/runs/10887000414/job/30208308030?pr=734) for projects which pip install Arelle 

pillow was previously pulled in automatically by another one of our dependencies, but a recent update has caused that to no longer happen. Arelle directly imports pillow (pil) and requires it.

#### Description of change
* Add pillow to pyproject library dependencies (it's already in requirements.txt).

#### Steps to Test
* CI

**review**:
@Arelle/arelle
