### PR TITLE
Fix saveHtmlEBAtables plugin

### DIFF
--- a/arelle/ViewFileRenderedGrid.py
+++ b/arelle/ViewFileRenderedGrid.py
@@ -15,6 +15,7 @@ from arelle.ModelRenderingObject import (StrctMdlBreakdown, StrctMdlStructuralNo
                                          DefnMdlClosedDefinitionNode, DefnMdlRuleDefinitionNode, DefnMdlAspectNode,
                                          OPEN_ASPECT_ENTRY_SURROGATE, ROLLUP_SPECIFIES_MEMBER, ROLLUP_FOR_DIMENSION_RELATIONSHIP_NODE,
                                          aspectStrctNodes)
+from arelle.rendering.RenderingLayout import layoutTable
 from arelle.rendering.RenderingResolution import resolveTableStructure, RENDER_UNITS_PER_CHAR
 from arelle.ModelValue import QName
 from arelle.ModelXbrl import DEFAULT

--- a/arelle/plugin/saveHtmlEBAtables.py
+++ b/arelle/plugin/saveHtmlEBAtables.py
@@ -11,7 +11,7 @@ def generateHtmlEbaTablesetFiles(dts, indexFile, lang="en"):
         import os, io
         from arelle import Version, XbrlConst, XmlUtil
         from arelle.ViewFileRenderedGrid import viewRenderedGrid
-        from arelle.ModelRenderingObject import ModelEuTable, ModelTable
+        from arelle.ModelRenderingObject import DefnMdlTable
 
         numTableFiles = 0
 
@@ -62,7 +62,7 @@ table {background:#fff}
         def viewTable(modelTable):
             if modelTable is None:
                 return
-            if isinstance(modelTable, (ModelEuTable, ModelTable)):
+            if isinstance(modelTable, (DefnMdlTable)):
                 # status
                 dts.modelManager.cntlr.addToLog("viewing: " + modelTable.id)
                 # for table file name, use table ELR

--- a/arelle/plugin/saveHtmlEBAtables.py
+++ b/arelle/plugin/saveHtmlEBAtables.py
@@ -70,7 +70,6 @@ table {background:#fff}
                 viewRenderedGrid(dts,
                                  tblFile,
                                  lang=lang,
-                                 sourceView=View(modelTable, False, False, True),
                                  cssExtras=tblCssExtras)
 
                 # generaate menu entry


### PR DESCRIPTION
#### Reason for change
The plugin saveHtmlEBAtables doesn't work anymore

#### Description of change
I fixed wrong and missing imports.
I'm not sure about the deletion of line 73 in saveHtmlEBAtables file, I didn't test it correctly yet.

#### Steps to Test
1. Open an EBA report
2. Launch the save of the report via the plugin

**review**:
@Arelle/arelle
