### PR TITLE
Improve CIPC.MandatoryElementInHiddenSection error message

### DIFF
--- a/arelle/plugin/validate/CIPC/__init__.py
+++ b/arelle/plugin/validate/CIPC/__init__.py
@@ -203,7 +203,7 @@ def validateXbrlFinally(val, *args, **kwargs):
             modelXbrl.error("CIPC.MandatoryElementInHiddenSection",
                             _("These mandatory concepts can not appear in a hidden section: %(facts)s."),
                             modelObject=foundHiddenFacts,
-                            facts=", ".join(sorted(set(str(fact.qname.localName) for fact in foundHiddenFacts)))
+                            facts=", ".join(sorted(set(str(fact.qname) for fact in foundHiddenFacts)))
                             )
 
         ''' checked by CIPC formula


### PR DESCRIPTION
#### Reason for change
The `CIPC.MandatoryElementInHiddenSection` message can be confusing without a prefix.

#### Description of change
Use plain `__str__` like other errors in the file.

#### Steps to Test
[filing_documents.zip](https://github.com/user-attachments/files/17115230/filing_documents.zip)

**review**:
@Arelle/arelle
