### PR TITLE
Fix conflict between isEnumeration / isEnumeration2

### DIFF
--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -756,10 +756,10 @@ class ModelConcept(ModelNamableTerm, ModelParticle):
     def isEnumeration2Item(self):
         """(bool) -- True if derived from enum2 item types"""
         try:
-            return self._isEnum
+            return self._isEnum2
         except AttributeError:
-            self._isEnum = self.instanceOfType(XbrlConst.qnEnumeration2ItemTypes)
-            return self._isEnum
+            self._isEnum2 = self.instanceOfType(XbrlConst.qnEnumeration2ItemTypes)
+            return self._isEnum2
 
     @property
     def enumDomainQname(self):


### PR DESCRIPTION
#### Reason for change

Extensible enumeration validation is broken because `isEnumeration` and `isEnumeration2` cache to the same attribute. This means that these two methods will always return the same answer, and what that answer is depends on which one gets called first.

#### Description of change

Use separate attributes for caching.

#### Steps to Test

I encountered this because an EE1 validation error was not being detected.  I'm confused about how this can pass the conformance suite.

**review**:
@Arelle/arelle
