### PR TITLE
Accommodate comments in SVGs in ESEF validation.

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_2021/Image.py
+++ b/arelle/plugin/validate/ESEF/ESEF_2021/Image.py
@@ -79,6 +79,9 @@ def checkSVGContent(
                                 _("Image SVG has root element which is not svg"),
                                 modelObject=imgElt)
             rootElement = False
+        # Comments, processing instructions, and maybe other special constructs don't have string tags.
+        if not isinstance(elt.tag, str):
+            continue
         eltTag = elt.tag.rpartition("}")[2] # strip namespace
         if eltTag in ("object", "script", "audio", "foreignObject", "iframe", "image", "use", "video"):
             href = elt.get("href","")

--- a/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/Image.py
@@ -194,6 +194,9 @@ def checkSVGContentElt(
                                 _("Image SVG has root element which is not svg"),
                                 modelObject=imgElts)
             rootElement = False
+        # Comments, processing instructions, and maybe other special constructs don't have string tags.
+        if not isinstance(elt.tag, str):
+            continue
         eltTag = elt.tag.rpartition("}")[2] # strip namespace
         if eltTag == "image":
             imgElts = [*imgElts, elt]


### PR DESCRIPTION
#### Reason for change
```
[exception:AttributeError] Instance validation exception: '_cython_3_0_11.cython_function_or_method' object has no attribute 'rpartition', instance: _IXDS - ../../IXDS test-2024-10-09-en.xhtml
Traceback (most recent call last):
  File "arelle/Validate.py", line 124, in validate
    self.instValidator.validate(self.modelXbrl, self.modelXbrl.modelManager.formulaOptions.typedParameters(self.modelXbrl.prefixedNamespaces))
  File "arelle/ValidateXbrl.py", line 406, in validate
    pluginXbrlMethod(self)
  File "arelle/plugin/validate/ESEF/__init__.py", line 285, in validateXbrlFinally
    return validateXbrlFinallyCurrent(val, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py", line 345, in validateXbrlFinally
    validateImage(elt.modelDocument.baseForElement(elt), src, modelXbrl, val, elt, evaluatedMsg, contentOtherThanXHTMLGuidance)
  File "arelle/plugin/validate/ESEF/ESEF_Current/Image.py", line 75, in validateImage
    checkImageContents(None, modelXbrl, elts, str(dataURLParts.mimeSubtype), False, imgContents, val.consolidated, val)
  File "arelle/plugin/validate/ESEF/ESEF_Current/Image.py", line 121, in checkImageContents
    checkSVGContent(baseURI, modelXbrl, imgElts, data, guidance, val)
  File "arelle/plugin/validate/ESEF/ESEF_Current/Image.py", line 169, in checkSVGContent
    checkSVGContentElt(elt, baseURI, modelXbrl, imgElts, guidance, val)
  File "arelle/plugin/validate/ESEF/ESEF_Current/Image.py", line 200, in checkSVGContentElt
    validateImage(baseUrl, getHref(elt), modelXbrl, val, imgElts, "", guidance)
  File "arelle/plugin/validate/ESEF/ESEF_Current/Image.py", line 75, in validateImage
    checkImageContents(None, modelXbrl, elts, str(dataURLParts.mimeSubtype), False, imgContents, val.consolidated, val)
  File "arelle/plugin/validate/ESEF/ESEF_Current/Image.py", line 121, in checkImageContents
    checkSVGContent(baseURI, modelXbrl, imgElts, data, guidance, val)
  File "arelle/plugin/validate/ESEF/ESEF_Current/Image.py", line 169, in checkSVGContent
    checkSVGContentElt(elt, baseURI, modelXbrl, imgElts, guidance, val)
  File "arelle/plugin/validate/ESEF/ESEF_Current/Image.py", line 197, in checkSVGContentElt
    eltTag = elt.tag.rpartition("}")[2] # strip namespace
             ^^^^^^^^^^^^^^^^^^
AttributeError: '_cython_3_0_11.cython_function_or_method' object has no attribute 'rpartition'
```

#### Steps to Test
Test ESEF validation with [document](https://github.com/user-attachments/files/17314757/test-2024-10-09-en.zip).

**review**:
@Arelle/arelle
