### PR TITLE
Load Report Packages

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -145,6 +145,10 @@ def parseArgs(args):
                       action="store_true",
                       dest="validateXmlOim",
                       help=_("Enables OIM validation for XML and iXBRL documents. OIM only formats (json, csv) are always OIM validated."))
+    parser.add_option("--reportPackage", "--reportPackage",
+                      action="store_true",
+                      dest="reportPackage",
+                      help=_("Ignore detected file type and validate all files as Report Packages."))
     parser.add_option("--deduplicateFacts", "--deduplicatefacts",
                       choices=[a.value for a in ValidateDuplicateFacts.DeduplicationType],
                       dest="deduplicateFacts",
@@ -829,6 +833,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
             duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(options.validateDuplicateFacts)
             duplicateType = duplicateTypeArg.duplicateType()
             self.modelManager.validateDuplicateFacts = duplicateType
+        self.modelManager.validateAllFilesAsReportPackages = bool(options.reportPackage)
         if options.utrUrl:  # override disclosureSystem utrUrl
             self.modelManager.disclosureSystem.utrUrl = [options.utrUrl]
             # can be set now because the utr is first loaded at validation time

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -15,6 +15,7 @@ from arelle import (Cntlr, FileSource, ModelDocument, XmlUtil, XbrlConst, Versio
                     ViewFileFormulae, ViewFileRelationshipSet, ViewFileTests, ViewFileRssFeed,
                     ViewFileRoleTypes)
 from arelle.oim.xml.Save import saveOimReportToXmlInstance
+from arelle.packages.report import ReportPackageConst
 from arelle.rendering import RenderingEvaluator
 from arelle.RuntimeOptions import RuntimeOptions, RuntimeOptionsException
 from arelle.BetaFeatures import BETA_FEATURES_AND_DESCRIPTIONS

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -555,33 +555,49 @@ def configAndRunCntlr(options, arellePluginModules):
         return cntlr
 
 
-def filesourceEntrypointFiles(filesource, entrypointFiles=[], inlineOnly=False):
+def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False):
+    if entrypointFiles is None:
+        entrypointFiles = []
     if filesource.isArchive:
         if filesource.isTaxonomyPackage:  # if archive is also a taxonomy package, activate mappings
             filesource.loadTaxonomyPackageMappings()
         # HF note: a web api request to load a specific file from archive is ignored, is this right?
         del entrypointFiles[:] # clear out archive from entrypointFiles
-        # attempt to find inline XBRL files before instance files, .xhtml before probing others (ESMA)
-        urlsByType = {}
-        if not entrypointFiles:
+        if reportPackage := filesource.reportPackage:
+            assert isinstance(filesource.basefile, str)
+            for report in reportPackage.reports or []:
+                if report.isInline:
+                    reportEntries = [{"file": f} for f in report.fullPathFiles]
+                    ixdsDiscovered = False
+                    for pluginXbrlMethod in pluginClassMethods("InlineDocumentSet.Discovery"):
+                        pluginXbrlMethod(filesource, reportEntries)
+                        ixdsDiscovered = True
+                    if not ixdsDiscovered and len(reportEntries) > 1:
+                        raise RuntimeError(_("Loading error. Inline document set encountered. Enable 'InlineDocumentSet' plug-in to load this filing: {0}").format(filesource.url))
+                    entrypointFiles.extend(reportEntries)
+                elif not inlineOnly:
+                    entrypointFiles.append({"file": report.fullPathPrimary})
+        else:
+            # attempt to find inline XBRL files before instance files, .xhtml before probing others (ESMA)
+            urlsByType = {}
             for _archiveFile in (filesource.dir or ()): # .dir might be none if IOerror
                 filesource.select(_archiveFile)
                 identifiedType = ModelDocument.Type.identify(filesource, filesource.url)
                 if identifiedType in (ModelDocument.Type.INSTANCE, ModelDocument.Type.INLINEXBRL, ModelDocument.Type.HTML):
                     urlsByType.setdefault(identifiedType, []).append(filesource.url)
-        # use inline instances, if any, else non-inline instances
-        for identifiedType in ((ModelDocument.Type.INLINEXBRL,) if inlineOnly else (ModelDocument.Type.INLINEXBRL, ModelDocument.Type.INSTANCE)):
-            for url in urlsByType.get(identifiedType, []):
-                entrypointFiles.append({"file":url})
-            if entrypointFiles:
-                if identifiedType == ModelDocument.Type.INLINEXBRL:
-                    for pluginXbrlMethod in pluginClassMethods("InlineDocumentSet.Discovery"):
-                        pluginXbrlMethod(filesource, entrypointFiles) # group into IXDS if plugin feature is available
-                break # found inline (or non-inline) entrypoint files, don't look for any other type
-        # for ESEF non-consolidated xhtml documents accept an xhtml entry point
-        if not entrypointFiles and not inlineOnly:
-            for url in urlsByType.get(ModelDocument.Type.HTML, []):
-                entrypointFiles.append({"file":url})
+            # use inline instances, if any, else non-inline instances
+            for identifiedType in ((ModelDocument.Type.INLINEXBRL,) if inlineOnly else (ModelDocument.Type.INLINEXBRL, ModelDocument.Type.INSTANCE)):
+                for url in urlsByType.get(identifiedType, []):
+                    entrypointFiles.append({"file":url})
+                if entrypointFiles:
+                    if identifiedType == ModelDocument.Type.INLINEXBRL:
+                        for pluginXbrlMethod in pluginClassMethods("InlineDocumentSet.Discovery"):
+                            pluginXbrlMethod(filesource, entrypointFiles) # group into IXDS if plugin feature is available
+                    break # found inline (or non-inline) entrypoint files, don't look for any other type
+            # for ESEF non-consolidated xhtml documents accept an xhtml entry point
+            if not entrypointFiles and not inlineOnly:
+                for url in urlsByType.get(ModelDocument.Type.HTML, []):
+                    entrypointFiles.append({"file":url})
 
 
     elif os.path.isdir(filesource.url):
@@ -1006,9 +1022,12 @@ class CntlrCmdLine(Cntlr.Cntlr):
         elif len(_entryPoints) == 1 and "file" in _entryPoints[0]: # check if an archive and need to discover entry points (and not IXDS)
             filesource = FileSource.openFileSource(_entryPoints[0].get("file",None), self, checkIfXmlIsEis=_checkIfXmlIsEis)
         _entrypointFiles = _entryPoints
-        if filesource and not filesource.selection:
-            if not (sourceZipStream and len(_entrypointFiles) > 0):
+        if filesource and not filesource.selection and not (sourceZipStream and len(_entrypointFiles) > 0):
+            try:
                 filesourceEntrypointFiles(filesource, _entrypointFiles)
+            except Exception as err:
+                self.addToLog(str(err), messageCode="error", level=logging.ERROR)
+                return False
 
         for pluginXbrlMethod in pluginClassMethods("CntlrCmdLine.Filing.Start"):
             pluginXbrlMethod(self, options, filesource, _entrypointFiles, sourceZipStream=sourceZipStream, responseZipStream=responseZipStream)
@@ -1026,6 +1045,9 @@ class CntlrCmdLine(Cntlr.Cntlr):
             try:
                 if filesource:
                     modelXbrl = self.modelManager.load(filesource, _("views loading"), entrypoint=_entrypoint)
+                    if filesource.isArchive:
+                        # Keep archive filesource potentially used by multiple reports open.
+                        modelXbrl.closeFileSource = False
             except ModelDocument.LoadingException:
                 pass
             except Exception as err:
@@ -1227,6 +1249,10 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         self.modelManager.close(modelDiffReport)
                     elif modelXbrl:
                         self.modelManager.close(modelXbrl)
+        if not options.keepOpen:
+            # Archive filesource potentially used by multiple reports may still be open.
+            filesource.close()
+
         if success:
             if options.validate:
                 for pluginXbrlMethod in pluginClassMethods("CntlrCmdLine.Filing.Validate"):

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -175,6 +175,11 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.validateXmlOim.trace("w", self.setValidateXmlOim)
         validateMenu.add_checkbutton(label=_("OIM validate xBRL-XML documents"), underline=0, variable=self.validateXmlOim, onvalue=True, offvalue=False)
 
+        self.modelManager.validateAllFilesAsReportPackages = self.config.setdefault("validateAllFilesAsReportPackages", False)
+        self.validateAllFilesAsReportPackages = BooleanVar(value=self.modelManager.validateAllFilesAsReportPackages)
+        self.validateAllFilesAsReportPackages.trace("w", self.setValidateAllFilesAsReportPackages)
+        validateMenu.add_checkbutton(label=_("Validate all files as Report Packages"), underline=0, variable=self.validateAllFilesAsReportPackages, onvalue=True, offvalue=False)
+
         self.validateDuplicateFacts = None
         self.buildValidateDuplicateFactsMenu(validateMenu)
 
@@ -1382,6 +1387,12 @@ class CntlrWinMain (Cntlr.Cntlr):
     def setValidateXmlOim(self, *args):
         self.modelManager.validateXmlOim = self.validateXmlOim.get()
         self.config["validateXmlOim"] = self.modelManager.validateXmlOim
+        self.saveConfig()
+        self.setValidateTooltipText()
+
+    def setValidateAllFilesAsReportPackages(self, *args):
+        self.modelManager.validateAllFilesAsReportPackages = self.validateAllFilesAsReportPackages.get()
+        self.config["validateAllFilesAsReportPackages"] = self.modelManager.validateAllFilesAsReportPackages
         self.saveConfig()
         self.setValidateTooltipText()
 

--- a/arelle/DialogOpenArchive.py
+++ b/arelle/DialogOpenArchive.py
@@ -32,24 +32,18 @@ def askArchiveFile(parent, filesource, multiselect=False, selectFiles=None):
     try:
         filenames = filesource.dir
         if filenames is not None:   # an IO or other error can return None
-            if filesource.isTaxonomyPackage:
-                dialog = DialogOpenArchive(parent,
-                                           ENTRY_POINTS,
-                                           filesource,
-                                           filenames,
-                                           _("Select Entry Point"),
-                                           _("File"),
-                                           showAltViewButton=True,
-                                           multiselect=multiselect)
-            else:
-                dialog = DialogOpenArchive(parent,
-                                           ARCHIVE,
-                                           filesource,
-                                           filenames,
-                                           _("Select Archive File"),
-                                           _("File"),
-                                           multiselect=multiselect,
-                                           selectFiles=selectFiles)
+            noReportTaxonomyPackage = bool(filesource.isTaxonomyPackage and not filesource.isReportPackage)
+            dialog = DialogOpenArchive(
+                parent,
+                ENTRY_POINTS if noReportTaxonomyPackage else ARCHIVE,
+                filesource,
+                filenames,
+                _("Select Entry Point") if noReportTaxonomyPackage else _("Select Archive File"),
+                _("File"),
+                showAltViewButton=noReportTaxonomyPackage,
+                multiselect=multiselect,
+                selectFiles=selectFiles,
+            )
             if dialog.accepted:
                 return filesource.url
     except Exception as e:

--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -747,6 +747,14 @@ class FileSource:
             else:
                 self.url = self.basedUrl(selection)
 
+    @property
+    def urlBasename(self) -> list[str] | str | None:
+        if isinstance(self.url, str):
+            return os.path.basename(self.url)
+        if isinstance(self.url, list):
+            return [os.path.basename(url) for url in self.url]
+        return None
+
 def openFileStream(
     cntlr: Cntlr | None, filepath: str, mode: str = "r", encoding: str | None = None
 ) -> io.BytesIO | IO[Any]:

--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -20,6 +20,8 @@ from lxml import etree
 
 import arelle.PluginManager
 from arelle import PackageManager, XmlUtil
+from arelle.packages.report.DetectReportPackage import isReportPackageExtension
+from arelle.packages.report.ReportPackage import ReportPackage
 from arelle.typing import TypeGetText
 from arelle.UrlUtil import isHttpUrl
 
@@ -70,7 +72,7 @@ def openFileSource(
                 and sourceFileSource.dir is not None
                 and sourceFileSource.isArchive
                 and selection in sourceFileSource.dir
-                and selection.endswith(".zip")
+                and isReportPackageExtension(selection)
             ):
                 assert cntlr is not None
                 filesource = FileSource(filename, cntlr)
@@ -157,7 +159,7 @@ class FileSource:
         self.isTarGz = self.type == ".tar.gz"
         if not self.isTarGz:
             self.type = self.type[3:]
-        self.isZip = self.type == ".zip"
+        self.isZip = self.type == ".zip" or isReportPackageExtension(self.url)
         self.isZipBackslashed = False # windows style backslashed paths
         self.isEis = self.type == ".eis"
         self.isXfd = (self.type == ".xfd" or self.type == ".frm")
@@ -405,6 +407,19 @@ class FileSource:
     @property
     def isTaxonomyPackage(self) -> bool:
         return bool(self.isZip and self.taxonomyPackageMetadataFiles) or self.isInstalledTaxonomyPackage
+
+    @property
+    def isReportPackage(self) -> bool:
+        return self.reportPackage is not None
+
+    @property
+    def reportPackage(self) -> ReportPackage | None:
+        try:
+            self._reportPackage: ReportPackage | None
+            return self._reportPackage
+        except AttributeError:
+            self._reportPackage = ReportPackage.fromFileSource(self) if self.isZip else None
+            return self._reportPackage
 
     @property
     def taxonomyPackageMetadataFiles(self) -> list[str]:

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -67,6 +67,7 @@ class ModelManager:
         self.loadedModelXbrls = []
         self.customTransforms: dict[QName, Callable[[str], str]] | None = None
         self.isLocaleSet = False
+        self.validateAllFilesAsReportPackages = False
         self.validateDuplicateFacts = ValidateDuplicateFacts.DuplicateType.NONE
         self.validateXmlOim = False
         self.setLocale()

--- a/arelle/ModelTestcaseObject.py
+++ b/arelle/ModelTestcaseObject.py
@@ -365,6 +365,13 @@ class ModelTestcaseVariation(ModelObject):
                 return _count
         return None
 
+    @property
+    def expectedReportCount(self):
+        resultElement = XmlUtil.descendant(self, None, "result")
+        if resultElement is None:
+            return None
+        report_count = resultElement.get('report_count')
+        return int(report_count) if report_count is not None else None
 
     @property
     def severityLevel(self):

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -58,7 +58,7 @@ _NOT_FOUND = object()
 LoggableValue = Union[str, Dict[Any, Any], List[Any], Set[Any], Tuple[Any, ...]]
 
 
-def load(modelManager: ModelManager, url: str | FileSourceClass, nextaction: str | None = None, base: str | None = None, useFileSource: FileSourceClass | None = None, errorCaptureLevel: str | None = None, **kwargs: str) -> ModelXbrl:
+def load(modelManager: ModelManager, url: str | FileSourceClass, nextaction: str | None = None, base: str | None = None, useFileSource: FileSourceClass | None = None, errorCaptureLevel: str | None = None, **kwargs: Any) -> ModelXbrl:
     """Each loaded instance, DTS, testcase, testsuite, versioning report, or RSS feed, is represented by an
     instance of a ModelXbrl object. The ModelXbrl object has a collection of ModelDocument objects, each
     representing an XML document (for now, with SQL whenever its time comes). One of the modelDocuments of

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -114,6 +114,7 @@ class RuntimeOptions:
     proxy: Optional[str] = None
     redirectFallbacks: Optional[dict[Pattern[str], str]] = None
     relationshipCols: Optional[int] = None
+    reportPackage: Optional[bool] = None
     roleTypesFile: Optional[str] = None
     rssReport: Optional[str] = None
     rssReportCols: Optional[int] = None

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -588,11 +588,13 @@ class Validate:
         hasAssertionResult = any(isinstance(e,dict) for e in _errors)
         expected = modelTestcaseVariation.expected
         expectedCount = modelTestcaseVariation.expectedCount
-        variationIdPath = f'{modelTestcaseVariation.base}:{modelTestcaseVariation.id}'
+        indexPath = modelTestcaseVariation.document.filepath
         if self.useFileSource is not None and self.useFileSource.isZip:
-            baseZipFile = self.useFileSource.basefile + "/"
-            if variationIdPath.startswith(baseZipFile):
-                variationIdPath = variationIdPath[len(baseZipFile):]
+            baseZipFile = self.useFileSource.basefile
+            if indexPath.startswith(baseZipFile):
+                indexPath = indexPath[len(baseZipFile) + 1:]
+            indexPath = indexPath.replace("\\", "/")
+        variationIdPath = f'{indexPath}:{modelTestcaseVariation.id}'
         if userExpectedErrors := testcaseExpectedErrors.get(variationIdPath):
             if expected is None:
                 expected = []

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -20,6 +20,7 @@ from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelTestcaseObject import testcaseVariationsByTarget, ModelTestcaseVariation
 from arelle.ModelValue import (qname, QName)
 from arelle.PluginManager import pluginClassMethods
+from arelle.packages.report.DetectReportPackage import isReportPackageExtension
 from arelle.rendering import RenderingEvaluator
 from arelle.XmlUtil import collapseWhitespace, xmlstring
 
@@ -248,7 +249,7 @@ class Validate:
                         modelXbrl = PrototypeInstanceObject.XbrlPrototype(self.modelXbrl.modelManager, readMeFirstUri)
                         PackageManager.packageInfo(self.modelXbrl.modelManager.cntlr, readMeFirstUri, reload=True, errors=modelXbrl.errors)
                     else: # not a multi-schemaRef versioning report
-                        if self.useFileSource.isArchive and (os.path.isabs(readMeFirstUri) or not readMeFirstUri.endswith(".zip")):
+                        if self.useFileSource.isArchive and (os.path.isabs(readMeFirstUri) or not isReportPackageExtension(readMeFirstUri)):
                             modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager,
                                                        readMeFirstUri,
                                                        _("validating"),
@@ -262,7 +263,7 @@ class Validate:
                             if (
                                 self.useFileSource
                                 and not os.path.isabs(readMeFirstUri)
-                                and readMeFirstUri.endswith('.zip')
+                                and isReportPackageExtension(readMeFirstUri)
                             ):
                                 if self.useFileSource.isArchive:
                                     sourceFileSource = self.useFileSource
@@ -274,12 +275,13 @@ class Validate:
 
                             filesource = FileSource.openFileSource(readMeFirstUri, self.modelXbrl.modelManager.cntlr, base=baseForElement,
                                                                    sourceFileSource=sourceFileSource)
+
                             if newSourceFileSource:
                                 sourceFileSource.close()
                             _errors = [] # accumulate pre-loading errors, such as during taxonomy package loading
                             if filesource and not filesource.selection and filesource.isArchive:
                                 try:
-                                    if filesource.isTaxonomyPackage or expectTaxonomyPackage:
+                                    if filesource.isTaxonomyPackage or (expectTaxonomyPackage and not filesource.isReportPackage):
                                         _rptPkgIxdsOptions = {}
                                         for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ReportPackageIxdsOptions"):
                                             pluginXbrlMethod(self, _rptPkgIxdsOptions)

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -192,379 +192,7 @@ class Validate:
                                         modelObject=testcaseVariation,
                                         variationId=testcaseVariation.id)
             for modelTestcaseVariation in testcaseVariations:
-                # update ui thread via modelManager (running in background here)
-                startTime = time.perf_counter()
-                self.modelXbrl.modelManager.viewModelObject(self.modelXbrl, modelTestcaseVariation.objectId())
-                # is this a versioning report?
-                resultIsVersioningReport = modelTestcaseVariation.resultIsVersioningReport
-                resultIsXbrlInstance = modelTestcaseVariation.resultIsXbrlInstance
-                resultIsTaxonomyPackage = modelTestcaseVariation.resultIsTaxonomyPackage
-                formulaOutputInstance = None
-                inputDTSes = defaultdict(list)
-                baseForElement = testcase.baseForElement(modelTestcaseVariation)
-                # try to load instance document
-                self.modelXbrl.info("info", _("Variation %(id)s%(name)s%(target)s: %(expected)s - %(description)s"),
-                                    modelObject=modelTestcaseVariation,
-                                    id=modelTestcaseVariation.id,
-                                    name=(" {}".format(modelTestcaseVariation.name) if modelTestcaseVariation.name else ""),
-                                    target=(" target {}".format(modelTestcaseVariation.ixdsTarget) if modelTestcaseVariation.ixdsTarget else ""),
-                                    expected=modelTestcaseVariation.expected,
-                                    description=modelTestcaseVariation.description)
-                if self.modelXbrl.modelManager.formulaOptions.testcaseResultsCaptureWarnings:
-                    errorCaptureLevel = logging._checkLevel("WARNING")
-                else:
-                    errorCaptureLevel = modelTestcaseVariation.severityLevel # default is INCONSISTENCY
-                parameters = modelTestcaseVariation.parameters.copy()
-                for i, readMeFirstUri in enumerate(modelTestcaseVariation.readMeFirstUris):
-                    readMeFirstElements = modelTestcaseVariation.readMeFirstElements
-                    expectTaxonomyPackage = (i < len(readMeFirstElements) and
-                                             readMeFirstElements[i] is not None and
-                                             readMeFirstElements[i].qname.localName == "taxonomyPackage")
-                    if isinstance(readMeFirstUri,tuple):
-                        # dtsName is for formula instances, but is from/to dts if versioning
-                        dtsName, readMeFirstUri = readMeFirstUri
-                    elif resultIsVersioningReport:
-                        if inputDTSes: dtsName = "to"
-                        else: dtsName = "from"
-                    else:
-                        dtsName = None
-                    if resultIsVersioningReport and dtsName: # build multi-schemaRef containing document
-                        if dtsName in inputDTSes:
-                            dtsName = inputDTSes[dtsName]
-                        else:
-                            modelXbrl = ModelXbrl.create(self.modelXbrl.modelManager,
-                                         Type.DTSENTRIES,
-                                         self.modelXbrl.modelManager.cntlr.webCache.normalizeUrl(readMeFirstUri[:-4] + ".dts", baseForElement),
-                                         isEntry=True,
-                                         errorCaptureLevel=errorCaptureLevel)
-                        DTSdoc = modelXbrl.modelDocument
-                        DTSdoc.inDTS = True
-                        doc = modelDocumentLoad(modelXbrl, readMeFirstUri, base=baseForElement)
-                        if doc is not None:
-                            DTSdoc.referencesDocument[doc] = ModelDocumentReference("import", DTSdoc.xmlRootElement)  #fake import
-                            doc.inDTS = True
-                    elif resultIsTaxonomyPackage:
-                        from arelle import PackageManager, PrototypeInstanceObject
-                        dtsName = readMeFirstUri
-                        modelXbrl = PrototypeInstanceObject.XbrlPrototype(self.modelXbrl.modelManager, readMeFirstUri)
-                        PackageManager.packageInfo(self.modelXbrl.modelManager.cntlr, readMeFirstUri, reload=True, errors=modelXbrl.errors)
-                    else: # not a multi-schemaRef versioning report
-                        if self.useFileSource.isArchive and (os.path.isabs(readMeFirstUri) or not isReportPackageExtension(readMeFirstUri)):
-                            modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager,
-                                                       readMeFirstUri,
-                                                       _("validating"),
-                                                       base=baseForElement,
-                                                       useFileSource=self.useFileSource,
-                                                       errorCaptureLevel=errorCaptureLevel,
-                                                       ixdsTarget=modelTestcaseVariation.ixdsTarget)
-                        else: # need own file source, may need instance discovery
-                            sourceFileSource = None
-                            newSourceFileSource = False
-                            if (
-                                self.useFileSource
-                                and not os.path.isabs(readMeFirstUri)
-                                and isReportPackageExtension(readMeFirstUri)
-                            ):
-                                if self.useFileSource.isArchive:
-                                    sourceFileSource = self.useFileSource
-                                elif expectTaxonomyPackage:
-                                    archiveFilenameParts = FileSource.archiveFilenameParts(baseForElement)
-                                    if archiveFilenameParts is not None:
-                                        sourceFileSource = FileSource.openFileSource(archiveFilenameParts[0], self.modelXbrl.modelManager.cntlr)
-                                        newSourceFileSource = True
-
-                            filesource = FileSource.openFileSource(readMeFirstUri, self.modelXbrl.modelManager.cntlr, base=baseForElement,
-                                                                   sourceFileSource=sourceFileSource)
-
-                            if newSourceFileSource:
-                                sourceFileSource.close()
-                            _errors = [] # accumulate pre-loading errors, such as during taxonomy package loading
-                            if filesource and not filesource.selection and filesource.isArchive:
-                                try:
-                                    if filesource.isTaxonomyPackage or (expectTaxonomyPackage and not filesource.isReportPackage):
-                                        _rptPkgIxdsOptions = {}
-                                        for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ReportPackageIxdsOptions"):
-                                            pluginXbrlMethod(self, _rptPkgIxdsOptions)
-                                        filesource.loadTaxonomyPackageMappings(errors=_errors, expectTaxonomyPackage=expectTaxonomyPackage)
-                                        filesource.select(None) # must select loadable reports (not the taxonomy package itself)
-                                        for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ReportPackageIxds"):
-                                            filesource.select(pluginXbrlMethod(filesource, **_rptPkgIxdsOptions))
-                                    else:
-                                        from arelle.CntlrCmdLine import filesourceEntrypointFiles
-                                        entrypoints = filesourceEntrypointFiles(filesource)
-                                        if entrypoints:
-                                            # resolve an IXDS in entrypoints
-                                            for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ArchiveIxds"):
-                                                pluginXbrlMethod(self, filesource,entrypoints)
-                                            filesource.select(entrypoints[0].get("file", None) )
-                                except Exception as err:
-                                    self.modelXbrl.error("exception:" + type(err).__name__,
-                                        _("Testcase variation validation exception: %(error)s, entry URL: %(instance)s"),
-                                        modelXbrl=self.modelXbrl, instance=readMeFirstUri, error=err)
-                                    continue # don't try to load this entry URL
-                            modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager,
-                                                       filesource,
-                                                       _("validating"),
-                                                       base=baseForElement,
-                                                       errorCaptureLevel=errorCaptureLevel,
-                                                       ixdsTarget=modelTestcaseVariation.ixdsTarget,
-                                                       isLoadable=modelTestcaseVariation.variationDiscoversDTS or filesource.url,
-                                                       errors=_errors)
-                        modelXbrl.isTestcaseVariation = True
-                    if not modelTestcaseVariation.variationDiscoversDTS and modelXbrl.modelDocument is None: # e.g., taxonomyPackage test
-                        self.determineTestStatus(modelTestcaseVariation, modelXbrl.errors)
-                        modelXbrl.close()
-                    elif modelXbrl.modelDocument is None:
-                        modelXbrl.info("arelle:notLoaded",
-                             _("Variation %(id)s %(name)s readMeFirst document not loaded: %(file)s"),
-                             modelXbrl=testcase, id=modelTestcaseVariation.id, name=modelTestcaseVariation.name, file=os.path.basename(readMeFirstUri))
-                        self.determineNotLoadedTestStatus(modelTestcaseVariation, modelXbrl.errors)
-                        modelXbrl.close()
-                    elif resultIsVersioningReport or resultIsTaxonomyPackage:
-                        inputDTSes[dtsName] = modelXbrl
-                    elif modelXbrl.modelDocument.type == Type.VERSIONINGREPORT:
-                        ValidateVersReport.ValidateVersReport(self.modelXbrl).validate(modelXbrl)
-                        self.determineTestStatus(modelTestcaseVariation, modelXbrl.errors)
-                        modelXbrl.close()
-                    elif testcase.type == Type.REGISTRYTESTCASE:
-                        self.instValidator.validate(modelXbrl)  # required to set up dimensions, etc
-                        self.instValidator.executeCallTest(modelXbrl, modelTestcaseVariation.id,
-                                   modelTestcaseVariation.cfcnCall, modelTestcaseVariation.cfcnTest)
-                        self.determineTestStatus(modelTestcaseVariation, modelXbrl.errors)
-                        self.instValidator.close()
-                        modelXbrl.close()
-                    else:
-                        inputDTSes[dtsName].append(modelXbrl)
-                        # validate except for formulas
-                        _hasFormulae = modelXbrl.hasFormulae
-                        modelXbrl.hasFormulae = False
-                        try:
-                            for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Xbrl.Loaded"):
-                                pluginXbrlMethod(self.modelXbrl, modelXbrl, modelTestcaseVariation)
-                            self.instValidator.validate(modelXbrl, parameters)
-                            for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Xbrl.Validated"):
-                                pluginXbrlMethod(self.modelXbrl, modelXbrl)
-                        except Exception as err:
-                            modelXbrl.error("exception:" + type(err).__name__,
-                                _("Testcase variation validation exception: %(error)s, instance: %(instance)s"),
-                                modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=(type(err) is not AssertionError))
-                        modelXbrl.hasFormulae = _hasFormulae
-                if resultIsVersioningReport and modelXbrl.modelDocument:
-                    versReportFile = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(
-                        modelTestcaseVariation.versioningReportUri, baseForElement)
-                    if os.path.exists(versReportFile): #validate existing
-                        modelVersReport = ModelXbrl.load(self.modelXbrl.modelManager, versReportFile, _("validating existing version report"))
-                        if modelVersReport and modelVersReport.modelDocument and modelVersReport.modelDocument.type == Type.VERSIONINGREPORT:
-                            ValidateVersReport.ValidateVersReport(self.modelXbrl).validate(modelVersReport)
-                            self.determineTestStatus(modelTestcaseVariation, modelVersReport.errors)
-                            modelVersReport.close()
-                    elif len(inputDTSes) == 2:
-                        ModelVersReport.ModelVersReport(self.modelXbrl).diffDTSes(
-                              versReportFile, inputDTSes["from"], inputDTSes["to"])
-                        modelTestcaseVariation.status = "generated"
-                    else:
-                        modelXbrl.error("arelle:notLoaded",
-                             _("Variation %(id)s %(name)s input DTSes not loaded, unable to generate versioning report: %(file)s"),
-                             modelXbrl=testcase, id=modelTestcaseVariation.id, name=modelTestcaseVariation.name, file=os.path.basename(readMeFirstUri))
-                        modelTestcaseVariation.status = "failed"
-                    for inputDTS in inputDTSes.values():
-                        inputDTS.close()
-                    del inputDTSes # dereference
-                elif resultIsTaxonomyPackage:
-                    self.determineTestStatus(modelTestcaseVariation, modelXbrl.errors)
-                    modelXbrl.close()
-                elif inputDTSes:
-                    # validate schema, linkbase, or instance
-                    modelXbrl = inputDTSes[None][0]
-                    expectedDataFiles = set(modelXbrl.modelManager.cntlr.webCache.normalizeUrl(uri, baseForElement)
-                                            for d in modelTestcaseVariation.dataUris.values() for uri in d
-                                            if not UrlUtil.isAbsolute(uri))
-                    foundDataFiles = set()
-                    variationBase = os.path.dirname(baseForElement)
-                    for dtsName, inputDTS in inputDTSes.items():  # input instances are also parameters
-                        if dtsName: # named instance
-                            parameters[dtsName] = (None, inputDTS) #inputDTS is a list of modelXbrl's (instance DTSes)
-                        elif len(inputDTS) > 1: # standard-input-instance with multiple instance documents
-                            parameters[XbrlConst.qnStandardInputInstance] = (None, inputDTS) # allow error detection in validateFormula
-                        for _inputDTS in inputDTS:
-                            for docUrl, doc in _inputDTS.urlDocs.items():
-                                if docUrl.startswith(variationBase) and not doc.type == Type.INLINEXBRLDOCUMENTSET:
-                                    if getattr(doc,"loadedFromXbrlFormula", False): # may have been sourced from xf file
-                                        if docUrl.replace("-formula.xml", ".xf") in expectedDataFiles:
-                                            docUrl = docUrl.replace("-formula.xml", ".xf")
-                                    foundDataFiles.add(docUrl)
-                    if expectedDataFiles - foundDataFiles:
-                        modelXbrl.info("arelle:testcaseDataNotUsed",
-                            _("Variation %(id)s %(name)s data files not used: %(missingDataFiles)s"),
-                            modelObject=modelTestcaseVariation, name=modelTestcaseVariation.name, id=modelTestcaseVariation.id,
-                            missingDataFiles=", ".join(sorted(os.path.basename(f) for f in expectedDataFiles - foundDataFiles)))
-                    if foundDataFiles - expectedDataFiles:
-                        modelXbrl.info("arelle:testcaseDataUnexpected",
-                            _("Variation %(id)s %(name)s files not in variation data: %(unexpectedDataFiles)s"),
-                            modelObject=modelTestcaseVariation, name=modelTestcaseVariation.name, id=modelTestcaseVariation.id,
-                            unexpectedDataFiles=", ".join(sorted(os.path.basename(f) for f in foundDataFiles - expectedDataFiles)))
-                    if modelXbrl.hasTableRendering or modelTestcaseVariation.resultIsTable:
-                        try:
-                            RenderingEvaluator.init(modelXbrl)
-                        except Exception as err:
-                            modelXbrl.error("exception:" + type(err).__name__,
-                                _("Testcase RenderingEvaluator.init exception: %(error)s, instance: %(instance)s"),
-                                modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=True)
-                    modelXbrlHasFormulae = modelXbrl.hasFormulae
-                    if modelXbrlHasFormulae and self.modelXbrl.modelManager.formulaOptions.formulaAction != "none":
-                        try:
-                            # validate only formulae
-                            self.instValidator.parameters = parameters
-                            ValidateFormula.validate(self.instValidator)
-                        except Exception as err:
-                            modelXbrl.error("exception:" + type(err).__name__,
-                                _("Testcase formula variation validation exception: %(error)s, instance: %(instance)s"),
-                                modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=(type(err) is not AssertionError))
-                    if modelTestcaseVariation.resultIsInfoset and self.modelXbrl.modelManager.validateInfoset:
-                        for pluginXbrlMethod in pluginClassMethods("Validate.Infoset"):
-                            pluginXbrlMethod(modelXbrl, modelTestcaseVariation.resultInfosetUri)
-                        infoset = ModelXbrl.load(self.modelXbrl.modelManager,
-                                                 modelTestcaseVariation.resultInfosetUri,
-                                                   _("loading result infoset"),
-                                                   base=baseForElement,
-                                                   useFileSource=self.useFileSource,
-                                                   errorCaptureLevel=errorCaptureLevel)
-                        if infoset.modelDocument is None:
-                            modelXbrl.error("arelle:notLoaded",
-                                _("Variation %(id)s %(name)s result infoset not loaded: %(file)s"),
-                                modelXbrl=testcase, id=modelTestcaseVariation.id, name=modelTestcaseVariation.name,
-                                file=os.path.basename(modelTestcaseVariation.resultXbrlInstance))
-                            modelTestcaseVariation.status = "result infoset not loadable"
-                        else:   # check infoset
-                            ValidateInfoset.validate(self.instValidator, modelXbrl, infoset)
-                        infoset.close()
-                    if modelXbrl.hasTableRendering or modelTestcaseVariation.resultIsTable: # and self.modelXbrl.modelManager.validateInfoset:
-                        # diff (or generate) table infoset
-                        resultTableUri = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(modelTestcaseVariation.resultTableUri, baseForElement)
-                        if not any(alternativeValidation(modelXbrl, resultTableUri)
-                                   for alternativeValidation in pluginClassMethods("Validate.TableInfoset")):
-                            try:
-                                ViewFileRenderedLayout.viewRenderedLayout(modelXbrl, resultTableUri, diffToFile=True)  # false to save infoset files
-                            except Exception as err:
-                                modelXbrl.error("exception:" + type(err).__name__,
-                                    _("Testcase table linkbase validation exception: %(error)s, instance: %(instance)s"),
-                                    modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=True)
-                    self.instValidator.close()
-                    extraErrors = []
-                    for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Validated"):
-                        pluginXbrlMethod(self.modelXbrl, modelXbrl, extraErrors, inputDTSes)
-                    self.determineTestStatus(modelTestcaseVariation, [e for inputDTSlist in inputDTSes.values() for inputDTS in inputDTSlist for e in inputDTS.errors] + extraErrors) # include infoset errors in status
-                    if modelXbrl.formulaOutputInstance and self.noErrorCodes(modelTestcaseVariation.actual):
-                        # if an output instance is created, and no string error codes, ignoring dict of assertion results, validate it
-                        modelXbrl.formulaOutputInstance.hasFormulae = False #  block formulae on output instance (so assertion of input is not lost)
-                        self.instValidator.validate(modelXbrl.formulaOutputInstance, modelTestcaseVariation.parameters)
-                        self.determineTestStatus(modelTestcaseVariation, modelXbrl.formulaOutputInstance.errors)
-                        if self.noErrorCodes(modelTestcaseVariation.actual): # if still 'clean' pass it forward for comparison to expected result instance
-                            formulaOutputInstance = modelXbrl.formulaOutputInstance
-                            modelXbrl.formulaOutputInstance = None # prevent it from being closed now
-                        self.instValidator.close()
-                    compareIxResultInstance = (modelXbrl.modelDocument.type in (Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET) and
-                                               modelTestcaseVariation.resultXbrlInstanceUri is not None)
-                    if compareIxResultInstance:
-                        formulaOutputInstance = modelXbrl # compare modelXbrl to generated output instance
-                        errMsgPrefix = "ix"
-                    else: # delete input instances before formula output comparision
-                        for inputDTSlist in inputDTSes.values():
-                            for inputDTS in inputDTSlist:
-                                inputDTS.close()
-                        del inputDTSes # dereference
-                        errMsgPrefix = "formula"
-                    if resultIsXbrlInstance and formulaOutputInstance and formulaOutputInstance.modelDocument:
-                        _matchExpectedResultIDs = not modelXbrlHasFormulae # formula restuls have inconsistent IDs
-                        expectedInstance = ModelXbrl.load(self.modelXbrl.modelManager,
-                                                   modelTestcaseVariation.resultXbrlInstanceUri,
-                                                   _("loading expected result XBRL instance"),
-                                                   base=baseForElement,
-                                                   useFileSource=self.useFileSource,
-                                                   errorCaptureLevel=errorCaptureLevel)
-                        if expectedInstance.modelDocument is None:
-                            self.modelXbrl.error("{}:expectedResultNotLoaded".format(errMsgPrefix),
-                                _("Testcase \"%(name)s\" %(id)s expected result instance not loaded: %(file)s"),
-                                modelXbrl=testcase, id=modelTestcaseVariation.id, name=modelTestcaseVariation.name,
-                                file=os.path.basename(modelTestcaseVariation.resultXbrlInstanceUri),
-                                messageCodes=("formula:expectedResultNotLoaded","ix:expectedResultNotLoaded"))
-                            modelTestcaseVariation.status = "result not loadable"
-                        else:   # compare facts
-                            for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.ExpectedInstance.Loaded"):
-                                pluginXbrlMethod(expectedInstance, formulaOutputInstance)
-                            if len(expectedInstance.facts) != len(formulaOutputInstance.facts):
-                                formulaOutputInstance.error("{}:resultFactCounts".format(errMsgPrefix),
-                                    _("Formula output %(countFacts)s facts, expected %(expectedFacts)s facts"),
-                                    modelXbrl=modelXbrl, countFacts=len(formulaOutputInstance.facts),
-                                    expectedFacts=len(expectedInstance.facts),
-                                    messageCodes=("formula:resultFactCounts","ix:resultFactCounts"))
-                            else:
-                                formulaOutputFootnotesRelSet = ModelRelationshipSet(formulaOutputInstance, "XBRL-footnotes")
-                                expectedFootnotesRelSet = ModelRelationshipSet(expectedInstance, "XBRL-footnotes")
-                                def factFootnotes(fact, footnotesRelSet):
-                                    footnotes = {}
-                                    footnoteRels = footnotesRelSet.fromModelObject(fact)
-                                    if footnoteRels:
-                                        # most process rels in same order between two instances, use labels to sort
-                                        for i, footnoteRel in enumerate(sorted(footnoteRels,
-                                                                               key=lambda r: (r.fromLabel,r.toLabel))):
-                                            modelObject = footnoteRel.toModelObject
-                                            if isinstance(modelObject, ModelResource):
-                                                xml = collapseWhitespace(modelObject.viewText().strip())
-                                                footnotes["Footnote {}".format(i+1)] = xml #re.sub(r'\s+', ' ', collapseWhitespace(modelObject.stringValue))
-                                            elif isinstance(modelObject, ModelFact):
-                                                footnotes["Footnoted fact {}".format(i+1)] = \
-                                                    "{} context: {} value: {}".format(
-                                                    modelObject.qname,
-                                                    modelObject.contextID,
-                                                    collapseWhitespace(modelObject.value))
-                                    return footnotes
-                                for expectedInstanceFact in expectedInstance.facts:
-                                    unmatchedFactsStack = []
-                                    formulaOutputFact = formulaOutputInstance.matchFact(expectedInstanceFact, unmatchedFactsStack, deemP0inf=True, matchId=_matchExpectedResultIDs, matchLang=False)
-                                    #formulaOutputFact = formulaOutputInstance.matchFact(expectedInstanceFact, unmatchedFactsStack, deemP0inf=True, matchId=True, matchLang=True)
-                                    if formulaOutputFact is None:
-                                        if unmatchedFactsStack: # get missing nested tuple fact, if possible
-                                            missingFact = unmatchedFactsStack[-1]
-                                        else:
-                                            missingFact = expectedInstanceFact
-                                        # is it possible to show value mismatches?
-                                        expectedFacts = formulaOutputInstance.factsByQname.get(missingFact.qname)
-                                        if expectedFacts and len(expectedFacts) == 1:
-                                            formulaOutputInstance.error("{}:expectedFactMissing".format(errMsgPrefix),
-                                                _("Output missing expected fact %(fact)s, extracted value \"%(value1)s\", expected value  \"%(value2)s\""),
-                                                modelXbrl=missingFact, fact=missingFact.qname, value1=missingFact.xValue, value2=next(iter(expectedFacts)).xValue,
-                                                messageCodes=("formula:expectedFactMissing","ix:expectedFactMissing"))
-                                        else:
-                                            formulaOutputInstance.error("{}:expectedFactMissing".format(errMsgPrefix),
-                                                _("Output missing expected fact %(fact)s"),
-                                                modelXbrl=missingFact, fact=missingFact.qname,
-                                                messageCodes=("formula:expectedFactMissing","ix:expectedFactMissing"))
-                                    else: # compare footnotes
-                                        expectedInstanceFactFootnotes = factFootnotes(expectedInstanceFact, expectedFootnotesRelSet)
-                                        formulaOutputFactFootnotes = factFootnotes(formulaOutputFact, formulaOutputFootnotesRelSet)
-                                        if (len(expectedInstanceFactFootnotes) != len(formulaOutputFactFootnotes) or
-                                            set(expectedInstanceFactFootnotes.values()) != set(formulaOutputFactFootnotes.values())):
-                                            formulaOutputInstance.error("{}:expectedFactFootnoteDifference".format(errMsgPrefix),
-                                                _("Output expected fact %(fact)s expected footnotes %(footnotes1)s produced footnotes %(footnotes2)s"),
-                                                modelXbrl=(formulaOutputFact,expectedInstanceFact), fact=expectedInstanceFact.qname, footnotes1=sorted(expectedInstanceFactFootnotes.items()), footnotes2=sorted(formulaOutputFactFootnotes.items()),
-                                                messageCodes=("formula:expectedFactFootnoteDifference","ix:expectedFactFootnoteDifference"))
-
-                            # for debugging uncomment next line to save generated instance document
-                            # formulaOutputInstance.saveInstance(r"c:\temp\test-out-inst.xml")
-                        expectedInstance.close()
-                        del expectedInstance # dereference
-                        self.determineTestStatus(modelTestcaseVariation, formulaOutputInstance.errors)
-                        formulaOutputInstance.close()
-                        del formulaOutputInstance
-                    if compareIxResultInstance:
-                        for inputDTSlist in inputDTSes.values():
-                            for inputDTS in inputDTSlist:
-                                inputDTS.close()
-                        del inputDTSes # dereference
-                # update ui thread via modelManager (running in background here)
-                self.modelXbrl.modelManager.viewModelObject(self.modelXbrl, modelTestcaseVariation.objectId())
-                modelTestcaseVariation.duration = time.perf_counter() - startTime
+                self._validateTestcaseVariation(testcase, modelTestcaseVariation)
 
             _statusCounts = OrderedDict((("pass",0),("fail",0)))
             for tv in getattr(testcase, "testcaseVariations", ()):
@@ -572,6 +200,408 @@ class Validate:
             self.modelXbrl.info("arelle:testCaseResults", ", ".join("{}={}".format(k,c) for k, c in _statusCounts.items() if k))
 
             self.modelXbrl.modelManager.showStatus(_("ready"), 2000)
+
+    def _validateTestcaseVariation(self, testcase, modelTestcaseVariation):
+        # update ui thread via modelManager (running in background here)
+        startTime = time.perf_counter()
+        self.modelXbrl.modelManager.viewModelObject(self.modelXbrl, modelTestcaseVariation.objectId())
+        # is this a versioning report?
+        resultIsVersioningReport = modelTestcaseVariation.resultIsVersioningReport
+        resultIsXbrlInstance = modelTestcaseVariation.resultIsXbrlInstance
+        resultIsTaxonomyPackage = modelTestcaseVariation.resultIsTaxonomyPackage
+        inputDTSes = defaultdict(list)
+        baseForElement = testcase.baseForElement(modelTestcaseVariation)
+        # try to load instance document
+        self.modelXbrl.info("info", _("Variation %(id)s%(name)s%(target)s: %(expected)s - %(description)s"),
+                            modelObject=modelTestcaseVariation,
+                            id=modelTestcaseVariation.id,
+                            name=(" {}".format(modelTestcaseVariation.name) if modelTestcaseVariation.name else ""),
+                            target=(" target {}".format(modelTestcaseVariation.ixdsTarget) if modelTestcaseVariation.ixdsTarget else ""),
+                            expected=modelTestcaseVariation.expected,
+                            description=modelTestcaseVariation.description)
+        if self.modelXbrl.modelManager.formulaOptions.testcaseResultsCaptureWarnings:
+            errorCaptureLevel = logging._checkLevel("WARNING")
+        else:
+            errorCaptureLevel = modelTestcaseVariation.severityLevel # default is INCONSISTENCY
+        parameters = modelTestcaseVariation.parameters.copy()
+        loadedModels = []
+        for i, readMeFirstUri in enumerate(modelTestcaseVariation.readMeFirstUris):
+            loadedModels.extend(self._testcaseLoadReadMeFirstUri(
+                testcase=testcase,
+                modelTestcaseVariation=modelTestcaseVariation,
+                index=i,
+                readMeFirstUri=readMeFirstUri,
+                resultIsVersioningReport=resultIsVersioningReport,
+                resultIsTaxonomyPackage=resultIsTaxonomyPackage,
+                inputDTSes=inputDTSes,
+                errorCaptureLevel=errorCaptureLevel,
+                baseForElement=baseForElement,
+                parameters=parameters,
+            ))
+        validateInputDTS = False
+        for modelXbrl in loadedModels:
+            if resultIsVersioningReport and modelXbrl.modelDocument:
+                versReportFile = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(
+                    modelTestcaseVariation.versioningReportUri, baseForElement)
+                if os.path.exists(versReportFile): #validate existing
+                    modelVersReport = ModelXbrl.load(self.modelXbrl.modelManager, versReportFile, _("validating existing version report"))
+                    if modelVersReport and modelVersReport.modelDocument and modelVersReport.modelDocument.type == Type.VERSIONINGREPORT:
+                        ValidateVersReport.ValidateVersReport(self.modelXbrl).validate(modelVersReport)
+                        self.determineTestStatus(modelTestcaseVariation, modelVersReport.errors)
+                        modelVersReport.close()
+                elif len(inputDTSes) == 2:
+                    ModelVersReport.ModelVersReport(self.modelXbrl).diffDTSes(
+                            versReportFile, inputDTSes["from"], inputDTSes["to"])
+                    modelTestcaseVariation.status = "generated"
+                else:
+                    modelXbrl.error("arelle:notLoaded",
+                            _("Variation %(id)s %(name)s input DTSes not loaded, unable to generate versioning report: %(file)s"),
+                            modelXbrl=testcase, id=modelTestcaseVariation.id, name=modelTestcaseVariation.name, file=os.path.basename(readMeFirstUri))
+                    modelTestcaseVariation.status = "failed"
+            elif resultIsTaxonomyPackage:
+                self.determineTestStatus(modelTestcaseVariation, modelXbrl.errors)
+                modelXbrl.close()
+            elif inputDTSes:
+                validateInputDTS = True
+        if validateInputDTS:
+            self._testcaseValidateInputDTS(testcase, modelTestcaseVariation, errorCaptureLevel, parameters, inputDTSes, baseForElement, resultIsXbrlInstance)
+        # update ui thread via modelManager (running in background here)
+        self.modelXbrl.modelManager.viewModelObject(self.modelXbrl, modelTestcaseVariation.objectId())
+        modelTestcaseVariation.duration = time.perf_counter() - startTime
+
+    def _testcaseLoadReadMeFirstUri(self, testcase, modelTestcaseVariation, index, readMeFirstUri, resultIsVersioningReport, resultIsTaxonomyPackage, inputDTSes, errorCaptureLevel, baseForElement, parameters):
+        loadedModels = []
+        readMeFirstElements = modelTestcaseVariation.readMeFirstElements
+        expectTaxonomyPackage = (index < len(readMeFirstElements) and
+                                    readMeFirstElements[index] is not None and
+                                    readMeFirstElements[index].qname.localName == "taxonomyPackage")
+        if isinstance(readMeFirstUri,tuple):
+            # dtsName is for formula instances, but is from/to dts if versioning
+            dtsName, readMeFirstUri = readMeFirstUri
+        elif resultIsVersioningReport:
+            if inputDTSes: dtsName = "to"
+            else: dtsName = "from"
+        else:
+            dtsName = None
+        if resultIsVersioningReport and dtsName: # build multi-schemaRef containing document
+            if dtsName in inputDTSes:
+                dtsName = inputDTSes[dtsName]
+            else:
+                modelXbrl = ModelXbrl.create(self.modelXbrl.modelManager,
+                                Type.DTSENTRIES,
+                                self.modelXbrl.modelManager.cntlr.webCache.normalizeUrl(readMeFirstUri[:-4] + ".dts", baseForElement),
+                                isEntry=True,
+                                errorCaptureLevel=errorCaptureLevel)
+                loadedModels.append(modelXbrl)
+            DTSdoc = modelXbrl.modelDocument
+            DTSdoc.inDTS = True
+            doc = modelDocumentLoad(modelXbrl, readMeFirstUri, base=baseForElement)
+            if doc is not None:
+                DTSdoc.referencesDocument[doc] = ModelDocumentReference("import", DTSdoc.xmlRootElement)  #fake import
+                doc.inDTS = True
+        elif resultIsTaxonomyPackage:
+            from arelle import PackageManager, PrototypeInstanceObject
+            dtsName = readMeFirstUri
+            modelXbrl = PrototypeInstanceObject.XbrlPrototype(self.modelXbrl.modelManager, readMeFirstUri)
+            loadedModels.append(modelXbrl)
+            PackageManager.packageInfo(self.modelXbrl.modelManager.cntlr, readMeFirstUri, reload=True, errors=modelXbrl.errors)
+        else: # not a multi-schemaRef versioning report
+            if self.useFileSource.isArchive and (os.path.isabs(readMeFirstUri) or not isReportPackageExtension(readMeFirstUri)):
+                modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager,
+                                            readMeFirstUri,
+                                            _("validating"),
+                                            base=baseForElement,
+                                            useFileSource=self.useFileSource,
+                                            errorCaptureLevel=errorCaptureLevel,
+                                            ixdsTarget=modelTestcaseVariation.ixdsTarget)
+                loadedModels.append(modelXbrl)
+            else: # need own file source, may need instance discovery
+                sourceFileSource = None
+                newSourceFileSource = False
+                if (
+                    self.useFileSource
+                    and not os.path.isabs(readMeFirstUri)
+                    and isReportPackageExtension(readMeFirstUri)
+                ):
+                    if self.useFileSource.isArchive:
+                        sourceFileSource = self.useFileSource
+                    elif expectTaxonomyPackage:
+                        archiveFilenameParts = FileSource.archiveFilenameParts(baseForElement)
+                        if archiveFilenameParts is not None:
+                            sourceFileSource = FileSource.openFileSource(archiveFilenameParts[0], self.modelXbrl.modelManager.cntlr)
+                            newSourceFileSource = True
+
+                filesource = FileSource.openFileSource(readMeFirstUri, self.modelXbrl.modelManager.cntlr, base=baseForElement,
+                                                        sourceFileSource=sourceFileSource)
+                if filesource.isReportPackage:
+                    expectTaxonomyPackage = filesource.isTaxonomyPackage
+
+                if newSourceFileSource:
+                    sourceFileSource.close()
+                _errors = [] # accumulate pre-loading errors, such as during taxonomy package loading
+                if filesource and not filesource.selection and filesource.isArchive:
+                    try:
+                        if filesource.isTaxonomyPackage or expectTaxonomyPackage:
+                            _rptPkgIxdsOptions = {}
+                            for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ReportPackageIxdsOptions"):
+                                pluginXbrlMethod(self, _rptPkgIxdsOptions)
+                            filesource.loadTaxonomyPackageMappings(errors=_errors, expectTaxonomyPackage=expectTaxonomyPackage)
+                            filesource.select(None) # must select loadable reports (not the taxonomy package itself)
+                            for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ReportPackageIxds"):
+                                filesource.select(pluginXbrlMethod(filesource, **_rptPkgIxdsOptions))
+                        else:
+                            from arelle.CntlrCmdLine import filesourceEntrypointFiles
+                            entrypoints = filesourceEntrypointFiles(filesource)
+                            if entrypoints:
+                                # resolve an IXDS in entrypoints
+                                for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ArchiveIxds"):
+                                    pluginXbrlMethod(self, filesource,entrypoints)
+                                filesource.select(entrypoints[0].get("file", None) )
+                    except Exception as err:
+                        self.modelXbrl.error("exception:" + type(err).__name__,
+                            _("Testcase variation validation exception: %(error)s, entry URL: %(instance)s"),
+                            modelXbrl=self.modelXbrl, instance=readMeFirstUri, error=err)
+                        return [] # don't try to load this entry URL
+                modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager,
+                                            filesource,
+                                            _("validating"),
+                                            base=baseForElement,
+                                            errorCaptureLevel=errorCaptureLevel,
+                                            ixdsTarget=modelTestcaseVariation.ixdsTarget,
+                                            isLoadable=modelTestcaseVariation.variationDiscoversDTS or filesource.url,
+                                            errors=_errors)
+                loadedModels.append(modelXbrl)
+            modelXbrl.isTestcaseVariation = True
+        if not modelTestcaseVariation.variationDiscoversDTS and modelXbrl.modelDocument is None: # e.g., taxonomyPackage test
+            self.determineTestStatus(modelTestcaseVariation, modelXbrl.errors)
+            modelXbrl.close()
+        elif modelXbrl.modelDocument is None:
+            modelXbrl.info("arelle:notLoaded",
+                    _("Variation %(id)s %(name)s readMeFirst document not loaded: %(file)s"),
+                    modelXbrl=testcase, id=modelTestcaseVariation.id, name=modelTestcaseVariation.name, file=os.path.basename(readMeFirstUri))
+            self.determineNotLoadedTestStatus(modelTestcaseVariation, modelXbrl.errors)
+            modelXbrl.close()
+        elif resultIsVersioningReport or resultIsTaxonomyPackage:
+            inputDTSes[dtsName] = modelXbrl
+        elif modelXbrl.modelDocument.type == Type.VERSIONINGREPORT:
+            ValidateVersReport.ValidateVersReport(self.modelXbrl).validate(modelXbrl)
+            self.determineTestStatus(modelTestcaseVariation, modelXbrl.errors)
+            modelXbrl.close()
+        elif testcase.type == Type.REGISTRYTESTCASE:
+            self.instValidator.validate(modelXbrl)  # required to set up dimensions, etc
+            self.instValidator.executeCallTest(modelXbrl, modelTestcaseVariation.id,
+                        modelTestcaseVariation.cfcnCall, modelTestcaseVariation.cfcnTest)
+            self.determineTestStatus(modelTestcaseVariation, modelXbrl.errors)
+            self.instValidator.close()
+            modelXbrl.close()
+        else:
+            inputDTSes[dtsName].append(modelXbrl)
+            # validate except for formulas
+            _hasFormulae = modelXbrl.hasFormulae
+            modelXbrl.hasFormulae = False
+            try:
+                for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Xbrl.Loaded"):
+                    pluginXbrlMethod(self.modelXbrl, modelXbrl, modelTestcaseVariation)
+                self.instValidator.validate(modelXbrl, parameters)
+                for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Xbrl.Validated"):
+                    pluginXbrlMethod(self.modelXbrl, modelXbrl)
+            except Exception as err:
+                modelXbrl.error("exception:" + type(err).__name__,
+                    _("Testcase variation validation exception: %(error)s, instance: %(instance)s"),
+                    modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=(type(err) is not AssertionError))
+            modelXbrl.hasFormulae = _hasFormulae
+        return loadedModels
+
+    def _testcaseValidateInputDTS(self, testcase, modelTestcaseVariation, errorCaptureLevel, parameters, inputDTSes, baseForElement, resultIsXbrlInstance):
+        # validate schema, linkbase, or instance
+        formulaOutputInstance = None
+        modelXbrl = inputDTSes[None][0]
+        expectedDataFiles = set(modelXbrl.modelManager.cntlr.webCache.normalizeUrl(uri, baseForElement)
+                                for d in modelTestcaseVariation.dataUris.values() for uri in d
+                                if not UrlUtil.isAbsolute(uri))
+        foundDataFiles = set()
+        variationBase = os.path.dirname(baseForElement)
+        for dtsName, inputDTS in inputDTSes.items():  # input instances are also parameters
+            if dtsName: # named instance
+                parameters[dtsName] = (None, inputDTS) #inputDTS is a list of modelXbrl's (instance DTSes)
+            elif len(inputDTS) > 1: # standard-input-instance with multiple instance documents
+                parameters[XbrlConst.qnStandardInputInstance] = (None, inputDTS) # allow error detection in validateFormula
+            for _inputDTS in inputDTS:
+                for docUrl, doc in _inputDTS.urlDocs.items():
+                    if docUrl.startswith(variationBase) and not doc.type == Type.INLINEXBRLDOCUMENTSET:
+                        if getattr(doc,"loadedFromXbrlFormula", False): # may have been sourced from xf file
+                            if docUrl.replace("-formula.xml", ".xf") in expectedDataFiles:
+                                docUrl = docUrl.replace("-formula.xml", ".xf")
+                        foundDataFiles.add(docUrl)
+        if expectedDataFiles - foundDataFiles:
+            modelXbrl.info("arelle:testcaseDataNotUsed",
+                _("Variation %(id)s %(name)s data files not used: %(missingDataFiles)s"),
+                modelObject=modelTestcaseVariation, name=modelTestcaseVariation.name, id=modelTestcaseVariation.id,
+                missingDataFiles=", ".join(sorted(os.path.basename(f) for f in expectedDataFiles - foundDataFiles)))
+        if foundDataFiles - expectedDataFiles:
+            modelXbrl.info("arelle:testcaseDataUnexpected",
+                _("Variation %(id)s %(name)s files not in variation data: %(unexpectedDataFiles)s"),
+                modelObject=modelTestcaseVariation, name=modelTestcaseVariation.name, id=modelTestcaseVariation.id,
+                unexpectedDataFiles=", ".join(sorted(os.path.basename(f) for f in foundDataFiles - expectedDataFiles)))
+        if modelXbrl.hasTableRendering or modelTestcaseVariation.resultIsTable:
+            try:
+                RenderingEvaluator.init(modelXbrl)
+            except Exception as err:
+                modelXbrl.error("exception:" + type(err).__name__,
+                    _("Testcase RenderingEvaluator.init exception: %(error)s, instance: %(instance)s"),
+                    modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=True)
+        modelXbrlHasFormulae = modelXbrl.hasFormulae
+        if modelXbrlHasFormulae and self.modelXbrl.modelManager.formulaOptions.formulaAction != "none":
+            try:
+                # validate only formulae
+                self.instValidator.parameters = parameters
+                ValidateFormula.validate(self.instValidator)
+            except Exception as err:
+                modelXbrl.error("exception:" + type(err).__name__,
+                    _("Testcase formula variation validation exception: %(error)s, instance: %(instance)s"),
+                    modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=(type(err) is not AssertionError))
+        if modelTestcaseVariation.resultIsInfoset and self.modelXbrl.modelManager.validateInfoset:
+            for pluginXbrlMethod in pluginClassMethods("Validate.Infoset"):
+                pluginXbrlMethod(modelXbrl, modelTestcaseVariation.resultInfosetUri)
+            infoset = ModelXbrl.load(self.modelXbrl.modelManager,
+                                        modelTestcaseVariation.resultInfosetUri,
+                                        _("loading result infoset"),
+                                        base=baseForElement,
+                                        useFileSource=self.useFileSource,
+                                        errorCaptureLevel=errorCaptureLevel)
+            if infoset.modelDocument is None:
+                modelXbrl.error("arelle:notLoaded",
+                    _("Variation %(id)s %(name)s result infoset not loaded: %(file)s"),
+                    modelXbrl=testcase, id=modelTestcaseVariation.id, name=modelTestcaseVariation.name,
+                    file=os.path.basename(modelTestcaseVariation.resultXbrlInstance))
+                modelTestcaseVariation.status = "result infoset not loadable"
+            else:   # check infoset
+                ValidateInfoset.validate(self.instValidator, modelXbrl, infoset)
+            infoset.close()
+        if modelXbrl.hasTableRendering or modelTestcaseVariation.resultIsTable: # and self.modelXbrl.modelManager.validateInfoset:
+            # diff (or generate) table infoset
+            resultTableUri = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(modelTestcaseVariation.resultTableUri, baseForElement)
+            if not any(alternativeValidation(modelXbrl, resultTableUri)
+                        for alternativeValidation in pluginClassMethods("Validate.TableInfoset")):
+                try:
+                    ViewFileRenderedLayout.viewRenderedLayout(modelXbrl, resultTableUri, diffToFile=True)  # false to save infoset files
+                except Exception as err:
+                    modelXbrl.error("exception:" + type(err).__name__,
+                        _("Testcase table linkbase validation exception: %(error)s, instance: %(instance)s"),
+                        modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=True)
+        self.instValidator.close()
+        extraErrors = []
+        for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Validated"):
+            pluginXbrlMethod(self.modelXbrl, modelXbrl, extraErrors, inputDTSes)
+        self.determineTestStatus(modelTestcaseVariation, [e for inputDTSlist in inputDTSes.values() for inputDTS in inputDTSlist for e in inputDTS.errors] + extraErrors) # include infoset errors in status
+        if modelXbrl.formulaOutputInstance and self.noErrorCodes(modelTestcaseVariation.actual):
+            # if an output instance is created, and no string error codes, ignoring dict of assertion results, validate it
+            modelXbrl.formulaOutputInstance.hasFormulae = False #  block formulae on output instance (so assertion of input is not lost)
+            self.instValidator.validate(modelXbrl.formulaOutputInstance, modelTestcaseVariation.parameters)
+            self.determineTestStatus(modelTestcaseVariation, modelXbrl.formulaOutputInstance.errors)
+            if self.noErrorCodes(modelTestcaseVariation.actual): # if still 'clean' pass it forward for comparison to expected result instance
+                formulaOutputInstance = modelXbrl.formulaOutputInstance
+                modelXbrl.formulaOutputInstance = None # prevent it from being closed now
+            self.instValidator.close()
+        compareIxResultInstance = (modelXbrl.modelDocument.type in (Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET) and
+                                    modelTestcaseVariation.resultXbrlInstanceUri is not None)
+        if compareIxResultInstance:
+            formulaOutputInstance = modelXbrl # compare modelXbrl to generated output instance
+            errMsgPrefix = "ix"
+        else: # delete input instances before formula output comparision
+            for inputDTSlist in inputDTSes.values():
+                for inputDTS in inputDTSlist:
+                    inputDTS.close()
+            del inputDTSes # dereference
+            errMsgPrefix = "formula"
+        if resultIsXbrlInstance and formulaOutputInstance and formulaOutputInstance.modelDocument:
+            _matchExpectedResultIDs = not modelXbrlHasFormulae # formula restuls have inconsistent IDs
+            expectedInstance = ModelXbrl.load(self.modelXbrl.modelManager,
+                                        modelTestcaseVariation.resultXbrlInstanceUri,
+                                        _("loading expected result XBRL instance"),
+                                        base=baseForElement,
+                                        useFileSource=self.useFileSource,
+                                        errorCaptureLevel=errorCaptureLevel)
+            if expectedInstance.modelDocument is None:
+                self.modelXbrl.error("{}:expectedResultNotLoaded".format(errMsgPrefix),
+                    _("Testcase \"%(name)s\" %(id)s expected result instance not loaded: %(file)s"),
+                    modelXbrl=testcase, id=modelTestcaseVariation.id, name=modelTestcaseVariation.name,
+                    file=os.path.basename(modelTestcaseVariation.resultXbrlInstanceUri),
+                    messageCodes=("formula:expectedResultNotLoaded","ix:expectedResultNotLoaded"))
+                modelTestcaseVariation.status = "result not loadable"
+            else:   # compare facts
+                for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.ExpectedInstance.Loaded"):
+                    pluginXbrlMethod(expectedInstance, formulaOutputInstance)
+                if len(expectedInstance.facts) != len(formulaOutputInstance.facts):
+                    formulaOutputInstance.error("{}:resultFactCounts".format(errMsgPrefix),
+                        _("Formula output %(countFacts)s facts, expected %(expectedFacts)s facts"),
+                        modelXbrl=modelXbrl, countFacts=len(formulaOutputInstance.facts),
+                        expectedFacts=len(expectedInstance.facts),
+                        messageCodes=("formula:resultFactCounts","ix:resultFactCounts"))
+                else:
+                    formulaOutputFootnotesRelSet = ModelRelationshipSet(formulaOutputInstance, "XBRL-footnotes")
+                    expectedFootnotesRelSet = ModelRelationshipSet(expectedInstance, "XBRL-footnotes")
+                    def factFootnotes(fact, footnotesRelSet):
+                        footnotes = {}
+                        footnoteRels = footnotesRelSet.fromModelObject(fact)
+                        if footnoteRels:
+                            # most process rels in same order between two instances, use labels to sort
+                            for i, footnoteRel in enumerate(sorted(footnoteRels,
+                                                                    key=lambda r: (r.fromLabel,r.toLabel))):
+                                modelObject = footnoteRel.toModelObject
+                                if isinstance(modelObject, ModelResource):
+                                    xml = collapseWhitespace(modelObject.viewText().strip())
+                                    footnotes["Footnote {}".format(i+1)] = xml #re.sub(r'\s+', ' ', collapseWhitespace(modelObject.stringValue))
+                                elif isinstance(modelObject, ModelFact):
+                                    footnotes["Footnoted fact {}".format(i+1)] = \
+                                        "{} context: {} value: {}".format(
+                                        modelObject.qname,
+                                        modelObject.contextID,
+                                        collapseWhitespace(modelObject.value))
+                        return footnotes
+                    for expectedInstanceFact in expectedInstance.facts:
+                        unmatchedFactsStack = []
+                        formulaOutputFact = formulaOutputInstance.matchFact(expectedInstanceFact, unmatchedFactsStack, deemP0inf=True, matchId=_matchExpectedResultIDs, matchLang=False)
+                        #formulaOutputFact = formulaOutputInstance.matchFact(expectedInstanceFact, unmatchedFactsStack, deemP0inf=True, matchId=True, matchLang=True)
+                        if formulaOutputFact is None:
+                            if unmatchedFactsStack: # get missing nested tuple fact, if possible
+                                missingFact = unmatchedFactsStack[-1]
+                            else:
+                                missingFact = expectedInstanceFact
+                            # is it possible to show value mismatches?
+                            expectedFacts = formulaOutputInstance.factsByQname.get(missingFact.qname)
+                            if expectedFacts and len(expectedFacts) == 1:
+                                formulaOutputInstance.error("{}:expectedFactMissing".format(errMsgPrefix),
+                                    _("Output missing expected fact %(fact)s, extracted value \"%(value1)s\", expected value  \"%(value2)s\""),
+                                    modelXbrl=missingFact, fact=missingFact.qname, value1=missingFact.xValue, value2=next(iter(expectedFacts)).xValue,
+                                    messageCodes=("formula:expectedFactMissing","ix:expectedFactMissing"))
+                            else:
+                                formulaOutputInstance.error("{}:expectedFactMissing".format(errMsgPrefix),
+                                    _("Output missing expected fact %(fact)s"),
+                                    modelXbrl=missingFact, fact=missingFact.qname,
+                                    messageCodes=("formula:expectedFactMissing","ix:expectedFactMissing"))
+                        else: # compare footnotes
+                            expectedInstanceFactFootnotes = factFootnotes(expectedInstanceFact, expectedFootnotesRelSet)
+                            formulaOutputFactFootnotes = factFootnotes(formulaOutputFact, formulaOutputFootnotesRelSet)
+                            if (len(expectedInstanceFactFootnotes) != len(formulaOutputFactFootnotes) or
+                                set(expectedInstanceFactFootnotes.values()) != set(formulaOutputFactFootnotes.values())):
+                                formulaOutputInstance.error("{}:expectedFactFootnoteDifference".format(errMsgPrefix),
+                                    _("Output expected fact %(fact)s expected footnotes %(footnotes1)s produced footnotes %(footnotes2)s"),
+                                    modelXbrl=(formulaOutputFact,expectedInstanceFact), fact=expectedInstanceFact.qname, footnotes1=sorted(expectedInstanceFactFootnotes.items()), footnotes2=sorted(formulaOutputFactFootnotes.items()),
+                                    messageCodes=("formula:expectedFactFootnoteDifference","ix:expectedFactFootnoteDifference"))
+
+                # for debugging uncomment next line to save generated instance document
+                # formulaOutputInstance.saveInstance(r"c:\temp\test-out-inst.xml")
+            expectedInstance.close()
+            del expectedInstance # dereference
+            self.determineTestStatus(modelTestcaseVariation, formulaOutputInstance.errors)
+            formulaOutputInstance.close()
+            del formulaOutputInstance
+        if compareIxResultInstance:
+            for inputDTSlist in inputDTSes.values():
+                for inputDTS in inputDTSlist:
+                    inputDTS.close()
+            del inputDTSes # dereference
 
     def noErrorCodes(self, modelTestcaseVariationActual):
         return not any(not isinstance(actual,dict) for actual in modelTestcaseVariationActual)

--- a/arelle/packages/PackageConst.py
+++ b/arelle/packages/PackageConst.py
@@ -1,0 +1,7 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+
+from __future__ import annotations
+
+META_INF_DIRECTORY = "META-INF"

--- a/arelle/packages/PackageType.py
+++ b/arelle/packages/PackageType.py
@@ -1,0 +1,13 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PackageType:
+    name: str
+    errorPrefix: str

--- a/arelle/packages/PackageUtils.py
+++ b/arelle/packages/PackageUtils.py
@@ -1,0 +1,22 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import zipfile
+
+    from arelle.FileSource import FileSource
+
+
+def isZipfileEncrypted(info: zipfile.ZipInfo) -> bool:
+    return bool(info.flag_bits & 0x1)
+
+def getPackageTopLevelFiles(filesource: FileSource) -> set[str]:
+    return {e for e in filesource.dir or [] if "/" not in e}
+
+def getPackageTopLevelDirectories(filesource: FileSource) -> set[str]:
+    return {e.partition("/")[0] for e in filesource.dir or [] if "/" in e}

--- a/arelle/packages/PackageValidation.py
+++ b/arelle/packages/PackageValidation.py
@@ -1,0 +1,134 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+
+from __future__ import annotations
+
+import os.path
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
+
+from arelle.packages import PackageUtils
+from arelle.packages.PackageConst import META_INF_DIRECTORY
+from arelle.packages.PackageType import PackageType
+from arelle.typing import TypeGetText
+from arelle.utils.validate.Validation import Validation
+
+if TYPE_CHECKING:
+    from arelle.FileSource import FileSource
+
+
+_: TypeGetText
+
+
+def validatePackageZipFormat(
+    packageType: PackageType,
+    filesource: FileSource,
+) -> Validation | None:
+    if filesource.dir is None:
+        return Validation.error(
+            codes=f"{packageType.errorPrefix}:invalidArchiveFormat",
+            msg=_("%(packageType)s package is not valid and could not be opened: %(file)s"),
+            args={
+                "packageType": packageType.name,
+                "file": os.path.basename(str(filesource.url)),
+            },
+        )
+    return None
+
+
+def validatePackageNotEncrypted(
+    packageType: PackageType,
+    filesource: FileSource,
+) -> Validation | None:
+    if any(PackageUtils.isZipfileEncrypted(f) for f in getattr(filesource.fs, "filelist", [])):
+        return Validation.error(
+            codes=f"{packageType.errorPrefix}:invalidArchiveFormat",
+            msg=_("%(packageType)s package contains encrypted files: %(file)s"),
+            args={
+                "packageType": packageType.name,
+                "file": os.path.basename(str(filesource.url)),
+            },
+        )
+    return None
+
+
+def validateZipFileSeparators(
+    packageType: PackageType,
+    filesource: FileSource,
+) -> Validation | None:
+    if filesource.isZipBackslashed:
+        return Validation.error(
+            codes=f"{packageType.errorPrefix}:invalidArchiveFormat",
+            msg=_("%(packageType)s package directory uses '\\' as a file separator."),
+            args={
+                "packageType": packageType.name,
+                "file": os.path.basename(str(filesource.url)),
+            },
+        )
+    return None
+
+
+def validateTopLevelFiles(
+    packageType: PackageType,
+    filesource: FileSource,
+) -> Validation | None:
+    topLevelFiles = PackageUtils.getPackageTopLevelFiles(filesource)
+    numTopLevelFiles = len(topLevelFiles)
+    if numTopLevelFiles > 0:
+        return Validation.error(
+            codes=f"{packageType.errorPrefix}:invalidDirectoryStructure",
+            msg=_("%(packageType)s package contains %(count)s top level file(s):  %(topLevelFiles)s"),
+            args={
+                "packageType": packageType.name,
+                "count": numTopLevelFiles,
+                "topLevelFiles": ", ".join(sorted(topLevelFiles)),
+                "file": os.path.basename(str(filesource.url)),
+            },
+        )
+    return None
+
+
+def validateTopLevelDirectories(
+    packageType: PackageType,
+    filesource: FileSource,
+) -> Validation | None:
+    topLevelDirectories = PackageUtils.getPackageTopLevelDirectories(filesource)
+    numTopLevelDirectories = len(topLevelDirectories)
+    if numTopLevelDirectories == 0:
+        return Validation.error(
+            codes=f"{packageType.errorPrefix}:invalidDirectoryStructure",
+            msg=_("%(packageType)s Package does not contain a top level directory"),
+            args={
+                "packageType": packageType.name,
+                "file": os.path.basename(str(filesource.url)),
+            },
+        )
+    if numTopLevelDirectories > 1:
+        return Validation.error(
+            codes=f"{packageType.errorPrefix}:invalidDirectoryStructure",
+            msg=_("%(packageType)s package contains %(count)s top level directories: %(topLevelDirectories)s"),
+            args={
+                "packageType": packageType.name,
+                "count": numTopLevelDirectories,
+                "topLevelDirectories": ", ".join(sorted(topLevelDirectories)),
+                "file": os.path.basename(str(filesource.url)),
+            },
+        )
+    return None
+
+
+def validateMetadataDirectory(
+    packageType: PackageType,
+    filesource: FileSource,
+) -> Validation | None:
+    if not any(META_INF_DIRECTORY in f.split("/")[1:][:1] for f in filesource.dir or []):
+        return Validation.error(
+            codes=f"{packageType.errorPrefix}:metadataDirectoryNotFound",
+            msg=_("%(packageType)s package top-level directory does not contain a subdirectory META-INF"),
+            args={
+                "packageType": packageType.name,
+                "file": os.path.basename(str(filesource.url)),
+            },
+        )
+    return None

--- a/arelle/packages/report/DetectReportPackage.py
+++ b/arelle/packages/report/DetectReportPackage.py
@@ -1,0 +1,13 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from arelle.packages.report import ReportPackageConst
+
+
+def isReportPackageExtension(filename: str) -> bool:
+    return Path(filename).suffix in ReportPackageConst.REPORT_PACKAGE_EXTENSIONS

--- a/arelle/packages/report/ReportPackage.py
+++ b/arelle/packages/report/ReportPackage.py
@@ -1,0 +1,180 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, cast
+
+from arelle.packages import PackageUtils
+from arelle.packages.report import ReportPackageConst as Const
+
+if TYPE_CHECKING:
+    from arelle.FileSource import FileSource
+
+
+def _getReportPackageTopLevelDirectory(filesource: FileSource) -> str | None:
+    packageEntries = set(filesource.dir or [])
+    potentialTopLevelReportDirs = {
+        topLevelDir
+        for topLevelDir in PackageUtils.getPackageTopLevelDirectories(filesource)
+        if any(f"{topLevelDir}/{path}" in packageEntries for path in Const.REPORT_PACKAGE_PATHS)
+    }
+    if len(potentialTopLevelReportDirs) == 1:
+        return next(iter(potentialTopLevelReportDirs))
+    return None
+
+
+def _getReportPackageJson(filesource: FileSource, stld: str | None) -> dict[str, Any] | None:
+    packageJsonPath = f"{stld}/{Const.REPORT_PACKAGE_FILE}"
+    if stld is None or packageJsonPath not in (filesource.dir or []):
+        return None
+    initialSelection = filesource.selection
+    initialUrl = filesource.url
+    try:
+        filesource.select(packageJsonPath)
+        fullPackageJsonPath = cast(str, filesource.url)
+        with filesource.file(fullPackageJsonPath, binary=True)[0] as rpj:
+            return cast(dict[str, Any], json.load(rpj))
+    except (OSError, zipfile.BadZipFile, json.JSONDecodeError):
+        return None
+    finally:
+        filesource.selection = initialSelection
+        filesource.url = initialUrl
+
+
+def _getAllReportEntries(filesource: FileSource, stld: str | None) -> list[ReportEntry] | None:
+    if stld is None:
+        return None
+    entries = filesource.dir or []
+    topReportEntries = []
+    entriesBySubDir = defaultdict(list)
+    for entry in entries:
+        if entry.endswith("/"):
+            continue
+        path = PurePosixPath(entry)
+        if path.suffix not in Const.REPORT_FILE_EXTENSIONS:
+            continue
+        if not (2 < len(path.parts) < 5):
+            continue
+        if not (path.parts[0] == stld and path.parts[1] == Const.REPORTS_DIRECTORY):
+            continue
+        if len(path.parts) == 3:
+            topReportEntries.append(entry)
+        else:
+            entriesBySubDir[path.parts[2]].append(entry)
+    reportEntries = []
+    assert isinstance(filesource.basefile, str)
+    if topReportEntries:
+        reportEntries.extend([ReportEntry(filesource.basefile, [entry]) for entry in topReportEntries])
+    else:
+        for entries in entriesBySubDir.values():
+            if len(entries) == 1 or all(PurePosixPath(entry).suffix in Const.INLINE_REPORT_FILE_EXTENSIONS for entry in entries):
+                reportEntries.append(ReportEntry(filesource.basefile, entries))
+            else:
+                reportEntries.extend(sorted(ReportEntry(filesource.basefile, [entry]) for entry in entries))
+    return sorted(reportEntries)
+
+
+@dataclass(frozen=True, order=True)
+class ReportEntry:
+    baseDir: str
+    files: list[str]
+
+    def __post_init__(self) -> None:
+        if len(self.files) == 0:
+            raise ValueError("Report entry must have at least one file")
+        elif len(self.files) > 1 and any(PurePosixPath(f).suffix not in Const.INLINE_REPORT_FILE_EXTENSIONS for f in self.files):
+            raise ValueError("Non-inline report entries must be a single file")
+
+    @property
+    def primary(self) -> str:
+        return self.files[0]
+
+    @property
+    def fullPathPrimary(self) -> str:
+        return f"{self.baseDir}/{self.primary}"
+
+    @property
+    def isInline(self) -> bool:
+        return PurePosixPath(self.primary).suffix in Const.INLINE_REPORT_FILE_EXTENSIONS
+
+    @property
+    def fullPathFiles(self) -> list[str]:
+        return [f"{self.baseDir}/{f}" for f in self.files]
+
+class ReportPackage:
+    def __init__(
+        self,
+        reportPackageZip: zipfile.ZipFile,
+        stld: str,
+        reportType: Const.ReportType,
+        reportPackageJson: dict[str, Any],
+        reports: list[ReportEntry],
+    ) -> None:
+        self._reportPackageZip = reportPackageZip
+        self._stld = stld
+        self._reportType = reportType
+        self._reportPackageJson = reportPackageJson
+        self._allReports = reports
+        self._reports = [
+            report for report in self._allReports
+            if all(PurePosixPath(f).suffix in reportType.reportFileExtensions for f in report.files)
+        ]
+
+    @staticmethod
+    def fromFileSource(filesource: FileSource) -> ReportPackage | None:
+        if not filesource.isOpen:
+            filesource.open()
+        if not isinstance(filesource.fs, zipfile.ZipFile):
+            return None
+        if not isinstance(filesource.basefile, str):
+            raise ValueError(f"Report Package base file must be a string: {filesource.basefile}")
+        reportType = Const.ReportType.fromExtension(Path(filesource.basefile).suffix)
+        if reportType is None:
+            return None
+        stld = _getReportPackageTopLevelDirectory(filesource)
+        if stld is None:
+            return None
+        reportPackageJson = _getReportPackageJson(filesource, stld)
+        reports = _getAllReportEntries(filesource, stld)
+        if reportPackageJson is None and reports is None:
+            return None
+        return ReportPackage(
+            reportPackageZip=filesource.fs,
+            stld=stld,
+            reportType=reportType,
+            reportPackageJson=reportPackageJson or {},
+            reports=reports or [],
+        )
+
+    @property
+    def documentType(self) -> Any:
+        if self._reportPackageJson is None:
+            return None
+        return self._reportPackageJson.get("documentInfo", {}).get("documentType")
+
+    @property
+    def reportType(self) -> Const.ReportType | None:
+        return self._reportType
+
+    @property
+    def allReports(self) -> list[ReportEntry]:
+        return self._allReports
+
+    @property
+    def reports(self) -> list[ReportEntry]:
+        return self._reports
+
+    @property
+    def reportPackageJson(self) -> dict[str, Any] | None:
+        return self._reportPackageJson
+
+    @property
+    def reportPackageZip(self) -> zipfile.ZipFile | None:
+        return self._reportPackageZip

--- a/arelle/packages/report/ReportPackageConst.py
+++ b/arelle/packages/report/ReportPackageConst.py
@@ -1,0 +1,71 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from arelle.packages.PackageConst import META_INF_DIRECTORY
+
+INLINE_XBRL_REPORT_PACKAGE_EXTENSION = ".xbri"
+NON_INLINE_XBRL_REPORT_PACKAGE_EXTENSION = ".xbr"
+UNCONSTRAINED_REPORT_PACKAGE_EXTENSION = ".zip"
+
+CONSTRAINED_REPORT_PACKAGE_EXTENSIONS = frozenset(
+    [
+        INLINE_XBRL_REPORT_PACKAGE_EXTENSION,
+        NON_INLINE_XBRL_REPORT_PACKAGE_EXTENSION,
+    ]
+)
+
+
+REPORT_PACKAGE_EXTENSIONS = frozenset(
+    [
+        INLINE_XBRL_REPORT_PACKAGE_EXTENSION,
+        NON_INLINE_XBRL_REPORT_PACKAGE_EXTENSION,
+        UNCONSTRAINED_REPORT_PACKAGE_EXTENSION,
+        UNCONSTRAINED_REPORT_PACKAGE_EXTENSION.upper(),
+    ]
+)
+
+REPORT_PACKAGE_FILE = f"{META_INF_DIRECTORY}/reportPackage.json"
+REPORTS_DIRECTORY = "reports"
+REPORT_PACKAGE_PATHS = [REPORT_PACKAGE_FILE, f"{REPORTS_DIRECTORY}/"]
+
+XBRL_2_1_REPORT_FILE_EXTENSION = ".xbrl"
+JSON_REPORT_FILE_EXTENSION = ".json"
+NON_INLINE_REPORT_FILE_EXTENSIONS = frozenset([
+    XBRL_2_1_REPORT_FILE_EXTENSION,
+    JSON_REPORT_FILE_EXTENSION,
+])
+INLINE_REPORT_FILE_EXTENSIONS = frozenset([".xhtml", ".html", ".htm"])
+REPORT_FILE_EXTENSIONS = frozenset(
+    [
+        *NON_INLINE_REPORT_FILE_EXTENSIONS,
+        *INLINE_REPORT_FILE_EXTENSIONS,
+    ]
+)
+
+
+class ReportType(Enum):
+    INLINE_XBRL_REPORT_PACKAGE = INLINE_XBRL_REPORT_PACKAGE_EXTENSION
+    NON_INLINE_XBRL_REPORT_PACKAGE = NON_INLINE_XBRL_REPORT_PACKAGE_EXTENSION
+    UNCONSTRAINED_REPORT_PACKAGE = UNCONSTRAINED_REPORT_PACKAGE_EXTENSION
+
+    @staticmethod
+    def fromExtension(extension: str) -> ReportType | None:
+        for reportType in ReportType:
+            if reportType.value == extension.lower():
+                return reportType
+        return None
+
+    @property
+    def reportFileExtensions(self) -> frozenset[str]:
+        if self == ReportType.INLINE_XBRL_REPORT_PACKAGE:
+            return INLINE_REPORT_FILE_EXTENSIONS
+        if self == ReportType.NON_INLINE_XBRL_REPORT_PACKAGE:
+            return NON_INLINE_REPORT_FILE_EXTENSIONS
+        if self == ReportType.UNCONSTRAINED_REPORT_PACKAGE:
+            return REPORT_FILE_EXTENSIONS
+        raise ValueError(f"Report type without defined report file extensions: {self}")

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -519,8 +519,14 @@ def runOpenInlineDocumentSetMenuCommand(cntlr, filenames, runInBackground=False,
                               [e["file"][l:] for i in entrypointFiles if "ixds" in i for e in i["ixds"] if "file" in e]
             except FileSource.ArchiveFileIOError:
                 selectFiles = None
-            from arelle import DialogOpenArchive
-            archiveEntries = DialogOpenArchive.askArchiveFile(cntlr, filesource, multiselect=True, selectFiles=selectFiles)
+            if filesource.isReportPackage:
+                archiveEntries = [
+                    f.get("file") for ixds in entrypointFiles
+                    for f in ixds.get("ixds", [])
+                ]
+            else:
+                from arelle import DialogOpenArchive
+                archiveEntries = DialogOpenArchive.askArchiveFile(cntlr, filesource, multiselect=True, selectFiles=selectFiles)
             if archiveEntries:
                 ixdsFirstFile = archiveEntries[0]
                 _archiveFilenameParts = archiveFilenameParts(ixdsFirstFile)

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
@@ -1,5 +1,9 @@
-from pathlib import PurePath, Path
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
+from pathlib import Path, PurePath
+
+from tests.integration_tests.validation.conformance_suite_config import (
+    ConformanceSuiteAssetConfig,
+    ConformanceSuiteConfig,
+)
 
 config = ConformanceSuiteConfig(
     assets=[
@@ -9,98 +13,121 @@ config = ConformanceSuiteConfig(
         ),
     ],
     expected_failure_ids=frozenset(f"report-package-conformance/index.csv:{s}" for s in [
-        "V-000-invalid-zip",
-        "V-003-multiple-top-level-directories",
-        "V-004-empty-zip",
-        "V-005-leading-slash-in-zip-entry",
-        "V-006-dot-slash-in-zip-entry",
-        "V-007-dot-dot-slash-in-zip-entry",
-        "V-008-double-slash-in-zip-entry",
-        "V-009-backslash-in-zip-entry",
-        "V-010-duplicate-paths-in-zip-entry",
-        "V-011-duplicate-paths-in-zip-entry-dir-under-file",
-        "V-012-encrypted-zip",
-        "V-100-invalid-documentType",
-        "V-101-missing-documentType",
-        "V-102-invalid-documentInfo",
-        "V-103-missing-documentInfo",
-        "V-104-invalid-reportPackage-json",
-        "V-105-invalid-reportPackage-json-duplicate-keys",
-        "V-106-utf16-reportPackage-json",
-        "V-107-utf7-reportPackage-json",
-        "V-108-utf32-reportPackage-json",
-        "V-200-unsupportedReportPackageVersion",
-        "V-201-missing-report-package-json",
-        "V-202-missing-report-package-json",
-        "V-203-xbri-documentType",
-        "V-204-xbr-documentType",
-        "V-205-unconstrained-documentType",
-        "V-206-xbri-documentType",
-        "V-207-xbri-without-reportPackage-json",
-        "V-208-xbri-without-reportPackage-json-and-reports",
-        "V-209-xbr-without-reportPackage-json",
-        "V-210-xbr-without-reportPackage-json-and-reports",
-        "V-211-unsupported-file-extension",
-        "V-300-xbri-with-single-xhtml",
-        "V-301-xbri-with-single-ixds",
-        "V-302-xbri-with-single-html",
-        "V-303-xbri-with-single-htm",
-        "V-304-xbri-with-no-taxonomy",
-        "V-305-xbri-with-xhtml-in-dot-json-directory",
-        "V-306-xbri-with-xhtml-in-dot-xbrl-directory",
-        "V-400-xbri-without-reports-directory",
-        "V-401-xbri-with-only-txt-in-reports-directory",
-        "V-402-xbri-with-xhtml-too-deep",
-        "V-403-xbri-with-multiple-reports",
-        "V-404-xbri-with-json-report",
-        "V-405-xbri-with-xbrl-report",
-        "V-406-xbri-with-multiple-reports-in-a-subdirectory",
-        "V-502-xbr-with-single-json",
-        "V-503-xbr-with-single-csv",
-        "V-504-xbr-with-single-xbrl",
-        "V-505-xbr-with-single-xbrl-in-subdir",
-        "V-506-xbr-with-single-json-and-extra-files",
-        "V-507-xbr-with-single-json-with-bom",
-        "V-508-xbr-with-no-taxonomy",
-        "V-509-xbr-with-json-in-dot-xhtml-directory",
-        "V-600-xbr-without-reports-directory",
-        "V-601-xbr-with-only-txt-in-reports-directory",
-        "V-603-xbr-with-invalid-jrr",
-        "V-604-xbr-with-invalid-jrr-duplicate-keys",
-        "V-605-xbr-with-invalid-jrr-utf32",
-        "V-606-xbr-with-invalid-jrr-utf16",
-        "V-607-xbr-with-invalid-jrr-utf7",
-        "V-608-xbr-with-invalid-jrr-missing-documentInfo",
-        "V-609-xbr-with-invalid-jrr-missing-documentType",
-        "V-610-xbr-with-invalid-jrr-non-string-documentType",
-        "V-611-xbr-with-invalid-jrr-non-object-documentInfo",
-        "V-612-xbr-with-multiple-reports",
-        "V-613-xbr-with-json-and-xbrl-too-deep",
-        "V-614-xbr-with-xhtml-report",
-        "V-615-xbr-with-html-report",
-        "V-616-xbr-with-htm-report",
-        "V-617-xbr-with-multiple-reports-in-a-subdirectory",
-        "V-701-zip-with-no-taxonomy",
-        "V-800-zip-without-reports-directory",
-        "V-801-zip-with-only-txt-in-reports-directory",
-        "V-802-zip-with-reports-too-deep",
-        "V-803-zip-with-multiple-reports-in-a-subdirectory",
-        "V-804-zip-with-multiple-reports-in-a-subdirectory-uppercase",
-        "V-900-future-zip",
-        "V-901-future-xbri",
-        "V-902-future-xbr",
-        "V-903-future-xbrx",
-        "V-904-future-package-with-invalid-reportPackage-json",
-        "V-905-future-package-with-invalid-reportPackage-json-duplicate-keys",
-        "V-906-future-package-with-invalid-reportPackage-json-utf32",
-        "V-907-future-package-with-invalid-reportPackage-json-utf16",
-        "V-908-future-package-with-invalid-reportPackage-json-utf7",
-        "V-909-future-package-with-invalid-reportPackage-json-missing-documentInfo",
-        "V-910-future-package-with-invalid-reportPackage-json-missing-documentType",
-        "V-911-future-package-with-invalid-reportPackage-json-non-string-documentType",
-        "V-912-future-package-with-invalid-reportPackage-json-non-object-documentInfo",
-        "V-913-future-package-with-bom-in-reportPackage-json",
-        "V-914-current-and-future-package",
+        # 0xx - basic zip structure and package identification tests
+        "V-000-invalid-zip",  # rpe:invalidArchiveFormat tpe:invalidArchiveFormat,0,A report package MUST conform to the .ZIP File Format Specification
+        # "V-001-valid-taxonomy-package",  # ,0,"Minimal valid taxonomy package (not a report package). If the package has a file extension of .zip and neither [META-INF/reportPackage.json nor reports] exists, the file is treated as a taxonomy package, and further constraints and processing defined by this specification are not applied."
+        # "V-002-invalid-taxonomy-package-metadata",  # tpe:invalidMetaDataFile,0,If a report package contains the path META-INF/taxonomyPackage.xml within the STLD then it MUST be a valid taxonomy package.
+        "V-003-multiple-top-level-directories",  # rpe:invalidDirectoryStructure tpe:invalidDirectoryStructure,0,A report package conforming to this specification MUST contain a single top-level directory
+        "V-004-empty-zip",  # rpe:invalidDirectoryStructure tpe:invalidDirectoryStructure,0,A report package conforming to this specification MUST contain a single top-level directory
+        "V-005-leading-slash-in-zip-entry",  # rpe:invalidArchiveFormat tpe:invalidArchiveFormat,0,Leading slash is illegal according to the ZIP specficiation
+        "V-006-dot-slash-in-zip-entry",  # rpe:invalidDirectoryStructure tpe:invalidDirectoryStructure,0,Forbidden dot segment
+        "V-007-dot-dot-slash-in-zip-entry",  # rpe:invalidDirectoryStructure tpe:invalidDirectoryStructure,0,Forbidden dot dot segment
+        "V-008-double-slash-in-zip-entry",  # rpe:invalidDirectoryStructure tpe:invalidDirectoryStructure,0,Forbidden empty segment
+        "V-009-backslash-in-zip-entry",  # rpe:invalidArchiveFormat tpe:invalidArchiveFormat,0,Backslash is illegal according to the zip specification
+        "V-010-duplicate-paths-in-zip-entry",  # rpe:invalidDirectoryStructure tpe:invalidDirectoryStructure,0,Two entries with the same path
+        "V-011-duplicate-paths-in-zip-entry-dir-under-file",  # rpe:invalidDirectoryStructure tpe:invalidDirectoryStructure,0,reportPackage.json as a directory as well as a file
+        "V-012-encrypted-zip",  # rpe:invalidArchiveFormat tpe:invalidArchiveFormat,0,A report package MUST NOT make use of the encryption features of the .ZIP File Format
+
+        # 1xx - structural JSON constraints for reportPackage.json
+        "V-100-invalid-documentType",  # rpe:invalidJSONStructure,0,The JSON Pointer /documentInfo/documentType MUST resolve to a string (rpe:invalidJSONStructure).
+        "V-101-missing-documentType",  # rpe:invalidJSONStructure,0,The JSON Pointer /documentInfo/documentType MUST resolve to a string (rpe:invalidJSONStructure).
+        "V-102-invalid-documentInfo",  # rpe:invalidJSONStructure,0,The JSON Pointer /documentInfo/documentType MUST resolve to a string (rpe:invalidJSONStructure).
+        "V-103-missing-documentInfo",  # rpe:invalidJSONStructure,0,The JSON Pointer /documentInfo/documentType MUST resolve to a string (rpe:invalidJSONStructure).
+        "V-104-invalid-reportPackage-json",  # rpe:invalidJSON,0,"JSON files defined by this specification MUST be valid JSON, per RFC 8259"
+        "V-105-invalid-reportPackage-json-duplicate-keys",  # rpe:invalidJSON,0,JSON documents defined by this specification MUST have unique keys
+        "V-106-utf16-reportPackage-json",  # rpe:invalidJSON,0,JSON documents MUST use the UTF-8 character encoding
+        "V-107-utf7-reportPackage-json",  # rpe:invalidJSON,0,JSON documents MUST use the UTF-8 character encoding
+        "V-108-utf32-reportPackage-json",  # rpe:invalidJSON,0,JSON documents MUST use the UTF-8 character encoding
+        # "V-109-utf8-reportPackage-json",  # ,1,"MAY include a Unicode Byte Order Mark, although this is neither required nor recommended"
+
+        # 2xx - co-constraints on documentType and package file extension
+        "V-200-unsupportedReportPackageVersion",  # rpe:unsupportedReportPackageVersion,0,There will never be a version of the spec with this documentType
+        "V-201-missing-report-package-json",  # rpe:documentTypeFileExtensionMismatch,0,"rpe:documentTypeFileExtensionMismatch is ... raised if ... The .xbr ... file extension is used, and reportPackage.json is absent"
+        "V-202-missing-report-package-json",  # rpe:documentTypeFileExtensionMismatch,0,"rpe:documentTypeFileExtensionMismatch is ... raised if ... The .xbri ... file extension is used, and reportPackage.json is absent"
+        "V-203-xbri-documentType",  # rpe:documentTypeFileExtensionMismatch,0,rpe:documentTypeFileExtensionMismatch is ... raised if ... One of the three document type URIs specified in Section 3.4 is used with the incorrect file extension
+        "V-204-xbr-documentType",  # rpe:documentTypeFileExtensionMismatch,0,rpe:documentTypeFileExtensionMismatch is ... raised if ... One of the three document type URIs specified in Section 3.4 is used with the incorrect file extension
+        "V-205-unconstrained-documentType",  # rpe:documentTypeFileExtensionMismatch,0,rpe:documentTypeFileExtensionMismatch is ... raised if ... One of the three document type URIs specified in Section 3.4 is used with the incorrect file extension
+        "V-206-xbri-documentType",  # rpe:documentTypeFileExtensionMismatch,0,rpe:documentTypeFileExtensionMismatch is ... raised if ... One of the three document type URIs specified in Section 3.4 is used with the incorrect file extension
+        "V-207-xbri-without-reportPackage-json",  # rpe:documentTypeFileExtensionMismatch,0,rpe:documentTypeFileExtensionMismatch is ... raised if ... One of the three document type URIs specified in Section 3.4 is used with the incorrect file extension
+        "V-208-xbri-without-reportPackage-json-and-reports",  # rpe:documentTypeFileExtensionMismatch,0,rpe:documentTypeFileExtensionMismatch is ... raised if ... One of the three document type URIs specified in Section 3.4 is used with the incorrect file extension
+        "V-209-xbr-without-reportPackage-json",  # rpe:documentTypeFileExtensionMismatch,0,rpe:documentTypeFileExtensionMismatch is ... raised if ... One of the three document type URIs specified in Section 3.4 is used with the incorrect file extension
+        "V-210-xbr-without-reportPackage-json-and-reports",  # rpe:documentTypeFileExtensionMismatch,0,rpe:documentTypeFileExtensionMismatch is ... raised if ... One of the three document type URIs specified in Section 3.4 is used with the incorrect file extension
+        "V-211-unsupported-file-extension",  # rpe:unsupportedFileExtension,0,Current report package with unsupported file extension (.xbrx)
+
+        # 3xx - valid.xbri packages
+        "V-300-xbri-with-single-xhtml",  # ,1,Simple .xbri file with a single .xhtml document
+        "V-301-xbri-with-single-ixds",  # ,1,.xbri file with multiple .xhtml documents in a single IXDS
+        "V-302-xbri-with-single-html",  # ,1,Simple .xbri file with a single .html document
+        "V-303-xbri-with-single-htm",  # ,1,Simple .xbri file with a single .htm document
+        "V-304-xbri-with-no-taxonomy",  # ,1,.xbri package without a taxonomy
+        "V-305-xbri-with-xhtml-in-dot-json-directory",  # ,1,.xhtml in reports subdirectory with recognised extension (tricky.json)
+        "V-306-xbri-with-xhtml-in-dot-xbrl-directory",  # ,1,.xhtml in reports subdirectory with recognised extension (tricky.xbrl)
+
+        # 4xx - invalid.xbri packages
+        "V-400-xbri-without-reports-directory",  # rpe:missingReportsDirectory,0,A report package MUST contain a directory called reports as a child of the STLD
+        "V-401-xbri-with-only-txt-in-reports-directory",  # rpe:missingReport,0,.xbri file without recognised files in the reports directory
+        "V-402-xbri-with-xhtml-too-deep",  # rpe:missingReport,0,.xbri file with .xhtml buried too deep to be recognised
+        "V-403-xbri-with-multiple-reports",  # rpe:multipleReports,0,If the report package is an Inline XBRL report package ... then there MUST NOT be more than one report in the report package
+        "V-404-xbri-with-json-report",  # rpe:incorrectReportType,0,If the report package is an Inline XBRL report package then the contained report MUST be an Inline XBRL Document Set 
+        "V-405-xbri-with-xbrl-report",  # rpe:incorrectReportType,0,If the report package is an Inline XBRL report package then the contained report MUST be an Inline XBRL Document Set 
+        "V-406-xbri-with-multiple-reports-in-a-subdirectory",  # rpe:multipleReportsInSubdirectory,0,.xbri file with multiple reports in a subdirectory
+
+        # 5xx - valid.xbr packages
+        "V-502-xbr-with-single-json",  # ,1,.xbr file with a single xBRL-JSON report
+        "V-503-xbr-with-single-csv",  # ,1,.xbr file with a single xBRL-CSV metadata file
+        "V-504-xbr-with-single-xbrl",  # ,1,.xbr file with a single xBRL-XML document (.xbrl)
+        "V-505-xbr-with-single-xbrl-in-subdir",  # ,1,.xbr file with a single xBRL-XML document (.xbrl) in a subdirectory
+        "V-506-xbr-with-single-json-and-extra-files",  # ,1,".xbr file with a single xBRL-JSON report and files with non-recognised extensions (.txt, .xml)"
+        "V-507-xbr-with-single-json-with-bom",  # ,1,.xbr file with a single xBRL-JSON report with a byte order mark 
+        "V-508-xbr-with-no-taxonomy",  # ,1,.xbr package without a taxonomy
+        "V-509-xbr-with-json-in-dot-xhtml-directory",  # ,1,.json in reports subdirectory with recognised extension (tricky.xhtml)
+
+        # 6xx - invalid.xbr packages
+        "V-600-xbr-without-reports-directory",  # rpe:missingReportsDirectory,0,A report package MUST contain a directory called reports as a child of the STLD
+        "V-601-xbr-with-only-txt-in-reports-directory",  # rpe:missingReport,0,.xbr file without recognised files in the reports directory
+        "V-603-xbr-with-invalid-jrr",  # rpe:invalidJSON,0,.xbr file with a single invalid JSON-rooted report
+        "V-604-xbr-with-invalid-jrr-duplicate-keys",  # rpe:invalidJSON,0,.xbr file with a single invalid JSON-rooted report (duplicate keys)
+        "V-605-xbr-with-invalid-jrr-utf32",  # rpe:invalidJSON,0,JSON documents MUST use the UTF-8 character encoding
+        "V-606-xbr-with-invalid-jrr-utf16",  # rpe:invalidJSON,0,JSON documents MUST use the UTF-8 character encoding
+        "V-607-xbr-with-invalid-jrr-utf7",  # rpe:invalidJSON,0,JSON documents MUST use the UTF-8 character encoding
+        "V-608-xbr-with-invalid-jrr-missing-documentInfo",  # rpe:invalidJSONStructure,0,The JSON Pointer /documentInfo/documentType MUST resolve to a string (rpe:invalidJSONStructure).
+        "V-609-xbr-with-invalid-jrr-missing-documentType",  # rpe:invalidJSONStructure,0,The JSON Pointer /documentInfo/documentType MUST resolve to a string (rpe:invalidJSONStructure).
+        "V-610-xbr-with-invalid-jrr-non-string-documentType",  # rpe:invalidJSONStructure,0,The JSON Pointer /documentInfo/documentType MUST resolve to a string (rpe:invalidJSONStructure).
+        "V-611-xbr-with-invalid-jrr-non-object-documentInfo",  # rpe:invalidJSONStructure,0,The JSON Pointer /documentInfo/documentType MUST resolve to a string (rpe:invalidJSONStructure).
+        "V-612-xbr-with-multiple-reports",  # rpe:multipleReports,0,.xbr file with multiple reports
+        "V-613-xbr-with-json-and-xbrl-too-deep",  # rpe:missingReport,0,.xbr file with .json and .xbrl buried too deep to be recognised
+        "V-614-xbr-with-xhtml-report",  # rpe:incorrectReportType,0,If the report package is a non-Inline XBRL report package then the contained report MUST be either an XBRL v2.1 report or an JSON-rooted report
+        "V-615-xbr-with-html-report",  # rpe:incorrectReportType,0,If the report package is a non-Inline XBRL report package then the contained report MUST be either an XBRL v2.1 report or an JSON-rooted report
+        "V-616-xbr-with-htm-report",  # rpe:incorrectReportType,0,If the report package is a non-Inline XBRL report package then the contained report MUST be either an XBRL v2.1 report or an JSON-rooted report
+        "V-617-xbr-with-multiple-reports-in-a-subdirectory",  # rpe:multipleReportsInSubdirectory,0,.xbr file with multiple reports in a subdirectory
+
+        # 7xx - valid.zip packages
+        # "V-700-zip-with-multiple-reports",  # ,4,.zip package with multiple reports
+        "V-701-zip-with-no-taxonomy",  # ,1,.zip package without a taxonomy
+
+        # 8xx - invalid.zip packages
+        "V-800-zip-without-reports-directory",  # rpe:missingReportsDirectory,0,A report package MUST contain a directory called reports as a child of the STLD
+        "V-801-zip-with-only-txt-in-reports-directory",  # rpe:missingReport,0,.zip file without recognised files in the reports directory
+        "V-802-zip-with-reports-too-deep",  # rpe:missingReport,0,".zip file with .json, .xbrl and .xhtml buried too deep to be recognised"
+        "V-803-zip-with-multiple-reports-in-a-subdirectory",  # rpe:multipleReportsInSubdirectory,0,.zip file with multiple reports in a subdirectory
+        "V-804-zip-with-multiple-reports-in-a-subdirectory-uppercase",  # rpe:multipleReportsInSubdirectory,0,.ZIP file (uppercase) with multiple reports in a subdirectory
+
+        # 9xx - future report packages
+        "V-900-future-zip",  # rpe:unsupportedReportPackageVersion,0,A future report package with a .zip extension
+        "V-901-future-xbri",  # rpe:unsupportedReportPackageVersion,0,A future report package with a .xbri extension
+        "V-902-future-xbr",  # rpe:unsupportedReportPackageVersion,0,A future report package with a .xbr extension
+        "V-903-future-xbrx",  # rpe:unsupportedFileExtension,0,A future report package with an as-yet-undefined extension (.xbrx)
+        "V-904-future-package-with-invalid-reportPackage-json",  # rpe:invalidJSON,0,Future report package with invalid JSON in META-INF/reportPackage.json
+        "V-905-future-package-with-invalid-reportPackage-json-duplicate-keys",  # rpe:invalidJSON,0,Future report package with invalid JSON in META-INF/reportPackage.json
+        "V-906-future-package-with-invalid-reportPackage-json-utf32",  # rpe:invalidJSON,0,Future report package with invalid JSON in META-INF/reportPackage.json
+        "V-907-future-package-with-invalid-reportPackage-json-utf16",  # rpe:invalidJSON,0,Future report package with invalid JSON in META-INF/reportPackage.json
+        "V-908-future-package-with-invalid-reportPackage-json-utf7",  # rpe:invalidJSON,0,Future report package with invalid JSON in META-INF/reportPackage.json
+        "V-909-future-package-with-invalid-reportPackage-json-missing-documentInfo",  # rpe:invalidJSONStructure,0,Future report package with invalid JSON in META-INF/reportPackage.json
+        "V-910-future-package-with-invalid-reportPackage-json-missing-documentType",  # rpe:invalidJSONStructure,0,Future report package with invalid JSON in META-INF/reportPackage.json
+        "V-911-future-package-with-invalid-reportPackage-json-non-string-documentType",  # rpe:invalidJSONStructure,0,Future report package with invalid JSON in META-INF/reportPackage.json
+        "V-912-future-package-with-invalid-reportPackage-json-non-object-documentInfo",  # rpe:invalidJSONStructure,0,Future report package with invalid JSON in META-INF/reportPackage.json
+        "V-913-future-package-with-bom-in-reportPackage-json",  # rpe:unsupportedReportPackageVersion,0,Future report package with Byte Order Mark in META-INF/reportPackage.json
+        "V-914-current-and-future-package",  # rpe:unsupportedReportPackageVersion,0,META-INF as STLD means this gets interpreted as a future report package
     ]),
     info_url="https://specifications.xbrl.org/work-product-index-taxonomy-packages-report-packages-1.0.html",
     membership_url="https://www.xbrl.org/join",

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
@@ -58,13 +58,13 @@ config = ConformanceSuiteConfig(
         "V-211-unsupported-file-extension",  # rpe:unsupportedFileExtension,0,Current report package with unsupported file extension (.xbrx)
 
         # 3xx - valid.xbri packages
-        "V-300-xbri-with-single-xhtml",  # ,1,Simple .xbri file with a single .xhtml document
-        "V-301-xbri-with-single-ixds",  # ,1,.xbri file with multiple .xhtml documents in a single IXDS
-        "V-302-xbri-with-single-html",  # ,1,Simple .xbri file with a single .html document
-        "V-303-xbri-with-single-htm",  # ,1,Simple .xbri file with a single .htm document
-        "V-304-xbri-with-no-taxonomy",  # ,1,.xbri package without a taxonomy
-        "V-305-xbri-with-xhtml-in-dot-json-directory",  # ,1,.xhtml in reports subdirectory with recognised extension (tricky.json)
-        "V-306-xbri-with-xhtml-in-dot-xbrl-directory",  # ,1,.xhtml in reports subdirectory with recognised extension (tricky.xbrl)
+        # "V-300-xbri-with-single-xhtml",  # ,1,Simple .xbri file with a single .xhtml document
+        # "V-301-xbri-with-single-ixds",  # ,1,.xbri file with multiple .xhtml documents in a single IXDS
+        # "V-302-xbri-with-single-html",  # ,1,Simple .xbri file with a single .html document
+        # "V-303-xbri-with-single-htm",  # ,1,Simple .xbri file with a single .htm document
+        # "V-304-xbri-with-no-taxonomy",  # ,1,.xbri package without a taxonomy
+        # "V-305-xbri-with-xhtml-in-dot-json-directory",  # ,1,.xhtml in reports subdirectory with recognised extension (tricky.json)
+        # "V-306-xbri-with-xhtml-in-dot-xbrl-directory",  # ,1,.xhtml in reports subdirectory with recognised extension (tricky.xbrl)
 
         # 4xx - invalid.xbri packages
         "V-400-xbri-without-reports-directory",  # rpe:missingReportsDirectory,0,A report package MUST contain a directory called reports as a child of the STLD
@@ -76,12 +76,12 @@ config = ConformanceSuiteConfig(
         "V-406-xbri-with-multiple-reports-in-a-subdirectory",  # rpe:multipleReportsInSubdirectory,0,.xbri file with multiple reports in a subdirectory
 
         # 5xx - valid.xbr packages
-        "V-502-xbr-with-single-json",  # ,1,.xbr file with a single xBRL-JSON report
-        "V-503-xbr-with-single-csv",  # ,1,.xbr file with a single xBRL-CSV metadata file
-        "V-504-xbr-with-single-xbrl",  # ,1,.xbr file with a single xBRL-XML document (.xbrl)
-        "V-505-xbr-with-single-xbrl-in-subdir",  # ,1,.xbr file with a single xBRL-XML document (.xbrl) in a subdirectory
-        "V-506-xbr-with-single-json-and-extra-files",  # ,1,".xbr file with a single xBRL-JSON report and files with non-recognised extensions (.txt, .xml)"
-        "V-507-xbr-with-single-json-with-bom",  # ,1,.xbr file with a single xBRL-JSON report with a byte order mark 
+        # "V-502-xbr-with-single-json",  # ,1,.xbr file with a single xBRL-JSON report
+        # "V-503-xbr-with-single-csv",  # ,1,.xbr file with a single xBRL-CSV metadata file
+        # "V-504-xbr-with-single-xbrl",  # ,1,.xbr file with a single xBRL-XML document (.xbrl)
+        # "V-505-xbr-with-single-xbrl-in-subdir",  # ,1,.xbr file with a single xBRL-XML document (.xbrl) in a subdirectory
+        # "V-506-xbr-with-single-json-and-extra-files",  # ,1,".xbr file with a single xBRL-JSON report and files with non-recognised extensions (.txt, .xml)"
+        # "V-507-xbr-with-single-json-with-bom",  # ,1,.xbr file with a single xBRL-JSON report with a byte order mark 
         "V-508-xbr-with-no-taxonomy",  # ,1,.xbr package without a taxonomy
         "V-509-xbr-with-json-in-dot-xhtml-directory",  # ,1,.json in reports subdirectory with recognised extension (tricky.xhtml)
 

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
@@ -6,6 +6,9 @@ from tests.integration_tests.validation.conformance_suite_config import (
 )
 
 config = ConformanceSuiteConfig(
+    args=[
+        "--reportPackage"
+    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path("report-package-conformance.zip"),

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
@@ -15,11 +15,21 @@ config = ConformanceSuiteConfig(
             entry_point=Path("report-package-conformance/index.csv"),
         ),
     ],
+    expected_additional_testcase_errors={f"report-package-conformance/index.csv:{s}": val for s, val in {
+        # "Empty" iXBRL docs are missing schema required elements.
+        "V-301-xbri-with-single-ixds": frozenset({"lxml.SCHEMAV_ELEMENT_CONTENT", "ix11.14.1.2:missingResources"}),
+        "V-302-xbri-with-single-html": frozenset({"lxml.SCHEMAV_ELEMENT_CONTENT", "ix11.14.1.2:missingResources"}),
+        "V-303-xbri-with-single-htm": frozenset({"lxml.SCHEMAV_ELEMENT_CONTENT", "ix11.14.1.2:missingResources"}),
+        # Report package references a taxonomy which does not exist.
+        "V-508-xbr-with-no-taxonomy": frozenset({"IOerror", "oime:invalidTaxonomy"}),
+        "V-509-xbr-with-json-in-dot-xhtml-directory": frozenset({"IOerror", "oime:invalidTaxonomy"}),
+        "V-701-zip-with-no-taxonomy": frozenset({"IOerror", "oime:invalidTaxonomy"}),
+    }.items()},
     expected_failure_ids=frozenset(f"report-package-conformance/index.csv:{s}" for s in [
         # 0xx - basic zip structure and package identification tests
         "V-000-invalid-zip",  # rpe:invalidArchiveFormat tpe:invalidArchiveFormat,0,A report package MUST conform to the .ZIP File Format Specification
         # "V-001-valid-taxonomy-package",  # ,0,"Minimal valid taxonomy package (not a report package). If the package has a file extension of .zip and neither [META-INF/reportPackage.json nor reports] exists, the file is treated as a taxonomy package, and further constraints and processing defined by this specification are not applied."
-        # "V-002-invalid-taxonomy-package-metadata",  # tpe:invalidMetaDataFile,0,If a report package contains the path META-INF/taxonomyPackage.xml within the STLD then it MUST be a valid taxonomy package.
+        "V-002-invalid-taxonomy-package-metadata",  # tpe:invalidMetaDataFile,0,If a report package contains the path META-INF/taxonomyPackage.xml within the STLD then it MUST be a valid taxonomy package.
         "V-003-multiple-top-level-directories",  # rpe:invalidDirectoryStructure tpe:invalidDirectoryStructure,0,A report package conforming to this specification MUST contain a single top-level directory
         "V-004-empty-zip",  # rpe:invalidDirectoryStructure tpe:invalidDirectoryStructure,0,A report package conforming to this specification MUST contain a single top-level directory
         "V-005-leading-slash-in-zip-entry",  # rpe:invalidArchiveFormat tpe:invalidArchiveFormat,0,Leading slash is illegal according to the ZIP specficiation
@@ -57,15 +67,6 @@ config = ConformanceSuiteConfig(
         "V-210-xbr-without-reportPackage-json-and-reports",  # rpe:documentTypeFileExtensionMismatch,0,rpe:documentTypeFileExtensionMismatch is ... raised if ... One of the three document type URIs specified in Section 3.4 is used with the incorrect file extension
         "V-211-unsupported-file-extension",  # rpe:unsupportedFileExtension,0,Current report package with unsupported file extension (.xbrx)
 
-        # 3xx - valid.xbri packages
-        # "V-300-xbri-with-single-xhtml",  # ,1,Simple .xbri file with a single .xhtml document
-        # "V-301-xbri-with-single-ixds",  # ,1,.xbri file with multiple .xhtml documents in a single IXDS
-        # "V-302-xbri-with-single-html",  # ,1,Simple .xbri file with a single .html document
-        # "V-303-xbri-with-single-htm",  # ,1,Simple .xbri file with a single .htm document
-        # "V-304-xbri-with-no-taxonomy",  # ,1,.xbri package without a taxonomy
-        # "V-305-xbri-with-xhtml-in-dot-json-directory",  # ,1,.xhtml in reports subdirectory with recognised extension (tricky.json)
-        # "V-306-xbri-with-xhtml-in-dot-xbrl-directory",  # ,1,.xhtml in reports subdirectory with recognised extension (tricky.xbrl)
-
         # 4xx - invalid.xbri packages
         "V-400-xbri-without-reports-directory",  # rpe:missingReportsDirectory,0,A report package MUST contain a directory called reports as a child of the STLD
         "V-401-xbri-with-only-txt-in-reports-directory",  # rpe:missingReport,0,.xbri file without recognised files in the reports directory
@@ -74,16 +75,6 @@ config = ConformanceSuiteConfig(
         "V-404-xbri-with-json-report",  # rpe:incorrectReportType,0,If the report package is an Inline XBRL report package then the contained report MUST be an Inline XBRL Document Set 
         "V-405-xbri-with-xbrl-report",  # rpe:incorrectReportType,0,If the report package is an Inline XBRL report package then the contained report MUST be an Inline XBRL Document Set 
         "V-406-xbri-with-multiple-reports-in-a-subdirectory",  # rpe:multipleReportsInSubdirectory,0,.xbri file with multiple reports in a subdirectory
-
-        # 5xx - valid.xbr packages
-        # "V-502-xbr-with-single-json",  # ,1,.xbr file with a single xBRL-JSON report
-        # "V-503-xbr-with-single-csv",  # ,1,.xbr file with a single xBRL-CSV metadata file
-        # "V-504-xbr-with-single-xbrl",  # ,1,.xbr file with a single xBRL-XML document (.xbrl)
-        # "V-505-xbr-with-single-xbrl-in-subdir",  # ,1,.xbr file with a single xBRL-XML document (.xbrl) in a subdirectory
-        # "V-506-xbr-with-single-json-and-extra-files",  # ,1,".xbr file with a single xBRL-JSON report and files with non-recognised extensions (.txt, .xml)"
-        # "V-507-xbr-with-single-json-with-bom",  # ,1,.xbr file with a single xBRL-JSON report with a byte order mark 
-        "V-508-xbr-with-no-taxonomy",  # ,1,.xbr package without a taxonomy
-        "V-509-xbr-with-json-in-dot-xhtml-directory",  # ,1,.json in reports subdirectory with recognised extension (tricky.xhtml)
 
         # 6xx - invalid.xbr packages
         "V-600-xbr-without-reports-directory",  # rpe:missingReportsDirectory,0,A report package MUST contain a directory called reports as a child of the STLD
@@ -103,10 +94,6 @@ config = ConformanceSuiteConfig(
         "V-615-xbr-with-html-report",  # rpe:incorrectReportType,0,If the report package is a non-Inline XBRL report package then the contained report MUST be either an XBRL v2.1 report or an JSON-rooted report
         "V-616-xbr-with-htm-report",  # rpe:incorrectReportType,0,If the report package is a non-Inline XBRL report package then the contained report MUST be either an XBRL v2.1 report or an JSON-rooted report
         "V-617-xbr-with-multiple-reports-in-a-subdirectory",  # rpe:multipleReportsInSubdirectory,0,.xbr file with multiple reports in a subdirectory
-
-        # 7xx - valid.zip packages
-        # "V-700-zip-with-multiple-reports",  # ,4,.zip package with multiple reports
-        "V-701-zip-with-no-taxonomy",  # ,1,.zip package without a taxonomy
 
         # 8xx - invalid.zip packages
         "V-800-zip-without-reports-directory",  # rpe:missingReportsDirectory,0,A report package MUST contain a directory called reports as a child of the STLD
@@ -136,4 +123,5 @@ config = ConformanceSuiteConfig(
     membership_url="https://www.xbrl.org/join",
     name=PurePath(__file__).stem,
     network_or_cache_required=False,
+    plugins=frozenset(["inlineXbrlDocumentSet"]),
 )


### PR DESCRIPTION
#### Reason for change
Report package spec is rec status.
Resolves #1245, Resolves #1247, Resolves #1249

#### Description of change
Adds support for loading the various report package formats across all of Arelle's loading code paths (CLI, web server, GUI, conformance suite runner, and Python API).

#### Steps to Test
* CI
* Testing matrix (Windows, macOS, and Linux):

| Format | CLI | Server | GUI | Conformance Suite Runner | Python API (macOS) |
|-|-|-|-|-|-|
| Inline XBRL Report Package: single inline doc |☑️|☑️|☑️|☑️|☑️|
| Inline XBRL Report Package: inline doc set |☑️|☑️|☑️|☑️|☑️|
| Non-Inline XBRL Report Package: xBRL-XML |☑️|☑️|☑️|☑️|☑️|
| Non-Inline XBRL Report Package: xBRL-JSON |☑️|☑️|☑️|☑️|☑️|
| Non-Inline XBRL Report Package: xBRL-CSV |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: single inline doc |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: inline doc set |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: multiple inline reports |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: xBRL-XML |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: multiple xBRL-XML |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: xBRL-JSON |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: multiple xBRL-JSON |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: xBRL-CSV |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: multiple xBRL-CSV |☑️|☑️|☑️|☑️|☑️|
| Unconstrained Report Package: multiple report types |☑️|☑️|☑️|☑️|☑️|
| SEC Zip (regression test) |☑️|☑️|☑️|☑️|☑️|
| ESEF Package (regression test) |☑️|☑️|☑️|☑️|☑️|

**review**:
@Arelle/arelle
