### PR TITLE
Write Values to Single Extra Requested Column in Rel Reports

### DIFF
--- a/arelle/ViewFileRelationshipSet.py
+++ b/arelle/ViewFileRelationshipSet.py
@@ -250,7 +250,7 @@ class ViewRelationshipSet(ViewFile.View):
                     cols.append(", ".join(w.label(preferredLabel,lang=self.lang,linkroleHint=relationshipSet.linkrole) for w in otherWider))
                 else:
                     cols.append("")
-            if self.cols and len(self.cols) > 1:
+            if self.cols:
                 for col in self.cols:
                     if col == "Name":
                         cols.append( (concept.qname or concept.prefixedName) )


### PR DESCRIPTION
#### Reason for change
Relationship set reports do not include values for requested columns unless there are more than one.

Includes empty `Name` column:
`python arelleCmdLine.py --cal cal.csv --file https://filings.xbrl.org/5493008U3H3W0NKPFL10/2024-06-30/ESEF/DK/0/GNStoreNord-2024-06-30.zip --relationshipCols=Name`

Includes populated `Name` and `Namespace` columns:
`python arelleCmdLine.py --cal cal.csv --file https://filings.xbrl.org/5493008U3H3W0NKPFL10/2024-06-30/ESEF/DK/0/GNStoreNord-2024-06-30.zip --relationshipCols=Name,Namespace`

#### Description of change
Populate column values when there is only a single requested extra column.

#### Steps to Test
* Run: `python arelleCmdLine.py --cal cal.csv --file https://filings.xbrl.org/5493008U3H3W0NKPFL10/2024-06-30/ESEF/DK/0/GNStoreNord-2024-06-30.zip --relationshipCols=Name`
* Verify that the `Name` column is populated in the csv report.

**review**:
@Arelle/arelle
