### PR TITLE
Improve package validation logging.

### DIFF
--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -423,6 +423,7 @@ def validateTaxonomyPackage(cntlr, filesource, errors=[]) -> bool:
                 cntlr.addToLog(
                     validation.msg,
                     messageCode=validation.codes,
+                    messageArgs=validation.args,
                     file=filesource.urlBasename,
                     level=logging.ERROR,
                 )
@@ -433,6 +434,7 @@ def validateTaxonomyPackage(cntlr, filesource, errors=[]) -> bool:
                 cntlr.addToLog(
                     validation.msg,
                     messageCode=validation.codes,
+                    messageArgs=validation.args,
                     file=filesource.urlBasename,
                     level=logging.ERROR,
                 )

--- a/arelle/packages/PackageValidation.py
+++ b/arelle/packages/PackageValidation.py
@@ -29,10 +29,8 @@ def validatePackageZipFormat(
         return Validation.error(
             codes=f"{packageType.errorPrefix}:invalidArchiveFormat",
             msg=_("%(packageType)s package is not valid and could not be opened: %(file)s"),
-            args={
-                "packageType": packageType.name,
-                "file": os.path.basename(str(filesource.url)),
-            },
+            packageType=packageType.name,
+            file=os.path.basename(str(filesource.url)),
         )
     return None
 
@@ -45,10 +43,8 @@ def validatePackageNotEncrypted(
         return Validation.error(
             codes=f"{packageType.errorPrefix}:invalidArchiveFormat",
             msg=_("%(packageType)s package contains encrypted files: %(file)s"),
-            args={
-                "packageType": packageType.name,
-                "file": os.path.basename(str(filesource.url)),
-            },
+            packageType=packageType.name,
+            file=os.path.basename(str(filesource.url)),
         )
     return None
 
@@ -61,10 +57,8 @@ def validateZipFileSeparators(
         return Validation.error(
             codes=f"{packageType.errorPrefix}:invalidArchiveFormat",
             msg=_("%(packageType)s package directory uses '\\' as a file separator."),
-            args={
-                "packageType": packageType.name,
-                "file": os.path.basename(str(filesource.url)),
-            },
+            packageType=packageType.name,
+            file=os.path.basename(str(filesource.url)),
         )
     return None
 
@@ -79,12 +73,10 @@ def validateTopLevelFiles(
         return Validation.error(
             codes=f"{packageType.errorPrefix}:invalidDirectoryStructure",
             msg=_("%(packageType)s package contains %(count)s top level file(s):  %(topLevelFiles)s"),
-            args={
-                "packageType": packageType.name,
-                "count": numTopLevelFiles,
-                "topLevelFiles": ", ".join(sorted(topLevelFiles)),
-                "file": os.path.basename(str(filesource.url)),
-            },
+            packageType=packageType.name,
+            count=numTopLevelFiles,
+            topLevelFiles=", ".join(sorted(topLevelFiles)),
+            file=os.path.basename(str(filesource.url)),
         )
     return None
 
@@ -99,21 +91,17 @@ def validateTopLevelDirectories(
         return Validation.error(
             codes=f"{packageType.errorPrefix}:invalidDirectoryStructure",
             msg=_("%(packageType)s Package does not contain a top level directory"),
-            args={
-                "packageType": packageType.name,
-                "file": os.path.basename(str(filesource.url)),
-            },
+            packageType=packageType.name,
+            file=os.path.basename(str(filesource.url)),
         )
     if numTopLevelDirectories > 1:
         return Validation.error(
             codes=f"{packageType.errorPrefix}:invalidDirectoryStructure",
             msg=_("%(packageType)s package contains %(count)s top level directories: %(topLevelDirectories)s"),
-            args={
-                "packageType": packageType.name,
-                "count": numTopLevelDirectories,
-                "topLevelDirectories": ", ".join(sorted(topLevelDirectories)),
-                "file": os.path.basename(str(filesource.url)),
-            },
+            packageType=packageType.name,
+            count=numTopLevelDirectories,
+            topLevelDirectories=", ".join(sorted(topLevelDirectories)),
+            file=os.path.basename(str(filesource.url)),
         )
     return None
 
@@ -126,9 +114,7 @@ def validateMetadataDirectory(
         return Validation.error(
             codes=f"{packageType.errorPrefix}:metadataDirectoryNotFound",
             msg=_("%(packageType)s package top-level directory does not contain a subdirectory META-INF"),
-            args={
-                "packageType": packageType.name,
-                "file": os.path.basename(str(filesource.url)),
-            },
+            packageType=packageType.name,
+            file=os.path.basename(str(filesource.url)),
         )
     return None


### PR DESCRIPTION
#### Steps to Test
Run the taxonomy package conformance suite and expect to see log message placeholders replaced, i.e. not
```
[tpe:invalidArchiveFormat] %(packageType)s package directory uses '\' as a file separator. - V-011-invalid-path-separator.zip
```

**review**:
@Arelle/arelle
