### PR TITLE
Add Support For Saving Both OIM JSON and CSV Formats

### DIFF
--- a/generateMessagesCatalog.py
+++ b/generateMessagesCatalog.py
@@ -8,12 +8,12 @@ def entityEncode(arg):  # be sure it's a string, vs int, etc, and encode &, <, "
 
 if __name__ == "__main__":
     startedAt = time.time()
-    
+
     idMsg = []
     numArelleSrcFiles = 0
 
     arelleSrcPath = (os.path.dirname(__file__) or os.curdir) + os.sep + "arelle"
-    for arelleSrcDir in (arelleSrcPath, 
+    for arelleSrcDir in (arelleSrcPath,
                          arelleSrcPath + os.sep + "plugin",
                          arelleSrcPath + os.sep + "plugin" + os.sep + "validate" + os.sep + "EFM",
                          # arelleSrcPath + os.sep + "plugin" + os.sep + "validate" + os.sep + "ESEF",
@@ -67,7 +67,7 @@ if __name__ == "__main__":
                                                for elt in ast.walk(msgCodeArg)):
                                             msgCodes = ("(dynamic)",)
                                         else:
-                                            msgCodes = [elt.s 
+                                            msgCodes = [elt.s
                                                         for elt in ast.walk(msgCodeArg)
                                                         if isinstance(elt, ast.Str)]
                                     msgArg = item.args[1 + iArgOffset]
@@ -90,16 +90,16 @@ if __name__ == "__main__":
                                                    for elt in ast.walk(msgCodeArg)):
                                                 pass # dynamic
                                             else:
-                                                msgCodes = [elt.s 
+                                                msgCodes = [elt.s
                                                             for elt in ast.walk(msgCodeArg)
                                                             if isinstance(elt, ast.Str)]
                                         else:
                                             keywords.append(keyword.arg)
                                     for msgCode in msgCodes:
-                                        idMsg.append((msgCode, msg, level, keywords, refFilename, item.lineno))                                        
+                                        idMsg.append((msgCode, msg, level, keywords, refFilename, item.lineno))
                         except (AttributeError, IndexError):
                             pass
-                    
+
 
     lines = []
     for id,msg,level,args,module,line in idMsg:
@@ -110,7 +110,7 @@ if __name__ == "__main__":
             else:
                 argAttr = ""
             lines.append("<message code=\"{0}\"\n         level=\"{3}\"\n         module=\"{4}\" line=\"{5}\"{2}>\n{1}\n</message>"
-                      .format(id, 
+                      .format(id,
                               entityEncode(msg),
                               argAttr,
                               level,
@@ -129,13 +129,13 @@ if __name__ == "__main__":
     variablePrefix="%("
     variableSuffix=")s"
     variablePrefixEscape="" >
-<!-- 
-This file contains Arelle messages text.   Each message has a code 
-that corresponds to the message code in the log file, level (severity), 
+<!--
+This file contains Arelle messages text.   Each message has a code
+that corresponds to the message code in the log file, level (severity),
 args (available through log file), and message replacement text.
 
-(Messages with dynamically composed error codes or text content 
-(such as ValidateXbrlDTS.py line 158 or lxml parser messages) 
+(Messages with dynamically composed error codes or text content
+(such as ValidateXbrlDTS.py line 158 or lxml parser messages)
 are reported as "(dynamic)".)
 
 -->
@@ -143,7 +143,7 @@ are reported as "(dynamic)".)
 ''')
         f.write("\n\n".join(sorted(lines)))
         f.write("\n\n</messages>")
-        
+
     with io.open(arelleSrcPath + os.sep + "doc" + os.sep + "messagesCatalog.xsd", 'wt', encoding='utf-8') as f:
         f.write(
 '''<?xml version="1.0" encoding="UTF-8"?>
@@ -173,5 +173,5 @@ are reported as "(dynamic)".)
   </xs:element>
 </xs:schema>
 ''')
-    
+
     print("Arelle messages catalog {0:.2f} secs, {1} formula files, {2} messages".format( time.time() - startedAt, numArelleSrcFiles, len(idMsg) ))

--- a/msgfmt.py
+++ b/msgfmt.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: iso-8859-1 -*-
-# Written by Martin v. Löwis <loewis@informatik.hu-berlin.de>
+# Written by Martin v. Lï¿½wis <loewis@informatik.hu-berlin.de>
 
 """Generate binary message catalog from textual translation description.
 
@@ -23,9 +23,9 @@ Options:
     -V
     --version
         Display version information and exit.
-        
+
 Example (for russian in arelle, run from this directory)
-    python3.5 msgfmt.py -o arelle/locale/ru/LC_MESSAGES/arelle.mo arelle/locale/ru/LC_MESSAGES/ru.po 
+    python3.5 msgfmt.py -o arelle/locale/ru/LC_MESSAGES/arelle.mo arelle/locale/ru/LC_MESSAGES/ru.po
 """
 
 import sys
@@ -121,7 +121,7 @@ def make(filename, outfile):
 
     msgid = None
     msgstr = None
-    
+
     # Parse the catalog
     lno = 0
     for l in lines:
@@ -229,4 +229,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ mypy==1.13.0
 boto3-stubs==1.35.49
 lxml-stubs==0.5.1
 types-PyMySQL==1.1.0.20240524
+types-openpyxl==3.1.5.20241025
 types-python-dateutil==2.9.0.20241003
 types-pytz==2024.2.0.20241003
 types-regex==2024.9.11.20240912

--- a/tests/integration_tests/scripts/script_util.py
+++ b/tests/integration_tests/scripts/script_util.py
@@ -47,7 +47,7 @@ def parse_args(
     parser.add_argument("--arelle", action="store", required=arelle,
                         help="CLI command to run Arelle.")
     parser.add_argument("--download-cache", action="store_true",
-                        help=f"Whether or not to download and apply cache.")
+                        help="Whether or not to download and apply cache.")
     parser.add_argument("--offline", action="store_true",
                         help="True if Arelle should run in offline mode.")
     parser.add_argument("--working-directory", action="store", default=".test",

--- a/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
+++ b/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
@@ -83,13 +83,13 @@ print(f"Checking for viewer: {viewer_path}")
 if not viewer_path.exists():
     errors.append(f'Viewer not generated at "{viewer_path}"')
 
-print(f"Checking for filtered logs...")
+print("Checking for filtered logs...")
 expected_filtered = 5
 actual_filtered = len(log_filter.filtered_records)
 if actual_filtered != expected_filtered:
     errors.append(f'Expected {expected_filtered} filtered log records, found {actual_filtered}.')
 
-print(f"Checking log XML for errors...")
+print("Checking log XML for errors...")
 assert log_xml == log_handler.getXml(clearLogBuffer=False, includeDeclaration=False)
 errors += validate_log_xml(log_xml)
 

--- a/tests/integration_tests/scripts/tests/python_api_query_model.py
+++ b/tests/integration_tests/scripts/tests/python_api_query_model.py
@@ -34,7 +34,7 @@ report_zip_url = get_s3_uri(
 print(f"Downloading report: {report_zip_path}")
 urllib.request.urlretrieve(report_zip_url, report_zip_path)
 
-print(f"Downloading packages...")
+print("Downloading packages...")
 package_assets = {
     package for year in [2017, 2019, 2020, 2021, 2022] for package in ESEF_PACKAGES[year]
 }

--- a/tests/integration_tests/scripts/tests/python_api_taxonomy_service.py
+++ b/tests/integration_tests/scripts/tests/python_api_taxonomy_service.py
@@ -57,7 +57,7 @@ with Session() as session:
     with open(arelle_log_file, 'w') as f:
         json.dump(log_messages, f, ensure_ascii=False, indent=4)
 
-print(f"Validating structured logs have errors for missing labels...")
+print("Validating structured logs have errors for missing labels...")
 message_code_groups = itertools.groupby(log_messages, key=lambda m: m['messageCode'])
 expected_code_counts = {
     'info': 1,

--- a/tests/integration_tests/scripts/tests/python_api_validate_esef.py
+++ b/tests/integration_tests/scripts/tests/python_api_validate_esef.py
@@ -34,7 +34,7 @@ report_zip_url = get_s3_uri(
 print(f"Downloading report: {report_zip_path}")
 urllib.request.urlretrieve(report_zip_url, report_zip_path)
 
-print(f"Downloading packages...")
+print("Downloading packages...")
 package_assets = {
     package for year in [2017, 2019, 2020, 2021, 2022] for package in ESEF_PACKAGES[year]
 }
@@ -63,7 +63,7 @@ with Session() as session:
     log_xml = session.get_logs('xml')
 # include end
 
-print(f"Checking log XML for errors...")
+print("Checking log XML for errors...")
 errors += validate_log_xml(log_xml, expected_results={
     'error': {
         regex.compile(r'^\[ESEF.2.2.1.precisionAttributeUsed] .*'): 1


### PR DESCRIPTION
#### Reason for change
We need the ability to save both JSON and CSV OIM formats in a single request.

#### Description of change
* Cleanup saveLoadableOIM plugin.
* Fix error handling bugs in saveLoadableOIM plugin.
* Add option to save all OIM formats to a directory (`--saveLoadableOIMDirectory`).

#### Steps to Test
* Run: `python arelleCmdLine.py --plugins saveLoadableOIM --file https://filings.xbrl.org/724500GJBUL3D9TW9Y18/2023-12-31/ESEF/NL/0/724500GJBUL3D9TW9Y18-2023-12-31-en.zip --saveLoadableOIMDirectory oim`
* Verify that both JSON and CSV OIM formats are saved into the `oim` directory.

**review**:
@Arelle/arelle
