### PR TITLE
[ESEF] Fix for calculation check, type and xbri packages

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -123,7 +123,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
 
                     if esefDisclosureSystemYear < 2023:
                         esefDomainItemTypes = qnDomainItemTypes
-                    elif esefDisclosureSystemYear == 2023:
+                    elif esefDisclosureSystemYear == 2023 or esefTaxonomyYear < 2024:
                         esefDomainItemTypes = qnDomainItemTypes2023
                     else:
                         esefDomainItemTypes = qnDomainItemTypes2024
@@ -316,11 +316,11 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                 if linkEltName == "calculationLink":
                     val.hasExtensionCal = True
                     linkbasesFound.add(linkEltName)
-                    if esefDisclosureSystemYear >= 2024:
+                    if esefTaxonomyYear >= 2024:
                         for arc in linkElt.iterdescendants(tag="{http://www.xbrl.org/2003/linkbase}calculationArc"):
-                            if arc.get("{http://www.w3.org/1999/xlink}arcrole") != "https://www.xbrl.org/2023/arcrole/summation-item":
+                            if arc.get("{http://www.w3.org/1999/xlink}arcrole") != "https://xbrl.org/2023/arcrole/summation-item":
                                 val.modelXbrl.error("ESEF.3.4.1.IncorrectSummationItemArcroleUsed",
-                                                    _("Starting from the ESEF 2024 taxonomy, only calculation linkbases using the arcrole 'https://www.xbrl.org/2023/arcrole/summation-item' are permitted. Arcrole  %(arcrole)s has been found."),
+                                                    _("Starting from the ESEF 2024 taxonomy, only calculation linkbases using the arcrole 'https://xbrl.org/2023/arcrole/summation-item' are permitted. Arcrole  %(arcrole)s has been found."),
                                                     arcrole=arc.get("{http://www.w3.org/1999/xlink}arcrole"))
                 if linkEltName == "definitionLink":
                     val.hasExtensionDef = True

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -132,9 +132,9 @@ class ESEFPlugin(PluginHooks):
                         return None  # allow zipped test case to load normally
 
                 isZipFormat = modelXbrl.fileSource.isZip
-                hasZipFileExtension = modelXbrl.fileSource.type.lower() == ".zip"
+                hasZipFileExtension = modelXbrl.fileSource.type.lower() == ".zip" or (modelXbrl.fileSource.type.lower() == ".xbri" and  disclosureSystemYear >= 2024)
                 if disclosureSystemYear >= 2023 and not (isZipFormat and hasZipFileExtension):
-                    modelXbrl.error("ESEF.2.6.1.disallowedReportPackageFileExtension",
+                    modelXbrl.error("ESEF.2.6.3.disallowedReportPackageFileExtension",
                                     _("A report package MUST conform to the .ZIP File Format Specification and MUST have a .zip extension."),
                                     fileSourceType=modelXbrl.fileSource.type,
                                     modelObject=modelXbrl)

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -132,10 +132,12 @@ class ESEFPlugin(PluginHooks):
                         return None  # allow zipped test case to load normally
 
                 isZipFormat = modelXbrl.fileSource.isZip
-                hasZipFileExtension = modelXbrl.fileSource.type.lower() == ".zip" or (modelXbrl.fileSource.type.lower() == ".xbri" and  disclosureSystemYear >= 2024)
+                hasZipFileExtension = modelXbrl.fileSource.type.lower() == ".zip" or (modelXbrl.fileSource.type == ".xbri" and  disclosureSystemYear >= 2024)
                 if disclosureSystemYear >= 2023 and not (isZipFormat and hasZipFileExtension):
+                    errorMessage = _("A report package MUST conform to the .ZIP File Format Specification and MUST have a .zip{} extension.")
+                    errorMessage = errorMessage.format(_(" or .xbri") if disclosureSystemYear >= 2024 else "")
                     modelXbrl.error("ESEF.2.6.3.disallowedReportPackageFileExtension",
-                                    _("A report package MUST conform to the .ZIP File Format Specification and MUST have a .zip extension."),
+                                    errorMessage,
                                     fileSourceType=modelXbrl.fileSource.type,
                                     modelObject=modelXbrl)
                     return LoadingException("ESEF Report Package must be .ZIP File Format")


### PR DESCRIPTION
#### Reason for change
This pr fix a few points raised in the arelle group

#### Description of change
* Fix the calculation arcrole and based it on the taxonomy
* Fix the type detection
* Update the package 2.6.1 to 2.6.3 and add xbri


#### Steps to Test
Validate a ESEF instance

**review**:
@Arelle/arelle
