### PR TITLE
Resolve OIM Errors

### DIFF
--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -598,6 +598,19 @@ def csvPeriod(cellValue, startOrEnd=None):
             return isoDuration
     return None
 
+def increaseMaxFieldSize():
+    # https://stackoverflow.com/a/15063941
+    maxInt = sys.maxsize
+
+    while True:
+        # decrease the maxInt value by factor 10
+        # as long as the OverflowError occurs.
+        try:
+            csv.field_size_limit(maxInt)
+            break
+        except OverflowError:
+            maxInt = int(maxInt/10)
+
 def idDeduped(modelXbrl, id):
     for i in range(99999):
         if i == 0:
@@ -719,6 +732,10 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                         _dialect = "excel-tab"
                         break
                 _file.seek(0)
+
+            # Must increase the max supported CSV field size before opening the CSV reader.
+            # Otherwise large HTML values will trigger csv.ERROR: field larger than field limit.
+            increaseMaxFieldSize()
             return csv.reader(_file, _dialect, doublequote=True)
 
         def ldError(msgCode, msgText, **kwargs):

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -719,7 +719,7 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                         _dialect = "excel-tab"
                         break
                 _file.seek(0)
-            return csv.reader(_file, _dialect)
+            return csv.reader(_file, _dialect, doublequote=True)
 
         def ldError(msgCode, msgText, **kwargs):
             loadDictErrors.append((msgCode, msgText, kwargs))

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -202,7 +202,7 @@ decimalsSuffixPattern = re.compile(r".*[0-9.][\r\n\t ]*d[\r\n\t ]*(0|-?[1-9][0-9
 
 htmlBodyTemplate = "<body xmlns='http://www.w3.org/1999/xhtml'>\n{0}\n</body>\n"
 xhtmlTagPrefix = "{http://www.w3.org/1999/xhtml}"
-DimensionsKeyPattern = re.compile(r"^(concept|entity|period|unit|language|(\w+:\w+))$")
+builtInDimensionKeys = frozenset({"concept", "entity", "period", "unit", "language"})
 
 UNSUPPORTED_DATA_TYPES = XbrlConst.dtrPrefixedContentItemTypes + (
     qname(XbrlConst.xbrli,"fractionItemType"), )
@@ -1927,7 +1927,7 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                                     error("oime:unsupportedDimensionDataType",
                                           _("Taxonomy-defined typed dimension value is complex: %(memberQName)s at %(path)s"),
                                           modelObject=modelXbrl, memberQName=dimValue, path="/".join(pathSegs+(dimName,)))
-                if pathSegs[-1] in ("/dimensions", "dimensions") and not DimensionsKeyPattern.match(dimName):
+                if pathSegs[-1] in ("/dimensions", "dimensions") and dimName not in builtInDimensionKeys and not SQNamePattern.match(dimName):
                     error("oimce:invalidSQName",
                           _("Invalid SQName: %(sqname)s"),
                           sourceFileLine=oimFile, sqname=dimName, path="/".join(pathSegs))

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -183,9 +183,11 @@ def saveLoadableOIM(
                     return "-INF" if obj < 0 else "INF"
                 elif isnan(obj):
                     return "NaN"
+                elif isinstance(obj, Decimal):
+                    # XML canonical representation of decimal requires a decimal point.
+                    # https://www.w3.org/TR/xmlschema-2/#decimal-canonical-representation
+                    return f"{obj:.1f}" if obj % 1 == 0 else f"{obj}"
                 else:
-                    if isinstance(obj, Decimal) and obj == obj.to_integral():
-                        obj = obj.quantize(ONE)  # drop any .0
                     return f"{obj}"
             except Exception:
                 return str(obj)


### PR DESCRIPTION
#### Reason for Change
Resolves issue #1402.

#### Description of Change
The OIM code had several issues:
	1.	It didn’t correctly handle [2DQUOTE within escaped CSV values](https://www.xbrl.org/Specification/xbrl-csv/REC-2021-10-13+errata-2023-04-19/xbrl-csv-REC-2021-10-13+corrected-errata-2023-04-19.html#sec-csv-file).
	2.	It couldn’t parse large (HTML) CSV fields, an issue masked by the above problem, which caused HTML text block values to be skipped after the first double quote.
	3.	Dimension value validation was overly strict, leading to errors on valid member names.
	4.	The save loadable OIM plugin specified the canonical values feature but failed to write decimal values in their [canonical XML form](https://www.w3.org/TR/xmlschema-2/#decimal-canonical-representation).

#### Steps to Test
• CI

**review**:
@Arelle/arelle