### PR TITLE
Fix Column Alignment for Dimensions Report with Extra Columns

### DIFF
--- a/arelle/ViewFileRelationshipSet.py
+++ b/arelle/ViewFileRelationshipSet.py
@@ -173,19 +173,27 @@ class ViewRelationshipSet(ViewFile.View):
                 text = concept.localName
                 xmlRowElementName = text
             cols = [text]
-            if arcrole == "XBRL-dimensions" and isRelation:
-                relArcrole = modelObject.arcrole
-                cols.append( os.path.basename( relArcrole ) )
-                if relArcrole in (XbrlConst.all, XbrlConst.notAll):
-                    cols.append( modelObject.contextElement )
-                    cols.append( modelObject.closed )
+            if arcrole == "XBRL-dimensions":
+                if isRelation:
+                    relArcrole = modelObject.arcrole
+                    cols.append( os.path.basename( relArcrole ) )
+                    if relArcrole in (XbrlConst.all, XbrlConst.notAll):
+                        cols.append( modelObject.contextElement )
+                        cols.append( modelObject.closed )
+                    else:
+                        cols.append(None)
+                        cols.append(None)
+                    if relArcrole in (XbrlConst.dimensionDomain, XbrlConst.domainMember):
+                        cols.append( modelObject.usable  )
+                    else:
+                        cols.append(None)
+                    childRelationshipSet = self.modelXbrl.relationshipSet(XbrlConst.consecutiveArcrole.get(relArcrole,"XBRL-dimensions"),
+                                                                        modelObject.consecutiveLinkrole)
                 else:
                     cols.append(None)
                     cols.append(None)
-                if relArcrole in (XbrlConst.dimensionDomain, XbrlConst.domainMember):
-                    cols.append( modelObject.usable  )
-                childRelationshipSet = self.modelXbrl.relationshipSet(XbrlConst.consecutiveArcrole.get(relArcrole,"XBRL-dimensions"),
-                                                                      modelObject.consecutiveLinkrole)
+                    cols.append(None)
+                    cols.append(None)
             if self.arcrole == XbrlConst.parentChild: # extra columns
                 if isRelation:
                     preferredLabel = modelObject.preferredLabel


### PR DESCRIPTION
#### Reason for change
<img width="400" alt="Screenshot 2024-11-19 at 11 54 16 AM" src="https://github.com/user-attachments/assets/9b2b710e-165b-4ad7-96e8-9f802b70b0c6">
<img width="400" alt="Screenshot 2024-11-19 at 11 54 56 AM" src="https://github.com/user-attachments/assets/51e1a013-5021-4ffa-b5e9-182e0c220265">


#### Description of change
Specifying extra columns for the dimensions report causes non-relational (root) nodes to output the extra column values under the wrong (relational) keys.

#### Steps to Test
`python arelleCmdLine.py --file https://filings.xbrl.org/W9NG6WMZIYEU8VEDOG48/2024-09-30/ESEF/DK/0/W9NG6WMZIYEU8VEDOG48-2024-09-30-en.zip --dim dim.json --relationshipCols Name,LocalName,Namespace`

**review**:
@Arelle/arelle
