### PR TITLE
Don't crash on missing units in ModelFact.isDuplicateOf.

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -512,7 +512,7 @@ class ModelFact(ModelObject):
             # parent test can only be done if in same instauce
             if self.modelXbrl == other.modelXbrl and self.parentElement != other.parentElement:
                 return False
-            if not (self.context.isEqualTo(other.context,dimensionalAspectModel=False) and
+            if not (self.context is not None and self.context.isEqualTo(other.context,dimensionalAspectModel=False) and
                     (not self.isNumeric or (self.unit is not None and self.unit.isEqualTo(other.unit)))):
                 return False
         elif self.isTuple:

--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -513,7 +513,7 @@ class ModelFact(ModelObject):
             if self.modelXbrl == other.modelXbrl and self.parentElement != other.parentElement:
                 return False
             if not (self.context.isEqualTo(other.context,dimensionalAspectModel=False) and
-                    (not self.isNumeric or self.unit.isEqualTo(other.unit))):
+                    (not self.isNumeric or (self.unit is not None and self.unit.isEqualTo(other.unit)))):
                 return False
         elif self.isTuple:
             if (self == other or


### PR DESCRIPTION
#### Steps to Test
Validate [s.zip](https://github.com/user-attachments/files/17909627/s.zip) and expect not to see
```
[DQC.US.0015.2688] Validation was unable to complete rule DQC.US.0015 due to an internal error.
```

**review**:
@Arelle/arelle
