### PR TITLE
Fix Footnotes GUI View

### DIFF
--- a/arelle/ModelRelationshipSet.py
+++ b/arelle/ModelRelationshipSet.py
@@ -222,7 +222,7 @@ class ModelRelationshipSet:
     def linkRoleUris(self):
         # order by document appearance of linkrole, required for Table Linkbase testcase 3220 v03
         if self.modellinkRoleUris is None:
-            linkroleObjSeqs = set((modelRel.linkrole, modelRel.arcElement.getparent().objectIndex) for modelRel in self.modelRelationships)
+            linkroleObjSeqs = set((modelRel.linkrole, getattr(modelRel.arcElement.getparent(), "objectIndex", sys.maxsize)) for modelRel in self.modelRelationships)
             self.modellinkRoleUris = OrderedSet([lr[0] for lr in sorted(linkroleObjSeqs, key=lambda l: l[1])])
         return self.modellinkRoleUris
 


### PR DESCRIPTION
#### Reason for change
Trying to view footnotes in the GUI raises an exception:
<img width="632" alt="Screenshot 2024-11-30 at 8 57 05 PM" src="https://github.com/user-attachments/assets/87de3fa3-74ec-4613-b811-8135ab9f208e">

#### Description of change
Update sort to handle prototype objects which do not have an index.

#### Steps to Test
* Use the right click "View" > "Additional View" > "Xbrl-Footnotes" menu with [a filing that has footnotes](https://github.com/user-attachments/files/17967857/filing_documents.zip).
* Confirm that an exception is no longer raised and that footnotes can be viewed in the tab that is opened.

**review**:
@Arelle/arelle
