### PR TITLE
Fix UnboundLocalError Exception

### DIFF
--- a/arelle/ViewFileFactTable.py
+++ b/arelle/ViewFileFactTable.py
@@ -84,9 +84,9 @@ class ViewFacts(ViewFile.View):
                                  modelXbrl=self.modelXbrl, col1=col0)
         self.isCol0Label = col0 in ("Concept", "Label")
         relationshipSet = self.modelXbrl.relationshipSet(self.arcrole, self.linkrole, self.linkqname, self.arcqname)
+        linkroleUris = []
         if relationshipSet:
             # sort URIs by definition
-            linkroleUris = []
             for linkroleUri in relationshipSet.linkRoleUris:
                 modelRoleTypes = self.modelXbrl.roleTypes.get(linkroleUri)
                 if modelRoleTypes:


### PR DESCRIPTION
#### Reason for change
Variable is initialized inside of a conditional, but referenced outside of it. If a fact table report is requested for a report without a presentation linkbase the CSV report should include a header, but no fact rows (the fact list report should be used instead).

#### Description of change
* Declare linkroleUris outside of conditional so reports without presentation linkbases don't throw.

#### Steps to Test
* Create fact table report for filing: [Export_consult_xbrl_20241204205626.zip](https://github.com/user-attachments/files/18016266/Export_consult_xbrl_20241204205626.zip)
* `python arelleCmdLine.py --file https://github.com/user-attachments/files/18016266/Export_consult_xbrl_20241204205626.zip --package https://www.nbb.be/doc/ba/xbrl/taxo2023/nbb-cbso-23.0.1.zip --factTable table.csv`
* Verify UnboundLocalError is not raised.



**review**:
@Arelle/arelle
