### PR TITLE
Use macos-13 Runner for Build

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -55,7 +55,7 @@ jobs:
   build-macos:
     environment: release
     # Intel runner produces universal binary
-    runs-on: macos-14-large
+    runs-on: macos-13
     outputs:
       artifact_versioned_name: ${{ steps.define-artifact-names.outputs.artifact_versioned_name }}
       uploaded_artifact_name: ${{ steps.define-artifact-names.outputs.uploaded_artifact_name }}


### PR DESCRIPTION
#### Reason for change
We have to use an Intel runner to produce a build that works on both Intel and arm macs. Our current runner (macos-14-large) is Intel, but it isn't free, and we keep running into billing limits that [fail our release pipeline](https://github.com/Arelle/Arelle/actions/runs/12170581349). macos-14 is arm, but macos-13 is both free and Intel.

[Standard (free) macOS runners]():
Virtual Machine | Processor (CPU) | Memory (RAM) | Storage (SSD) | Workflow label
-- | -- | -- | -- | --
Linux | 4 | 16 GB | 14 GB | ubuntu-latest, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04
Windows | 4 | 16 GB | 14 GB | windows-latest, windows-2022, windows-2019
macOS | 3 | 14 GB | 14 GB | macos-12
macOS | 4 | 14 GB | 14 GB | macos-13
macOS | 3 (M1) | 7 GB | 14 GB | macos-latest, macos-14, macos-15 [Public preview]

[Larger (not free) macOS runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#about-macos-larger-runners):
Runner Size | Architecture | Processor (CPU) | Memory (RAM) | Storage (SSD) | Workflow label
-- | -- | -- | -- | -- | --
Large | Intel | 12 | 30 GB | 14 GB | macos-latest-large, macos-12-large, macos-13-large, macos-14-large [latest], macos-15-large [Public preview]
XLarge | arm64 (M1) | 6 (+ 8 GPU hardware acceleration) | 14 GB | 14 GB | macos-latest-xlarge, macos-13-xlarge , macos-14-xlarge [latest], macos-15-xlarge [Public preview]


#### Description of change
Use free Intel runner for macOS builds.

#### Steps to Test
* CI (verify that [build with macos-13 runner](https://github.com/Arelle/Arelle/actions/runs/12170634688) completes)

**review**:
@Arelle/arelle
