### PR TITLE
Recognize HTTPS CIPC URLs.

### DIFF
--- a/arelle/plugin/validate/CIPC/__init__.py
+++ b/arelle/plugin/validate/CIPC/__init__.py
@@ -26,7 +26,7 @@ cipcBlockedInlineHtmlElements = {
     'object', 'script'}
 
 namePattern = re.compile(r"^(.*) - ((18|19|20)\d{2}-[0-9]+-(06|07|08|09|10|12|20|21|22|23|24|25|26|30|31)) - (20[1-9]\d)$")
-reportingModulePattern = re.compile(r"http://xbrl.cipc.co.za/taxonomy/.*/\w*(ca_fas|full_ifrs|ifrs_for_smes)\w*[_-]20[12][0-9]-[0-9]{2}-[0-9]{2}.xsd")
+reportingModulePattern = re.compile(r"https?://xbrl.cipc.co.za/taxonomy/.*/\w*(ca_fas|full_ifrs|ifrs_for_smes)\w*[_-]20[12][0-9]-[0-9]{2}-[0-9]{2}.xsd")
 
 TRANSFORMATION_REGISTRY_3 = {
     'namespace': 'http://www.xbrl.org/inlineXBRL/transformation/2015-02-26',


### PR DESCRIPTION
#### Reason for change
CIPC 2024 uses HTTPS in its URLs.

#### Steps to Test
Validate a CIPC 2024 document and expect not to see "cipc:reportingModuleAmbiguous".

**review**:
@Arelle/arelle
