### PR TITLE
Wrap all XSD patterns with XsdPattern.

### DIFF
--- a/arelle/FunctionXfi.py
+++ b/arelle/FunctionXfi.py
@@ -1171,7 +1171,7 @@ def concept_relationships_step(xc, inst, relationshipSet, rels, axis, generation
                         # search all incoming relationships for those with right consecutiveLinkrole
                         stepRels = [rel
                                     for rel in stepRelationshipSet.toModelObject(concept)
-                                    if rel.consectuiveLinkrole == modelRel.linkrole]
+                                    if rel.consecutiveLinkrole == modelRel.linkrole]
                     else:
                         stepRelationshipSet = relationshipSet
                         stepRels = stepRelationshipSet.toModelObject(concept)

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -22,7 +22,7 @@ objects to interface to SQL-obtained data.
 
 ModelType represents an anonymous or explicit element type.  It includes methods that determine
 the base XBRL type (such as monetaryItemType), the base XML type (such as decimal), substitution
-group chains, facits, and attributes.
+group chains, facets, and attributes.
 
 ModelAttributeGroup and ModelAttribute provide sufficient mechanism to identify element attributes,
 their types, and their default or fixed values.
@@ -1408,7 +1408,7 @@ class ModelType(ModelNamableTerm):
                 ("QName", self.qname),
                 ("xsd type", self.baseXsdType),
                 ("derived from", self.qnameDerivedFrom),
-                ("facits", self.facets))
+                ("facets", self.facets))
 
     def __repr__(self):
         return ("modelType[{0}, qname: {1}, derivedFrom: {2}, {3}, line {4}]"

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -2,11 +2,12 @@
 See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
+from dataclasses import dataclass
 import logging, os
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 from lxml import etree
-from regex import Match, compile as re_compile
+from regex import Match, Pattern, compile as re_compile
 from decimal import Decimal, InvalidOperation
 from fractions import Fraction
 from arelle import UrlUtil, XbrlConst, XmlUtil, XmlValidateConst
@@ -34,15 +35,19 @@ iNameChar = "[_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F
 cNameChar = r"[_\-\.:"   "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040]"
 cMinusCNameChar = r"[_\-\."   "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040]"
 
-class XsdPattern():
+@dataclass(frozen=True)
+class XsdPattern:
+    xsdPattern: str
+    pyPattern: Pattern[str]
+
     # shim class for python wrapper of xsd pattern
-    def compile(self, p: str) -> XsdPattern:
-        self.xsdPattern = p
+    @classmethod
+    def compile(cls, p: str) -> XsdPattern:
         if r"\i" in p or r"\c" in p:
             p = p.replace(r"[\i-[:]]", iNameChar).replace(r"\i", iNameChar) \
                  .replace(r"[\c-[:]]", cMinusCNameChar).replace(r"\c", cNameChar)
-        self.pyPattern = re_compile(p + "$") # must match whole string
-        return self
+        pyPattern = re_compile(p + "$") # must match whole string
+        return cls(p, pyPattern)
 
     def match(self, string: str) -> Match[str] | None:
         return self.pyPattern.match(string)
@@ -110,10 +115,13 @@ lexicalPatterns = {
 
 # patterns difficult to compile into python
 xmlSchemaPatterns = {
-    r"\c+": NMTOKENPattern,
-    r"\i\c*": namePattern,
-    r"[\i-[:]][\c-[:]]*": NCNamePattern,
-    }
+    pattern: XsdPattern(xsdPattern=pattern, pyPattern=pyPattern)
+    for pattern, pyPattern in (
+        (r"\c+", NMTOKENPattern),
+        (r"\i\c*", namePattern),
+        (r"[\i-[:]][\c-[:]]*", NCNamePattern),
+    )
+}
 
 baseXsdTypePatterns = {
                 "Name": namePattern,
@@ -548,7 +556,7 @@ def validateValue(
                         if value in xmlSchemaPatterns:
                             xValue = xmlSchemaPatterns[value]
                         else:
-                            xValue = XsdPattern().compile(value)
+                            xValue = XsdPattern.compile(value)
                     except Exception as err:
                         raise ValueError(err)
                 elif baseXsdType == "fraction":

--- a/arelle/archive/plugin/validate/SBRnl/Filing.py
+++ b/arelle/archive/plugin/validate/SBRnl/Filing.py
@@ -376,7 +376,7 @@ def validateFiling(val, modelXbrl):
                     _("Typed dimension domain element %(concept)s has disallowed complex content"),
                     modelObject=domainElt, concept=domainElt.qname)
 
-    modelXbrl.profileActivity("... SBR role types and type facits checks", minTimeToShow=1.0)
+    modelXbrl.profileActivity("... SBR role types and type facets checks", minTimeToShow=1.0)
     # end moved from ValidateFiling
 
     # 3.2.4.4 check each using prefix against taxonomy declaring the prefix

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -312,9 +312,6 @@ class ESEFPlugin(PluginHooks):
                             _("RTS on ESEF requires valid XBRL instances, %(numXbrlErrors)s errors were reported."),
                             modelObject=modelXbrl, numXbrlErrors=numXbrlErrors)
 
-        # force reporting of unsatisfied assertions for which there are no messages
-        traceUnmessagedUnsatisfiedAssertions = True
-
     @staticmethod
     def validateFormulaCompiled(
         modelXbrl: ModelXbrl,

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -132,7 +132,7 @@ class ESEFPlugin(PluginHooks):
                         return None  # allow zipped test case to load normally
 
                 isZipFormat = modelXbrl.fileSource.isZip
-                hasZipFileExtension = modelXbrl.fileSource.type.lower() == ".zip" or (modelXbrl.fileSource.type == ".xbri" and  disclosureSystemYear >= 2024)
+                hasZipFileExtension = modelXbrl.fileSource.type.lower() == ".zip" or (modelXbrl.fileSource.type == ".xbri" and disclosureSystemYear >= 2024)
                 if disclosureSystemYear >= 2023 and not (isZipFormat and hasZipFileExtension):
                     errorMessage = _("A report package MUST conform to the .ZIP File Format Specification and MUST have a .zip{} extension.")
                     errorMessage = errorMessage.format(_(" or .xbri") if disclosureSystemYear >= 2024 else "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ module = [
     'arelle.ValidateUtr',
     'arelle.ValidateVersReport',
     'arelle.ValidateXbrlCalcs',
-    'arelle.ValidateXbrlCalcs',
     'arelle.ValidateXbrlDTS',
     'arelle.ValidateXbrlDimensions',
     'arelle.Version',

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -417,7 +417,7 @@ BASE_XSD_TYPES = {
         {"value": r"\c+", "expected": ("=", XsdPattern(xsdPattern=r"\c+", pyPattern=NMTOKENPattern), VALID)},
         {"value": r"\i\c*", "expected": ("=", XsdPattern(xsdPattern=r"\i\c*", pyPattern=namePattern), VALID)},
         {"value": r"[\i-[:]][\c-[:]]*", "expected": ("=", XsdPattern(xsdPattern=r"[\i-[:]][\c-[:]]*", pyPattern=NCNamePattern), VALID)},
-        # {"value": "test", "expected": ("=", XsdPattern().compile("test"), VALID)},  # TODO: XsdPattern equality not working
+        {"value": "test", "expected": ("=", XsdPattern.compile("test"), VALID)},
         {"value": r"invalid(", "expected": ("=", None, INVALID)},
     ],
 }

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -11,7 +11,7 @@ import regex
 from unittest.mock import Mock
 
 from arelle.ModelValue import QName, DateTime, Time, isoDuration, gDay, gMonth, gMonthDay, gYear, gYearMonth
-from arelle.XmlValidate import validateValue, VALID, UNKNOWN, INVALID, VALID_ID, NMTOKENPattern, namePattern, NCNamePattern, VALID_NO_CONTENT
+from arelle.XmlValidate import validateValue, VALID, UNKNOWN, INVALID, VALID_ID, NMTOKENPattern, namePattern, NCNamePattern, VALID_NO_CONTENT, XsdPattern
 
 FLOAT_CASES = [
     {"value": "-1", "expected": (-1, -1, VALID)},
@@ -414,9 +414,9 @@ BASE_XSD_TYPES = {
         {"value": "invalid", "expected": ("=", None, INVALID)},
     ],
     "xsd-pattern": [
-        {"value": r"\c+", "expected": ("=", NMTOKENPattern, VALID)},
-        {"value": r"\i\c*", "expected": ("=", namePattern, VALID)},
-        {"value": r"[\i-[:]][\c-[:]]*", "expected": ("=", NCNamePattern, VALID)},
+        {"value": r"\c+", "expected": ("=", XsdPattern(xsdPattern=r"\c+", pyPattern=NMTOKENPattern), VALID)},
+        {"value": r"\i\c*", "expected": ("=", XsdPattern(xsdPattern=r"\i\c*", pyPattern=namePattern), VALID)},
+        {"value": r"[\i-[:]][\c-[:]]*", "expected": ("=", XsdPattern(xsdPattern=r"[\i-[:]][\c-[:]]*", pyPattern=NCNamePattern), VALID)},
         # {"value": "test", "expected": ("=", XsdPattern().compile("test"), VALID)},  # TODO: XsdPattern equality not working
         {"value": r"invalid(", "expected": ("=", None, INVALID)},
     ],


### PR DESCRIPTION
#### Reason for change
They're sometimes compiled regular expressions, which is inconsistent and drops the original pattern string, i.e. before translation to a Python regular expression.

`.replace(r"\i", iNameChar)` remains a problem.

#### Steps to Test
CI

**review**:
@Arelle/arelle
