### PR TITLE
Revert "Bump softprops/action-gh-release from 2.1.0 to 2.2.0 in the gha-dependencies group"

### DIFF
--- a/.github/workflows/publish-frozen-build.yml
+++ b/.github/workflows/publish-frozen-build.yml
@@ -38,7 +38,7 @@ jobs:
           name: ${{ inputs.github_artifact }}
 
       - name: Upload build to release
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2.1.0
         with:
           fail_on_unmatched_files: true
           files: ${{ inputs.build_name }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -73,7 +73,7 @@ jobs:
           TWINE_REPOSITORY: ${{ github.repository == 'Arelle/Arelle' && 'pypi' || 'testpypi' }}
         run: pipx run twine upload ./*
       - name: Upload release artifact
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2.1.0
         with:
           fail_on_unmatched_files: true
           files: './*'


### PR DESCRIPTION
Reverts Arelle/Arelle#1446 because https://github.com/softprops/action-gh-release/issues/556