### PR TITLE
[ESEF 2024]Correct the check  ESEF.2.2.5.roundedValueBelowScaleNotNull

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -669,7 +669,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                         modelXbrl.error("ESEF.2.2.7.improperApplicationOfEscapeAttribute",
                                           _("Facts with datatype 'dtr-types:textBlockItemType' MUST use the 'escape' attribute set to 'true'. Facts with any other datatype MUST use the 'escape' attribute set to 'false' - fact %(conceptName)s"),
                                           modelObject=f, conceptName=f.concept.qname)
-                    if f.effectiveValue == "0" and f.xValue != 0:
+                    if f.effectiveValue in ["0", "-0"] and f.xValue != 0:
                         modelXbrl.warning("ESEF.2.2.5.roundedValueBelowScaleNotNull",
                                           _("A value that has been rounded and is below the scale should show a value of zero. It has been found to have the value %(value)s - fact %(conceptName)s"),
                                           modelObject=f, value=f.value, conceptName=f.concept.qname)


### PR DESCRIPTION
#### Reason for change

Rounding to 0 for negative  numbers in facts is not recognized. 

#### Description of change
The effective XBRL value of negative rounded figures is '-0'. An explicit check for this value has been added besides the check for value '0'. 

#### Steps to Test
Validate in Arelle the following file:

[error-esef-225.zip](https://github.com/user-attachments/files/18163091/error-esef-225.zip)

In the current version of Arelle, it detects 1 ESEF.2.2.5.roundedValueBelowScaleNotNull error.

The corrected version of Arelle correctly detects 2 ESEF.2.2.5.roundedValueBelowScaleNotNull errors.

**review**:
@Arelle/arelle
@austinmatherne-wk 
