### PR TITLE
Add Explicit Read the Docs Sphinx Config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,5 @@ python:
     - requirements: requirements-docs.txt
 
 sphinx:
+  configuration: docs/source/conf.py
   fail_on_warning: true


### PR DESCRIPTION
#### Reason for change
Auto discovery of the sphinx configuration script by Read The Docs is being removed. See https://github.com/readthedocs/readthedocs.org/issues/10637

We received a notification email informing us we need to make this change to continue publishing to Read The Docs:
> Deprecation timeline
> We will implement this change gradually:
> 
> January 6, 2025: Builds will be temporarily disabled for 12 hours (00:01 PST to 11:59 PST)
> January 13, 2025: Builds will be temporarily disabled for 24 hours (00:01 PST to 23:59 PST)
> January 20, 2025: Final cutoff date - builds without explicit configuration will be permanently disabled

#### Description of change
Add configuration script to readthedocs yaml file

#### Steps to Test
* CI

**review**:
@Arelle/arelle
