### PR TITLE
Add Retry for DMG Build Step

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,6 +21,11 @@ on:
         description: 'xbrlus/xule branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
+      create_dmg_attempt_limit:
+        description: 'Number of attempts to create the DMG (workaround for macos-13 runner bug)'
+        required: false
+        default: 10
+        type: number
     outputs:
       artifact_versioned_name:
         description: 'The file name of the DMG including the version, e.g. "arelle-macos-1.0.0.dmg".'
@@ -48,6 +53,11 @@ on:
         description: 'xbrlus/xule branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
+      create_dmg_attempt_limit:
+        description: 'Number of attempts to create the DMG (workaround for macos-13 runner bug)'
+        required: true
+        default: 10
+        type: number
 
 permissions: {}
 
@@ -144,7 +154,19 @@ jobs:
           mkdir dist_dmg
           SIZE=`du -ms | awk '{print int($1 + 20 + 0.5)}'`
           ls build
-          hdiutil create -srcfolder build/Arelle.app -volname Arelle -fs HFS+ -fsargs "-c c=64,a=16,e=16" -format UDRW -size ${SIZE}M dist_dmg/arelle_tmp.dmg
+          # Retry used to workaround macos-13 runner bug. Can be removed when bug is fixed or we update to macos-14:
+          # https://github.com/actions/runner-images/issues/7522
+          for i in {1..${{ inputs.create_dmg_attempt_limit }}}; do
+            if hdiutil create -ov -srcfolder build/Arelle.app -volname Arelle -fs HFS+ -fsargs "-c c=64,a=16,e=16" -format UDRW -size ${SIZE}M dist_dmg/arelle_tmp.dmg; then
+              echo "Successfully created DMG on attempt $i"
+              break
+            elif [[ $i -eq ${{ inputs.create_dmg_attempt_limit }} ]]; then
+              echo "Failed to create DMG after $i attempts"
+              exit 1
+            else
+              echo "Failed to create DMG on attempt $i, retrying"
+            fi
+          done
           echo "Created DMG: arelle_tmp.dmg"
           DEVICE=$(hdiutil attach -readwrite -noverify dist_dmg/arelle_tmp.dmg | egrep '^/dev/' | sed 1q | awk '{print $1}')
           sleep 2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 

--- a/tests/integration_tests/validation/discover_tests.py
+++ b/tests/integration_tests/validation/discover_tests.py
@@ -10,7 +10,7 @@ from .conformance_suite_configurations.efm_current import config as efm_current
 from .conformance_suite_configurations.xbrl_2_1 import config as xbrl_2_1
 
 
-LINUX = 'ubuntu-22.04'
+LINUX = 'ubuntu-24.04'
 MACOS = 'macos-14'
 WINDOWS = 'windows-2022'
 ALL_PYTHON_VERSIONS = (


### PR DESCRIPTION
#### Reason for change
Our macOS builds are in [an unfortunate state](https://github.com/Arelle/Arelle/actions/runs/12437266128/attempts/8).

The macos-13 runner [suffers from a bug](https://github.com/actions/runner-images/issues/7522) that causes frequent failures during the DMG build stage.

Our builds are stuck with macos-13 for now because it's the only free non-deprecated macOS Intel runner:

1. We need an Intel runner for universal builds and while macos-14-large is Intel, macos-14 is arm.
2. The macos-14-large runner is not free and we keep hitting spending limits (probably because of other repos under the Arelle org).
3. macos-12 is deprecated. 

#### Description of change
* Update a couple of older Ubuntu runners to 24.04
* Add a retry around the Build DMG stage so we don't have to manually retry the entire build after each failure. 

#### Steps to Test
* CI
* Here's [an example](https://github.com/Arelle/Arelle/actions/runs/12442465135/job/34740630126) of the DMG build completing on the third attempt.

**review**:
@Arelle/arelle
