### PR TITLE
ESEF Reporting Manual 2024 changes (for 2025 filings)

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -249,7 +249,7 @@ def parseArgs(args):
                       help=_("Skip DTS activities (loading, discovery, validation), useful when an instance needs only to be parsed."))
     parser.add_option("--skipLoading", "--skiploading", action="store", dest="skipLoading",
                       help=_("Skip loading discovered or schemaLocated files matching pattern (unix-style file name patterns separated by '|'), useful when not all linkbases are needed."))
-    parser.add_option("--skipBaseTaxonomiesValidation", "--skipbasetaxonomiesvalidation", action="storeTrue", dest="skipBaseTaxonomiesValidation",
+    parser.add_option("--skipBaseTaxonomiesValidation", "--skipbasetaxonomiesvalidation", action="store_true", dest="skipBaseTaxonomiesValidation",
                       help=_("Skip validation of base taxonomies."))
     parser.add_option("--logFile", "--logfile", action="store", dest="logFile",
                       help=_("Write log messages into file, otherwise they go to standard output.  "

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -249,6 +249,8 @@ def parseArgs(args):
                       help=_("Skip DTS activities (loading, discovery, validation), useful when an instance needs only to be parsed."))
     parser.add_option("--skipLoading", "--skiploading", action="store", dest="skipLoading",
                       help=_("Skip loading discovered or schemaLocated files matching pattern (unix-style file name patterns separated by '|'), useful when not all linkbases are needed."))
+    parser.add_option("--skipBaseTaxonomiesValidation", "--skipbasetaxonomiesvalidation", action="storeTrue", dest="skipBaseTaxonomiesValidation",
+                      help=_("Skip validation of base taxonomies."))
     parser.add_option("--logFile", "--logfile", action="store", dest="logFile",
                       help=_("Write log messages into file, otherwise they go to standard output.  "
                              "If file ends in .xml it is xml-formatted, otherwise it is text. "))
@@ -858,6 +860,8 @@ class CntlrCmdLine(Cntlr.Cntlr):
         if options.skipLoading: # skip loading matching files (list of unix patterns)
             self.modelManager.skipLoading = re.compile(
                 '|'.join(fnmatch.translate(f) for f in options.skipLoading.split('|')))
+        if options.skipBaseTaxonomiesValidation:
+            self.modelManager.skipBaseTaxonomiesValidation = True
 
         # disclosure system sets logging filters, override disclosure filters, if specified by command line
         if options.logLevelFilter:

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -180,6 +180,11 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.validateAllFilesAsReportPackages.trace("w", self.setValidateAllFilesAsReportPackages)
         validateMenu.add_checkbutton(label=_("Validate all files as Report Packages"), underline=0, variable=self.validateAllFilesAsReportPackages, onvalue=True, offvalue=False)
 
+        self.modelManager.skipBaseTaxonomiesValidation = self.config.setdefault("skipBaseTaxonomiesValidation", False)
+        self.skipBaseTaxonomiesValidation = BooleanVar(value=self.modelManager.skipBaseTaxonomiesValidation)
+        self.skipBaseTaxonomiesValidation.trace("w", self.setSkipBaseTaxonomiesValidation)
+        validateMenu.add_checkbutton(label=_("Skip validation of base taxonomies"), underline=0, variable=self.skipBaseTaxonomiesValidation, onvalue=True, offvalue=False)
+
         self.validateDuplicateFacts = None
         self.buildValidateDuplicateFactsMenu(validateMenu)
 
@@ -1418,6 +1423,12 @@ class CntlrWinMain (Cntlr.Cntlr):
     def setValidateAllFilesAsReportPackages(self, *args):
         self.modelManager.validateAllFilesAsReportPackages = self.validateAllFilesAsReportPackages.get()
         self.config["validateAllFilesAsReportPackages"] = self.modelManager.validateAllFilesAsReportPackages
+        self.saveConfig()
+        self.setValidateTooltipText()
+
+    def setSkipBaseTaxonomiesValidation(self, *args):
+        self.modelManager.skipBaseTaxonomiesValidation = self.skipBaseTaxonomiesValidation.get()
+        self.config["skipBaseTaxonomiesValidation"] = self.modelManager.skipBaseTaxonomiesValidation
         self.saveConfig()
         self.setValidateTooltipText()
 

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -70,6 +70,7 @@ class ModelManager:
         self.validateAllFilesAsReportPackages = False
         self.validateDuplicateFacts = ValidateDuplicateFacts.DuplicateType.NONE
         self.validateXmlOim = False
+        self.skipBaseTaxonomiesValidation = False
         self.setLocale()
         ValidateXbrlCalcs.init() # required due to circular dependencies in module
 

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -422,7 +422,7 @@ class ModelXbrl:
         else:
             return self.fileSource.url
 
-    def relationshipSet(self, arcrole: tuple[str, ...] | str, linkrole: tuple[str, ...] | str | None = None, linkqname: QName | None = None, arcqname: QName | None = None, includeProhibits: bool = False) -> ModelRelationshipSetClass:
+    def relationshipSet(self, arcrole: tuple[str] | str, linkrole: tuple[str, ...] | str | None = None, linkqname: QName | None = None, arcqname: QName | None = None, includeProhibits: bool = False) -> ModelRelationshipSetClass:
         """Returns a relationship set matching specified parameters (only arcrole is required).
 
         Resolve and determine relationship set.  If a relationship set of the same parameters was previously resolved, it is returned from a cache.

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -422,7 +422,7 @@ class ModelXbrl:
         else:
             return self.fileSource.url
 
-    def relationshipSet(self, arcrole: str, linkrole: tuple[str, ...] | str | None = None, linkqname: QName | None = None, arcqname: QName | None = None, includeProhibits: bool = False) -> ModelRelationshipSetClass:
+    def relationshipSet(self, arcrole: tuple[str, ...] | str, linkrole: tuple[str, ...] | str | None = None, linkqname: QName | None = None, arcqname: QName | None = None, includeProhibits: bool = False) -> ModelRelationshipSetClass:
         """Returns a relationship set matching specified parameters (only arcrole is required).
 
         Resolve and determine relationship set.  If a relationship set of the same parameters was previously resolved, it is returned from a cache.

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -125,6 +125,7 @@ class RuntimeOptions:
     showEnvironment: Optional[bool] = None
     showOptions: Optional[bool] = None
     skipDTS: Optional[bool] = None
+    skipBaseTaxonomiesValidation: Optional[bool] = None
     skipLoading: Optional[bool] = None
     statusPipe: Optional[str] = None
     tableFile: Optional[str] = None

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -323,7 +323,7 @@ class Validate:
                     if archivePath:
                         with self.useFileSource.fs.open(archivePath[1]) as embeddedFile:
                             readMeFirstUriIsEmbeddedZipFile = zipfile.is_zipfile(embeddedFile)
-            if not readMeFirstUriIsEmbeddedZipFile:
+            if not (readMeFirstUriIsEmbeddedZipFile or isReportPackageExtension(readMeFirstUri)):
                 modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager,
                                             readMeFirstUri,
                                             _("validating"),

--- a/arelle/ValidateXbrlDTS.py
+++ b/arelle/ValidateXbrlDTS.py
@@ -262,9 +262,10 @@ def checkDTS(val: ValidateXbrl, modelDocument: ModelDocument.ModelDocument, chec
     val.extendedElementName = None
     isFilingDocument = False
     # validate contents of entry point document or its sibling/descendant documents or in report package of entry point
-    if ((modelDocument.uri.startswith(val.modelXbrl.uriDir) or # document uri in same subtree as entry doocument
-         (val.modelXbrl.fileSource.isOpen and modelDocument.filepath.startswith(val.modelXbrl.fileSource.baseurl))) and # document in entry submission's package
-        modelDocument.targetNamespace not in val.disclosureSystem.baseTaxonomyNamespaces and
+    if ((((modelDocument.uri.startswith(val.modelXbrl.uriDir) or # document uri in same subtree as entry doocument
+          (val.modelXbrl.fileSource.isOpen and modelDocument.filepath.startswith(val.modelXbrl.fileSource.baseurl))) and # document in entry submission's package
+          modelDocument.targetNamespace not in val.disclosureSystem.baseTaxonomyNamespaces)
+         or not val.modelXbrl.modelManager.skipBaseTaxonomiesValidation) and
         modelDocument.xmlDocument):
         isFilingDocument = True
         val.valUsedPrefixes = set()

--- a/arelle/ViewWinTests.py
+++ b/arelle/ViewWinTests.py
@@ -95,9 +95,15 @@ class ViewTests(ViewWinTree.ViewTree):
         else:
             pass
 
-    def viewTestcase(self, modelDocument, parentNode, n):
+    def viewTestcase(self, modelDocument, parentNode, n, parentUri=None):
+        name = os.path.basename(modelDocument.uri)
+        if parentUri: # determine relative testcase location
+            baseDir = os.path.dirname(parentUri)
+            testDir = os.path.dirname(modelDocument.uri)
+            if testDir.startswith(baseDir) and len(baseDir) < len(testDir):
+                name = testDir[len(baseDir)+1:] + os.sep + name
         node = self.treeView.insert(parentNode, "end", modelDocument.objectId(),
-                                    text=os.path.basename(modelDocument.uri),
+                                    text=name,
                                     tags=("odd" if n & 1 else "even",))
         self.id += 1;
         if hasattr(modelDocument, "testcaseVariations"):

--- a/arelle/ViewWinTests.py
+++ b/arelle/ViewWinTests.py
@@ -86,7 +86,7 @@ class ViewTests(ViewWinTree.ViewTree):
                     testcases.append((referencedDocument.uri, referencedDocument.objectId()))
             testcases.sort()
             for i, testcaseTuple in enumerate(testcases):
-                self.viewTestcase(self.modelXbrl.modelObject(testcaseTuple[1]), node, i)
+                self.viewTestcase(self.modelXbrl.modelObject(testcaseTuple[1]), node, i, modelDocument.uri)
         elif modelDocument.type in (ModelDocument.Type.TESTCASE, ModelDocument.Type.REGISTRYTESTCASE):
             self.viewTestcase(modelDocument, parentNode, 1)
         elif modelDocument.type == ModelDocument.Type.XPATHTESTSUITE:
@@ -104,9 +104,15 @@ class ViewTests(ViewWinTree.ViewTree):
             for i, modelTestcaseVariation in enumerate(modelDocument.testcaseVariations):
                 self.viewTestcaseVariation(modelTestcaseVariation, node, n + i + 1)
 
-    def viewTestGroup(self, group, parentNode, n):
+    def viewTestcase(self, modelDocument, parentNode, n, parentUri=None):
+        name = os.path.basename(modelDocument.uri)
+        if parentUri: # determine relative testcase location
+            baseDir = os.path.dirname(parentUri)
+            testDir = os.path.dirname(modelDocument.uri)
+            if testDir.startswith(baseDir) and len(baseDir) < len(testDir):
+                name = testDir[len(baseDir)+1:] + os.sep + name
         node = self.treeView.insert(parentNode, "end", group.objectId(),
-                                    text=group.get("name"),
+                                    text=name,
                                     tags=("odd" if n & 1 else "even",))
         titleElt = XmlUtil.child(group, None, "title")
         if titleElt is not None:

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -319,7 +319,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                     if esefTaxonomyYear >= 2024:
                         for arc in linkElt.iterdescendants(tag="{http://www.xbrl.org/2003/linkbase}calculationArc"):
                             if arc.get("{http://www.w3.org/1999/xlink}arcrole") != "https://xbrl.org/2023/arcrole/summation-item":
-                                val.modelXbrl.error("ESEF.3.4.1.incorrectSummationItemArcroleUsed",
+                                val.modelXbrl.error("ESEF.3.4.1.IncorrectSummationItemArcroleUsed",
                                                     _("Starting from the ESEF 2024 taxonomy, only calculation linkbases using the arcrole 'https://xbrl.org/2023/arcrole/summation-item' are permitted. Arcrole  %(arcrole)s has been found."),
                                                     arcrole=arc.get("{http://www.w3.org/1999/xlink}arcrole"))
                 if linkEltName == "definitionLink":

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -99,7 +99,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
         parentChildRelSet = val.modelXbrl.relationshipSet(XbrlConst.parentChild)
         widerNarrowerRelSet = val.modelXbrl.relationshipSet(XbrlConst.widerNarrower)
         generalSpecialRelSet = val.modelXbrl.relationshipSet(XbrlConst.generalSpecial)
-        calcRelSet = val.modelXbrl.relationshipSet(XbrlConst.summationItem)
+        calcRelSet = val.modelXbrl.relationshipSet(XbrlConst.summationItems)
         dimensionDefaults = val.modelXbrl.relationshipSet(dimensionDefault, DefaultDimensionLinkroles)
         labelsRelationshipSet = val.modelXbrl.relationshipSet(XbrlConst.conceptLabel)
         if modelDocument.targetNamespace is not None:

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -319,7 +319,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                     if esefTaxonomyYear >= 2024:
                         for arc in linkElt.iterdescendants(tag="{http://www.xbrl.org/2003/linkbase}calculationArc"):
                             if arc.get("{http://www.w3.org/1999/xlink}arcrole") != "https://xbrl.org/2023/arcrole/summation-item":
-                                val.modelXbrl.error("ESEF.3.4.1.IncorrectSummationItemArcroleUsed",
+                                val.modelXbrl.error("ESEF.3.4.1.incorrectSummationItemArcroleUsed",
                                                     _("Starting from the ESEF 2024 taxonomy, only calculation linkbases using the arcrole 'https://xbrl.org/2023/arcrole/summation-item' are permitted. Arcrole  %(arcrole)s has been found."),
                                                     arcrole=arc.get("{http://www.w3.org/1999/xlink}arcrole"))
                 if linkEltName == "definitionLink":

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -65,6 +65,7 @@
             "https://www.xbrl.org/lrr/",
             "http://www.xbrl.org/utr/",
             "https://www.xbrl.org/utr/",
+            "https://xbrl.org/2020/extensible-enumerations-2.0",
             "http://www.w3.org/1999/xlink/",
             "https://www.w3.org/1999/xlink/"
         ],
@@ -143,7 +144,9 @@
         ],
         "effectiveTaxonomyURLs": [
             "http://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd",
-            "https://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd"
+            "https://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd",
+            "http://www.esma.europa.eu/taxonomy/2024-03-27/esef_cor.xsd",
+            "https://www.esma.europa.eu/taxonomy/2024-03-27/esef_cor.xsd"
         ]
     },
     "AT": {


### PR DESCRIPTION
#### Reason for change
Reporting manual 2024 changes needed

Base Spec 2.1 requires validating all discovered taxonomies, previously base taxonomy validation was skipped.  A new option "skipBaseTaxonomyValidation" is added with default false, set true for prior behavior.

#### Description of change
See commit messages

Add skipBaseTaxonomyValidation (default false) for fully-conformant behavior.  (Was required in the past for some situations.)

#### Steps to Test
When available use conformance suite for reporting manual 2024 (estimated availability end 2024 to early 2025)

Also spot check other validations to ensure no change or serious timing impact for skipBaseTaxonomyValidation being false.

**review**:
@Arelle/arelle
