### PR TITLE
Fix extensibility of xBRL-CSV table templates.

### DIFF
--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -349,7 +349,7 @@ CsvMemberTypes = {
     "/tableTemplates/*/columns": dict,
     "/tableTemplates/*/decimals": (int,str),
     "/tableTemplates/*/dimensions": dict,
-    "/tableTemplates/*:*": (int,float,bool,str,dict,list,type(None),NoRecursionCheck,CheckPrefix), # custom extensions
+    "/tableTemplates/*/*:*": (int,float,bool,str,dict,list,type(None),NoRecursionCheck,CheckPrefix), # custom extensions
     "/tableTemplates/*/dimensions/concept": str,
     "/tableTemplates/*/dimensions/entity": str,
     "/tableTemplates/*/dimensions/period": str,


### PR DESCRIPTION
Fixes #1472

#### Reason for change

Bug fix / spec conformance.

#### Description of change

[xBRL-CSV permits](https://www.xbrl.org/Specification/xbrl-csv/REC-2021-10-13+errata-2023-04-19/xbrl-csv-REC-2021-10-13+corrected-errata-2023-04-19.html#sec-additional-properties) additional properties in "table template objects". Arelle was incorrectly allowing them in the `templates` object, rather than in individual table template objects.

#### Steps to Test

Confirm that samples on #1472 now open correctly.

**review**:
@Arelle/arelle
