### PR TITLE
Fix saveHtmlEbaTables plugin

### DIFF
--- a/arelle/ViewFileRenderedGrid.py
+++ b/arelle/ViewFileRenderedGrid.py
@@ -40,7 +40,7 @@ headerOmittedRollupAspects  = {
     Aspect.UNIT_MEASURES, Aspect.MULTIPLY_BY, Aspect.DIVIDE_BY}
 
 
-def viewRenderedGrid(modelXbrl, outfile, lang=None, viewTblELR=None, sourceView=None, diffToFile=False, cssExtras=""):
+def viewRenderedGrid(modelXbrl, outfile, lang=None, viewTblELR=None, sourceView=None, diffToFile=False, cssExtras="", table=None):
     modelXbrl.modelManager.showStatus(_("saving rendered tagle"))
     view = ViewRenderedGrid(modelXbrl, outfile, lang, cssExtras)
 
@@ -50,7 +50,7 @@ def viewRenderedGrid(modelXbrl, outfile, lang=None, viewTblELR=None, sourceView=
         else:
             lytMdlTblMdl = layoutTable(sourceView)
     else:
-        layoutTable(view)
+        layoutTable(view, table)
         lytMdlTblMdl = view.lytMdlTblMdl
     if view.tblElt is not None: # may be None if there is no table
         view.view(lytMdlTblMdl)

--- a/arelle/plugin/saveHtmlEBAtables.py
+++ b/arelle/plugin/saveHtmlEBAtables.py
@@ -67,10 +67,16 @@ table {background:#fff}
                 dts.modelManager.cntlr.addToLog("viewing: " + modelTable.id)
                 # for table file name, use table ELR
                 tblFile = os.path.join(os.path.dirname(indexFile), modelTable.id + ".html")
+                tableName = modelTable.id
+                if tableName.startswith("eba_t"):
+                    tableName = tableName.removeprefix("eba_t")
+                if tableName.startswith("srb_t"):
+                    tableName = tableName.removeprefix("srb_t")
                 viewRenderedGrid(dts,
                                  tblFile,
                                  lang=lang,
-                                 cssExtras=tblCssExtras)
+                                 cssExtras=tblCssExtras,
+                                 table=tableName)
 
                 # generaate menu entry
                 elt = etree.SubElement(listElt, "{http://www.w3.org/1999/xhtml}li")

--- a/arelle/rendering/RenderingLayout.py
+++ b/arelle/rendering/RenderingLayout.py
@@ -37,7 +37,7 @@ headerOmittedRollupAspects  = {
     Aspect.PERIOD_TYPE, Aspect.START, Aspect.END, Aspect.INSTANT,
     Aspect.UNIT_MEASURES, Aspect.MULTIPLY_BY, Aspect.DIVIDE_BY}
 
-def layoutTable(view):
+def layoutTable(view, table = None):
     view.modelXbrl.modelManager.showStatus(_("layout model generation"))
     viewTblELR = getattr(view, "tblELR", None)
 
@@ -45,6 +45,8 @@ def layoutTable(view):
         tblELRs = (viewTblELR,)
     else:
         tblELRs = sorted(view.modelXbrl.relationshipSet("Table-rendering").linkRoleUris)
+        if table is not None:
+            tblELRs = list(filter(lambda x: x.endswith(table), tblELRs))
 
     view.lytMdlTblMdl = LytMdlTableModel(view.modelXbrl.modelDocument.basename)
 


### PR DESCRIPTION
#### Reason for change
In the issue https://github.com/Arelle/Arelle/issues/1477, it is described that all tables appear in all files generated by the plugin

#### Description of change
I added a filter on table name to display only one table per file, by default the filter is empty and all tables are displayed like before

#### Steps to Test
Open any file from EBA reporting framework
Use plugin to generate html files

**review**:
@Arelle/arelle
