### PR TITLE
Add missing param to format_number XPath func

### DIFF
--- a/arelle/FunctionFn.py
+++ b/arelle/FunctionFn.py
@@ -845,7 +845,7 @@ def static_base_uri(xc, p, contextItem, args):
     raise fnFunctionNotAvailable()
 
 # added in XPATH 3
-def  format_number(xc, p, args):
+def format_number(xc, p, contextItem, args):
     if len(args) != 2: raise XPathContext.FunctionNumArgs()
     value = numericArg(xc, p, args, 0, missingArgFallback='NaN', emptyFallback='NaN')
     picture = stringArg(xc, args, 1, "xs:string", missingArgFallback='', emptyFallback='')


### PR DESCRIPTION
#### Reason for change
XPath functions [are passed 4 args](https://github.com/Arelle/Arelle/blob/59ae68cab76c93064ed7752f6fadae99603518ca/arelle/FunctionFn.py#L38). However, the format-number XPath function is defined to only accept 3 and raises a type error:
`TypeError: format_number() takes 3 positional arguments but 4 were given`

#### Description of change
* Add missing unused param to format_number function.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
