### PR TITLE
Adding support for EXG message prefixes

### DIFF
--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -754,8 +754,7 @@ def openFileStream(
     if PackageManager.isMappedUrl(filepath):  # type: ignore[no-untyped-call]
         filepath = PackageManager.mappedUrl(filepath)  # type: ignore[no-untyped-call]
     elif (
-            isHttpUrl(filepath)
-            and cntlr
+            cntlr
             and hasattr(cntlr, "modelManager")
         ): # may be called early in initialization for PluginManager
         filepath = cntlr.modelManager.disclosureSystem.mappedUrl(filepath)  # type: ignore[no-untyped-call]

--- a/arelle/ModelTestcaseObject.py
+++ b/arelle/ModelTestcaseObject.py
@@ -333,6 +333,8 @@ class ModelTestcaseVariation(ModelObject):
                 return expected
             for assertElement in XmlUtil.children(resultElement, None, "assert"):
                 num = assertElement.get("num")
+                if num.startswith("EXG."):
+                    return num
                 if num == "99999": # inline test, use name as expected
                     return assertElement.get("name")
                 if len(num) == 5:

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -654,6 +654,7 @@ class Validate:
                              (_exp == "EFM.6.04.03" and (testErr.startswith("xmlSchema:") or testErr.startswith("utr:") or testErr.startswith("xbrl.") or testErr.startswith("xlink:"))) or
                              (_exp == "EFM.6.05.35" and testErr.startswith("utre:")) or
                              (_exp.startswith("EFM.") and testErr.startswith(_exp)) or
+                             (_exp.startswith("EXG.") and testErr.startswith(_exp)) or
                              (_exp == "vere:invalidDTSIdentifier" and testErr.startswith("xbrl"))
                              ))):
                             _expMatched = True


### PR DESCRIPTION
#### Reason for change
Latest updates from the SEC

#### Description of change
Some EDGAR validations will now use the EXG prefix.

#### Steps to Test

**review**:
@Arelle/arelle
