### PR TITLE
Don't log file not found message on zip detection

### DIFF
--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -194,11 +194,14 @@ class FileSource:
                 if basefile:
                     with openFileStream(self.cntlr, basefile, 'rb') as fileStream:
                         self.isZip = zipfile.is_zipfile(fileStream)
+            except OSError:
+                # Can't load self.url content. It's not a zip file.
+                # We don't use os.path.isfile because self.url may be an embeded zip file.
+                pass
             except Exception as err:
-                # Log the error, but don't record a validation error.
+                # Log the error at info level (which is sent to the GUI log), but don't record a validation error.
                 # Validation is deferred to the validation classes. Filesource is unaware of the specific errors that should be raised.
                 self.logError(err)
-                pass
 
 
         # for SEC xml files, check if it's an EIS anyway


### PR DESCRIPTION
#### Reason for change
When extracting EDGAR iXBRL to XML, a non-zip file is created. In this case, the filesource logs an info message for “file not found” because the base file does not exist yet when we attempt to open it. This check is used to determine whether the file is an improperly named zip file. However, since info messages appear in the GUI messages window alongside actual errors, this can cause confusion.

#### Description of change
* Suppress OSError messages during zip file detection to prevent unnecessary info messages.

#### Steps to Test
1. Open the GUI.
2. Enable EDGAR/render.
3. Enable the EFM disclosure system.
4. Open an SEC report.
5. Confirm that “file not found” info messages no longer appear in the GUI messages box.

**review**:
@Arelle/arelle
