### PR TITLE
Add capture warnings option to RSS feed processing

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -314,7 +314,7 @@ def parseArgs(args):
                       help=_("If any filters are provided, any testcase variation path in the form {testcaseFilepath}:{testcaseVariationId} that doesn't pass any filter "
                              "will be skipped." ))
     parser.add_option("--testcaseResultsCaptureWarnings", "--testcaseresultscapturewarnings", action="store_true", dest="testcaseResultsCaptureWarnings",
-                      help=_("For testcase variations capture warning results, default is inconsistency or warning if there is any warning expected result.  "))
+                      help=_("For testcase variations and RSS feed items, capture warning results, default is inconsistency or warning if there is any warning expected result.  "))
     parser.add_option("--testcaseResultOptions", choices=("match-any", "match-all"), action="store", dest="testcaseResultOptions",
                       help=_("For testcase results, default is match any expected result, options to match any or match all expected result(s).  "))
     parser.add_option("--formulaRunIDs", "--formularunids", action="store", dest="formulaRunIDs", help=_("Specify formula/assertion IDs to run, separated by a '|' character, or a regex expression."))

--- a/arelle/DialogFormulaParameters.py
+++ b/arelle/DialogFormulaParameters.py
@@ -79,7 +79,7 @@ class DialogFormulaParameters(Toplevel):
         # checkbox entries
         label(frame, 1, y, "Parameter Trace:")
         label(frame, 1, y + 3, "API Calls Trace:")
-        label(frame, 1, y + 8, "Testcase Results:")
+        label(frame, 1, y + 8, "Testcase Results & RSS Items:")
         label(frame, 2, y, "Variable Set Trace:")
         label(frame, 3, y, "Variables Trace:")
         self.checkboxes = (

--- a/arelle/DialogRssWatch.py
+++ b/arelle/DialogRssWatch.py
@@ -146,7 +146,7 @@ class DialogRssWatch(Toplevel):
                     "Unsuccessful formula assertions",
                     "alertAssertionUnsuccessful"),
            checkbox(frame, 2, row+2,
-                    "Validation errors",
+                    "Validation errors (or warnings, see Formula Parameters)",
                     "alertValiditionError"),
            # Note: if adding to this list keep ModelFormulaObject.FormulaOptions in sync
            )

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -143,6 +143,10 @@ class Validate:
         self.modelXbrl.info("info", "RSS Feed", modelDocument=self.modelXbrl)
         from arelle.FileSource import openFileSource
         reloadCache = getattr(self.modelXbrl, "reloadCache", False)
+        if self.modelXbrl.modelManager.formulaOptions.testcaseResultsCaptureWarnings:
+            errorCaptureLevel = logging._checkLevel("WARNING")
+        else:
+            errorCaptureLevel = logging._checkLevel("INCONSISTENCY")# default is INCONSISTENCY
         for rssItem in self.modelXbrl.modelDocument.rssItems:
             if getattr(rssItem, "skipRssItem", False):
                 self.modelXbrl.info("info", _("skipping RSS Item %(accessionNumber)s %(formType)s %(companyName)s %(period)s"),
@@ -173,7 +177,7 @@ class Validate:
                                 _("RSS item validation exception: %(error)s, entry URL: %(instance)s"),
                                 modelXbrl=self.modelXbrl, instance=rssItemUrl, error=err)
                             continue # don't try to load this entry URL
-                    modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager, filesource, _("validating"), rssItem=rssItem)
+                    modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager, filesource, _("validating"), rssItem=rssItem, errorCaptureLevel=errorCaptureLevel)
                 for pluginXbrlMethod in pluginClassMethods("RssItem.Xbrl.Loaded"):
                     pluginXbrlMethod(modelXbrl, {}, rssItem)
                 if getattr(rssItem, "doNotProcessRSSitem", False) or modelXbrl.modelDocument is None:


### PR DESCRIPTION
#### Reason for change
RSS Feed would only show error messages under the result column in the CSV report.

#### Description of change
- CmdLine has updated description of --testcaseResultsCaptureWarnings to include both test cases and RSS feed items
- GUI Formula parameter option to capture warnings is now described for and works for RSS items
- RSS Watch dialog on error checkbox refers one to formula parameter to capture warnings as well
- RSS report actually captures the warnings along with errors

#### Steps to Test

**review**:
@Arelle/arelle
