### PR TITLE
Remove certain validations from running on multi-target danish validations

### DIFF
--- a/arelle/plugin/validate/DBA/rules/fr.py
+++ b/arelle/plugin/validate/DBA/rules/fr.py
@@ -20,6 +20,7 @@ from . import errorOnDateFactComparison, errorOnRequiredFact, getFactsWithDimens
     minimumRequiredFactsFound
 from ..PluginValidationDataExtension import PluginValidationDataExtension
 from ..ValidationPluginExtension import DANISH_CURRENCY_ID, ROUNDING_MARGIN, PERSONNEL_EXPENSE_THRESHOLD, REQUIRED_DISCLOSURE_OF_EQUITY_FACTS, REQUIRED_STATEMENT_OF_CHANGES_IN_EQUITY_FACTS
+from ..DisclosureSystems import STAND_ALONE_DISCLOSURE_SYSTEMS
 
 _: TypeGetText
 
@@ -77,6 +78,7 @@ def rule_fr7(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr20(
         pluginData: PluginValidationDataExtension,
@@ -177,6 +179,7 @@ def rule_fr25(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr33(
         pluginData: PluginValidationDataExtension,
@@ -219,6 +222,7 @@ def rule_fr33(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr34(
         pluginData: PluginValidationDataExtension,
@@ -254,6 +258,7 @@ def rule_fr34(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
  )
 def rule_fr35(
         pluginData: PluginValidationDataExtension,
@@ -336,6 +341,7 @@ def rule_fr37(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr41(
         pluginData: PluginValidationDataExtension,
@@ -392,6 +398,7 @@ def rule_fr41(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr48(
         pluginData: PluginValidationDataExtension,
@@ -423,6 +430,7 @@ def rule_fr48(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr52(
         pluginData: PluginValidationDataExtension,
@@ -497,6 +505,7 @@ def rule_fr53(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr56(
         pluginData: PluginValidationDataExtension,
@@ -549,6 +558,7 @@ def rule_fr56(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr57(
         pluginData: PluginValidationDataExtension,
@@ -816,6 +826,7 @@ def rule_fr59(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr63(
         pluginData: PluginValidationDataExtension,
@@ -854,6 +865,7 @@ def rule_fr63(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr71(
         pluginData: PluginValidationDataExtension,
@@ -1019,6 +1031,7 @@ def rule_fr74(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr75(
         pluginData: PluginValidationDataExtension,
@@ -1053,6 +1066,7 @@ def rule_fr75(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr77(
         pluginData: PluginValidationDataExtension,
@@ -1130,6 +1144,7 @@ def rule_fr81(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=STAND_ALONE_DISCLOSURE_SYSTEMS,
 )
 def rule_fr83(
         pluginData: PluginValidationDataExtension,


### PR DESCRIPTION
#### Reason for change
Multi-target validation for ARL does not include financial information and thus any validation that checks for financial information needs to not rum for multi-target validation

#### Steps to Test
CI

**review**:
@Arelle/arelle
