### PR TITLE
ESEF.1.4.1 doesn't check datatype namespace URIs

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -168,13 +168,13 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                         narrowerConcept = widerNarrowerRelSet.toModelObject(modelConcept)
 
                         # Transform the qname to str for the later join()
-                        widerTypes = set(str(r.toModelObject.typeQname) for r in widerConcept)
-                        narrowerTypes = set(str(r.fromModelObject.typeQname) for r in narrowerConcept)
+                        widerTypes = set(r.toModelObject.typeQname for r in widerConcept)
+                        narrowerTypes = set(r.fromModelObject.typeQname for r in narrowerConcept)
 
-                        if (narrowerTypes and narrowerTypes != {str(modelConcept.typeQname)}) or (widerTypes and widerTypes != {str(modelConcept.typeQname)}):
+                        if (narrowerTypes and narrowerTypes != {modelConcept.typeQname}) or (widerTypes and widerTypes != {modelConcept.typeQname}):
                             widerNarrowerType = "{} {}".format(
-                                "Wider: {}".format(", ".join(widerTypes)) if widerTypes else "",
-                                "Narrower: {}".format(", ".join(narrowerTypes)) if narrowerTypes else ""
+                                "Wider: {}".format(", ".join(t.clarkNotation for t in widerTypes)) if widerTypes else "",
+                                "Narrower: {}".format(", ".join(t.clarkNotation for t in narrowerTypes)) if narrowerTypes else ""
                             )
                             val.modelXbrl.warning("ESEF.1.4.1.differentExtensionDataType",
                                                 _("Issuers should anchor their extension elements to ESEF core taxonomy elements sharing the same data type. Concept: %(qname)s type: %(type)s %(widerNarrowerType)s"),

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
@@ -21,6 +21,11 @@ config = ConformanceSuiteConfig(
     ] + [
         package for year in [2017, 2019, 2020, 2021, 2022, 2024] for package in ESEF_PACKAGES[year]
     ],
+    expected_additional_testcase_errors={f"esef_conformance_suite_2024/tests/inline_xbrl/{s}": val for s, val in {
+        # Typo in the test case namespace declaration: incorrectly uses the Extensible Enumeration 1 namespace with the
+        # commonly used Extensible Enumeration 2 prefix: xmlns:enum2="http://xbrl.org/2014/extensible-enumerations"
+        'G2-4-1_1/index.xml:TC2_valid': frozenset({'differentExtensionDataType'}),
+    }.items()},
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2024',
     name=PurePath(__file__).stem,
     network_or_cache_required=False,


### PR DESCRIPTION
#### Reason for change
Arelle’s QName string representation follows a non-standard prefix:namespace format, making it unsuitable for equality checks. Because of this, the ESEF 2.4.1 validation checks that data type prefixes and local names match instead of the namespace URI and local name.

#### Description of change
Perform direct QName comparison between data types in the ESEF 1.4.1 validation.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
