### PR TITLE
Consolidate and fix code for handling schema whitespace normalization replace and collapse

### DIFF
--- a/arelle/FunctionFn.py
+++ b/arelle/FunctionFn.py
@@ -193,10 +193,14 @@ def string_length(xc, p, contextItem, args):
     if len(args) > 1: raise XPathContext.FunctionNumArgs()
     return len( stringArg(xc, args, 0, "xs:string", missingArgFallback=contextItem) )
 
-nonSpacePattern = re.compile(r"\S+")
+
 def normalize_space(xc, p, contextItem, args):
+    # https://www.w3.org/TR/xpath-functions/#func-normalize-space
+    # Defined to be the same as whitespace = collapse in XML schema
+    # So we use the same implementation
     if len(args) > 1: raise XPathContext.FunctionNumArgs()
-    return ' '.join( nonSpacePattern.findall( stringArg(xc, args, 0, "xs:string", missingArgFallback=contextItem) ) )
+    return XmlUtil.collapseWhitespace(stringArg(xc, args, 0, "xs:string", missingArgFallback=contextItem))
+
 
 def normalize_unicode(xc, p, contextItem, args):
     raise fnFunctionNotAvailable()

--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -42,6 +42,7 @@ from arelle.Aspect import Aspect
 from arelle.ValidateXbrlCalcs import inferredPrecision, inferredDecimals, roundValue, rangeValue, ValidateCalcsMode
 from arelle.XmlValidateConst import UNVALIDATED, INVALID, VALID
 from arelle.XmlValidate import validate as xmlValidate
+from arelle.XmlUtil import collapseWhitespace
 from arelle.PrototypeInstanceObject import DimValuePrototype
 from math import isnan, isinf
 from arelle.ModelObject import ModelObject
@@ -634,13 +635,21 @@ class ModelInlineValueObject:
     @property
     def rawValue(self):
         ixEscape = self.get("escape") in ("true", "1")
-        return XmlUtil.innerText(
+        raw = XmlUtil.innerText(
             self,
             ixExclude="tuple" if self.elementQname == XbrlConst.qnIXbrl11Tuple else "html",
             ixEscape=ixEscape,
             ixContinuation=(self.elementQname == XbrlConst.qnIXbrl11NonNumeric),
             ixResolveUris=ixEscape,
-            strip=(self.format is not None))  # transforms are whitespace-collapse, otherwise it is preserved.
+            strip = False)
+        if self.format is not None:
+            # Most transforms are whitespace-collapse, so do that now.
+            #
+            # TODO: this collapsing should be moved to the individual
+            # transformation functions in order to support non-collapsing
+            # transformations
+            raw = collapseWhitespace(raw)
+        return raw
 
     @property
     def value(self):

--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -424,8 +424,12 @@ class ModelFact(ModelObject):
                         return Locale.format(self.modelXbrl.locale, "{:.{}f}", (num,dec), True)
                 except ValueError:
                     return "(error)"
+            # non-numeric fact at this point
             if len(val) == 0: # zero length string for HMRC fixed fact
                 return "(reported)"
+            if self.xValid >= VALID:
+                # Prefer the PSVI value
+                return str(self.xValue)
             return val
         except Exception as ex:
             return str(ex)  # could be transform value of inline fact
@@ -576,7 +580,7 @@ class ModelFact(ModelObject):
                  ("decimals", self.decimals),
                  ("precision", self.precision),
                  ("xsi:nil", self.xsiNil),
-                 ("value", self.effectiveValue.strip()))
+                 ("value", self.effectiveValue))
                  if self.isItem else () ))
 
     def __repr__(self):
@@ -669,7 +673,10 @@ class ModelInlineValueObject:
                 self._ixValue = v
             else:
                 if self.localName == "nonNumeric":
-                    self._ixValue = v
+                    if self.xValid >= VALID:
+                        self._ixValue = str(self.xValue)
+                    else:
+                        self._ixValue = v
                 elif self.localName == "tuple":
                     self._ixValue = ""
                 elif self.localName == "fraction":

--- a/arelle/ViewFileFactList.py
+++ b/arelle/ViewFileFactList.py
@@ -116,7 +116,7 @@ class ViewFacts(ViewFile.View):
                         elif col == "Lang":
                             cols.append( lang )
                         elif col == "Value":
-                            cols.append( "(nil)" if modelFact.xsiNil == "true" else modelFact.effectiveValue.strip() )
+                            cols.append( "(nil)" if modelFact.xsiNil == "true" else modelFact.effectiveValue )
                         elif col == "EntityScheme":
                             cols.append( modelFact.context.entityIdentifier[0] )
                         elif col == "EntityIdentifier":

--- a/arelle/ViewWinFactList.py
+++ b/arelle/ViewWinFactList.py
@@ -108,7 +108,7 @@ class ViewFactList(ViewWinTree.ViewTree):
                     self.treeView.set(node, "language", lang)
                     if self.footnotesRelationshipSet.fromModelObject(modelFact):
                         self.treeView.set(node, "footnoted", "*")
-                    self.treeView.set(node, "value", modelFact.effectiveValue.strip())
+                    self.treeView.set(node, "value", modelFact.effectiveValue)
                 self.id += 1;
                 n += 1
                 self.viewFacts(modelFact.modelTupleFacts, node, n)

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -202,9 +202,9 @@ def innerText(
     try:
         text = "".join(text for text in innerTextNodes(element, ixExclude, ixEscape, ixContinuation, ixResolveUris))
         if strip:
-            # Defined as removing leading and trailing [ \t\r\n], the same
-            # characters as xs:whiteSpace operates on. Note, this is a different
-            # normlization to any of whiteSpace = preserve/replace/collapse
+            # For legacy reasons, strip=True removes leading/trailing
+            # whitespace even though most callers probably want
+            # collapseWhitespace semantics instead.
             return text.strip(" \t\r\n")
         return text
     except (AttributeError, TypeError):

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -202,7 +202,10 @@ def innerText(
     try:
         text = "".join(text for text in innerTextNodes(element, ixExclude, ixEscape, ixContinuation, ixResolveUris))
         if strip:
-            return text.strip(" \t\r\n") # strip follows xml whitespace collapse, only blank, tab and newlines
+            # Defined as removing leading and trailing [ \t\r\n], the same
+            # characters as xs:whiteSpace operates on. Note, this is a different
+            # normlization to any of whiteSpace = preserve/replace/collapse
+            return text.strip(" \t\r\n")
         return text
     except (AttributeError, TypeError):
         return ""

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -28,7 +28,10 @@ xmlDeclarationPattern = re.compile(r"(\s+)?(<\?xml[^><\?]*\?>)", re.DOTALL)
 xmlEncodingPattern = re.compile(r"\s*<\?xml\s.*encoding=['\"]([^'\"]*)['\"].*\?>")
 xpointerFragmentIdentifierPattern = re.compile(r"([\w.]+)(\(([^)]*)\))?")
 xmlnsStripPattern = re.compile(r'\s*xmlns(:[\w.-]+)?="[^"]*"')
-nonSpacePattern = re.compile(r"\S+")
+
+_consecutiveSpacePattern = re.compile(r" {2,}")
+_replaceWhitespaceTable = str.maketrans("\t\n\r", " " * 3)
+
 
 class XmlDeclarationLocationException(Exception):
     def __init__(self) -> None:
@@ -297,8 +300,16 @@ def escapedText(text: str) -> str:
                    else c
                    for c in text)
 
+
+def replaceWhitespace(s: str) -> str:
+    # https://www.w3.org/TR/xmlschema-1/#d0e1654
+    return s.translate(_replaceWhitespaceTable)
+
+
 def collapseWhitespace(s: str) -> str:
-    return ' '.join( nonSpacePattern.findall(s) )
+    # https://www.w3.org/TR/xmlschema-1/#d0e1654
+    return " ".join(_consecutiveSpacePattern.split(replaceWhitespace(s))).strip(" ")
+
 
 def parentId(
     element: ModelObject,

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -75,8 +75,6 @@ modelGroupCompositorTitle: Callable[[Any], str] | None = None
 ModelInlineValueObject: type[Any] | None = None
 ixMsgCode: Callable[..., str] | None = None
 
-normalizeWhitespacePattern = re_compile(r"[\t\n\r]") # replace tab, line feed, return with space (XML Schema Rules, note: does not include NBSP)
-collapseWhitespacePattern = re_compile(r"[ \t\n\r]+") # collapse multiple spaces, tabs, line feeds and returns to single space
 entirelyWhitespacePattern = re_compile(r"^[ \t\n\r]+$") # collapse multiple spaces, tabs, line feeds and returns to single space
 languagePattern = re_compile("[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$")
 NCNamePattern = re_compile("^[_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF]"
@@ -429,9 +427,9 @@ def validateValue(
                 if "whiteSpace" in facets:
                     whitespaceReplace, whitespaceCollapse = {"preserve":(False,False), "replace":(True,False), "collapse":(False,True)}[facets["whiteSpace"]]
             if whitespaceReplace:
-                value = normalizeWhitespacePattern.sub(' ', value) # replace tab, line feed, return with space
+                value = XmlUtil.replaceWhitespace(value)
             elif whitespaceCollapse:
-                value = ' '.join(value.split())
+                value = XmlUtil.collapseWhitespace(value)
             if baseXsdType == "noContent":
                 if len(value) > 0 and not entirelyWhitespacePattern.match(value): # only xml schema pattern whitespaces removed
                     raise ValueError("value content not permitted")

--- a/arelle/formula/XPathContext.py
+++ b/arelle/formula/XPathContext.py
@@ -927,8 +927,10 @@ class XPathContext:
             x = qname(e, v)
         elif baseXsdType == "anyURI":
             x = anyURI(v.strip())
+        elif baseXsdType == "normalizedString":
+            # https://www.w3.org/TR/xmlschema-2/#normalizedString
+            x = XmlUtil.replaceWhitespace(v)
         elif baseXsdType in (
-            "normalizedString",
             "token",
             "language",
             "NMTOKEN",
@@ -938,7 +940,9 @@ class XPathContext:
             "IDREF",
             "ENTITY",
         ):
-            x = v.strip()
+            # https://www.w3.org/TR/xmlschema-2/#token
+            # That is token and its derived built-in types
+            x = XmlUtil.collapseWhitespace(v)
         elif baseXsdType == "XBRLI_DATEUNION":
             x = dateTime(v, type=DATEUNION)
         elif baseXsdType == "date":

--- a/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
@@ -53,8 +53,8 @@ from arelle.PluginManager import pluginClassMethods
 from arelle.PrototypeInstanceObject import DimValuePrototype
 from arelle.PythonUtil import flattenSequence
 from arelle.ValidateXbrlCalcs import roundValue
-from arelle.XmlValidate import collapseWhitespacePattern, UNVALIDATED, VALID
-from arelle.XmlUtil import elementChildSequence, xmlstring, addQnameValue, addChild
+from arelle.XmlValidate import UNVALIDATED, VALID
+from arelle.XmlUtil import elementChildSequence, xmlstring, addQnameValue, addChild, collapseWhitespace
 from arelle import XbrlConst, ValidateXbrlDimensions
 from arelle.UrlUtil import authority, ensureUrl
 from .SqlDb import XPDBException, isSqlConnection, SqlDbConnection
@@ -1092,7 +1092,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                                   fact.decimals,
                                   roundValue(fact.value, fact.precision, fact.decimals) if fact.isNumeric and not fact.isNil else None,
                                   fact.xmlLang if not fact.isNumeric and not fact.isNil else None,
-                                  collapseWhitespacePattern.sub(' ', fact.value.strip()) if fact.value is not None else None,
+                                  collapseWhitespace(value) if fact.value is not None else None,
                                   fact.value,
                                   ))
             table = self.getTable('fact', 'fact_pk',
@@ -1149,7 +1149,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                                      None if isinstance(toObj, ModelFact) else toObj.role,
                                      self.factId[(self.documentIds[toObj.modelDocument], elementChildSequence(toObj))] if isinstance(toObj, ModelFact) else None,
                                      None if isinstance(toObj, ModelFact) else toObj.xmlLang,
-                                     None if isinstance(toObj, ModelFact) else collapseWhitespacePattern.sub(' ', xmlstring(toObj, stripXmlns=True, contentsOnly=True, includeText=True)),
+                                     None if isinstance(toObj, ModelFact) else collapseWhitespace(xmlstring(toObj, stripXmlns=True, contentsOnly=True, includeText=True)),
                                      None if isinstance(toObj, ModelFact) else xmlstring(toObj, stripXmlns=True, contentsOnly=True, includeText=True))
                                     for fact in self.modelXbrl.factsInInstance
                                     for footnoteRel in footnotesRelationshipSet.fromModelObject(fact)

--- a/tests/unit_tests/arelle/test_functionfn.py
+++ b/tests/unit_tests/arelle/test_functionfn.py
@@ -1,8 +1,10 @@
 import pytest
 import regex
 
-from arelle.FunctionFn import tokenize
+from arelle.FunctionFn import tokenize, normalize_space
 from arelle.formula import XPathContext
+
+from test_xmlutil import COLLAPSE_WHITESPACE_TESTS
 
 # See https://www.w3.org/TR/xpath-functions/#func-tokenize for test sources:
 TOKENIZE_TESTS = [
@@ -53,3 +55,33 @@ def test_tokenize(args, expected, raises):
     else:
         with pytest.raises(XPathContext.XPathException, match=regex.escape(raises)):
             result = tokenize(xc, p, contextItem, args)
+
+
+@pytest.mark.parametrize("test,expected", COLLAPSE_WHITESPACE_TESTS)
+def test_normalize_whitespace(test, expected):
+    xc = None
+    p = None
+    contextItem = None
+    args = (test,)
+    result = normalize_space(xc, p, contextItem, args)
+    assert result == expected
+
+
+XPATH_NORMALIZE_SPACE_EXAMPLES = {
+    (
+        (
+            " The    wealthy curled darlings                                         of    our    nation. ",
+        ),
+        "The wealthy curled darlings of our nation.",
+    ),
+    (((),), ""),
+}
+
+
+@pytest.mark.parametrize("args,expected", XPATH_NORMALIZE_SPACE_EXAMPLES)
+def test_normalize_whitespace_examples(args, expected):
+    xc = None
+    p = None
+    contextItem = None
+    result = normalize_space(xc, p, contextItem, args)
+    assert result == expected

--- a/tests/unit_tests/arelle/test_xmlutil.py
+++ b/tests/unit_tests/arelle/test_xmlutil.py
@@ -39,11 +39,12 @@ REPLACE_WHITESPACE_TESTS = [
     ("\n", " "),
     ("\r", " "),
     ("\t", " "),
+    ("\r\t\n", " " * 3),
+    ("\t\t \n\n \r\r", " " * 8),
+    ("\r \n \t", " " * 5),
     # literal or entity \v and \f are illegal in XML but we shouldn't be touching them
     ("\r\v\t", " \v "),
     ("\r\f\t", " \f "),
-    ("\r\t\n", "   "),
-    ("\t\t \n\n \r\r", " " * 8),
     # Python's whitespace (\s, str.isspace) definition includes em space (U+2003)
     # but XSD replace does not so we shouldn't be touching it
     ("1\u2003", "1\u2003"),
@@ -64,20 +65,20 @@ COLLAPSE_WHITESPACE_TESTS = [
     ("\t", ""),
     ("\r\t\n", ""),
     ("\t\t \n\n \r\r", ""),
-    (" " * 10, ""),
-    (" " * 10 + "1", "1"),
-    (" " * 10 + "1  1", "1 1"),
-    (" " * 10 + "1  1" + " " * 10, "1 1"),
-    ("\r \n \t", ""),
     ("\r \n \t", ""),
     # literal or entity \v and \f are illegal in XML but we shouldn't be touching them
     ("\r\v\t", "\v"),
     ("\r\f\t", "\f"),
-    (" x  xm   xml    xmln     ", "x xm xml xmln"),
-    ("time: \n\tround\n\ttuit  \r\n", "time: round tuit"),
     # Python's whitespace (\s, str.strip) definition includes em space (U+2003)
     # but XSD collapse does not so we shouldn't be touching it
     (" \u2003 \u2003  ", "\u2003 \u2003"),
+    (" " * 10, ""),
+    (" " * 10 + "1", "1"),
+    (" " * 10 + "1  1", "1 1"),
+    (" " * 10 + "1  1" + " " * 10, "1 1"),
+    ("  \r\n  the \tspace  \t\nis  \n  right  \r\n\r\n", "the space is right"),
+    (" x  xm   xml    xmln     ", "x xm xml xmln"),
+    ("time: \n\tround\n\ttuit  \r\n", "time: round tuit"),
 ]
 
 

--- a/tests/unit_tests/arelle/test_xmlutil.py
+++ b/tests/unit_tests/arelle/test_xmlutil.py
@@ -6,6 +6,7 @@ from arelle.ModelValue import qname
 from arelle.XmlUtil import (
     escapedNode,
     collapseWhitespace,
+    replaceWhitespace,
 )
 from arelle.XhtmlValidate import (
     htmlEltUriAttrs,
@@ -34,6 +35,24 @@ def test_opaque_uris_not_path_normed():
     assert node == f'<img src="{uri}">'
 
 
+REPLACE_WHITESPACE_TESTS = [
+    ("\n", " "),
+    ("\r", " "),
+    ("\t", " "),
+    ("\r\v\t", " \v "),
+    ("\r\t\n", "   "),
+    ("\t\t \n\n \r\r", " " * 8),
+    (" m u s h r o o m  ", " m u s h r o o m  "),
+    (" m u s h\tr o o m  ", " m u s h r o o m  "),
+]
+
+
+@pytest.mark.parametrize("value, expected", REPLACE_WHITESPACE_TESTS)
+def test_replaceWhitespace(value, expected):
+    result = replaceWhitespace(value)
+    assert result == expected, f"""Input: "{repr(value)}"; Output: "{repr(result)}"; Wanted: "{repr(expected)}" """
+
+
 COLLAPSE_WHITESPACE_TESTS = [
     ("\n", ""),
     ("\r", ""),
@@ -46,9 +65,11 @@ COLLAPSE_WHITESPACE_TESTS = [
     (" " * 10 + "1  1" + " " * 10, "1 1"),
     ("\r \n \t", ""),
     ("\r \n \t", ""),
-# not working tests
-#   ("\r\v\t", "\v"),
-#   ("\v\f", "\v\f"),
+    ("\r\v\t", "\v"),
+    ("\r \f \t", "\f"),
+    ("\v\f", "\v\f"),
+    ("\v  \f", "\v \f"),
+    ("\n \f \v \f \n", "\f \v \f"),
     (" x  xm   xml    xmln     ", "x xm xml xmln"),
     ("time: \n\tround\n\ttuit  \r\n", "time: round tuit")
 ]
@@ -57,4 +78,4 @@ COLLAPSE_WHITESPACE_TESTS = [
 @pytest.mark.parametrize("value, expected", COLLAPSE_WHITESPACE_TESTS)
 def test_collapseWhitespace(value, expected):
     result = collapseWhitespace(value)
-    assert result == expected, f"Original value: {repr(value)} became {repr(result)} ; wanted {repr(expected)}"
+    assert result == expected, f"""Input: "{repr(value)}"; Output: "{repr(result)}"; Wanted: "{repr(expected)}" """

--- a/tests/unit_tests/arelle/test_xmlutil.py
+++ b/tests/unit_tests/arelle/test_xmlutil.py
@@ -39,9 +39,14 @@ REPLACE_WHITESPACE_TESTS = [
     ("\n", " "),
     ("\r", " "),
     ("\t", " "),
+    # literal or entity \v and \f are illegal in XML but we shouldn't be touching them
     ("\r\v\t", " \v "),
+    ("\r\f\t", " \f "),
     ("\r\t\n", "   "),
     ("\t\t \n\n \r\r", " " * 8),
+    # Python's whitespace (\s, str.isspace) definition includes em space (U+2003)
+    # but XSD replace does not so we shouldn't be touching it
+    ("1\u2003", "1\u2003"),
     (" m u s h r o o m  ", " m u s h r o o m  "),
     (" m u s h\tr o o m  ", " m u s h r o o m  "),
 ]
@@ -50,7 +55,7 @@ REPLACE_WHITESPACE_TESTS = [
 @pytest.mark.parametrize("value, expected", REPLACE_WHITESPACE_TESTS)
 def test_replaceWhitespace(value, expected):
     result = replaceWhitespace(value)
-    assert result == expected, f"""Input: "{repr(value)}"; Output: "{repr(result)}"; Wanted: "{repr(expected)}" """
+    assert result == expected
 
 
 COLLAPSE_WHITESPACE_TESTS = [
@@ -65,17 +70,18 @@ COLLAPSE_WHITESPACE_TESTS = [
     (" " * 10 + "1  1" + " " * 10, "1 1"),
     ("\r \n \t", ""),
     ("\r \n \t", ""),
+    # literal or entity \v and \f are illegal in XML but we shouldn't be touching them
     ("\r\v\t", "\v"),
-    ("\r \f \t", "\f"),
-    ("\v\f", "\v\f"),
-    ("\v  \f", "\v \f"),
-    ("\n \f \v \f \n", "\f \v \f"),
+    ("\r\f\t", "\f"),
     (" x  xm   xml    xmln     ", "x xm xml xmln"),
-    ("time: \n\tround\n\ttuit  \r\n", "time: round tuit")
+    ("time: \n\tround\n\ttuit  \r\n", "time: round tuit"),
+    # Python's whitespace (\s, str.strip) definition includes em space (U+2003)
+    # but XSD collapse does not so we shouldn't be touching it
+    (" \u2003 \u2003  ", "\u2003 \u2003"),
 ]
 
 
 @pytest.mark.parametrize("value, expected", COLLAPSE_WHITESPACE_TESTS)
 def test_collapseWhitespace(value, expected):
     result = collapseWhitespace(value)
-    assert result == expected, f"""Input: "{repr(value)}"; Output: "{repr(result)}"; Wanted: "{repr(expected)}" """
+    assert result == expected


### PR DESCRIPTION
#### Reason for change
There are a variety of implementations of schema whitespace normalization, in particular replace and collapse, through the Arelle codebase. Some of them accidentally do too much, too little or both. For example, `str.strip()` (the no argument variant) both does too much by removing all leading and trailing whitespace characters and does too little by not replacing and/or collapsing the relevant whitespace characters when they are inside the string body.

References:
- https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/datatypes.html#rf-whiteSpace
- https://www.w3.org/TR/xmlschema-1/#d0e1654

#### Description of change
Update `XmlUtil.collapseWhitespace` and add `XmlUtil.replaceWhitespace` and use them in place of various other implementations in the codebase. With `XmlUtil.replaceWhitespace`, we make use of `str.translate`  as it's about 10x faster than a regex. With `XmlUtil.collapseWhitespace`, we don't need to find every space, just every run of two or more spaces, so we avoid having to split & join any run of already collapsed text.

Change `ModelFact.effectiveValue` to prefer using the PSVI value (`xValue`) for non-numeric facts so that the normalized fact values are displayed.


#### Steps to Test

1. Download [sample_report_and_taxonomy.zip](https://github.com/user-attachments/files/19060800/sample_report_and_taxonomy.zip)
2. Open it in a published release of Arelle in the GUI. You can see the first three fact values all look the same despite the underlying data types meaning they should look different post schema validation. The values are not actually the raw values either due to the `effectiveValue.strip()` calls. If you don't like the GUI, just use `--facts` and dump the facts to CSV to see the same thing.
3. It will look a bit like this ![arelle-pre-whitespace-fixes](https://github.com/user-attachments/assets/1cefa8a4-9266-4033-b89f-c73881b49ca3)
4. Try doing the same thing in a build with this set of changes in. It will look a bit like this ![arelle-post-whitespace-fixes](https://github.com/user-attachments/assets/6ea86638-972d-4d14-8e31-c486b7be4463)


**review**:
@Arelle/arelle
