### PR TITLE
When running testcases and null message code (Xule) prevent testcase crash

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -1012,8 +1012,8 @@ class ModelXbrl:
 
         for argCode in messageCodes if isinstance(messageCodes,tuple) else (messageCodes,):
             if (isinstance(argCode, ModelValue.QName) or
-                (_validationType and argCode.startswith(_validationType)) or
-                (not _exclusiveTypesPattern or _exclusiveTypesPattern.match(argCode) == None)):
+                (_validationType and argCode and argCode.startswith(_validationType)) or
+                (not _exclusiveTypesPattern or _exclusiveTypesPattern.match(argCode or "") == None)):
                 effectiveMessageCode = argCode
                 break
         return effectiveMessageCode


### PR DESCRIPTION
#### Reason for change
A null message code could cause an exception in ModelXbrl.

