### PR TITLE
Add missing validation that if ix:nonFraction has a text node child, it must be a non-empty string.

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -701,7 +701,7 @@ class ModelInlineValueObject:
                         num = Decimal(v)
                     except (ValueError, InvalidOperation):
                         self.setInvalid()
-                        raise ValueError("Invalid value for {} number: {}".format(self.localName, v))
+                        raise ValueError("Invalid value for {} number: '{}'".format(self.localName, v))
                     try:
                         scale = self.scale
                         if scale is not None:
@@ -717,7 +717,7 @@ class ModelInlineValueObject:
                             self._ixValue = "{:f}".format(num)
                     except (ValueError, InvalidOperation):
                         self.setInvalid()
-                        raise ValueError("Invalid value for {} scale {} for number {}".format(self.localName, scale, v))
+                        raise ValueError("Invalid value for {} scale '{}' for number '{}'".format(self.localName, scale, v))
             return self._ixValue
 
     @property

--- a/arelle/ValidateXbrlDTS.py
+++ b/arelle/ValidateXbrlDTS.py
@@ -975,6 +975,10 @@ def checkElements(val, modelDocument, parent):
                                 modelObject=(elt,e2))
                     else:
                         c = XmlUtil.children(elt, '*', '*')
+                        if not c and elt.text is None:
+                            val.modelXbrl.error(ixMsgCode("nonFraction", elt, sect="constraint"),
+                                _("Inline XBRL ix:nonFraction The text node child, if present, MUST be a non-empty string."),
+                                modelObject=elt)
                         if c and (len(c) != 1 or c[0].namespaceURI != elt.namespaceURI or c[0].localName != "nonFraction"):
                             val.modelXbrl.error(ixMsgCode("nonFractionChildren", elt, sect="validation"),
                                 _("Inline XBRL nil ix:nonFraction may only have one child ix:nonFraction"),

--- a/arelle/ValidateXbrlDTS.py
+++ b/arelle/ValidateXbrlDTS.py
@@ -975,7 +975,7 @@ def checkElements(val, modelDocument, parent):
                                 modelObject=(elt,e2))
                     else:
                         c = XmlUtil.children(elt, '*', '*')
-                        if not c and elt.text is None:
+                        if not c and XmlUtil.innerText(elt, strip = False) == '':
                             val.modelXbrl.error(ixMsgCode("nonFraction", elt, sect="constraint"),
                                 _("Inline XBRL ix:nonFraction The text node child, if present, MUST be a non-empty string."),
                                 modelObject=elt)


### PR DESCRIPTION
#### Reason for change
Increase Inline XBRL 1.1 Specification Conformance by adding missing validation. Fixes #1562 

#### Description of change
Check that the `ix:nonFraction` element is not nil, has no children and that the text node child is empty … if so raise `[ix11.10.1.1:nonFraction]`

#### Steps to Test

1. Open [sample_report_and_taxonomy_nonfraction.zip](https://github.com/user-attachments/files/19096420/sample_report_and_taxonomy_nonfraction.zip)
2. Arelle should raise two `[ix11.10.1.1:nonFraction]` but only one `[xmlSchema:valueError]` as the `fixed-zero` transform on one of the facts prevents the value error

**review**:
@Arelle/arelle
