### PR TITLE
Format Boolean fact values as lowercase

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -430,6 +430,8 @@ class ModelFact(ModelObject):
                 return "(reported)"
             if self.xValid >= VALID:
                 # Prefer the PSVI value
+                if isinstance(self.xValue, bool):
+                    return str(self.xValue).lower()
                 return str(self.xValue)
             return val
         except Exception as ex:


### PR DESCRIPTION
#### Reason for change
A recent change to effectiveValue used `str(xValue)`. However, while in Python `str(bool)` returns `True/False`, XML Boolean values are lowercase `true/false`.

effectiveValue is used for rendering fact values within the GUI and for formatting values in the XML log.

#### Description of change
Render boolean values using their XML valid format.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
