### PR TITLE
Taxonomy Package autoloader

### DIFF
--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -20,6 +20,7 @@ from arelle.packages.PackageType import PackageType
 from arelle.typing import TypeGetText
 from arelle.UrlUtil import isAbsolute, isHttpUrl
 from arelle.XmlValidate import lxmlResolvingParser
+pluginClassMethods = None
 
 if TYPE_CHECKING:
     from arelle.Cntlr import Cntlr
@@ -343,6 +344,7 @@ _cntlr = None
 
 def init(cntlr: Cntlr, loadPackagesConfig: bool = True) -> None:
     global packagesJsonFile, packagesConfig, packagesMappings, _cntlr
+
     if loadPackagesConfig:
         try:
             packagesJsonFile = cntlr.userAppDir + os.sep + "taxonomyPackages.json"
@@ -624,6 +626,11 @@ def rebuildRemappings(cntlr):
 
 
 def isMappedUrl(url):
+    global pluginClassMethods
+    if pluginClassMethods is None:
+        from arelle.PluginManager import pluginClassMethods
+    for pluginMethod in pluginClassMethods("TaxonomyPackage.AutoLoad"):
+        pluginMethod(_cntlr, packagesConfig, url)
     return (packagesConfig is not None and url is not None and
             any(url.startswith(mapFrom) and not url.startswith(mapTo) # prevent recursion in mapping for url hosted Packages
                 for mapFrom, mapTo in packagesConfig.get('remappings', {}).items()))

--- a/arelle/plugin/txmyPkgAutoLoad.py
+++ b/arelle/plugin/txmyPkgAutoLoad.py
@@ -1,0 +1,47 @@
+"""
+
+Auto load taxonomy package for entry points in XBRL Taxonomy Registry (via STANDARD_PACKAGES_URL).
+
+See COPYRIGHT.md for copyright information.
+"""
+
+import json
+
+from arelle import PackageManager
+from arelle.DialogPackageManager import STANDARD_PACKAGES_URL
+from arelle.Version import authorLabel, copyrightLabel
+
+entryPointsPackageUrl = None
+
+def taxonomyPackageAutoLoad(_cntlr, packagesConfig, url):
+    global entryPointsPackageUrl
+    if packagesConfig is not None and url is not None and url.startswith("http"):
+        if entryPointsPackageUrl is None: # load standard taxonomy packages
+            entryPointsPackageUrl = {}
+            with open(_cntlr.webCache.getfilename(STANDARD_PACKAGES_URL, reload=True), 'r', errors='replace') as fh:
+                regPkgs = json.load(fh) # always reload
+            for pkgTxmy in regPkgs.get("taxonomies", []):
+                _url = pkgTxmy.get("Links",{}).get("AuthoritativeURL")
+                if _url.endswith(".zip"):
+                    # Ignore taxonomies that lack a direct download link.
+                    # Although future valid taxonomy download links from the registry might not have a ".zip" extension,
+                    # as of October 27th, 2024, all links that without a zip file extension have been invalid.
+                    for _ep in pkgTxmy.get("EntryPoints") or ():
+                        for _doc in _ep.get("EntryPointDocuments") or ():
+                            entryPointsPackageUrl[_doc] = _url
+        if url in entryPointsPackageUrl and not any(
+            url.startswith(mapFrom) and not url.startswith(mapTo)
+            for mapFrom, mapTo in packagesConfig.get('remappings', {}).items()):
+                #print(f"loading package {url}")
+                PackageManager.addPackage(_cntlr, entryPointsPackageUrl[url])
+
+__pluginInfo__ = {
+    "name": "Taxonomy Package Auto Load",
+    "version": "1.0",
+    "description": "This plug-in auto loads taxonomy packages from XBRL registry.",
+    "license": "Apache-2",
+    "author": authorLabel,
+    "copyright": copyrightLabel,
+    # classes of mount points (required)
+    "TaxonomyPackage.AutoLoad": taxonomyPackageAutoLoad,
+}


### PR DESCRIPTION
#### Reason for change
It's a PIA to specify taxonomy packages manually with the GUI, or to list them out in the cmd line, when they are loadable from the XBRL Taxonomy Registry.

#### Description of change
This plugin grabs the XBRL Taxonomy Packages Registry and checks all references to http[s] URLs to see if any appear as a taxonomy package entry point.  If found to be an entry point and the defining taxonomy package isn't loaded, calls the TaxonomyPackage loader for the package.

If the taxonomy package is malformed or has mappings conflicting with prior-loaded taxonomy packages this will raise an 
Arelle warning.

(Suggest that there should be a CI script at XII which fires up arelle to load every taxonomy package in the registry in a single run, and give black stars to those raising mapping conflicts.)

(If operating with a preview unpublished taxonomy package not yet in Registry, it still has to be manually specified by GUI or cmd line.)

Please see if you can come up with a shorter or better name for the plugin and its methods.

#### Steps to Test
Suggest:
  1. Clean out cache (GUI tools menu).
  2. Try an instance with entry points which are in a package in the registry (us-gaap, srt, ifrs, etc).
  3. Verify that package was inserted into cache and entry point file was not inserted into cache (and that nothing else broke).

**review**:
@Arelle/arelle
