### PR TITLE
Removed unused import to tkinter.tix

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -25,7 +25,6 @@ try:
     import syslog
 except ImportError:
     syslog = None
-import tkinter.tix
 import tkinter.filedialog
 import tkinter.messagebox, traceback
 import tkinter.simpledialog
@@ -306,7 +305,6 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.statusbarTimerId  = self.statusbar.after(5000, self.uiClearStatusTimerEvent)
         self.statusbar.grid(row=2, column=0, columnspan=2, sticky=EW)
 
-        #self.balloon = tkinter.tix.Balloon(windowFrame, statusbar=self.statusbar)
         self.toolbar_images = []
         toolbar = Frame(windowFrame)
         menubarColumn = 0


### PR DESCRIPTION
#### Reason for change
Resolves #1574 

> [Deprecated](https://docs.python.org/3.12/library/tkinter.tix.html) since version 3.6: This Tk extension is unmaintained and should not be used in new code. Use tkinter.ttk instead.

#### Description of change
Remove unused import and commented out code.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
