### PR TITLE
Don't treat overridden fact groups as unmapped

### DIFF
--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -1608,6 +1608,8 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                                                                      (tableDimensions, "table dimension"),
                                                                      (reportDimensions, "report dimension")):
                                         for dimName, dimValue in inheritedDims.items():
+                                            if dimSource.startswith("propertyGroup"):
+                                                factDimensionPropGrpCol[dimName] = propGroupDimSource[dimName]
                                             if dimName not in colFactDims and dimName not in noValueDimNames:
                                                 dimValue = inheritedDims[dimName]
                                                 dimAttr = None
@@ -1651,8 +1653,6 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                                                     noValueDimNames.add(dimName)
                                                 else:
                                                     colFactDims[dimName] = dimValue
-                                                if dimSource.startswith("propertyGroup"):
-                                                    factDimensionPropGrpCol[dimName] = propGroupDimSource[dimName]
                                     if factDecimals.get(colName) is not None:
                                         dimValue = factDecimals[colName]
                                         dimSource = "column decimals"


### PR DESCRIPTION
#### Reason for change
A future OIM conformance suite will require this.

[3.2.5 Unmapped cell values](https://www.xbrl.org/Specification/xbrl-csv/REC-2021-10-13+errata-2023-04-19/xbrl-csv-REC-2021-10-13+corrected-errata-2023-04-19.html#sec-unmapped-cell-values) says:

> A value makes a contribution to the model if:
> ...
> 5. It provides a fact property group for a fact, as described in Section 3.2.7.

Even if the property group dimensions are overridden by column dimensions and doesn't contribute any dimensions to the final fact, it still provides a property group and shouldn't trigger `xbrlce:unmappedCellValue`.

#### Description of change
Mark fact group column cells as mapped even if they don't contribute dimensions to the final fact.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
