### PR TITLE
Add XULE for EDGAR CI

### DIFF
--- a/.github/actions/test_conformance_suite/action.yml
+++ b/.github/actions/test_conformance_suite/action.yml
@@ -23,6 +23,21 @@ runs:
       with:
         repository: Arelle/EDGAR
         path: arelle/plugin/EDGAR
+    - name: Checkout XULE
+      if: ${{ inputs.name == 'efm_current' }}
+      uses: actions/checkout@v4.2.2
+      with:
+        repository: xbrlus/xule
+        path: tmp
+        ref: ${{ inputs.xule_ref }}
+    - name: Setup XULE
+      if: ${{ inputs.name == 'efm_current' }}
+      shell: bash
+      run: |
+        mv tmp/plugin/validate/* arelle/plugin/validate/
+        rm -rf tmp/plugin/validate
+        mv tmp/plugin/* arelle/plugin/
+        rm -rf tmp
     - name: Install Python 3
       uses: actions/setup-python@v5.4.0
       with:

--- a/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
@@ -30,7 +30,11 @@ config = ConformanceSuiteConfig(
     cache_version_id='uP0cfVbwatKVkwwuQ9m6ogaYt1exP01M',
     info_url='https://www.sec.gov/structureddata/osdinteractivedatatestsuite',
     name=PurePath(__file__).stem,
-    plugins=frozenset({'EDGAR/validate', 'inlineXbrlDocumentSet'}),
+    plugins=frozenset({
+        'EDGAR/validate',
+        'inlineXbrlDocumentSet',
+        'xule',
+    }),
     shards=40,
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
@@ -6,7 +6,7 @@ from tests.integration_tests.validation.conformance_suite_config import (
     ConformanceSuiteConfig,
 )
 
-CONFORMANCE_SUITE_ZIP_NAME = 'efm-72-241216.zip'
+CONFORMANCE_SUITE_ZIP_NAME = 'efm-73d-250219.zip'
 
 config = ConformanceSuiteConfig(
     additional_plugins_by_prefix=[(f'conf/{t}', frozenset({'EDGAR/render'})) for t in [
@@ -27,7 +27,12 @@ config = ConformanceSuiteConfig(
             source=AssetSource.S3_PUBLIC,
         )
     ],
-    cache_version_id='uP0cfVbwatKVkwwuQ9m6ogaYt1exP01M',
+    expected_failure_ids=frozenset(f'conf/{s}' for s in [
+        # Test case failure due to EFM 25.1 running against prior conformance suite.
+        # Failures are expected to be resolved with the release of the 25.1 conformance suite.
+        "605-instance-syntax/605-20-required-document-elts/605-20-man/605-20-man-testcase.xml:_394gw",
+    ]),
+    cache_version_id='vdnIlAvzCgYXhM_5sm6pPDEZKtswihfA',
     info_url='https://www.sec.gov/structureddata/osdinteractivedatatestsuite',
     name=PurePath(__file__).stem,
     plugins=frozenset({


### PR DESCRIPTION
#### Reason for change
EDGAR 25.1 was released which requires XULE. CI is currently failing the EFM suite due to not configuring and running XULE with the EFM suite.

#### Description of change
* Add XULE to EFM runner.
* Update EDGAR suite to latest from February. A 25.1 suite hasn't been released yet.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
