### PR TITLE
When displaying strings, prefer to use them after whitespace normalization

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -428,6 +428,9 @@ class ModelFact(ModelObject):
             # non-numeric fact at this point
             if len(val) == 0: # zero length string for HMRC fixed fact
                 return "(reported)"
+            if self.xValid >= VALID and isinstance(self.xValue, str):
+                # Prefer the xs:whiteSpace normalized version of strings
+                return self.xValue
             return val
         except Exception as ex:
             return str(ex)  # could be transform value of inline fact


### PR DESCRIPTION
For anything that is still of string data type after schema validation, prefer to display the string after schema whitespace normalization.

#### Reason for change
Fixes #1581 

#### Description of change
Use the PSVI value as the `effectiveValue` for display if and only if the PSVI type is still string.

This is a more minimal change than previously attempted as part of 6568d5169d15a54ed31fd6ed7785cda56ab80d52 and reverted in 37a7ae98469a27c08a6fd44e28a51c3aae831bc9 so hopefully will be more successful in working with whatever downstream requirements exist.

#### Steps to Test

**review**:
@Arelle/arelle
