### PR TITLE
ESEF.1.4.1: Guard against None narrower wider concepts

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -168,8 +168,8 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                         narrowerConcept = widerNarrowerRelSet.toModelObject(modelConcept)
 
                         # Transform the qname to str for the later join()
-                        widerTypes = set(r.toModelObject.typeQname for r in widerConcept)
-                        narrowerTypes = set(r.fromModelObject.typeQname for r in narrowerConcept)
+                        widerTypes = set(r.toModelObject.typeQname for r in widerConcept if r.toModelObject is not None)
+                        narrowerTypes = set(r.fromModelObject.typeQname for r in narrowerConcept if r.fromModelObject is not None)
 
                         if (narrowerTypes and narrowerTypes != {modelConcept.typeQname}) or (widerTypes and widerTypes != {modelConcept.typeQname}):
                             widerNarrowerType = "{} {}".format(


### PR DESCRIPTION
#### Reason for change
Resolves [arelle-users/c/N0_zaAFoS44](https://groups.google.com/g/arelle-users/c/N0_zaAFoS44)

```bash
[exception:AttributeError] Instance validation exception: 'NoneType' object has no attribute 'typeQname', instance: 3157002JBFAI478MD587-2024-12-31-0-sk.xhtml - 3157002JBFAI478MD587-2024-12-31-0-sk.xhtml 
Traceback (most recent call last):
  File "D:\a\Arelle\Arelle\arelle\Validate.py", line 131, in validate
  File "D:\a\Arelle\Arelle\arelle\ValidateXbrl.py", line 406, in validate
  File "C:\Program Files\Arelle\plugin\validate\ESEF\__init__.py", line 289, in validateXbrlFinally
    return validateXbrlFinallyCurrent(val, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Arelle\plugin\validate\ESEF\ESEF_Current\ValidateXbrlFinally.py", line 148, in validateXbrlFinally
    checkFilingDTS(val, modelXbrl.modelDocument, esefNotesConcepts, [], ifrsNses=_ifrsNses)
  File "C:\Program Files\Arelle\plugin\validate\ESEF\ESEF_Current\DTS.py", line 38, in checkFilingDTS
    checkFilingDTS(val, referencedDocument, esefNotesConcepts,
  File "C:\Program Files\Arelle\plugin\validate\ESEF\ESEF_Current\DTS.py", line 172, in checkFilingDTS
    narrowerTypes = set(r.fromModelObject.typeQname for r in narrowerConcept)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Arelle\plugin\validate\ESEF\ESEF_Current\DTS.py", line 172, in <genexpr>
    narrowerTypes = set(r.fromModelObject.typeQname for r in narrowerConcept)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'typeQname'
```

#### Description of change
For broken filings the model objects can be None in ESEF.1.4.1. Check that they aren't before accessing `typeQname`.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
