### PR TITLE
Support CLI taxonomy package entry point discovery

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -597,6 +597,10 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False
             if not entrypointFiles and not inlineOnly:
                 for url in urlsByType.get(ModelDocument.Type.HTML, []):
                     entrypointFiles.append({"file":url})
+            if not entrypointFiles and filesource.taxonomyPackage is not None:
+                for packageEntry in filesource.taxonomyPackage.get('entryPoints', {}).values():
+                    for _resolvedUrl, remappedUrl, _closest in packageEntry:
+                        entrypointFiles.append({"file": remappedUrl})
 
 
     elif os.path.isdir(filesource.url):


### PR DESCRIPTION
#### Reason for change
The GUI already supports opening a taxonomy package directly through the
file menu. This brings the CLI up to speed by allowing it to
automatically discover packages entry points and load them.

#### Description of change
During CLI entry point discovery, as a final step, if the file source is a taxonomy package and no entry points have been found, the system will append all entries defined in taxonomyPackage.xml.

#### Steps to Test
* Run the following command:
  `python arelleCmdLine.py --file https://www.esma.europa.eu/sites/default/files/2025-01/esef_taxonomy_2024.zip`
* Verify that entry loaded messages appear in the log.

**review**:
@Arelle/arelle
