### PR TITLE
Fix Calculation GUI View

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -988,7 +988,7 @@ class CntlrWinMain (Cntlr.Cntlr):
                 hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, XbrlConst.parentChild, lang=self.labelLang)
                 if hasView and topView is None: topView = modelXbrl.views[-1]
                 currentAction = "calculation linkbase view"
-                hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, ("Calculation",(XbrlConst.summationItem, XbrlConst.summationItem11)), lang=self.labelLang)
+                hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, ("Calculation", XbrlConst.summationItems), lang=self.labelLang)
                 if hasView and topView is None: topView = modelXbrl.views[-1]
                 currentAction = "dimensions relationships view"
                 hasView = ViewWinRelationshipSet.viewRelationshipSet(modelXbrl, self.tabWinTopRt, "XBRL-dimensions", lang=self.labelLang)

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -681,7 +681,16 @@ class CntlrWinMain (Cntlr.Cntlr):
                     elif isinstance(view, ViewWinDTS.ViewDTS):
                         ViewFileDTS.viewDTS(modelXbrl, filename)
                     else:
-                        ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, filename, view.tabTitle, view.arcrole, labelrole=view.labelrole, lang=view.lang)
+                        if isinstance(view.arcrole, tuple) and len(view.arcrole) > 0 and view.arcrole[0] == "Calculation":
+                            # "arcrole" is overloaded with special strings that are sometimes used magically to query
+                            # the model and other times just to provide a header value. In the case of Calculation, it's
+                            # only the header used in the GUI view and including it here when going to save will throw
+                            # an exception.
+                            arcrole = XbrlConst.summationItems
+                        else:
+                            arcrole = view.arcrole
+
+                        ViewFileRelationshipSet.viewRelationshipSet(modelXbrl, filename, view.tabTitle, arcrole, labelrole=view.labelrole, lang=view.lang)
                 except (IOError, EnvironmentError) as err:
                     tkinter.messagebox.showwarning(_("arelle - Error"),
                                         _("Failed to save {0}:\n{1}").format(

--- a/arelle/ViewFileRelationshipSet.py
+++ b/arelle/ViewFileRelationshipSet.py
@@ -31,8 +31,10 @@ COL_WIDTHS = {
     "Name": 40, "Namespace": 60, "LocalName": 40, "Documentation": 80
     }
 
-def hasCalcArcrole(arcroles: tuple[str] | str) -> bool:
-    return any(arcrole in XbrlConst.summationItems for arcrole in (arcroles if isinstance(arcroles, (tuple,list)) else (arcroles,)))
+def hasCalcArcrole(arcroles: tuple[str | tuple[str, ...], ...] | str) -> bool:
+    if isinstance(arcroles, (tuple, list)):
+        return any(hasCalcArcrole(arcrole) for arcrole in arcroles)
+    return arcroles in XbrlConst.summationItems
 
 class ViewRelationshipSet(ViewFile.View):
     def __init__(self, modelXbrl, outfile, header, labelrole, lang, cols):

--- a/arelle/ViewWinRelationshipSet.py
+++ b/arelle/ViewWinRelationshipSet.py
@@ -8,6 +8,7 @@ from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelDtsObject import ModelRelationship
 from arelle.ModelFormulaObject import ModelFilter
 from arelle.ModelObject import ModelObject
+from arelle.ViewFileRelationshipSet import hasCalcArcrole
 from arelle.ViewUtil import viewReferences, groupRelationshipSet, groupRelationshipLabel
 from arelle.XbrlConst import conceptNameLabelRole, documentationLabel, widerNarrower
 
@@ -89,7 +90,7 @@ class ViewRelationshipSet(ViewWinTree.ViewTree):
                     self.treeView.heading("type", text=_("Type"))
                     self.treeView.column("references", width=200, anchor="w", stretch=False)
                     self.treeView.heading("references", text=_("References"))
-                elif self.arcrole in XbrlConst.summationItems: # extra columns
+                elif hasCalcArcrole(self.arcrole):
                     self.treeView.column("#0", width=300, anchor="w")
                     self.treeView["columns"] = ("weight", "balance")
                     self.treeView.column("weight", width=48, anchor="w", stretch=False)
@@ -253,7 +254,7 @@ class ViewRelationshipSet(ViewWinTree.ViewTree):
                     self.treeView.set(childnode, "preferredLabel", preferredLabel)
                 self.treeView.set(childnode, "type", concept.niceType)
                 self.treeView.set(childnode, "references", viewReferences(concept))
-            elif self.arcrole in XbrlConst.summationItems:
+            elif hasCalcArcrole(self.arcrole):
                 if isRelation:
                     self.treeView.set(childnode, "weight", "{:+0g} ".format(modelObject.weight))
                 self.treeView.set(childnode, "balance", concept.balance)
@@ -313,7 +314,7 @@ class ViewRelationshipSet(ViewWinTree.ViewTree):
                 for modelRel in childRelationshipSet.fromModelObject(concept):
                     nestedRelationshipSet = childRelationshipSet
                     targetRole = modelRel.targetRole
-                    if self.arcrole in XbrlConst.summationItems:
+                    if hasCalcArcrole(self.arcrole):
                         childPrefix = "({:0g}) ".format(modelRel.weight) # format without .0 on integer weights
                     elif targetRole is None or len(targetRole) == 0:
                         targetRole = relationshipSet.linkrole


### PR DESCRIPTION
#### Reason for change
Calc 1.1 support introduced more bugs to the GUI calc views.

* Weight and balance columns are no longer displayed.
* Saving calc table to csv throws an exception.

![image](https://github.com/user-attachments/assets/3e479ee0-141a-4990-a988-fcbd3962987d)


#### Description of change
* Correctly detect calculation arcroles.
* Fix thrown exception on saving calc table view to an excel file.

#### Steps to Test
* Open a report with calculations (either 1.1 or XBRL 2.1).
* Confirm that weight and balance columns are populated in the calculation table view.
* With the calculation tab selected use the file > save menu to save the table to an excel spreadsheet and confirm no exceptions are thrown.

**review**:
@Arelle/arelle