### PR TITLE
Fix another typo from table linkbase refactor

### DIFF
--- a/arelle/rendering/RenderingLayout.py
+++ b/arelle/rendering/RenderingLayout.py
@@ -464,7 +464,7 @@ def bodyCells(view, row, yStrctNodes, xStrctNodes, zAspectStrctNodes, lytMdlYCel
                     if justify is None:
                         justify = "right" if fp.isNumeric else "left"
                     if conceptNotAbstract:
-                        if factsVals or ignoreDimValidity or isFactDimensionallyValid(self, fp) or isEntryPrototype:
+                        if factsVals or ignoreDimValidity or isFactDimensionallyValid(view, fp) or isEntryPrototype:
                             lytMdlCell = LytMdlBodyCell(lytMdlXCells, isOpenAspectEntrySurrogate)
                             lytMdlCell.facts = factsVals
                     fp.clear()  # dereference


### PR DESCRIPTION
#### Reason for change
Fixes another bug introduced by #1111 / b734fd708cf9687a6ada631cfa594b134178ec93

#### Description of change
Reference to self wasn't updated to view when class method was refactored to a function.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
