### PR TITLE
Check that filesource is not None before closing

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1296,7 +1296,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         self.modelManager.close(modelDiffReport)
                     elif modelXbrl:
                         self.modelManager.close(modelXbrl)
-        if not options.keepOpen:
+        if filesource is not None and not options.keepOpen:
             # Archive filesource potentially used by multiple reports may still be open.
             filesource.close()
 

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1069,7 +1069,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
 
         for pluginXbrlMethod in PluginManager.pluginClassMethods("CntlrCmdLine.Filing.Start"):
             pluginXbrlMethod(self, options, filesource, _entrypointFiles, sourceZipStream=sourceZipStream, responseZipStream=responseZipStream)
-        if len(_entrypointFiles) == 0:
+        if len(_entrypointFiles) == 0 and not options.packages:
             if options.entrypointFile:
                 msg = _("No XBRL entry points could be loaded from provided file: {}").format(options.entrypointFile)
             else:


### PR DESCRIPTION
#### Reason for change
Resolves google group issue [AG81U9zFCfA](https://groups.google.com/g/arelle-users/c/AG81U9zFCfA).

Requests to the API to add a taxonomy package do not load a filesource.

#### Description of change
Check that filesource is defined before attempting to close from the CLI.

#### Steps to Test
* `python arelleCmdLine.py --webserver localhost:8080`
* `curl http://localhost:8080/rest/configure?packages=/Users/austinmatherne/git/Arelle/tests/resources/packages/esef_taxonomy_2024.zip`
* Confirm package activated message is in the response.

**review**:
@Arelle/arelle
