### PR TITLE
Support Loading EBA xBRL-CSV Sample Reports

### DIFF
--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -1673,7 +1673,10 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                                     elif "decimals" in cellPropGroup:
                                         dimValue = cellPropGroup["decimals"]
                                         dimSource = "propertyGroup " + propFromColName
-                                        factDimensionPropGrpCol["decimals"] = propGroupDimSource[dimName]
+                                        if _isParamRef(dimValue):
+                                            factDimensionPropGrpCol["decimals"] = _getParamRefName(dimValue)
+                                        else:
+                                            factDimensionPropGrpCol["decimals"] = dimValue
                                     elif tableDecimals is not None:
                                         dimValue = tableDecimals
                                         dimSource = "table decimals"

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -377,6 +377,7 @@ CsvMemberTypes = {
     "/tableTemplates/*/columns/*/propertiesFrom/": str,
     "/tableTemplates/*/columns/*/propertyGroups": dict,
     "/tableTemplates/*/columns/*/propertyGroups/*": dict,
+    "/tableTemplates/*/columns/*/propertyGroups/*/*:*": (int,float,bool,str,dict,list,type(None),NoRecursionCheck,CheckPrefix), # custom extensions
     "/tableTemplates/*/columns/*/propertyGroups/*/decimals": (int,str),
     "/tableTemplates/*/columns/*/propertyGroups/*/dimensions": dict,
     "/tableTemplates/*/columns/*/propertyGroups/*/dimensions/concept": str,

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -1640,8 +1640,10 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                                                                 factDimensionSourceCol[dimName] = paramName
                                                         elif paramName in tableParameters:
                                                             dimValue = tableParameters[paramName]
+                                                            factDimensionSourceCol[dimName] = paramName
                                                         elif paramName in reportParameters:
                                                             dimValue = reportParameters[paramName]
+                                                            factDimensionSourceCol[dimName] = paramName
                                                         elif paramName in unreportedFactDimensionColumns:
                                                             dimValue = NONE_CELL
                                                         else:

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -1554,6 +1554,8 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                                                 else:
                                                     cellPropGroup[prop] = val
                                                     propGroupDimSource[prop] = propFromColName
+                                                    if _isParamRef(val):
+                                                        rowPropGrpParamRefs.add(_getParamRefName(val))
                                     if factDimensions[colName] is None:
                                         if colName in paramRefColNames:
                                             value = _cellValue(row[colNameIndex[colName]])
@@ -1564,8 +1566,14 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                                         if not cellPropGroup:
                                             continue # not a fact column
                                     for rowPropGrpParamRef in rowPropGrpParamRefs:
-                                        value = _cellValue(row[colNameIndex[rowPropGrpParamRef]])
-                                        if value is EMPTY_CELL or value is NONE_CELL:
+                                        value = None
+                                        if rowPropGrpParamRef in colNameIndex:
+                                            value = _cellValue(row[colNameIndex[rowPropGrpParamRef]])
+                                        elif rowPropGrpParamRef in tableParameters:
+                                            value = tableParameters.get(rowPropGrpParamRef)
+                                        elif rowPropGrpParamRef in reportParameters:
+                                            value = reportParameters.get(rowPropGrpParamRef)
+                                        if value in (None, EMPTY_CELL, NONE_CELL):
                                             emptyCols.add(rowPropGrpParamRef)
                                     # assemble row and fact Ids
                                     if idColIndex is not None and not rowId:

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -318,7 +318,7 @@ CsvMemberTypes = {
     "/documentInfo/baseURL": URIType,
     "/documentInfo/documentType": str,
     "/documentInfo/features": dict,
-    "/documentInfo/features/*:*": (int,float,bool,str,type(None)),
+    "/documentInfo/features/*:*": (int,float,bool,str,dict,list,type(None),NoRecursionCheck),
     "/documentInfo/final": dict,
     "/documentInfo/namespaces": dict,
     "/documentInfo/namespaces/*": URIType,

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -1541,6 +1541,9 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                                     for propFromColName in propFromColNames:
                                         if propFromColName in rowPropGroups:
                                             for prop, val in rowPropGroups[propFromColName].items():
+                                                if ":" in prop:
+                                                    # Extension property
+                                                    continue
                                                 if isinstance(val, dict):
                                                     _valDict = cellPropGroup.setdefault(prop, {})
                                                     for dim, _val in val.items():


### PR DESCRIPTION
#### Reason for change
Resolves Google group issue [cQabLs7WcL0](https://groups.google.com/a/arelle.org/g/support/c/cQabLs7WcL0)

The sample xBRL-CSV reports provided for the EBA reporting framework 4.0 demonstrate holes in the OIM conformance suite and bugs in the Arelle xBRL-CSV loading code.

#### Description of change


#### Steps to Test
* Use samples reports from [EBA site](https://www.eba.europa.eu/risk-and-data-analysis/reporting-frameworks/reporting-framework-40#:~:text=c.%20Sample%20files%20for%20taxonomy%20under%20taxonomy%20architecture%20v2.0%20(Updated%20on%2006/01/2025)).
* Load them in Arelle and confirm xBRL-CSV loading errors aren't logged:
* `python arelleCmdLine.py --package taxo_package_4.0_errata5/EBA_XBRL_4.0_Dictionary_4.0.0.0.zip --package taxo_package_4.0_errata5/EBA_XBRL_4.0_Reporting_Frameworks_4.0.0.0.zip --package taxo_package_4.0_errata5/EBA_XBRL_4.0_Severity_4.0.0.0.zip --file "sample_documents/instances xBRL-CSV/DUMMYLEI123456789012.CON_FR_COREP040000_COREPLR_2024-12-31_20241213173849920.zip"`

**review**:
@Arelle/arelle
