### PR TITLE
Perform special value parsing on OIM report parameters

### DIFF
--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -1205,6 +1205,7 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
             reportDimensions = oimObject.get("dimensions", EMPTY_DICT)
             reportDecimals = oimObject.get("decimals", None)
             reportParameters = oimObject.get("parameters", {}) # fresh empty dict because csv-loaded parameters get added
+            parseMetadataCellValues(reportParameters)
             tableTemplates = oimObject.get("tableTemplates", EMPTY_DICT)
             tables = oimObject.get("tables", EMPTY_DICT)
             footnotes = (oimObject.get("links", {}), )


### PR DESCRIPTION
#### Reason for change
OIM report parameters can have [special values](https://www.xbrl.org/Specification/xbrl-csv/REC-2021-10-13+errata-2023-04-19/xbrl-csv-REC-2021-10-13+corrected-errata-2023-04-19.html#sec-special-values) (`#nil`, `#none`). Currently Arelle doesn't transform these values.

#### Description of change
Apply metadata cell value parsing logic to report parameters.

#### Steps to Test
* Use [csv-param.zip](https://github.com/user-attachments/files/19492745/csv-param.zip)
* Run `python arelleCmdLine.py --file csv-param.zip --saveOIMToXMLReport csv-param.xbrl`
* In the saved `csv-param.xbrl` instance file, verify that the `tcr:keyThree` typed member has a `xsi:nil="true"` attribute and not a literal value of `#nil`.

**review**:
@Arelle/arelle
