### PR TITLE
Workaround Python stdin bug when run as Windows service 

### DIFF
--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -233,9 +233,9 @@ def getLocale() -> str | None:
     # Try getting locale language code from system on macOS and Windows before resorting to the less reliable locale.getlocale.
     systemLocale = None
     if sys.platform == MACOS_PLATFORM:
-        systemLocale = _tryRunShellCommand("defaults read -g AppleLocale")
+        systemLocale = _tryRunCommand("defaults", "read", "-g", "AppleLocale")
     elif sys.platform == WINDOWS_PLATFORM:
-        systemLocale = _tryRunShellCommand("pwsh", "-Command", "Get-Culture | Select -ExpandProperty IetfLanguageTag")
+        systemLocale = _tryRunCommand("pwsh", "-Command", "Get-Culture | Select -ExpandProperty IetfLanguageTag")
     if pythonCompatibleLocale := findCompatibleLocale(systemLocale):
         _locale = pythonCompatibleLocale
     elif sys.version_info < (3, 12):
@@ -247,9 +247,9 @@ def getLocale() -> str | None:
     return _locale
 
 
-def _tryRunShellCommand(*args: str) -> str | None:
+def _tryRunCommand(*args: str) -> str | None:
     """
-    Tries to return the results of the provided shell command.
+    Tries to return the results of the provided command.
     Returns stdout or None if the command exists with a non-zero code.
     """
     try:
@@ -257,7 +257,6 @@ def _tryRunShellCommand(*args: str) -> str | None:
             args,
             capture_output=True,
             check=True,
-            shell=True,
             text=True,
             # A call to get std handle throws an OSError if stdin is not specified when run on Windows as a service.
             stdin=subprocess.PIPE,
@@ -314,7 +313,7 @@ def getLocaleList() -> list[str]:
     global _systemLocales
     if _systemLocales is not None:
         return _systemLocales
-    if sys.platform != WINDOWS_PLATFORM and (locales := _tryRunShellCommand("locale -a")):
+    if sys.platform != WINDOWS_PLATFORM and (locales := _tryRunCommand("locale", "-a")):
         _systemLocales = locales.splitlines()
     else:
         _systemLocales = []

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -253,7 +253,13 @@ def _tryRunShellCommand(*args: str) -> str | None:
     Returns stdout or None if the command exists with a non-zero code.
     """
     try:
-        return subprocess.run(args, capture_output=True, check=True, shell=True, text=True).stdout.strip()
+        return subprocess.run(
+            args,
+            capture_output=True,
+            check=True,
+            shell=True,
+            text=True,
+        ).stdout.strip()
     except subprocess.SubprocessError:
         return None
 

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -259,6 +259,8 @@ def _tryRunShellCommand(*args: str) -> str | None:
             check=True,
             shell=True,
             text=True,
+            # A call to get std handle throws an OSError if stdin is not specified when run on Windows as a service.
+            stdin=subprocess.PIPE,
         ).stdout.strip()
     except subprocess.SubprocessError:
         return None

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -262,7 +262,7 @@ def _tryRunShellCommand(*args: str) -> str | None:
             # A call to get std handle throws an OSError if stdin is not specified when run on Windows as a service.
             stdin=subprocess.PIPE,
         ).stdout.strip()
-    except subprocess.SubprocessError:
+    except (OSError, subprocess.SubprocessError):
         return None
 
 

--- a/arelle/PythonUtil.py
+++ b/arelle/PythonUtil.py
@@ -5,11 +5,12 @@ Python version specific utilities
 do not convert 3 to 2
 '''
 from __future__ import annotations
+
 import sys
-from decimal import Decimal
-from fractions import Fraction
 from collections import OrderedDict
 from collections.abc import MappingView, MutableSet
+from decimal import Decimal
+from fractions import Fraction
 from typing import Any
 
 from arelle.typing import OptionalString

--- a/arelle/PythonUtil.py
+++ b/arelle/PythonUtil.py
@@ -6,6 +6,7 @@ do not convert 3 to 2
 '''
 from __future__ import annotations
 
+import subprocess
 import sys
 from collections import OrderedDict
 from collections.abc import MappingView, MutableSet
@@ -250,3 +251,21 @@ def pyObjectSize(obj, seen=None):
     elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
         size += sum([pyObjectSize(i, seen) for i in obj])
     return size
+
+
+def tryRunCommand(*args: str) -> str | None:
+    """
+    Tries to return the results of the provided command.
+    Returns stdout or None if the command exists with a non-zero code.
+    """
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            check=True,
+            text=True,
+            # A call to get std handle throws an OSError if stdin is not specified when run on Windows as a service.
+            stdin=subprocess.PIPE,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return None

--- a/arelle/Version.py
+++ b/arelle/Version.py
@@ -6,6 +6,8 @@ See COPYRIGHT.md for copyright information.
 """
 from __future__ import annotations
 
+from arelle.PythonUtil import tryRunCommand
+
 
 def getBuildVersion() -> str | None:
     try:
@@ -16,12 +18,7 @@ def getBuildVersion() -> str | None:
 
 
 def getGitHash() -> str | None:
-    import subprocess
-    try:
-        return subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True, check=True, text=True).stdout.strip()
-    except (FileNotFoundError, subprocess.SubprocessError):
-        return None
-
+    return tryRunCommand('git', 'rev-parse', 'HEAD')
 
 def getDefaultVersion() -> str:
     return '0.0.0'


### PR DESCRIPTION
#### Reason for change
Resolves google group issue [ktGBv3B-Do4](https://groups.google.com/g/arelle-users/c/ktGBv3B-Do4)

#### Description of change
When making a call to subprocess.run/Popen and:
1. Either stdout, or stderr is provided, or capture_output is True.
2. stdin is not provided.
3. Arelle is run as a Windows service.

An OSError is raised by a call to _winapi.GetStdHandle to set stdin. This can be avoided by explicitly specifying stdin.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
