### PR TITLE
Plugin hook for transforming URLs within WebCache

### DIFF
--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -486,7 +486,7 @@ def _get_name_dir_prefix(
     packageImportPrefix: str
 
     moduleFilename = controller.webCache.getfilename(
-        url=moduleURL, normalize=True, base=pluginBase
+        url=moduleURL, normalize=True, base=pluginBase, allowTransformation=False
     )
 
     if moduleFilename:

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -455,7 +455,13 @@ class WebCache:
     def getfilename(
             self, url: str | None, base: str | None = None,
             reload: bool = False, checkModifiedTime: bool = False,
-            normalize: bool = False, filenameOnly: bool = False) -> str | None:
+            normalize: bool = False, filenameOnly: bool = False,
+            allowTransformation: bool = True) -> str | None:
+        if allowTransformation:
+            for pluginXbrlMethod in pluginClassMethods("WebCache.TransformURL"):
+                url, final = pluginXbrlMethod(self.cntlr, url, base)
+                if final:
+                    return url
         if url is None:
             return url
         if base is not None or normalize:

--- a/arelle/utils/PluginHooks.py
+++ b/arelle/utils/PluginHooks.py
@@ -790,3 +790,26 @@ class PluginHooks(ABC):
         :return: None
         """
         raise NotImplementedError
+
+    @staticmethod
+    def webCacheTransformUrl(
+            cntlr: CntlrCmdLine,
+            url: str | None,
+            base: str | None,
+            *args: Any,
+            **kwargs: Any,
+    ) -> tuple[str | None, bool]:
+        """
+        Plugin hook: `WebCache.TransformURL`
+
+        This hook is triggered before the web cache maps a URL to a file path.
+        It's useful if you need to map certain URLs to a location other than the web cache.
+
+        :param cntlr: The [Cntlr](#arelle.Cntlr.Cntlr) being initialized.
+        :param url: The URL to transform.
+        :param base: The base URL.
+        :param args: Argument capture to ensure new parameters don't break plugin hook.
+        :param kwargs: Argument capture to ensure new named parameters don't break plugin hook.
+        :return: Tuple of transformed URL or filepath and a boolean indicating if the URL should be returned as the final filename.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
#### Reason for change
Some plugins may want to map URLs to their own file locations

#### Description of change
Add plugin hook to allow transformation of URLs before normal mapping to web cache filepaths, or to transform URLs into filepaths directly.

#### Steps to Test
CI

**review**:
@Arelle/arelle
