### PR TITLE
Close PluginManager on Session close

### DIFF
--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -105,10 +105,13 @@ def save(cntlr: Cntlr) -> None:
             f.write(jsonStr)
         pluginConfigChanged = False
 
-def close():  # close all loaded methods
-    pluginConfig.clear()
-    modulePluginInfos.clear()
-    pluginMethodsForClasses.clear()
+def close() -> None:  # close all loaded methods
+    if pluginConfig is not None:
+        pluginConfig.clear()
+    if modulePluginInfos is not None:
+        modulePluginInfos.clear()
+    if pluginMethodsForClasses is not None:
+        pluginMethodsForClasses.clear()
     global webCache
     webCache = None
 

--- a/arelle/api/Session.py
+++ b/arelle/api/Session.py
@@ -36,6 +36,7 @@ class Session:
     def close(self) -> None:
         if self._cntlr is not None:
             self._cntlr.close()
+        PluginManager.close()
 
     def get_log_messages(self) -> list[dict[str, Any]]:
         """


### PR DESCRIPTION
#### Reason for change
PluginManager isn't fully reset between Sessions

#### Description of change
Ensure PluginManager data structures are fully cleared on Session close

#### Steps to Test
CI

**review**:
@Arelle/arelle
