### PR TITLE
fix undefined validatedObjectLabel variable bug

### DIFF
--- a/arelle/ValidateFilingText.py
+++ b/arelle/ValidateFilingText.py
@@ -620,7 +620,7 @@ def validateTextBlockFacts(modelXbrl):
                                 if attrTag in efmBlockedInlineHtmlElementAttributes.get(eltTag,()):
                                     modelXbrl.error(("EFM.5.02.05.disallowedAttribute", "FERC.5.02.05.disallowedAttribute"),
                                         _("%(validatedObjectLabel)s has disallowed attribute on element <%(element)s>: %(attribute)s=\"%(value)s\""),
-                                        modelObject=elt, validatedObjectLabel=validatedObjectLabel,
+                                        modelObject=elt, validatedObjectLabel=f1.qname,
                                         element=eltTag, attribute=attrTag, value=attrValue)
                             if ((attrTag == "href" and eltTag == "a") or
                                 (attrTag == "src" and eltTag == "img")):


### PR DESCRIPTION
#### Reason for change
the ValidateTextBlockFacts function in ValidateFilingText.py had a reference to an undefine variable that would raise an exception.

#### Description of change
Replaced validatedObjectLabel with f1.qname

#### Steps to Test
Can test with e60516016gd-20081231.htm in [60516016gd.zip](https://github.com/user-attachments/files/19816374/60516016gd.zip)
**review**:
@Arelle/arelle

