### PR TITLE
Remove cipc-ca-enum:DescriptionOfNatureOfFinancialStatements from must not be hidden list

### DIFF
--- a/arelle/plugin/validate/CIPC/Const.py
+++ b/arelle/plugin/validate/CIPC/Const.py
@@ -20,7 +20,6 @@ mustNotBeHiddenElements = [
     "cipc-ca:DisclosureOfDirectorsResponsibilityExplanatory",
     "cipc-ca:FullRegisteredNameOfCompany",
     "cipc-ca:RegistrationNumberOfCompany",
-    "cipc-ca-enum:DescriptionOfNatureOfFinancialStatements",
     "ifrs-full:DateOfEndOfReportingPeriod2013",
     "ifrs-full:DescriptionOfNatureOfFinancialStatements",
     "ifrs-full:DescriptionOfPresentationCurrency",


### PR DESCRIPTION
#### Reason for change
`cipc-ca-enum:DescriptionOfNatureOfFinancialStatements` has been removed from the must not hide list at CIPC

#### Steps to Test
CI

**review**:
@Arelle/arelle
