### PR TITLE
Ixds footnotes

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -1704,6 +1704,35 @@ def inlineIxdsDiscover(modelXbrl, modelIxdsDocument, setTargetModelXbrl=False, *
                             for _target in sourceFactTargets:
                                 targetRoleUris[_target].add(footnoteRole)
 
+    for htmlElement in modelXbrl.ixdsHtmlElements:
+        # Discover iXBRL 1.0 footnote roles and arcroles.
+        iXBRL1_0Footnotes = list(htmlElement.iterdescendants(tag=XbrlConst.qnIXbrlFootnote.clarkNotation))
+        if not iXBRL1_0Footnotes:
+            continue
+        footnoteRefElems = (
+            XbrlConst.qnIXbrlFraction.clarkNotation,
+            XbrlConst.qnIXbrlNonFraction.clarkNotation,
+            XbrlConst.qnIXbrlNonNumeric.clarkNotation,
+            XbrlConst.qnIXbrlTuple.clarkNotation,
+        )
+        targetsByFootnoteId = defaultdict(set)
+        for elem in htmlElement.iterdescendants(footnoteRefElems):
+            if isinstance(elem, ModelObject):
+                refs = elem.get("footnoteRefs")
+                if refs:
+                    _target = elem.get("target")
+                    for footnoteRef in refs.split():
+                        targetsByFootnoteId[footnoteRef].add(_target)
+        for modelInlineFootnote in iXBRL1_0Footnotes:
+            arcrole = modelInlineFootnote.get("arcrole", XbrlConst.factFootnote)
+            footnoteLinkRole = modelInlineFootnote.get("footnoteLinkRole", XbrlConst.defaultLinkRole)
+            footnoteRole = modelInlineFootnote.get("footnoteRole")
+            for _target in targetsByFootnoteId[modelInlineFootnote.footnoteID]:
+                targetRoleUris[_target].add(footnoteLinkRole)
+                targetArcroleUris[_target].add(arcrole)
+                if footnoteRole:
+                    targetRoleUris[_target].add(footnoteRole)
+
     contextRefs = factTargetContextRefs[ixdsTarget]
     unitRefs = factTargetUnitRefs[ixdsTarget]
     allContextRefs = set.union(*factTargetContextRefs.values())

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -441,7 +441,7 @@ def createTargetInstance(
         arcrole, linkrole, linkqname, arcqname = linkKey
         if (linkrole and linkqname and arcqname and  # fully specified roles
             arcrole != "XBRL-footnotes" and
-            any(lP.modelDocument.type in [Type.INLINEXBRL,Type.INLINEXBRLDOCUMENTSET] for lP in linkPrototypes)):
+            any(lP.modelDocument.type in (Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET) for lP in linkPrototypes)):
             for linkPrototype in linkPrototypes:
                 if linkPrototype not in footnoteLinks[linkrole]:
                     footnoteLinks[linkrole].append(linkPrototype)

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -441,7 +441,7 @@ def createTargetInstance(
         arcrole, linkrole, linkqname, arcqname = linkKey
         if (linkrole and linkqname and arcqname and  # fully specified roles
             arcrole != "XBRL-footnotes" and
-            any(lP.modelDocument.type == Type.INLINEXBRL for lP in linkPrototypes)):
+            any(lP.modelDocument.type in [Type.INLINEXBRL,Type.INLINEXBRLDOCUMENTSET] for lP in linkPrototypes)):
             for linkPrototype in linkPrototypes:
                 if linkPrototype not in footnoteLinks[linkrole]:
                     footnoteLinks[linkrole].append(linkPrototype)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ flake8-noqa==1.4.0
 
 mypy==1.15.0
 
-boto3-stubs==1.38.3
+boto3-stubs==1.38.8
 lxml-stubs==0.5.1
 types-PyMySQL==1.1.0.20241103
 types-openpyxl==3.1.5.20250306

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-boto3==1.38.3
+boto3==1.38.8
 pytest==8.3.5
 
 -r requirements.txt


### PR DESCRIPTION
#### Reason for change
Footnotes from an ixds were missing from the _htm.xml instance doc.

#### Description of change
Check for Type.INLINEXBRLDOCUMENTSET in addition to Type.INLINEXBRL in the createTargetInstance function of arelle\plugin\inlineXbrlDocumentSet.py.

#### Steps to Test

**review**:
@Arelle/arelle
