### PR TITLE
Adding nl_kvk validation 3.3.1.1 and 3.3.1.2

### DIFF
--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -269,3 +269,50 @@ def rule_nl_kvk_3_2_1_1 (
             msg=_('Precision should not be used on numeric facts.'),
             modelObject = factsWithPrecision
         )
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=[
+        DISCLOSURE_SYSTEM_NL_INLINE_2024
+    ],
+)
+def rule_nl_kvk_3_3_1_1 (
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation]:
+    """
+    NL-KVK.3.3.1.1: Ensure that every nonempty <link:footnote> element is associated with at least one fact in the XBRL document.
+    """
+    orphanedFootnotes = pluginData.getOrphanedFootnotes(val.modelXbrl)
+    if len(orphanedFootnotes) >0:
+        yield Validation.error(
+            codes='NL.NL-KVK.3.3.1.1.unusedFootnote',
+            msg=_('Ensure that every nonempty <link:footnote> element is associated with at least one fact in the XBRL document.'),
+            modelObject = orphanedFootnotes
+        )
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=[
+        DISCLOSURE_SYSTEM_NL_INLINE_2024
+    ],
+)
+def rule_nl_kvk_3_3_1_2 (
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation]:
+    """
+    NL-KVK.3.3.1.2: The xml:lang attribute of each footnote matches the language of at least one textual fact.
+    """
+    noMatchLangFootnotes = pluginData.getNoMatchLangFootnotes(val.modelXbrl)
+    if len(noMatchLangFootnotes) >0:
+        yield Validation.error(
+            codes='NL.NL-KVK.3.3.1.2.footnoteInLanguagesOtherThanLanguageOfContentOfAnyTextualFact',
+            msg=_('The xml:lang attribute of each footnote matches the language of at least one textual fact.'),
+            modelObject = noMatchLangFootnotes
+        )

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -26,8 +26,7 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC5_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC6_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC7_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_1/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_2/index.xml:TC3_invalid',
+        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_2/index.xml:TC3_invalid', # Expects an error code with a preceding double quote. G3-3-1_3 expects the same code without the typo.
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_3/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_1/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_2/index.xml:TC2_invalid',
@@ -61,6 +60,7 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-2_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_1/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_2/index.xml:TC2_invalid',
+        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-1_1/index.xml:TC2_invalid', # Expects scenarioNotUsedInExtensionTaxonomy and segmentUsed errors.  scenarioNotUsedInExtensionTaxonomy not yet implemented.
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-2_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-3_1/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-1_1/index.xml:TC2_invalid',
@@ -114,5 +114,5 @@ config = ConformanceSuiteConfig(
     network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=8,
-    test_case_result_options='match-any',
+    test_case_result_options='match-all',
 )


### PR DESCRIPTION
#### Description of change

Added nl_kvk validation 3.3.1.1 and 3.3.1.2
Changed conformance suite to match-all instead of match-any.

#### Steps to Test

CI for 3.3.1.1. 
There is a typo in the expected results in the conformance suite for 3.3.1.2 so the conformance suite is not enabled.  It will be covered with the addition of  nl_kvk validation 3.3.1.3 and linked conformance suite which expects both 3.3.1.2 and 3.3.1.3. 

**review**:
@Arelle/arelle
