### PR TITLE
ESEF.2.1.2.inappropriateInstantDate: Log Specific Context

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -606,7 +606,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
             for context in contextsWithWrongInstantDate:
                 modelXbrl.error("ESEF.2.1.2.inappropriateInstantDate",
                                 _("Instant date %(actualValue)s in context %(contextID)s shall be replaced by %(expectedValue)s to ensure a better comparability between the facts."),
-                                modelObject=contextsWithWrongInstantDate, actualValue=context.instantDate, expectedValue=context.instantDate - timedelta(days=1), contextID=context.id)
+                                modelObject=context, actualValue=context.instantDate, expectedValue=context.instantDate - timedelta(days=1), contextID=context.id)
 
         # identify unique contexts and units
         mapContext = {}


### PR DESCRIPTION
#### Reason for change
Resolves #1629

#### Description of change

For `ESEF.2.1.2.inappropriateInstantDate` we log an error for EACH context that has an inappropriate date, but the model object refs that are logged with each error includes ALL contexts that have an inappropriate date.

#### Steps to Test
- Use [TC1_modified.zip](https://github.com/user-attachments/files/20051953/TC1_modified.zip)
- `python arelleCmdLine.py --logFile log.xml --plugins validate/ESEF --disclosureSystem esef --validate --file TC1_modified.zip`
- Confirm that the context refs logged for each `ESEF.2.1.2.inappropriateInstantDate` error is limited to the context referred to in the error message.

**review**:
@Arelle/arelle
