### PR TITLE
Support Saving iXDS to OIM from GUI

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -603,7 +603,7 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False
                         pluginXbrlMethod(filesource, reportEntries)
                         ixdsDiscovered = True
                     if not ixdsDiscovered and len(reportEntries) > 1:
-                        raise RuntimeError(_("Loading error. Inline document set encountered. Enable 'InlineDocumentSet' plug-in to load this filing: {0}").format(filesource.url))
+                        raise RuntimeError(_("Loading error. Inline document set encountered. Enable 'InlineXbrlDocumentSet' plug-in to load this filing: {0}").format(filesource.url))
                     entrypointFiles.extend(reportEntries)
                 elif not inlineOnly:
                     entrypointFiles.append({"file": report.fullPathPrimary})

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -74,6 +74,7 @@ reservedLinkTypeAndGroupAliases = {
 XLINKTYPE = "{http://www.w3.org/1999/xlink}type"
 XLINKLABEL = "{http://www.w3.org/1999/xlink}label"
 XLINKARCROLE = "{http://www.w3.org/1999/xlink}arcrole"
+XLINKROLE = "{http://www.w3.org/1999/xlink}role"
 XLINKFROM = "{http://www.w3.org/1999/xlink}from"
 XLINKTO = "{http://www.w3.org/1999/xlink}to"
 XLINKHREF = "{http://www.w3.org/1999/xlink}href"
@@ -2717,6 +2718,7 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                             footnoteLinkNotes[linkrole].add(noteId)
                             xbrlNote = xbrlNoteTbl[noteId]
                             attrs = {XLINKTYPE: "resource",
+                                     XLINKROLE: XbrlConst.footnote,
                                      XLINKLABEL: footnoteToLabel,
                                      "id": idDeduped(modelXbrl, noteId),
                                      # "oimNoteId": noteId

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -2816,6 +2816,8 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                     modelObject=modelXbrl, action=currentAction, error=ex,
                     traceback=traceback.format_tb(sys.exc_info()[2]))
 
+    # Reset modified status of model so user is not prompted for changes triggered by this loading operation.
+    _return.isModified = False
     return _return
 
 def _isParamRef(value):

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import operator
 import os
 import threading
 import zipfile
@@ -124,6 +125,17 @@ qnOimPeriodAspect = qname("period", noPrefixIsNoNamespace=True)
 qnOimEntityAspect = qname("entity", noPrefixIsNoNamespace=True)
 qnOimUnitAspect = qname("unit", noPrefixIsNoNamespace=True)
 
+reservedUriAliases = {
+    nsOim: "xbrl",
+    XbrlConst.defaultLinkRole: "_",
+    XbrlConst.factExplanatoryFact: "explanatoryFact",
+    XbrlConst.factFootnote: "footnote",
+    XbrlConst.iso4217: "iso4217",
+    XbrlConst.utr: "utr",
+    XbrlConst.xbrli: "xbrli",
+    XbrlConst.xsd: "xs",
+}
+
 ONE = Decimal(1)
 TEN = Decimal(10)
 NILVALUE = "nil"
@@ -141,6 +153,43 @@ csvOpenNewline = ""
 
 OimFact = dict[str, Any]
 OimReport = dict[str, Any]
+
+class NamespacePrefixes:
+    def __init__(self, prefixesByNamespace: dict[str, str] | None = None) -> None:
+        self._prefixesByNamespace: dict[str, str] = prefixesByNamespace or {}
+        self._usedPrefixes: set[str] = set(self._prefixesByNamespace.values())
+
+    @property
+    def namespaces(self) -> dict[str, str]:
+        return {
+            prefix: namespace
+            for namespace, prefix in sorted(
+                self._prefixesByNamespace.items(),
+                key=operator.itemgetter(1)
+            )
+        }
+
+    def __contains__(self, namespace: str) -> bool:
+        return namespace in self._prefixesByNamespace
+
+    def getPrefix(self, namespace: str) -> str | None:
+        return self._prefixesByNamespace.get(namespace)
+
+    def addNamespace(self, namespace: str, preferredPrefix: str) -> str:
+        prefix = self._prefixesByNamespace.get(namespace)
+        if prefix is not None:
+            return prefix
+
+        prefix = reservedUriAliases.get(namespace)
+        if prefix is None:
+            prefix = preferredPrefix
+            i = 2
+            while prefix in self._usedPrefixes:
+                prefix = f"{preferredPrefix}{i}"
+                i += 1
+        self._prefixesByNamespace[namespace] = prefix
+        self._usedPrefixes.add(prefix)
+        return prefix
 
 
 def saveLoadableOIM(
@@ -162,18 +211,16 @@ def saveLoadableOIM(
     if not isJSON and not isCSVorXL:
         return
 
-    namespacePrefixes = {nsOim: "xbrl"}
-    prefixNamespaces: dict[str, str] = {}
+    namespacePrefixes = NamespacePrefixes({nsOim: "xbrl"})
     if extensionPrefixes:
         for extensionPrefix, extensionNamespace in extensionPrefixes.items():
-            namespacePrefixes[extensionNamespace] = extensionPrefix
-            prefixNamespaces[extensionPrefix] = extensionNamespace
+            namespacePrefixes.addNamespace(extensionNamespace, extensionPrefix)
     linkTypeAliases = {}
     groupAliases = {}
 
     def compileQname(qname: QName) -> None:
         if qname.namespaceURI is not None and qname.namespaceURI not in namespacePrefixes:
-            namespacePrefixes[qname.namespaceURI] = qname.prefix or ""
+            namespacePrefixes.addNamespace(qname.namespaceURI, qname.prefix or "")
 
     aspectsDefined = {qnOimConceptAspect, qnOimEntityAspect, qnOimPeriodAspect}
 
@@ -183,12 +230,8 @@ def saveLoadableOIM(
             return " ".join([oimValue(o) for o in obj])
         if isinstance(obj, QName) and obj.namespaceURI is not None:
             if obj.namespaceURI not in namespacePrefixes:
-                if obj.prefix:
-                    namespacePrefixes[obj.namespaceURI] = obj.prefix
-                else:
-                    _prefix = "_{}".format(sum(1 for p in namespacePrefixes if p.startswith("_")))
-                    namespacePrefixes[obj.namespaceURI] = _prefix
-            return f"{namespacePrefixes[obj.namespaceURI]}:{obj.localName}"
+                namespacePrefixes.addNamespace(obj.namespaceURI, obj.prefix or "_")
+            return f"{namespacePrefixes.getPrefix(obj.namespaceURI)}:{obj.localName}"
         if isinstance(obj, (float, Decimal)):
             try:
                 if isinf(obj):
@@ -283,8 +326,8 @@ def saveLoadableOIM(
                         _schemePrefix = "scheme"
                 else:
                     _schemePrefix = f"scheme{len(entitySchemePrefixes) + 1}"
-                entitySchemePrefixes[scheme] = _schemePrefix
-                namespacePrefixes[scheme] = _schemePrefix
+                namespacePrefixes.addNamespace(scheme, _schemePrefix)
+                entitySchemePrefixes[scheme] = namespacePrefixes.getPrefix(scheme)
         for dim in cntx.qnameDims.values():
             compileQname(dim.dimensionQname)
             aspectsDefined.add(dim.dimensionQname)
@@ -297,23 +340,17 @@ def saveLoadableOIM(
                 for measure in measures:
                     compileQname(measure)
 
-    if XbrlConst.xbrli in namespacePrefixes and namespacePrefixes[XbrlConst.xbrli] != "xbrli":
-        namespacePrefixes[XbrlConst.xbrli] = "xbrli"  # normalize xbrli prefix
-
     if hasLang:
         aspectsDefined.add(qnOimLangAspect)
     if hasUnits:
         aspectsDefined.add(qnOimUnitAspect)
 
     for footnoteRel in footnotesRelationshipSet.modelRelationships:
-        typePrefix = "ftTyp_" + os.path.basename(footnoteRel.arcrole)
-        if footnoteRel.linkrole == XbrlConst.defaultLinkRole:
-            groupPrefix = "ftGrp_default"
-        else:
-            groupPrefix = "ftGrp_" + os.path.basename(footnoteRel.linkrole)
         if footnoteRel.arcrole not in linkTypeAliases:
+            typePrefix = reservedUriAliases.get(footnoteRel.arcrole, f"ftTyp_{os.path.basename(footnoteRel.arcrole)}")
             linkTypeAliases[footnoteRel.arcrole] = typePrefix
-        if groupPrefix not in groupAliases:
+        if footnoteRel.linkrole not in groupAliases:
+            groupPrefix = reservedUriAliases.get(footnoteRel.linkrole, f"ftGrp_{os.path.basename(footnoteRel.linkrole)}")
             groupAliases[footnoteRel.linkrole] = groupPrefix
 
     dtsReferences = set()
@@ -441,19 +478,17 @@ def saveLoadableOIM(
             factFootnotes(fact, oimFact=oimFact)
         return oimFact
 
-    namespaces = {p: ns for ns, p in sorted(namespacePrefixes.items(), key=lambda item: item[1])}
-
     # common metadata
     oimReport = {}  # top level of oim json output
     oimReport["documentInfo"] = oimDocInfo = {}
     oimDocInfo["documentType"] = nsOim + ("/xbrl-json" if isJSON else "/xbrl-csv")
     if isJSON:
         oimDocInfo["features"] = oimFeatures = {}
-    oimDocInfo["namespaces"] = namespaces
+    oimDocInfo["namespaces"] = namespacePrefixes.namespaces
     if linkTypeAliases:
-        oimDocInfo["linkTypes"] = {a: u for u, a in sorted(linkTypeAliases.items(), key=lambda item: item[1])}
-    if linkTypeAliases:
-        oimDocInfo["linkGroups"] = {a: u for u, a in sorted(groupAliases.items(), key=lambda item: item[1])}
+        oimDocInfo["linkTypes"] = {a: u for u, a in sorted(linkTypeAliases.items(), key=operator.itemgetter(1))}
+    if groupAliases:
+        oimDocInfo["linkGroups"] = {a: u for u, a in sorted(groupAliases.items(), key=operator.itemgetter(1))}
     oimDocInfo["taxonomy"] = dtsReferences
     if isJSON:
         oimFeatures["xbrl:canonicalValues"] = True

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -780,7 +780,7 @@ def saveLoadableOIMMenuCommand(cntlr: CntlrWinMain) -> None:
     oimFile = cntlr.uiFileDialog(
         "save",
         title=_("arelle - Save Loadable OIM file"),
-        initialdir=cntlr.config.setdefault("loadableExcelFileDir", "."),
+        initialdir=cntlr.config.setdefault("loadableOIMFileDir", "."),
         filetypes=[(_("JSON file .json"), "*.json"), (_("CSV file .csv"), "*.csv"), (_("XLSX file .xlsx"), "*.xlsx")],
         defaultextension=".json",
     )  # type: ignore[no-untyped-call]

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -241,7 +241,11 @@ def saveLoadableOIM(
                 elif isinstance(obj, Decimal):
                     # XML canonical representation of decimal requires a decimal point.
                     # https://www.w3.org/TR/xmlschema-2/#decimal-canonical-representation
-                    return f"{obj:.1f}" if obj % 1 == 0 else f"{obj}"
+                    if obj % 1 == 0:
+                        return f"{obj:.1f}"
+                    intPart, fracPart = f"{obj:f}".split(".")
+                    canonicalFracPart = fracPart.rstrip("0") or "0"
+                    return f"{intPart}.{canonicalFracPart}"
                 else:
                     return f"{obj}"
             except Exception:

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -209,7 +209,8 @@ def saveLoadableOIM(
     isXL = oimFile.endswith(".xlsx")
     isCSVorXL = isCSV or isXL
     if not isJSON and not isCSVorXL:
-        return
+        oimFile = oimFile + ".json"
+        isJSON = True
 
     namespacePrefixes = NamespacePrefixes({nsOim: "xbrl"})
     if extensionPrefixes:

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -553,6 +553,8 @@ def saveLoadableOIM(
             if outputZip:
                 fh.seek(0)
                 outputZip.writestr(os.path.basename(oimFile), fh.read())
+        if not outputZip:
+            modelXbrl.modelManager.cntlr.showStatus(_("Saved JSON OIM file {}").format(oimFile))
 
     elif isCSVorXL:
         # save CSV
@@ -754,16 +756,17 @@ def saveLoadableOIM(
         # save metadata
         if isCSV:
             assert isinstance(_baseURL, str)
-            with open(_baseURL + "-metadata.json", "w", encoding="utf-8") as fh:
+            csvMetadataFile = _baseURL + "-metadata.json"
+            with open(csvMetadataFile, "w", encoding="utf-8") as fh:
                 fh.write(json.dumps(oimReport, ensure_ascii=False, indent=2, sort_keys=False))
+            modelXbrl.modelManager.cntlr.showStatus(_("Saved CSV OIM metadata file {}").format(csvMetadataFile))
         elif isXL:
             _open(None, "metadata")
             _writerow(["metadata"], header=True)
             _writerow([json.dumps(oimReport, ensure_ascii=False, indent=1, sort_keys=False)])
             _close()
-
-        if isXL:
             workbook.save(oimFile)
+            modelXbrl.modelManager.cntlr.showStatus(_("Saved Excel file {}").format(oimFile))
 
 
 def saveLoadableOIMMenuCommand(cntlr: CntlrWinMain) -> None:

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -776,6 +776,10 @@ def saveLoadableOIMMenuCommand(cntlr: CntlrWinMain) -> None:
         or cntlr.modelManager.modelXbrl.modelDocument.type
         not in (ModelDocument.Type.INSTANCE, ModelDocument.Type.INLINEXBRL, ModelDocument.Type.INLINEXBRLDOCUMENTSET)
     ):
+        cntlr.addToLog(
+            messageCode="arelleOIMsaver",
+            message=_("No supported XBRL instance documents loaded that can be saved to OIM format."),
+        )
         return
         # get file name into which to save log file while in foreground thread
     oimFile = cntlr.uiFileDialog(
@@ -786,6 +790,7 @@ def saveLoadableOIMMenuCommand(cntlr: CntlrWinMain) -> None:
         defaultextension=".json",
     )  # type: ignore[no-untyped-call]
     if not isinstance(oimFile, str):
+        # User cancelled file dialog.
         return
 
     cntlr.config["loadableOIMFileDir"] = os.path.dirname(oimFile)

--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -722,7 +722,7 @@ def saveLoadableOIMMenuCommand(cntlr: CntlrWinMain) -> None:
         or cntlr.modelManager.modelXbrl is None
         or cntlr.modelManager.modelXbrl.modelDocument is None
         or cntlr.modelManager.modelXbrl.modelDocument.type
-        not in (ModelDocument.Type.INSTANCE, ModelDocument.Type.INLINEXBRL)
+        not in (ModelDocument.Type.INSTANCE, ModelDocument.Type.INLINEXBRL, ModelDocument.Type.INLINEXBRLDOCUMENTSET)
     ):
         return
         # get file name into which to save log file while in foreground thread


### PR DESCRIPTION
#### Reason for change
We already support converting from a multi-doc iXDS using the CLI, but trying to do the same in the GUI exits silently.
A new testing doc also uncovered more bugs when saving reports to OIM formats. 

#### Description of change
* Add inline document sets to the types supported by the OIM plugin GUI callback function.
* Fix an error message typo.
* Respect the reserved URI prefixes from the OIM specs when saving to OIM formats.
* Handle decimal values with trailing zeros (`0.20`) when saving values to their canonical XML format (`0.2`).
* Bug fixes for writing out xBRL-CSV footnotes.
* Various Save to OIM GUI improvements (status messages and default to json)

#### Steps to Test
* GUI Support
	1. In the GUI enable both the `saveLoadableOIM` and `InlineXbrlDocumentSet` plugins.
	1. Use [filing_documents.zip](https://github.com/user-attachments/files/20052089/filing_documents.zip)
	1. From the multi doc file open dialog:
		1. `File` > `Open File Inline Doc Set`
		1. Select both `wk-20230930.htm` and `wk-20230930_d2.htm` docs.
	1. Select `Tools` > `Save Loadable OIM`
	1. Provide a filename ending in either `.json` or `.csv`.
	1. Verify that the OIM report was generated.
* Bug Fixes
	1. Use an internal testing doc and save it to xBRL-CSV.
	1. Open and validate exported xBRL-CSV doc.
	1. Confirm there are no canonical value errors.
	1. Confirm there are no reserved prefix errors.
	1. Confirm there are no footnote related errors.


**review**:
@Arelle/arelle
