### PR TITLE
NL-KVK message code update

### DIFF
--- a/arelle/plugin/validate/NL/ValidationPluginExtension.py
+++ b/arelle/plugin/validate/NL/ValidationPluginExtension.py
@@ -136,7 +136,7 @@ class ValidationPluginExtension(ValidationPlugin):
             jenvNamespace = 'http://www.nltaxonomie.nl/nt19/jenv/20241211/dictionary/jenv-bw2-data'
             kvkINamespace = 'http://www.nltaxonomie.nl/nt19/kvk/20241211/dictionary/kvk-data'
             nlTypesNamespace = 'http://www.nltaxonomie.nl/nt19/sbr/20240301/dictionary/nl-types'
-            titel9Namespace = 'https://www.nltaxonomie.nl/jenv/2024-03-31/bw2-titel9-cor'
+            titel9Namespace = 'https://www.nltaxonomie.nl/bw2-titel9/2024-12-31/bw2-titel9-cor' if disclosureSystem == DISCLOSURE_SYSTEM_NL_INLINE_2024 else ''
             entrypointRoot = 'http://www.nltaxonomie.nl/nt19/kvk/20241211/entrypoints/'
             entrypoints = {entrypointRoot + e for e in [
                 'kvk-rpt-jaarverantwoording-2024-ifrs-full.xsd',

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -60,7 +60,7 @@ def rule_nl_kvk_3_1_1_1(
     for entityId in entityIdentifierValues:
         if not XBRLI_IDENTIFIER_PATTERN.match(entityId[1]):
             yield Validation.error(
-                codes='NL.NL-KVK-3.1.1.1',
+                codes='NL.NL-KVK-RTS_Annex_IV_Par_2_G3-1-1_1.invalidIdentifierFormat',
                 msg=_('xbrli:identifier content to match KVK number format that must consist of 8 consecutive digits.'
                       'Additionally the first two digits must not be "00".'),
                 modelObject = val.modelXbrl
@@ -87,7 +87,7 @@ def rule_nl_kvk_3_1_1_2(
     for entityId in entityIdentifierValues:
         if XBRLI_IDENTIFIER_SCHEMA != entityId[0]:
             yield Validation.error(
-                codes='NL.NL-KVK-3.1.1.2',
+                codes='NL.NL-KVK-RTS_Annex_IV_Par_2_G3-1-1_2.invalidIdentifier',
                 msg=_('The scheme attribute of the xbrli:identifier does not match the required content.'
                       'This should be "http://www.kvk.nl/kvk-id".'),
                 modelObject = val.modelXbrl
@@ -209,7 +209,7 @@ def rule_nl_kvk_3_1_4_1 (
     entityIdentifierValues = pluginData.entityIdentifiersInDocument(val.modelXbrl)
     if len(entityIdentifierValues) >1:
         yield Validation.error(
-            codes='NL.NL-KVK-3.1.4.1',
+            codes='NL.NL-KVK-RTS_Annex_IV_Par_1_G3-1-4_1.multipleIdentifiers',
             msg=_('All entity identifiers and schemes must have identical content.'),
             modelObject = entityIdentifierValues
         )
@@ -236,7 +236,7 @@ def rule_nl_kvk_3_1_4_2 (
         regFact = next(iter(registrationNumberFacts))
         if regFact.xValid >= VALID and regFact.xValue != regFact.context.entityIdentifier[1]:
             yield Validation.error(
-                codes='NL-KVK.3.1.4.2',
+                codes='NL.NL-KVK-RTS_Annex_IV_Par_1_G3-1-4_2.nonIdenticalIdentifier',
                 msg=_("xbrli:identifier value must be identical to bw2-titel9:ChamberOfCommerceRegistrationNumber fact value.").format(
                     regFact.xValue,
                     regFact.context.entityIdentifier[1]

--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -192,7 +192,7 @@ class ConformanceSuiteConfig:
     cache_version_id: str | None = None
     capture_warnings: bool = True
     ci_enabled: bool = True
-    expected_additional_testcase_errors: dict[str, frozenset[str]] = field(default_factory=dict)
+    expected_additional_testcase_errors: dict[str, dict[str, int]] = field(default_factory=dict)
     expected_failure_ids: frozenset[str] = frozenset()
     expected_missing_testcases: frozenset[str] = frozenset()
     expected_model_errors: frozenset[str] = frozenset()

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
@@ -25,7 +25,9 @@ config = ConformanceSuiteConfig(
     expected_additional_testcase_errors={f"esef_conformance_suite_2024/tests/inline_xbrl/{s}": val for s, val in {
         # Typo in the test case namespace declaration: incorrectly uses the Extensible Enumeration 1 namespace with the
         # commonly used Extensible Enumeration 2 prefix: xmlns:enum2="http://xbrl.org/2014/extensible-enumerations"
-        'G2-4-1_1/index.xml:TC2_valid': frozenset({'differentExtensionDataType'}),
+        'G2-4-1_1/index.xml:TC2_valid': {
+            'differentExtensionDataType': 1,
+        },
     }.items()},
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2024',
     name=PurePath(__file__).stem,

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -18,9 +18,17 @@ config = ConformanceSuiteConfig(
         *NL_PACKAGES['NL-INLINE-2024'],
     ],
     expected_additional_testcase_errors={f"conformance-suite-2024-sbr-domein-handelsregister/tests/{s}": val for s, val in {
-        'RTS_Annex_IV_Par_2_G3-1-1_2/index.xml:TC2_invalid': frozenset({'message:lei-identifier-format', 'message:valueKvKIdentifierScheme'}),
-        'RTS_Annex_IV_Par_1_G3-1-4_1/index.xml:TC2_invalid': frozenset({'nonIdenticalIdentifier', 'message:valueKvKIdentifier'}),
-        'RTS_Annex_IV_Par_1_G3-1-4_2/index.xml:TC2_invalid': frozenset({'message:valueKvKIdentifier'}),
+        'RTS_Annex_IV_Par_2_G3-1-1_2/index.xml:TC2_invalid': {
+            'message:lei-identifier-format': 105,
+            'message:valueKvKIdentifierScheme': 105,
+        },
+        'RTS_Annex_IV_Par_1_G3-1-4_1/index.xml:TC2_invalid': {
+            'message:valueKvKIdentifier': 13,
+            'nonIdenticalIdentifier': 1,
+        },
+        'RTS_Annex_IV_Par_1_G3-1-4_2/index.xml:TC2_invalid': {
+            'message:valueKvKIdentifier': 13,
+        },
     }.items()},
     expected_failure_ids=frozenset([
         # Conformance Suite Errors

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -17,7 +17,15 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NL-INLINE-2024'],
     ],
+    expected_additional_testcase_errors={f"conformance-suite-2024-sbr-domein-handelsregister/tests/{s}": val for s, val in {
+        'RTS_Annex_IV_Par_2_G3-1-1_2/index.xml:TC2_invalid': frozenset({'message:lei-identifier-format', 'message:valueKvKIdentifierScheme'}),
+        'RTS_Annex_IV_Par_1_G3-1-4_1/index.xml:TC2_invalid': frozenset({'nonIdenticalIdentifier', 'message:valueKvKIdentifier'}),
+        'RTS_Annex_IV_Par_1_G3-1-4_2/index.xml:TC2_invalid': frozenset({'message:valueKvKIdentifier'}),
+    }.items()},
     expected_failure_ids=frozenset([
+        # Conformance Suite Errors
+        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_2_G3-1-1_1/index.xml:TC2_invalid',  # Expects NonIdenticalIdentifier instead of nonIdenticalIdentifier (note the cap N)
+
         # Not Implemented
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-4_2/index.xml:TC4_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC4_invalid',
@@ -88,10 +96,6 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_11_G4-2-2_1/index.xml:TC3_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC4_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_14_G3-5-1_1/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_1_G3-1-4_1/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_1_G3-1-4_2/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_2_G3-1-1_1/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_2_G3-1-1_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_1/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC3_invalid',

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_2_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_2_1.py
@@ -21,7 +21,9 @@ config = ConformanceSuiteConfig(
     expected_additional_testcase_errors={f"XBRL-CONF-2024-12-17/Common/{s}": val for s, val in {
         # 202.02b in the absence of source/target constraints, an empty href doesn't pose a problem
         # 202-02b-HrefResolutionCounterExample-custom.xml Expected: valid, Actual: arelle:hrefWarning
-        '200-linkbase/202-xlinkLocator.xml:V-02b': frozenset({'arelle:hrefWarning'}),
+        '200-linkbase/202-xlinkLocator.xml:V-02b': {
+            'arelle:hrefWarning': 1,
+        },
     }.items()},
     expected_missing_testcases=frozenset([f"XBRL-CONF-2024-12-17/Common/{s}" for s in [
         "related-standards/xlink/arc-duplication/arc-duplication-testcase.xml",

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
@@ -17,13 +17,31 @@ config = ConformanceSuiteConfig(
     ],
     expected_additional_testcase_errors={f"report-package-conformance/index.csv:{s}": val for s, val in {
         # "Empty" iXBRL docs are missing schema required elements.
-        "V-301-xbri-with-single-ixds": frozenset({"lxml.SCHEMAV_ELEMENT_CONTENT", "ix11.14.1.2:missingResources"}),
-        "V-302-xbri-with-single-html": frozenset({"lxml.SCHEMAV_ELEMENT_CONTENT", "ix11.14.1.2:missingResources"}),
-        "V-303-xbri-with-single-htm": frozenset({"lxml.SCHEMAV_ELEMENT_CONTENT", "ix11.14.1.2:missingResources"}),
+        "V-301-xbri-with-single-ixds": {
+            "lxml.SCHEMAV_ELEMENT_CONTENT": 1,
+            "ix11.14.1.2:missingResources": 1,
+        },
+        "V-302-xbri-with-single-html": {
+            "lxml.SCHEMAV_ELEMENT_CONTENT": 1,
+            "ix11.14.1.2:missingResources": 1,
+        },
+        "V-303-xbri-with-single-htm": {
+            "lxml.SCHEMAV_ELEMENT_CONTENT": 1,
+            "ix11.14.1.2:missingResources": 1,
+        },
         # Report package references a taxonomy which does not exist.
-        "V-508-xbr-with-no-taxonomy": frozenset({"IOerror", "oime:invalidTaxonomy"}),
-        "V-509-xbr-with-json-in-dot-xhtml-directory": frozenset({"IOerror", "oime:invalidTaxonomy"}),
-        "V-701-zip-with-no-taxonomy": frozenset({"IOerror", "oime:invalidTaxonomy"}),
+        "V-508-xbr-with-no-taxonomy": {
+            "IOerror": 1,
+            "oime:invalidTaxonomy": 1,
+        },
+        "V-509-xbr-with-json-in-dot-xhtml-directory": {
+            "IOerror": 1,
+            "oime:invalidTaxonomy": 1,
+        },
+        "V-701-zip-with-no-taxonomy": {
+            "IOerror": 1,
+            "oime:invalidTaxonomy": 1,
+        },
     }.items()},
     info_url="https://specifications.xbrl.org/work-product-index-taxonomy-packages-report-packages-1.0.html",
     membership_url="https://www.xbrl.org/join",

--- a/tests/integration_tests/validation/validation_util.py
+++ b/tests/integration_tests/validation/validation_util.py
@@ -247,7 +247,7 @@ def _get_elems_by_local_name(tree: etree._ElementTree, local_name: str) -> list[
 
 def get_conformance_suite_arguments(config: ConformanceSuiteConfig, filename: str,
         additional_plugins: frozenset[str], build_cache: bool, offline: bool, log_to_file: bool,
-        expected_additional_testcase_errors: dict[str, frozenset[str]],
+        expected_additional_testcase_errors: dict[str, dict[str, int]],
         expected_failure_ids: frozenset[str], shard: int | None,
         testcase_filters: list[str]) -> tuple[list[Any], dict[str, Any]]:
     use_shards = shard is not None
@@ -279,7 +279,10 @@ def get_conformance_suite_arguments(config: ConformanceSuiteConfig, filename: st
         args.extend(['--internetConnectivity', 'offline'])
     for pattern in testcase_filters:
         args.extend(['--testcaseFilter', pattern])
-    for testcase_id, errors in expected_additional_testcase_errors.items():
+    for testcase_id, errorCounts in expected_additional_testcase_errors.items():
+        errors = []
+        for error, count in errorCounts.items():
+            errors.extend([error] * count)
         args.extend(['--testcaseExpectedErrors', f'{testcase_id}|{",".join(errors)}'])
     kws = dict(
         expected_failure_ids=expected_failure_ids,


### PR DESCRIPTION
#### Reason for change
The following codes were updated based on the conformance suite and their tests unlocked:
- NL.NL-KVK-3.1.1.1 -> NL.NL-KVK-RTS_Annex_IV_Par_2_G3-1-1_1.invalidIdentifierFormat
- NL.NL-KVK-3.1.1.2 -> NL.NL-KVK-RTS_Annex_IV_Par_2_G3-1-1_2.invalidIdentifier
- NL.NL-KVK-3.1.4.1 -> NL.NL-KVK-RTS_Annex_IV_Par_1_G3-1-4_1.multipleIdentifiers
- NL.NL-KVK.3.1.4.2 -> NL.NL-KVK-RTS_Annex_IV_Par_1_G3-1-4_2.nonIdenticalIdentifier

#### Steps to Test
CI

**review**:
@Arelle/arelle
