### PR TITLE
Log better errors when packages are missing

### DIFF
--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -839,7 +839,21 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                 filepath = modelXbrl.modelManager.cntlr.webCache.getfilename(mappedUrl) # , reload=reloadCache, checkModifiedTime=kwargs.get("checkModifiedTime",False))
                 if filepath:
                     url = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(filepath)
-            if filepath and filepath.endswith(".csv") or ("metadata" in filepath and filepath.endswith(".json")):
+            if filepath is None:
+                if extendingFile is None:
+                    raise OIMException(
+                        "oime:unresolvableFile",
+                        _("Unable to resolve file %(oimFile)s. A taxonomy package may be required to load this report."),
+                        oimFile=oimFile,
+                    )
+                else:
+                    raise OIMException(
+                        "xbrlce:unresolvableBaseMetadataFile",
+                        _("Unable to resolve extended metadata file %(extendingFile)s, referenced from %(oimFile)s. A taxonomy package may be required to load this report."),
+                        extendingFile=extendingFile,
+                        oimFile=oimFile,
+                    )
+            if filepath.endswith(".csv") or ("metadata" in filepath and filepath.endswith(".json")):
                 errPrefix = "xbrlce"
             else:
                 errPrefix = "xbrlje"


### PR DESCRIPTION
#### Reason for change
Resolves google group issue [H35s4j4wG9I](https://groups.google.com/g/arelle-users/c/H35s4j4wG9I)

![Arelle-Dora](https://github.com/user-attachments/assets/248e6565-605c-4dfa-b6fe-14a2965f2fa4)

#### Description of change
If a xBRL-CSV metadata file extends 

#### Steps to Test
1. CI/OIM conformance suite
2. Use [DUMMYLEI123456789012.CON_FR_DORA010100_DORA_2024-12-31_20241213174803429.zip](https://github.com/user-attachments/files/20211656/DUMMYLEI123456789012.CON_FR_DORA010100_DORA_2024-12-31_20241213174803429.zip)
    1. `python arelleCmdLine.py --file DUMMYLEI123456789012.CON_FR_DORA010100_DORA_2024-12-31_20241213174803429.zip`
    2. Verify that a `'NoneType' is not iterable` error is no longer raised.
    3. Verify that a `xbrlce:unresolvableBaseMetadataFile` error is raised and informs the user that a taxonomy package may be required.


**review**:
@Arelle/arelle
