### PR TITLE
Update XML Schema validation and parsing

### DIFF
--- a/arelle/PackageManager.py
+++ b/arelle/PackageManager.py
@@ -130,7 +130,7 @@ def _parsePackageMetadata(
     try:
         metadataFileContent = filesource.file(metadataFile)[0] # URL in zip, plain file in file system or web
         tree = _parseFile(cntlr, parser, metadataFile, metadataFileContent, TP_XSD)
-    except (etree.XMLSyntaxError, etree.DocumentInvalid) as err:
+    except (etree.XMLSyntaxError, etree.DocumentInvalid, etree.XMLSchemaError) as err:
         cntlr.addToLog(_("Taxonomy package file syntax error %(error)s"),
                        messageArgs={"error": str(err)},
                        messageCode="tpe:invalidMetaDataFile",

--- a/arelle/ValidateFilingText.py
+++ b/arelle/ValidateFilingText.py
@@ -3,7 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 #import xml.sax, xml.sax.handler
-from lxml.etree import XML, DTD, SubElement, _ElementTree, _Comment, _ProcessingInstruction, XMLSyntaxError, XMLParser
+from lxml.etree import XML, DTD, SubElement, _ElementTree, _Comment, _ProcessingInstruction, _Entity, XMLSyntaxError, XMLParser
 from dataclasses import dataclass
 from PIL import Image as pilImage
 import os, io, base64
@@ -604,7 +604,7 @@ def validateTextBlockFacts(modelXbrl):
                         eltTag = elt.tag
                         if isinstance(elt, ModelObject) and elt.namespaceURI == xhtml:
                             eltTag = elt.localName
-                        elif isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction)):
+                        elif isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
                             continue # comment or other non-parsed element
                         else:
                             eltTag = elt.tag
@@ -730,7 +730,7 @@ def validateHtmlContent(modelXbrl, referenceElt, htmlEltTree, validatedObjectLab
     for elt in htmlEltTree.iter():
         if isinstance(elt, ModelObject) and elt.namespaceURI == xhtml:
             eltTag = elt.localName
-        elif isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction)):
+        elif isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
             continue # comment or other non-parsed element
         else:
             eltTag = elt.tag

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -777,7 +777,7 @@ def lxmlSchemaValidate(modelDocument: ModelDocument, extraSchema : str | None = 
                                    file=modelDocument.basename,
                                    level=logging.ERROR)
                     modelDocument.modelXbrl.errors.append(msgCode)
-        except etree.XMLSyntaxError as err:
+        except (etree.XMLSyntaxError, etree.XMLSchemaError) as err:
             msgCode = "lxml.schemaError"
             cntlr.addToLog(_("XML file syntax error %(error)s"),
                            messageArgs={"error": str(err)},

--- a/arelle/plugin/validate/CIPC/__init__.py
+++ b/arelle/plugin/validate/CIPC/__init__.py
@@ -12,7 +12,7 @@ Taxonomy packages:
 """
 import os
 import regex as re
-from lxml.etree import _ElementTree, _Comment, _ProcessingInstruction
+from lxml.etree import _ElementTree, _Comment, _ProcessingInstruction, _Entity
 from arelle import ModelDocument, XbrlConst
 from arelle.ModelDtsObject import ModelResource
 from arelle.ModelInstanceObject import ModelFact, ModelInlineFact, ModelInlineFootnote
@@ -125,7 +125,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                 eltTag = elt.tag
                 if isinstance(elt, ModelObject) and elt.namespaceURI == xhtml:
                     eltTag = elt.localName
-                elif isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction)):
+                elif isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
                     continue # comment or other non-parsed element
                 else:
                     eltTag = elt.tag

--- a/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
@@ -11,7 +11,7 @@ from math import isnan
 from typing import Any, cast
 
 import regex as re
-from lxml.etree import EntityBase, _Comment, _ElementTree, _ProcessingInstruction, _Entity
+from lxml.etree import EntityBase, _Comment, _Element, _ElementTree, _ProcessingInstruction, _Entity
 
 from arelle import LeiUtil, ModelDocument, XbrlConst
 from arelle.ModelDtsObject import ModelConcept
@@ -726,7 +726,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                 _("The xlink:role attribute of a link:footnote and link:footnoteLink element as well as xlink:arcrole attribute of a link:footnoteArc MUST be defined in the XBRL Specification 2.1."),
                 modelObject=footnoteRoleErrors)
 
-        nonStdFootnoteElts = list()
+        nonStdFootnoteElts: list[_Element] = list()
         for modelLink in modelXbrl.baseSets[("XBRL-footnotes",None,None,None)]:
             for uncast_elt in modelLink.iterchildren():
                 elt = cast(Any, uncast_elt)

--- a/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
@@ -11,7 +11,7 @@ from math import isnan
 from typing import Any, cast
 
 import regex as re
-from lxml.etree import EntityBase, _Comment, _Element, _ElementTree, _ProcessingInstruction, _Entity
+from lxml.etree import _Comment, _Element, _ElementTree, _Entity, _ProcessingInstruction
 
 from arelle import LeiUtil, ModelDocument, XbrlConst
 from arelle.ModelDtsObject import ModelConcept
@@ -275,7 +275,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     elt = cast(Any, uncast_elt)
 
                     eltTag = elt.tag
-                    if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity, EntityBase)):
+                    if isinstance(elt, (_Comment, _ElementTree, _Entity, _ProcessingInstruction)):
                         continue # comment or other non-parsed element
                     else:
                         eltTag = elt.tag
@@ -731,7 +731,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
             for uncast_elt in modelLink.iterchildren():
                 elt = cast(Any, uncast_elt)
 
-                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
+                if isinstance(elt, (_Comment, _ElementTree, _Entity, _ProcessingInstruction)):
                     continue # comment or other non-parsed element
                 if elt.qname not in FOOTNOTE_LINK_CHILDREN:
                     nonStdFootnoteElts.append(elt)

--- a/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
@@ -11,7 +11,7 @@ from math import isnan
 from typing import Any, cast
 
 import regex as re
-from lxml.etree import EntityBase, _Comment, _ElementTree, _ProcessingInstruction
+from lxml.etree import EntityBase, _Comment, _ElementTree, _ProcessingInstruction, _Entity
 
 from arelle import LeiUtil, ModelDocument, XbrlConst
 from arelle.ModelDtsObject import ModelConcept
@@ -275,7 +275,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     elt = cast(Any, uncast_elt)
 
                     eltTag = elt.tag
-                    if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, EntityBase)):
+                    if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity, EntityBase)):
                         continue # comment or other non-parsed element
                     else:
                         eltTag = elt.tag
@@ -731,7 +731,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
             for uncast_elt in modelLink.iterchildren():
                 elt = cast(Any, uncast_elt)
 
-                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction)):
+                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
                     continue # comment or other non-parsed element
                 if elt.qname not in FOOTNOTE_LINK_CHILDREN:
                     nonStdFootnoteElts.append(elt)

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 
 import regex as re
 import tinycss2.ast  # type: ignore[import-untyped]
-from lxml.etree import EntityBase, _Comment, _ElementTree, _ProcessingInstruction, _Entity
+from lxml.etree import EntityBase, _Comment, _Element, _ElementTree, _ProcessingInstruction, _Entity
 
 from arelle import LeiUtil, ModelDocument, XbrlConst
 from arelle.ModelDtsObject import ModelConcept
@@ -808,7 +808,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                 _("The xlink:role attribute of a link:footnote and link:footnoteLink element as well as xlink:arcrole attribute of a link:footnoteArc MUST be defined in the XBRL Specification 2.1."),
                 modelObject=footnoteRoleErrors)
 
-        nonStdFootnoteElts = list()
+        nonStdFootnoteElts: list[_Element] = list()
         for modelLink in modelXbrl.baseSets[("XBRL-footnotes",None,None,None)]:
             for uncast_elt in modelLink.iterchildren():
                 elt = cast(Any, uncast_elt)

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 
 import regex as re
 import tinycss2.ast  # type: ignore[import-untyped]
-from lxml.etree import EntityBase, _Comment, _ElementTree, _ProcessingInstruction
+from lxml.etree import EntityBase, _Comment, _ElementTree, _ProcessingInstruction, _Entity
 
 from arelle import LeiUtil, ModelDocument, XbrlConst
 from arelle.ModelDtsObject import ModelConcept
@@ -319,7 +319,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     elt = cast(Any, uncast_elt)
 
                     eltTag = elt.tag
-                    if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, EntityBase)):
+                    if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity, EntityBase)):
                         continue # comment or other non-parsed element
                     else:
                         eltTag = elt.tag
@@ -813,7 +813,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
             for uncast_elt in modelLink.iterchildren():
                 elt = cast(Any, uncast_elt)
 
-                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction)):
+                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
                     continue # comment or other non-parsed element
                 if elt.qname not in FOOTNOTE_LINK_CHILDREN:
                     nonStdFootnoteElts.append(elt)

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 
 import regex as re
 import tinycss2.ast  # type: ignore[import-untyped]
-from lxml.etree import EntityBase, _Comment, _Element, _ElementTree, _ProcessingInstruction, _Entity
+from lxml.etree import _Comment, _Element, _ElementTree, _Entity, _ProcessingInstruction
 
 from arelle import LeiUtil, ModelDocument, XbrlConst
 from arelle.ModelDtsObject import ModelConcept
@@ -319,7 +319,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     elt = cast(Any, uncast_elt)
 
                     eltTag = elt.tag
-                    if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity, EntityBase)):
+                    if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
                         continue # comment or other non-parsed element
                     else:
                         eltTag = elt.tag
@@ -813,7 +813,7 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
             for uncast_elt in modelLink.iterchildren():
                 elt = cast(Any, uncast_elt)
 
-                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
+                if isinstance(elt, (_Comment, _ElementTree, _Entity, _ProcessingInstruction)):
                     continue # comment or other non-parsed element
                 if elt.qname not in FOOTNOTE_LINK_CHILDREN:
                     nonStdFootnoteElts.append(elt)

--- a/arelle/plugin/validate/NL/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/NL/PluginValidationDataExtension.py
@@ -3,22 +3,21 @@ See COPYRIGHT.md for copyright information.
 """
 from __future__ import annotations
 
-from typing import cast, Any
-
-import regex as re
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import lru_cache
+from typing import Any, cast
+
+import regex as re
+from lxml.etree import _Comment, _ElementTree, _Entity, _ProcessingInstruction
 
 from arelle.FunctionIxt import ixtNamespaces
-from arelle.ModelInstanceObject import ModelUnit, ModelContext, ModelFact, ModelInlineFootnote
+from arelle.ModelInstanceObject import ModelContext, ModelFact, ModelInlineFootnote, ModelUnit
 from arelle.ModelValue import QName
 from arelle.ModelXbrl import ModelXbrl
-from arelle.utils.validate.ValidationUtil import etreeIterWithDepth
 from arelle.utils.PluginData import PluginData
+from arelle.utils.validate.ValidationUtil import etreeIterWithDepth
 from arelle.XmlValidate import lexicalPatterns
-
-from lxml.etree import EntityBase, _Comment, _ElementTree, _ProcessingInstruction
 
 XBRLI_IDENTIFIER_PATTERN = re.compile(r"^(?!00)\d{8}$")
 XBRLI_IDENTIFIER_SCHEMA = 'http://www.kvk.nl/kvk-id'
@@ -176,8 +175,7 @@ class PluginValidationDataExtension(PluginData):
         for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
             for uncast_elt, depth in etreeIterWithDepth(ixdsHtmlRootElt):
                 elt = cast(Any, uncast_elt)
-                eltTag = elt.tag
-                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, EntityBase)):
+                if isinstance(elt, (_Comment, _ElementTree, _Entity, _ProcessingInstruction)):
                     continue
                 if firstIxdsDoc and (not reportXmlLang or depth < firstRootmostXmlLangDepth):
                     xmlLang = elt.get("{http://www.w3.org/XML/1998/namespace}lang")

--- a/arelle/plugin/validate/ROS/rules/ros.py
+++ b/arelle/plugin/validate/ROS/rules/ros.py
@@ -13,7 +13,7 @@ from arelle.typing import TypeGetText
 from arelle.ValidateXbrl import ValidateXbrl
 from collections import defaultdict
 from math import isnan
-from lxml.etree import _ElementTree, _Comment, _ProcessingInstruction, _Entity
+from lxml.etree import _Comment, _ElementTree, _Entity, _ProcessingInstruction
 from arelle import ModelDocument
 from arelle.ModelInstanceObject import ModelInlineFact, ModelUnit
 from arelle.ModelValue import qname
@@ -86,7 +86,7 @@ def rule_main(
         ixTargets = set()
         for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
             for elt in ixdsHtmlRootElt.iter():
-                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
+                if isinstance(elt, (_Comment, _ElementTree, _Entity, _ProcessingInstruction)):
                     continue # comment or other non-parsed element
                 if isinstance(elt, ModelInlineFact):
                     if elt.format is not None and elt.format.namespaceURI not in TR_NAMESPACES:

--- a/arelle/plugin/validate/ROS/rules/ros.py
+++ b/arelle/plugin/validate/ROS/rules/ros.py
@@ -13,7 +13,7 @@ from arelle.typing import TypeGetText
 from arelle.ValidateXbrl import ValidateXbrl
 from collections import defaultdict
 from math import isnan
-from lxml.etree import _ElementTree, _Comment, _ProcessingInstruction
+from lxml.etree import _ElementTree, _Comment, _ProcessingInstruction, _Entity
 from arelle import ModelDocument
 from arelle.ModelInstanceObject import ModelInlineFact, ModelUnit
 from arelle.ModelValue import qname
@@ -86,7 +86,7 @@ def rule_main(
         ixTargets = set()
         for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
             for elt in ixdsHtmlRootElt.iter():
-                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction)):
+                if isinstance(elt, (_ElementTree, _Comment, _ProcessingInstruction, _Entity)):
                     continue # comment or other non-parsed element
                 if isinstance(elt, ModelInlineFact):
                     if elt.format is not None and elt.format.namespaceURI not in TR_NAMESPACES:


### PR DESCRIPTION
#### Reason for change

* lxml exception XmlSchemaError (or its subclasses) were not caught and appear to occur with old python versions and current lxml
* XML element parsing had not been skipping _Entity objects, when expecting element objects, with newer supported lxml

#### Description of change

 * add catching of XmlSchemaError in addition to XmlSyntaxError where applicable
 * add skipping of _Entity objects where _Comments and other non-elements are skipped and real Elements are expected

#### Steps to Test

 * EFM test 605-instance-syntax/605-15-text-blocks-xml-well-formed/e60515018ng-20081231.xml had begun to crash Arelle
 * EFM, ESEF, ROS test suites

**review**:
@Arelle/arelle
