### PR TITLE
Rework NL.NL-KVK.3.5.2.2.taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport

### DIFF
--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -380,7 +380,7 @@ def areFactsValueEqual(factA: ModelFact, factB: ModelFact) -> bool:
 
 
 def getAspectEqualFacts(
-    hashEquivalentFacts: list[ModelFact], includeSingles: bool
+    hashEquivalentFacts: list[ModelFact], includeSingles: bool, useLang: bool = True
 ) -> Iterator[list[ModelFact]]:
     """
     Given a list of concept/context/unit hash-equivalent facts,
@@ -389,20 +389,14 @@ def getAspectEqualFacts(
     :param includeSingles: Whether to include lists of single facts (with no duplicates).
     :return: Lists of aspect-equal facts.
     """
-    aspectEqualFacts: dict[
-        tuple[QName, str | None], dict[tuple[ModelContext, ModelUnit], list[ModelFact]]
-    ] = defaultdict(dict)
-    for (
-        fact
-    ) in (
-        hashEquivalentFacts
-    ):  # check for hash collision by value checks on context and unit
+    aspectEqualFacts: dict[tuple[QName, str | None], dict[tuple[ModelContext, ModelUnit], list[ModelFact]]] = defaultdict(dict)
+    for fact in hashEquivalentFacts:  # check for hash collision by value checks on context and unit
         contextUnitDict = aspectEqualFacts[
             (
                 fact.qname,
                 (
                     cast(str, fact.xmlLang or "").lower()
-                    if fact.concept.type.isWgnStringFactType
+                    if useLang and fact.concept.type.isWgnStringFactType
                     else None
                 ),
             )

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -17,7 +17,7 @@ from arelle.typing import TypeGetText
 from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
-from arelle.ValidateDuplicateFacts import getHashEquivalentFactGroups
+from arelle.ValidateDuplicateFacts import getHashEquivalentFactGroups, getAspectEqualFacts
 from ..DisclosureSystems import DISCLOSURE_SYSTEM_NL_INLINE_2024
 from ..PluginValidationDataExtension import PluginValidationDataExtension, XBRLI_IDENTIFIER_PATTERN, XBRLI_IDENTIFIER_SCHEMA, DISALLOWED_IXT_NAMESPACES
 
@@ -512,9 +512,10 @@ def rule_nl_kvk_3_5_2_2(
                       f.context is not None]
     factGroups = getHashEquivalentFactGroups(filtered_facts)
     for fgroup in factGroups:
-        if not any(f.xmlLang == reportXmlLang for f in fgroup):
-            yield Validation.error(
-                codes='NL.NL-KVK.3.5.2.2.taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport',
-                msg=_('Tagged text facts MUST be provided in the language of the report.'),
-                modelObject=fgroup
-            )
+        for flist in getAspectEqualFacts(fgroup, includeSingles=True, useLang=False):
+            if not any(f.xmlLang == reportXmlLang for f in flist):
+                yield Validation.error(
+                    codes='NL.NL-KVK.3.5.2.2.taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport',
+                    msg=_('Tagged text facts MUST be provided in the language of the report.'),
+                    modelObject=fgroup
+                )

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -17,6 +17,7 @@ from arelle.typing import TypeGetText
 from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
+from arelle.ValidateDuplicateFacts import getHashEquivalentFactGroups
 from ..DisclosureSystems import DISCLOSURE_SYSTEM_NL_INLINE_2024
 from ..PluginValidationDataExtension import PluginValidationDataExtension, XBRLI_IDENTIFIER_PATTERN, XBRLI_IDENTIFIER_SCHEMA, DISALLOWED_IXT_NAMESPACES
 
@@ -505,17 +506,15 @@ def rule_nl_kvk_3_5_2_2(
     NL-KVK.3.5.2.2: All tagged text facts MUST be provided in at least the language of the report.
     """
     reportXmlLang = pluginData.getReportXmlLang(val.modelXbrl)
-    factsWithWrongLang = set()
-    for fact in val.modelXbrl.facts:
-        if (fact is not None and
-                fact.concept is not None and
-                fact.concept.type is not None and
-                fact.concept.type.isOimTextFactType and
-                fact.xmlLang != reportXmlLang):
-            factsWithWrongLang.add(fact)
-    if len(factsWithWrongLang) > 0:
-        yield Validation.error(
-            codes='NL.NL-KVK.3.5.2.2.taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport',
-            msg=_('Tagged text facts MUST be provided in the language of the report.'),
-            modelObject=factsWithWrongLang
-        )
+    filtered_facts = [f for f in val.modelXbrl.facts if f.concept is not None and
+                      f.concept.type is not None and
+                      f.concept.type.isOimTextFactType and
+                      f.context is not None]
+    factGroups = getHashEquivalentFactGroups(filtered_facts)
+    for fgroup in factGroups:
+        if not any(f.xmlLang == reportXmlLang for f in fgroup):
+            yield Validation.error(
+                codes='NL.NL-KVK.3.5.2.2.taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport',
+                msg=_('Tagged text facts MUST be provided in the language of the report.'),
+                modelObject=fgroup
+            )

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -18,20 +18,17 @@ config = ConformanceSuiteConfig(
         *NL_PACKAGES['NL-INLINE-2024'],
     ],
     expected_additional_testcase_errors={f"conformance-suite-2024-sbr-domein-handelsregister/tests/{s}": val for s, val in {
-        'G3-2-4_2/index.xml:TC3_valid': {
-            'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 1,
-        },
         'G4-1-2_1/index.xml:TC2_valid': {
             'undefinedLanguageForTextFact': 1,
-            'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 1,
+            'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
         },
         'RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC2_valid': {
             'undefinedLanguageForTextFact': 1,
-            'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 1,
+            'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
         },
         'RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC4_invalid': {
             'undefinedLanguageForTextFact': 1,
-            'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 1,
+            'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
         },
         'RTS_Annex_IV_Par_1_G3-1-4_1/index.xml:TC2_invalid': {
             'message:valueKvKIdentifier': 13,
@@ -46,7 +43,7 @@ config = ConformanceSuiteConfig(
         },
         'RTS_Annex_IV_Par_6/index.xml:TC2_valid': {
             'undefinedLanguageForTextFact': 1,
-            'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 1,
+            'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
         },
     }.items()},
     expected_failure_ids=frozenset([


### PR DESCRIPTION
#### Reason for change
Rework NL.NL-KVK.3.5.2.2.taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport to handle groups of consistent facts

#### Steps to Test
CI

**review**:
@Arelle/arelle
