### PR TITLE
Separate Mac Builds for Intel and Apple Silicon

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,6 +12,11 @@ on:
         description: 'Arelle/EDGAR branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
+      macos_version:
+        default: '15'
+        description: 'MacOS version to use (15, 14, 13, latest, etc.)'
+        required: false
+        type: string
       python_version:
         default: '3.13.3'
         description: 'Python version to use'
@@ -49,6 +54,11 @@ on:
         description: 'Arelle/EDGAR branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
+      macos_version:
+        default: '15'
+        description: 'MacOS version to use (15, 14, 13, latest, etc.)'
+        required: true
+        type: string
       python_version:
         default: '3.13.3'
         description: 'Python version to use'
@@ -74,7 +84,7 @@ permissions: {}
 jobs:
   build-macos:
     environment: release
-    runs-on: macos-15
+    runs-on: macos-${{ inputs.macos_version }}
     outputs:
       artifact_versioned_name: ${{ steps.define-artifact-names.outputs.artifact_versioned_name }}
       uploaded_artifact_name: ${{ steps.define-artifact-names.outputs.uploaded_artifact_name }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -64,8 +64,7 @@ permissions: {}
 jobs:
   build-macos:
     environment: release
-    # Intel runner produces universal binary
-    runs-on: macos-13
+    runs-on: macos-15
     outputs:
       artifact_versioned_name: ${{ steps.define-artifact-names.outputs.artifact_versioned_name }}
       uploaded_artifact_name: ${{ steps.define-artifact-names.outputs.uploaded_artifact_name }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -17,6 +17,11 @@ on:
         description: 'Python version to use'
         required: false
         type: string
+      python_architecture:
+        default: 'arm64'
+        description: 'Python architecture to use (x64, arm64)'
+        required: false
+        type: string
       xule_ref:
         description: 'xbrlus/xule branch, tag or SHA to checkout (blank for default)'
         required: false
@@ -47,6 +52,11 @@ on:
       python_version:
         default: '3.13.3'
         description: 'Python version to use'
+        required: true
+        type: string
+      python_architecture:
+        default: 'arm64'
+        description: 'Python architecture to use (x64, arm64)'
         required: true
         type: string
       xule_ref:
@@ -80,6 +90,7 @@ jobs:
           cache: 'pip'
           check-latest: true
           python-version: ${{ inputs.python_version }}
+          architecture: ${{ inputs.python_architecture }}
       - run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements-build.txt
@@ -104,9 +115,9 @@ jobs:
       - name: Define artifact names
         id: define-artifact-names
         run: |
-          echo "artifact_versioned_name=arelle-macos-${{ env.BUILD_VERSION }}.dmg" >> $GITHUB_OUTPUT
+          echo "artifact_versioned_name=arelle-macos-${{ inputs.python_architecture }}-${{ env.BUILD_VERSION }}.dmg" >> $GITHUB_OUTPUT
           echo "uploaded_artifact_name=macos distribution" >> $GITHUB_OUTPUT
-          echo "DMG_BUILD_ARTIFACT_PATH=dist_dmg/arelle-macos-${{ env.BUILD_VERSION }}.dmg" >> $GITHUB_ENV
+          echo "DMG_BUILD_ARTIFACT_PATH=dist_dmg/arelle-macos-${{ inputs.python_architecture }}-${{ env.BUILD_VERSION }}.dmg" >> $GITHUB_ENV
       - name: Install certificate
         if: ${{ inputs.codesign_and_notarize }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,12 @@ jobs:
       build_alias: arelle-ubuntu.tgz
     secrets: inherit
 
-  build-macos:
+  build-macos-x64:
     uses: ./.github/workflows/build-macos.yml
+    with:
+      python_architecture: x64
     secrets: inherit
-  publish-macos:
+  publish-macos-x64:
     permissions:
       contents: write
     needs: build-macos
@@ -44,7 +46,23 @@ jobs:
     with:
       github_artifact: ${{ needs.build-macos.outputs.uploaded_artifact_name }}
       build_name: ${{ needs.build-macos.outputs.artifact_versioned_name }}
-      build_alias: arelle-macos.dmg
+      build_alias: arelle-macos-x64.dmg
+    secrets: inherit
+
+  build-macos-arm64:
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      python_architecture: arm64
+    secrets: inherit
+  publish-macos-arm64:
+    permissions:
+      contents: write
+    needs: build-macos
+    uses: ./.github/workflows/publish-frozen-build.yml
+    with:
+      github_artifact: ${{ needs.build-macos.outputs.uploaded_artifact_name }}
+      build_name: ${{ needs.build-macos.outputs.artifact_versioned_name }}
+      build_alias: arelle-macos-arm64.dmg
     secrets: inherit
 
   build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
   build-macos-x64:
     uses: ./.github/workflows/build-macos.yml
     with:
+      macos_version: 13
       python_architecture: x64
     secrets: inherit
   publish-macos-x64:
@@ -52,6 +53,7 @@ jobs:
   build-macos-arm64:
     uses: ./.github/workflows/build-macos.yml
     with:
+      macos_version: 15
       python_architecture: arm64
     secrets: inherit
   publish-macos-arm64:

--- a/arelle/Updater.py
+++ b/arelle/Updater.py
@@ -17,6 +17,7 @@ from urllib.error import URLError
 import regex
 
 from arelle import Version
+from arelle.SystemInfo import getSystemInfo
 from arelle.typing import TypeGetText
 
 if TYPE_CHECKING:
@@ -90,7 +91,9 @@ def _getLatestArelleRelease(cntlr: CntlrWinMain) -> ArelleRelease:
 
 def _getArelleReleaseDownloadUrl(assets: list[dict[str, Any]]) -> str | None:
     if sys.platform == "darwin":
-        return _getArelleReleaseDownloadUrlByFileExtension(assets, ".dmg")
+        if getSystemInfo().get('arch') == 'arm64':
+            return _getArelleReleaseDownloadUrlByFileExtension(assets, ".dmg", nameIncludes='-arm64')
+        return _getArelleReleaseDownloadUrlByFileExtension(assets, ".dmg", nameIncludes='-x64')
     elif sys.platform == "win32":
         return _getArelleReleaseDownloadUrlByFileExtension(assets, ".exe")
     else:
@@ -98,12 +101,13 @@ def _getArelleReleaseDownloadUrl(assets: list[dict[str, Any]]) -> str | None:
 
 
 def _getArelleReleaseDownloadUrlByFileExtension(
-    assets: list[dict[str, Any]], fileExtension: str
+    assets: list[dict[str, Any]], fileExtension: str, nameIncludes: str | None = None,
 ) -> str | None:
     for asset in assets:
         downloadUrl = asset.get("browser_download_url")
         if isinstance(downloadUrl, str) and downloadUrl.endswith(fileExtension):
-            return downloadUrl
+            if nameIncludes is None or nameIncludes in downloadUrl:
+                return downloadUrl
     return None
 
 


### PR DESCRIPTION
#### Description of change
A single universal MacOS Arelle build is not feasible, we'll have to generate separate builds.

#### Steps to Test
Test each build on the corresponding MacOS system:
- [Intel](https://github.com/Arelle/Arelle/actions/runs/15687742172)
- [Apple Silicon](https://github.com/Arelle/Arelle/actions/runs/15686288499)

**review**:
@Arelle/arelle
