### PR TITLE
Pass logFileName to super

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -622,7 +622,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
     """
 
     def __init__(self, logFileName=None, uiLang=None, disable_persistent_config=False):
-        super().__init__(hasGui=False, uiLang=uiLang, disable_persistent_config=disable_persistent_config)
+        super().__init__(hasGui=False, uiLang=uiLang, disable_persistent_config=disable_persistent_config, logFileName=logFileName)
         self.preloadedPlugins =  {}
 
     def run(self, options: RuntimeOptions, sourceZipStream=None, responseZipStream=None, sourceZipStreamFileName=None) -> bool:


### PR DESCRIPTION
#### Reason for change
See #1685 
logFileName is None in all Arelle code paths, but third party code might try to use it if they don't need to configure any of the advanced options on startLogging().

#### Description of change
Pass logFileName from CLI to base Cntlr.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
