### PR TITLE
Add multiprocessing freeze support

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -13,6 +13,7 @@ import gettext
 import glob
 import json
 import logging
+import multiprocessing
 import os
 import platform
 import shlex
@@ -56,8 +57,8 @@ from arelle.RuntimeOptions import RuntimeOptions, RuntimeOptionsException
 from arelle.SocketUtils import INTERNET_CONNECTIVITY, OFFLINE
 from arelle.SystemInfo import PlatformOS, getSystemInfo, getSystemWordSize, hasWebServer, isCGI, isGAE
 from arelle.typing import TypeGetText
-from arelle.utils.EntryPointDetection import filesourceEntrypointFiles
 from arelle.UrlUtil import isHttpUrl
+from arelle.utils.EntryPointDetection import filesourceEntrypointFiles
 from arelle.ValidateXbrlDTS import ValidateBaseTaxonomiesMode
 from arelle.WebCache import proxyTuple
 
@@ -1341,11 +1342,6 @@ class CntlrCmdLine(Cntlr.Cntlr):
                     messageCode="info", file=packageInfo.get("URL"))
 
 if __name__ == "__main__":
-    '''
-    if '--COMserver' in sys.argv:
-        from arelle import CntlrComServer
-        CntlrComServer.main()
-    else:
-        main()
-    '''
+    if getattr(sys, 'frozen', False):
+        multiprocessing.freeze_support()
     main()

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -1757,7 +1757,8 @@ def main():
                 application.lift()
                 application.call('wm', 'attributes', '.', '-topmost', True)
                 cntlrWinMain.uiThreadQueue.put((application.call, ['wm', 'attributes', '.', '-topmost', False]))
-                os.system('''/usr/bin/osascript -e 'tell app "Finder" to set frontmost of process "Python" to true' ''')
+                processName = "arelleGUI" if getattr(sys, 'frozen', False) else "python"
+                os.system(f'/usr/bin/osascript -e \'tell app "Finder" to set frontmost of process "{processName}" to true\'')
             application.mainloop()
         except Exception: # unable to start Tk or other fatal error
             exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -38,6 +38,7 @@ from arelle.ValidateXbrlDTS import ValidateBaseTaxonomiesMode
 from arelle.Version import copyrightLabel
 from arelle.oim.xml.Save import saveOimReportToXmlInstance
 import logging
+import multiprocessing
 
 import threading, queue
 
@@ -1779,6 +1780,8 @@ def main():
                 syslog.closelog()
 
 if __name__ == "__main__":
+    if getattr(sys, 'frozen', False):
+        multiprocessing.freeze_support()
     # this is the entry called by MacOS open and MacOS shell scripts
     # check if ARELLE_ARGS are used to emulate command line operation
     if os.getenv("ARELLE_ARGS"):


### PR DESCRIPTION
#### Reason for change
The use of a [multiprocessing queue in XULE](https://github.com/xbrlus/xule/blob/51287b17468b5c2aac3c54411a3ec1192dfb2e9c/plugin/xule/XuleContext.py#L240) raises an exception when run
from the frozen macOS build. Adding freeze support fixes it. This was
noticed by a user who was testing the new XULE dependency of the EDGAR
plugin.

> /Applications/Arelle.app/Contents/MacOS/arelleCmdLine \\
    --plugins EDGAR \\
    -f xbrl.zip \\
    --disclosuresystem efm \\
    --validate

```python
sys.argv: ['arelleCmdLine', '-S', '-I', '-c', 'from multiprocessing.resource_tracker import main;main(8)']

arelleCmdLine: error: no such option: -S
```

#### Description of change
* Enable multiprocessing freeze support.
* Fix error when launching GUI from macOS: `execution error: Finder got an error: Can’t set process "Python" to true` 

#### Steps to Test
* Test internal doc (or any that triggers a XULE rule set) with a frozen macOS build.

**review**:
@Arelle/arelle
