### PR TITLE
Use getattr for optional attribute

### DIFF
--- a/arelle/plugin/validate/NL/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/NL/PluginValidationDataExtension.py
@@ -306,7 +306,7 @@ class PluginValidationDataExtension(PluginData):
 
     @lru_cache(1)
     def getIxdsDocBasenames(self, modelXbrl: ModelXbrl) -> set[str]:
-        return set(Path(url).name for url in modelXbrl.ixdsDocUrls)
+        return set(Path(url).name for url in getattr(modelXbrl, "ixdsDocUrls", []))
 
     def getNoMatchLangFootnotes(self, modelXbrl: ModelXbrl) -> set[ModelInlineFootnote]:
         return self.checkInlineHTMLElements(modelXbrl).noMatchLangFootnotes


### PR DESCRIPTION
#### Reason for change
`ixdsDocUrls` isn't guaranteed to be defined on model XBRL.
```shell
[exception:AttributeError] Instance validation exception: 'ModelXbrl' object has no attribute 'ixdsDocUrls', instance: test-2025-05-29-en.xhtml - test-2025-05-29-en.xhtml
``` 

#### Description of change
* Use getattr to avoid undefined attribute error.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
