### PR TITLE
Add NL-KVK.4.1.2.2, NL-KVK.4.1.5.1 and NL-KVK.4.1.5.2

### DIFF
--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -67,6 +67,7 @@ class ValidateXbrl:
     consolidated: bool
     domainMembers: set[ModelConcept]
     DTSreferenceResourceIDs: dict[str, Any]
+    extensionDocumentNames: set[str]
     extensionImportedUrls: set[str]
     genericArcArcroles: set[str]
     hasExtensionCal: bool

--- a/arelle/plugin/validate/NL/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/NL/PluginValidationDataExtension.py
@@ -57,10 +57,16 @@ ALLOWABLE_LANGUAGES = frozenset((
     'fr'
 ))
 
-EFFECTIVE_GAAP_IFRS_TAXONOMY_URLS = {
+EFFECTIVE_KVK_GAAP_IFRS_ENTRYPOINT_FILES = frozenset((
+    'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-nlgaap-ext.xsd',
+    'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-ifrs-ext.xsd',
+))
+
+TAXONOMY_URLS_BY_YEAR = {
     '2024': [
         'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-nlgaap-ext.xsd',
         'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-ifrs-ext.xsd',
+        'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-other-gaap.xsd',
     ]
 }
 
@@ -116,6 +122,7 @@ class PluginValidationDataExtension(PluginData):
     documentResubmissionUnsurmountableInaccuraciesQn: QName
     entrypointRoot: str
     entrypoints: set[str]
+    financialReportingPeriodQn: QName
     financialReportingPeriodCurrentStartDateQn: QName
     financialReportingPeriodCurrentEndDateQn: QName
     financialReportingPeriodPreviousStartDateQn: QName
@@ -371,6 +378,13 @@ class PluginValidationDataExtension(PluginData):
 
     def getTupleElements(self, modelXbrl: ModelXbrl) -> set[tuple[Any]]:
         return self.checkInlineHTMLElements(modelXbrl).tupleElements
+
+    @lru_cache(1)
+    def getReportingPeriod(self, modelXbrl: ModelXbrl) -> str:
+        reportingPeriodFacts = modelXbrl.factsByQname.get(self.financialReportingPeriodQn, set())
+        for fact in reportingPeriodFacts:
+            if fact.xValid >= VALID:
+                return fact.xValue
 
     @lru_cache(1)
     def getReportXmlLang(self, modelXbrl: ModelXbrl) -> str | None:

--- a/arelle/plugin/validate/NL/ValidationPluginExtension.py
+++ b/arelle/plugin/validate/NL/ValidationPluginExtension.py
@@ -186,6 +186,7 @@ class ValidationPluginExtension(ValidationPlugin):
             documentResubmissionUnsurmountableInaccuraciesQn=qname(f'{{{kvkINamespace}}}DocumentResubmissionDueToUnsurmountableInaccuracies'),
             entrypointRoot=entrypointRoot,
             entrypoints=entrypoints,
+            financialReportingPeriodQn=qname(f'{{{jenvNamespace}}}FinancialReportingPeriod'),
             financialReportingPeriodCurrentStartDateQn=qname(f'{{{jenvNamespace}}}FinancialReportingPeriodCurrentStartDate'),
             financialReportingPeriodCurrentEndDateQn=qname(f'{{{jenvNamespace}}}FinancialReportingPeriodCurrentEndDate'),
             financialReportingPeriodPreviousStartDateQn=qname(f'{{{jenvNamespace}}}FinancialReportingPeriodPreviousStartDate'),

--- a/arelle/plugin/validate/NL/__init__.py
+++ b/arelle/plugin/validate/NL/__init__.py
@@ -45,6 +45,7 @@ def modelXbrlLoadComplete(*args: Any, **kwargs: Any) -> ModelDocument | LoadingE
 
 def validateXbrlStart(val: ValidateXbrl, parameters: dict[Any, Any], *args: Any, **kwargs: Any) -> None:
     val.extensionImportedUrls = set()
+    val.extensionDocumentNames = set()
 
 def validateXbrlFinally(*args: Any, **kwargs: Any) -> None:
     return validationPlugin.validateXbrlFinally(*args, **kwargs)

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -22,7 +22,7 @@ from arelle.ValidateDuplicateFacts import getHashEquivalentFactGroups, getAspect
 from arelle.utils.validate.ValidationUtil import etreeIterWithDepth
 from ..DisclosureSystems import DISCLOSURE_SYSTEM_NL_INLINE_2024
 from ..PluginValidationDataExtension import (PluginValidationDataExtension, ALLOWABLE_LANGUAGES,
-                                             DISALLOWED_IXT_NAMESPACES, EFFECTIVE_TAXONOMY_URLS,
+                                             DISALLOWED_IXT_NAMESPACES, EFFECTIVE_GAAP_IFRS_TAXONOMY_URLS,
                                              MAX_REPORT_PACKAGE_SIZE_MBS, XBRLI_IDENTIFIER_PATTERN,
                                              XBRLI_IDENTIFIER_SCHEMA)
 
@@ -866,7 +866,8 @@ def rule_nl_kvk_4_1_2_1(
     """
     if val.modelXbrl.modelDocument is not None:
         pluginData.checkFilingDTS(val, val.modelXbrl.modelDocument, [])
-        if not any(e in val.extensionImportedUrls for e in EFFECTIVE_TAXONOMY_URLS):
+        taxonomyUrls = [url for effectiveUrls in EFFECTIVE_GAAP_IFRS_TAXONOMY_URLS.values() for url in effectiveUrls]
+        if not any(e in val.extensionImportedUrls for e in taxonomyUrls):
             yield Validation.error(
                 codes='NL.NL-KVK.4.1.2.1.requiredEntryPointNotImported',
                 msg=_('The extension taxonomy must import the entry point of the taxonomy files prepared by KVK.'),

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -770,7 +770,7 @@ def rule_nl_kvk_3_6_3_1(
     """
     invalidBasenames = []
     for basename in pluginData.getIxdsDocBasenames(val.modelXbrl):
-        filenameParts = pluginData.getFilenameParts(basename)
+        filenameParts = pluginData.getFilenameParts(basename, pluginData.getFilenameFormatPattern())
         if not filenameParts:
             continue  # Filename is not formatted correctly enough to determine {base}
         if len(filenameParts.get('base', '')) > 20:
@@ -803,7 +803,7 @@ def rule_nl_kvk_3_6_3_2(
     """
     invalidBasenames = []
     for basename in pluginData.getIxdsDocBasenames(val.modelXbrl):
-        filenameParts = pluginData.getFilenameParts(basename)
+        filenameParts = pluginData.getFilenameParts(basename, pluginData.getFilenameFormatPattern())
         if not filenameParts:
             invalidBasenames.append(basename)
     if len(invalidBasenames) > 0:
@@ -895,12 +895,80 @@ def rule_nl_kvk_4_1_2_2(
     if val.modelXbrl.modelDocument is not None:
         if not val.extensionImportedUrls:
             pluginData.checkFilingDTS(val, val.modelXbrl.modelDocument, [])
-        if not any(e in val.extensionImportedUrls for e in TAXONOMY_URLS_BY_YEAR.get(reportingPeriod, [])):
+        if not reportingPeriod or not any(e in val.extensionImportedUrls for e in TAXONOMY_URLS_BY_YEAR.get(reportingPeriod, [])):
             yield Validation.error(
                 codes='NL.NL-KVK.4.1.2.2.incorrectKvkTaxonomyVersionUsed',
-                msg=_('The extension taxonomy MUST import the applicable version of the taxonomy files prepared by KVK.'),
+                msg=_('The extension taxonomy MUST import the applicable version of the taxonomy files prepared by KVK '
+                      'for the reported financial reporting period of %(reportingPeriod)s.'),
                 modelObject=val.modelXbrl.modelDocument
             )
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=[
+        DISCLOSURE_SYSTEM_NL_INLINE_2024
+    ],
+)
+def rule_nl_kvk_4_1_5_1(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation]:
+    """
+    NL-KVK.4.1.5.1: The `{base}` component of the extension document filename SHOULD not exceed twenty characters.
+    """
+    invalidBasenames = []
+    if val.modelXbrl.modelDocument is not None and not val.extensionDocumentNames:
+        pluginData.checkFilingDTS(val, val.modelXbrl.modelDocument, [])
+    for basename in val.extensionDocumentNames:
+        filenameParts = pluginData.getFilenameParts(basename, pluginData.getExtensionFilenameFormatPattern())
+        if not filenameParts:
+            continue  # Filename is not formatted correctly enough to determine {base}
+        if len(filenameParts.get('base', '')) > 20:
+            invalidBasenames.append(basename)
+    if len(invalidBasenames) > 0:
+        yield Validation.warning(
+            codes='NL.NL-KVK.4.1.5.1.baseComponentInNameOfTaxonomyFileExceedsTwentyCharacters',
+            invalidBasenames=', '.join(invalidBasenames),
+            msg=_('The {base} component of the extension document filename is greater than twenty characters. '
+                  'The {base} component can either be the KVK number or the legal entity\'s name. '
+                  'If the legal entity\'s name has been utilized, review to shorten the name to twenty characters or less. '
+                  'Invalid filenames: %(invalidBasenames)s'))
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=[
+        DISCLOSURE_SYSTEM_NL_INLINE_2024
+    ],
+)
+def rule_nl_kvk_4_1_5_2(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation]:
+    """
+    NL-KVK.4.1.5.2: Extension document filename SHOULD match the {base}-{date}_{suffix}-{lang}.{extension} pattern.
+    """
+    invalidBasenames = []
+    if val.modelXbrl.modelDocument is not None and not val.extensionDocumentNames:
+        pluginData.checkFilingDTS(val, val.modelXbrl.modelDocument, [])
+    for basename in val.extensionDocumentNames:
+        filenameParts = pluginData.getFilenameParts(basename, pluginData.getExtensionFilenameFormatPattern())
+        if not filenameParts:
+            invalidBasenames.append(basename)
+    if len(invalidBasenames) > 0:
+        yield Validation.warning(
+            codes='NL.NL-KVK.4.1.5.2.extensionTaxonomyDocumentNameDoesNotFollowNamingConvention',
+            invalidBasenames=', '.join(invalidBasenames),
+            msg=_('The extension document filename does not match the naming convention outlined by the KVK. '
+                  'It is recommended to be in the {base}-{date}_{suffix}-{lang}.{extension} format. '
+                  '{extension} must be one of the following: html, htm, xhtml. '
+                  'Review formatting and update as appropriate. '
+                  'Invalid filenames: %(invalidBasenames)s'))
 
 
 @validation(

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -96,7 +96,6 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_1/index.xml:TC7_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_2/index.xml:TC3_invalid',
-        # 'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-2_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_1/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-1_1/index.xml:TC2_invalid', # Expects scenarioNotUsedInExtensionTaxonomy and segmentUsed errors.  scenarioNotUsedInExtensionTaxonomy not yet implemented.

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -23,6 +23,7 @@ config = ConformanceSuiteConfig(
             'arelle:ixdsTargetNotDefined': 1,
             # This test is looking at the usage of the target attribute and does not import the correct taxonomy urls
             'requiredEntryPointNotImported': 1,
+            'incorrectKvkTaxonomyVersionUsed': 1,
         },
         'G3-6-3_3/index.xml:TC2_invalid': {
             # Testcase expects only 3.6.3.3, but has a filename that has invalid characters (3.6.3.3)
@@ -33,15 +34,21 @@ config = ConformanceSuiteConfig(
             'undefinedLanguageForTextFact': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
         },
+        'G4-1-2_2/index.xml:TC2_invalid': {
+            # Test imports https://www.nltaxonomie.nl/kvk/2024-03-31/kvk-annual-report-nlgaap-ext.xsd which is the draft taxonomy and not the final
+            'requiredEntryPointNotImported': 1,
+        },
         'G5-1-3_1/index.xml:TC1_valid': {
             # This test is looking at the import of the Other GAAP entry point and thus does not import
             # the standard GAAP or IFRS
             'requiredEntryPointNotImported': 1,
+            'incorrectKvkTaxonomyVersionUsed': 1,
         },
         'G5-1-3_2/index.xml:TC1_valid': {
             # This test is looking at the import of the Other GAAP entry point and thus does not import
             # the standard GAAP or IFRS
             'requiredEntryPointNotImported': 1,
+            'incorrectKvkTaxonomyVersionUsed': 1,
         },
         'RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC2_valid': {
             'undefinedLanguageForTextFact': 1,
@@ -89,7 +96,7 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_1/index.xml:TC7_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_2/index.xml:TC3_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-2_2/index.xml:TC2_invalid',
+        # 'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-2_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_1/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_2/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-1_1/index.xml:TC2_invalid', # Expects scenarioNotUsedInExtensionTaxonomy and segmentUsed errors.  scenarioNotUsedInExtensionTaxonomy not yet implemented.


### PR DESCRIPTION
#### Reason for change
Add the following NL rules:
- NL.NL-KVK.4.1.2.2.incorrectKvkTaxonomyVersionUsed
- NL.NL-KVK.4.1.5.1.baseComponentInNameOfTaxonomyFileExceedsTwentyCharacters
- NL.NL-KVK.4.1.5.2.extensionTaxonomyDocumentNameDoesNotFollowNamingConvention

#### Steps to Test
CI

**review**:
@Arelle/arelle
