### PR TITLE
Create thread lock around Session API

### DIFF
--- a/docs/source/python_api/python_api.md
+++ b/docs/source/python_api/python_api.md
@@ -2,6 +2,21 @@
 
 The `arelle.api` module is the supported method for integrating Arelle into other Python applications.
 
+:::{warning}
+Arelle uses shared global state (PackageManager, PluginManager) which is NOT thread-safe.
+Only ONE Session can run at a time across the entire process.
+
+Safe usage:
+
+- Use one Session at a time per process
+- Use a process pool instead of thread pool for parallelism
+
+Unsafe usage:
+
+- Running multiple Sessions concurrently in any threads
+- Threading.Thread with Session.run()
+:::
+
 ## Session
 
 The Arelle Python API provides `Session` to run Arelle and access output.


### PR DESCRIPTION
#### Reason for change
Arelle is not thread safe. Add documentation and a lock to make sure users of the Session API don't find this out the hard way.

#### Description of change
Add a lock around the Session Python API and documentation to help users avoid running into threading issues.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
