### PR TITLE
NL.NL-KVK.4.3.1.1, 4.3.2.1 validations

### DIFF
--- a/arelle/ModelRelationshipSet.py
+++ b/arelle/ModelRelationshipSet.py
@@ -218,6 +218,9 @@ class ModelRelationshipSet:
     def __bool__(self):  # some modelRelationships exist
         return len(self.modelRelationships) > 0
 
+    def contains(self, modelObject: ModelObject) -> bool:
+        return bool(self.fromModelObject(modelObject) or self.toModelObject(modelObject))
+
     @property
     def linkRoleUris(self):
         # order by document appearance of linkrole, required for Table Linkbase testcase 3220 v03

--- a/arelle/plugin/validate/NL/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/NL/PluginValidationDataExtension.py
@@ -118,8 +118,9 @@ class ContextData:
 
 @dataclass(frozen=True)
 class DimensionalData:
-    domainMembers: set[ModelConcept]
+    domainMembers: frozenset[ModelConcept]
     elrPrimaryItems: dict[str, set[ModelConcept]]
+    primaryItems: frozenset[ModelConcept]
 
 
 @dataclass(frozen=True)
@@ -415,6 +416,7 @@ class PluginValidationDataExtension(PluginData):
         elrPrimaryItems = defaultdict(set)
         hcPrimaryItems: set[ModelConcept] = set()
         hcMembers: set[Any] = set()
+        primaryItems: set[ModelConcept] = set()
         for hasHypercubeArcrole in (XbrlConst.all, XbrlConst.notAll):
             hasHypercubeRelationships = modelXbrl.relationshipSet(hasHypercubeArcrole).fromModelObjects()
             for hasHcRels in hasHypercubeRelationships.values():
@@ -425,6 +427,7 @@ class PluginValidationDataExtension(PluginData):
                     for domMbrRel in modelXbrl.relationshipSet(XbrlConst.domainMember).fromModelObject(sourceConcept):
                         if domMbrRel.consecutiveLinkrole == hasHcRel.linkrole: # only those related to this hc
                             self.addDomMbrs(modelXbrl, domMbrRel.toModelObject, domMbrRel.consecutiveLinkrole, hcPrimaryItems)
+                    primaryItems.update(hcPrimaryItems)
                     hc = hasHcRel.toModelObject
                     for hcDimRel in modelXbrl.relationshipSet(XbrlConst.hypercubeDimension, hasHcRel.consecutiveLinkrole).fromModelObject(hc):
                         dim = hcDimRel.toModelObject
@@ -442,8 +445,9 @@ class PluginValidationDataExtension(PluginData):
                     hcPrimaryItems.clear()
                     hcMembers.clear()
         return DimensionalData(
-            domainMembers=domainMembers,
+            domainMembers=frozenset(domainMembers),
             elrPrimaryItems=elrPrimaryItems,
+            primaryItems=frozenset(primaryItems),
         )
 
     def getEligibleForTransformHiddenFacts(self, modelXbrl: ModelXbrl) -> set[ModelInlineFact]:

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -52,6 +52,7 @@ config = ConformanceSuiteConfig(
             'extensionTaxonomyLineItemNotLinkedToAnyHypercube': 11,
         },
         'G4-1-2_2/index.xml:TC2_invalid': {
+            'anchoringRelationshipsForConceptsDefinedInElrContainingDimensionalRelationships': 1,  # Also fails 4.3.2.1
             'incorrectSummationItemArcroleUsed': 1,  # Also fails 4.4.1.1
             # Test imports https://www.nltaxonomie.nl/kvk/2024-03-31/kvk-annual-report-nlgaap-ext.xsd which is the draft taxonomy and not the final
             'requiredEntryPointNotImported': 1,
@@ -109,10 +110,6 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_5/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_5/index.xml:TC3_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-2_1/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-1_1/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-1_1/index.xml:TC3_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-1_1/index.xml:TC4_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-2_1/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G5-1-3_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP Other
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G5-1-3_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP Other
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G5-1-3_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP Other


### PR DESCRIPTION
#### Description of change
NL-KVK.4.3.1.1: Anchoring relationships for elements other than concepts MUST not use ‘http://www.esma.europa.eu/xbrl/esef/arcrole/wider-narrower’ arcrole

NL-KVK.4.3.2.1: Anchoring relationships for concepts MUST be defined in a dedicated extended link role (or roles if needed to properly represent the relationships), e.g. http://{default pattern for roles}/Anchoring.

#### Steps to Test
CI

**review**:
@Arelle/arelle
