### PR TITLE
NL-KVK.RTS_Annex_IV_Par_4_1. extensionElementDuplicatesCoreElement

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -116,7 +116,6 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_III_Par_1/index.xml:TC3_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC4_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_14_G3-5-1_1/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_1/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC3_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC4_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC5_invalid',


### PR DESCRIPTION
#### Reason for change
Description: Extension elements must not duplicate the existing elements from the core taxonomy and be identifiable

Conditions: Review extension elements and ensure they do not match a standard element from the taxonomy based on element name, balance and period type attributes.  If a duplicate is found, it should fail.

[ESEF Implementation
](https://github.com/Arelle/Arelle/blob/2826ddd88c26e268bc0e83a63074de6121965655/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py#L1080-L1097)
#### Steps to Test
CI

**review**:
@Arelle/arelle
