### PR TITLE
NL-KVK.RTS_Annex_IV_Par_5 validation

### DIFF
--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -832,6 +832,24 @@ def isNumericRole(role: str) -> bool:
     }
 
 
+standardDimensionArcroles = frozenset({
+    all,
+    notAll,
+    hypercubeDimension,
+    dimensionDomain,
+    domainMember,
+    dimensionDefault,
+})
+
+
+standardDefinitionArcroles = frozenset(standardDimensionArcroles | {
+    essenceAlias,
+    generalSpecial,
+    requiresElement,
+    similarTuples,
+})
+
+
 def isStandardArcrole(role: str) -> bool:
     return role in {
         "http://www.w3.org/1999/xlink/properties/linkbase",

--- a/arelle/plugin/validate/NL/LinkbaseType.py
+++ b/arelle/plugin/validate/NL/LinkbaseType.py
@@ -32,6 +32,12 @@ class LinkbaseType(Enum):
         """
         return LINKBASE_ARC_QN[self]
 
+    def getArcroles(self) -> frozenset[str]:
+        """
+        Returns the standard arcrole URIs associated with this LinkbaseType.
+        """
+        return LINKBASE_ARCROLES[self]
+
     def getLinkQn(self) -> QName:
         """
         Returns the qname of the link associated with this LinkbaseType.
@@ -57,6 +63,17 @@ LINKBASE_ARC_QN = {
     LinkbaseType.LABEL: XbrlConst.qnLinkLabelArc,
     LinkbaseType.PRESENTATION: XbrlConst.qnLinkPresentationArc,
     LinkbaseType.REFERENCE: XbrlConst.qnLinkReferenceArc,
+}
+
+LINKBASE_ARCROLES = {
+    LinkbaseType.CALCULATION: frozenset({
+        XbrlConst.summationItem,
+        XbrlConst.summationItem11,
+    }),
+    LinkbaseType.DEFINITION: XbrlConst.standardDefinitionArcroles,
+    LinkbaseType.LABEL: frozenset({XbrlConst.conceptLabel}),
+    LinkbaseType.PRESENTATION: frozenset({XbrlConst.parentChild}),
+    LinkbaseType.REFERENCE: frozenset({XbrlConst.conceptReference}),
 }
 
 LINKBASE_LINK_QN = {

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -12,7 +12,7 @@ import zipfile
 
 from lxml.etree import Element
 
-from arelle.ModelDtsObject import ModelLink, ModelResource, ModelType
+from arelle.ModelDtsObject import ModelConcept, ModelLink, ModelResource, ModelType
 from arelle.ModelInstanceObject import ModelInlineFact
 from arelle.ModelObject import ModelObject
 from arelle.PrototypeDtsObject import PrototypeObject
@@ -1890,6 +1890,54 @@ def rule_nl_kvk_RTS_Annex_IV_Par_4_2(
             codes='NL.NL-KVK.RTS_Annex_IV_Par_4_2.monetaryConceptWithoutBalance',
             msg=_('Extension elements must have an appropriate balance attribute.'),
             modelObject=errors
+        )
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_NL_INLINE_DISCLOSURE_SYSTEMS,
+)
+def rule_nl_kvk_RTS_Annex_IV_Par_5(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation]:
+    """
+    NL-KVK.RTS_Annex_IV_Par_5: Each extension taxonomy element used in tagging
+    must be included in at least one presentation and definition linkbase hierarchy.
+    """
+    extensionData = pluginData.getExtensionData(val.modelXbrl)
+    taggedExtensionConcepts = set(extensionData.extensionConcepts) & set(fact.concept for fact in val.modelXbrl.facts)
+
+    def getConceptsInLinkbase(arcroles: frozenset[str], concepts: set[ModelConcept]) -> None:
+        for fromModelObject, toRels in val.modelXbrl.relationshipSet(tuple(arcroles)).fromModelObjects().items():
+            if isinstance(fromModelObject, ModelConcept):
+                concepts.add(fromModelObject)
+            for toRel in toRels:
+                if isinstance(toRel.toModelObject, ModelConcept):
+                    concepts.add(toRel.toModelObject)
+
+    conceptsInDefinition = set()
+    getConceptsInLinkbase(LinkbaseType.DEFINITION.getArcroles(), conceptsInDefinition)
+    conceptsMissingFromDefinition = taggedExtensionConcepts - conceptsInDefinition
+    if len(conceptsMissingFromDefinition) > 0:
+        yield Validation.error(
+            codes='NL.NL-KVK.RTS_Annex_IV_Par_5.usableConceptsNotIncludedInDefinitionLink',
+            msg=_('Extension elements are missing from definition linkbase. '
+                  'Review use of extension elements.'),
+            modelObject=conceptsMissingFromDefinition
+        )
+
+    conceptsInPresentation = set()
+    getConceptsInLinkbase(LinkbaseType.PRESENTATION.getArcroles(), conceptsInPresentation)
+    conceptsMissingFromPresentation = taggedExtensionConcepts - conceptsInPresentation
+    if len(conceptsMissingFromPresentation) > 0:
+        yield Validation.error(
+            codes='NL.NL-KVK.RTS_Annex_IV_Par_5.usableConceptsNotIncludedInPresentationLink',
+            msg=_('Extension elements are missing from presentation linkbase. '
+                  'Review use of extension elements.'),
+            modelObject=conceptsMissingFromPresentation
         )
 
 

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -1918,7 +1918,7 @@ def rule_nl_kvk_RTS_Annex_IV_Par_5(
                 if isinstance(toRel.toModelObject, ModelConcept):
                     concepts.add(toRel.toModelObject)
 
-    conceptsInDefinition = set()
+    conceptsInDefinition: set[ModelConcept] = set()
     getConceptsInLinkbase(LinkbaseType.DEFINITION.getArcroles(), conceptsInDefinition)
     conceptsMissingFromDefinition = taggedExtensionConcepts - conceptsInDefinition
     if len(conceptsMissingFromDefinition) > 0:
@@ -1929,7 +1929,7 @@ def rule_nl_kvk_RTS_Annex_IV_Par_5(
             modelObject=conceptsMissingFromDefinition
         )
 
-    conceptsInPresentation = set()
+    conceptsInPresentation: set[ModelConcept] = set()
     getConceptsInLinkbase(LinkbaseType.PRESENTATION.getArcroles(), conceptsInPresentation)
     conceptsMissingFromPresentation = taggedExtensionConcepts - conceptsInPresentation
     if len(conceptsMissingFromPresentation) > 0:

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -1477,13 +1477,18 @@ def rule_nl_kvk_4_4_2_4(
     extended link role
     """
     elrPrimaryItems = pluginData.getDimensionalData(val.modelXbrl).elrPrimaryItems
-    errors = set(concept
-        for qn, facts in val.modelXbrl.factsByQname.items()
-        if any(not f.context.qnameDims for f in facts if f.context is not None)
-        for concept in (val.modelXbrl.qnameConcepts.get(qn),)
-        if concept is not None and
-        not any(concept in elrPrimaryItems.get(lr, set()) for lr in NON_DIMENSIONALIZED_LINE_ITEM_LINKROLES) and
-        concept not in elrPrimaryItems.get("*", set()))
+    errors = set()
+    for concept in val.modelXbrl.qnameConcepts.values():
+        if concept.qname not in val.modelXbrl.factsByQname:
+            continue
+        if any(
+                concept in elrPrimaryItems.get(lr, set())
+                for lr in NON_DIMENSIONALIZED_LINE_ITEM_LINKROLES
+        ):
+            continue
+        if concept in elrPrimaryItems.get("*", set()):
+            continue
+        errors.add(concept)
     for error in errors:
         yield Validation.error(
             codes='NL.NL-KVK.4.4.2.4.extensionTaxonomyLineItemNotLinkedToAnyHypercube',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -24,6 +24,7 @@ config = ConformanceSuiteConfig(
         },
         'G3-1-3_2/index.xml:TC2_invalid': {
             'extensionTaxonomyLineItemNotLinkedToAnyHypercube': 1,
+            'usableConceptsNotIncludedInDefinitionLink': 1,
         },
         'G3-5-1_5/index.xml:TC2_invalid': {
             # This is the expected error, but we return two of them, slightly different.
@@ -48,6 +49,12 @@ config = ConformanceSuiteConfig(
         'G4-1-1_1/index.xml:TC4_invalid': {
             'extensionTaxonomyWrongFilesStructure': 1,
         },
+        'G4-1-1_1/index.xml:TC5_invalid': {
+            'usableConceptsNotIncludedInPresentationLink': 1,
+        },
+        'G4-1-1_1/index.xml:TC7_invalid': {
+            'usableConceptsNotIncludedInPresentationLink': 1,
+        },
         'G4-1-2_1/index.xml:TC2_valid': {
             'undefinedLanguageForTextFact': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
@@ -68,6 +75,9 @@ config = ConformanceSuiteConfig(
         },
         'G4-4-2_1/index.xml:TC2_invalid': {
             'closedNegativeHypercubeInDefinitionLinkbase': 1,  # Also fails 4.4.2.3
+        },
+        'G4-4-2_4/index.xml:TC2_invalid': {
+            'usableConceptsNotIncludedInDefinitionLink': 1,
         },
         'RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC2_valid': {
             'undefinedLanguageForTextFact': 1,
@@ -122,8 +132,6 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC3_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC4_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC5_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_5/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_5/index.xml:TC3_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC3_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_9_Par_10/index.xml:TC3_invalid',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -63,6 +63,9 @@ config = ConformanceSuiteConfig(
             'UsableConceptsNotAppliedByTaggedFacts': 1,  # Also fails 4.4.6.1
             'extensionTaxonomyLineItemNotLinkedToAnyHypercube': 10,
         },
+        'G4-2-3_1/index.xml:TC2_invalid': {
+            'extensionTaxonomyLineItemNotLinkedToAnyHypercube': 1,
+        },
         'G4-4-2_1/index.xml:TC2_invalid': {
             'closedNegativeHypercubeInDefinitionLinkbase': 1,  # Also fails 4.4.2.3
         },


### PR DESCRIPTION
#### Reason for change
Description: Each extension taxonomy element used in tagging must be included in at least one presentation and definition linkbase hierarchy

Conditions: Revew that extension elements are included in presentation and definition linkbase (beyond anchoring relationships).  If extension elements are missing presentation and definition linkbase (outside of anchoring role), it should fail.

#### Steps to Test
CI

**review**:
@Arelle/arelle
