### PR TITLE
NL-KVK.RTS_Art_6_a validation

### DIFF
--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -20,7 +20,7 @@ from arelle.PrototypeDtsObject import PrototypeObject
 from arelle.ValidateDuplicateFacts import getDuplicateFactSets
 from arelle.XmlValidateConst import VALID
 
-from arelle import XbrlConst, XmlUtil
+from arelle import XbrlConst, XmlUtil, ModelDocument
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.typing import TypeGetText
 from arelle.utils.PluginHooks import ValidationHook
@@ -2004,4 +2004,34 @@ def rule_nl_kvk_RTS_Art_3(
                       'inline 1.1 requires schema validation: %(doctype)s'),
                 modelObject=val.modelXbrl.modelDocument,
                 doctype=docinfo.doctype,
+            )
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_NL_INLINE_DISCLOSURE_SYSTEMS,
+)
+def rule_nl_kvk_RTS_Art_6_a(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation]:
+    """
+    NL-KVK.RTS_Art_6_a: Legal entities shall embed markups in the annual reports
+    in XHTML format using the Inline XBRL specifications
+    """
+    for modelDocument in val.modelXbrl.urlDocs.values():
+        if modelDocument.type != ModelDocument.Type.INLINEXBRL:
+            continue
+        factElements = list(modelDocument.xmlRootElement.iterdescendants(
+            modelDocument.ixNStag + "nonNumeric",
+            modelDocument.ixNStag + "nonFraction",
+            modelDocument.ixNStag + "fraction"
+        ))
+        if len(factElements) == 0:
+            yield Validation.error(
+                codes='NL.NL-KVK.RTS_Art_6_a.noInlineXbrlTags',
+                msg=_('Annual report is using xhtml extension, but there are no inline mark up tags identified.'),
+                modelObject=modelDocument,
             )

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -105,7 +105,20 @@ config = ConformanceSuiteConfig(
             'undefinedLanguageForTextFact': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
             'extensionTaxonomyWrongFilesStructure': 1,
-        }
+        },
+        'RTS_Art_6_a/index.xml:TC2_invalid': {
+            'UsableConceptsNotAppliedByTaggedFacts': 1,
+            'incorrectKvkTaxonomyVersionUsed': 1,
+            'message:existsAtLeastOnce_ChamberOfCommerceRegistrationNumber': 1,
+            'message:existsAtLeastOnce_FinancialReportingPeriod': 1,
+            'message:existsAtLeastOnce_FinancialReportingPeriodEndDate': 1,
+            'message:existsAtLeastOnce_LegalEntityLegalForm': 1,
+            'message:existsAtLeastOnce_LegalEntityName': 1,
+            'message:existsAtLeastOnce_LegalEntityRegisteredOffice': 1,
+            'message:existsOnlyOnce_AuditorsReportFinancialStatementsPresent': 1,
+            'message:existsOnlyOnce_DocumentAdoptionStatus': 1,
+            'message:existsOnlyOnce_FinancialStatementsConsolidated': 1,
+        },
     }.items()},
     expected_failure_ids=frozenset([
         # Conformance Suite Errors
@@ -135,7 +148,6 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC2_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC3_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_9_Par_10/index.xml:TC3_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Art_6_a/index.xml:TC2_invalid',
     ]),
     info_url='https://www.sbr-nl.nl/sbr-domeinen/handelsregister/uitbreiding-elektronische-deponering-handelsregister',
     name=PurePath(__file__).stem,


### PR DESCRIPTION
#### Reason for change
Description: Legal entities shall embed markups in the annual reports in XHTML format using the Inline XBRL specifications

Conditions: Review that the annual reports has markup in xhtml format based on Inline XBRL specifications.  If using xhtml, but no inline mark up, it should fail.

#### Steps to Test
CI

**review**:
@Arelle/arelle
