### PR TITLE
NL.NL-KVK.RTS_Annex_IV_Par_9_Par_10 validation

### DIFF
--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -2011,6 +2011,30 @@ def rule_nl_kvk_RTS_Annex_IV_Par_8_G4_4_5(
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=NL_INLINE_GAAP_IFRS_DISCLOSURE_SYSTEMS,
+)
+def rule_nl_kvk_RTS_Annex_IV_Par_9_Par_10(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation]:
+    """
+    NL-KVK.RTS_Annex_IV_Par_9_par_10: Legal entities MUST ensure that the
+    extension taxonomy elements are linked to one or more core taxonomy elements.
+    """
+    anchorData = pluginData.getAnchorData(val.modelXbrl)
+    if len(anchorData.extLineItemsNotAnchored) > 0:
+        yield Validation.error(
+            codes='NL.NL-KVK.RTS_Annex_IV_Par_9_Par_10.extensionConceptsNotAnchored',
+            msg=_('Extension concept found without an anchor. '
+                  'Extension concepts, excluding subtotals, are required to be anchored.'),
+            modelObject=anchorData.extLineItemsNotAnchored,
+        )
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
     disclosureSystems=ALL_NL_INLINE_DISCLOSURE_SYSTEMS,
 )
 def rule_nl_kvk_RTS_Art_3(

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -145,7 +145,6 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC3_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC4_invalid',
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC5_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_9_Par_10/index.xml:TC3_invalid',
     ]),
     info_url='https://www.sbr-nl.nl/sbr-domeinen/handelsregister/uitbreiding-elektronische-deponering-handelsregister',
     name=PurePath(__file__).stem,


### PR DESCRIPTION
#### Reason for change
Description: Legal entities MUST ensure that the extension taxonomy elements are linked to one or more core taxonomy elements 

Conditions: Review that all extension concepts are anchored to standard taxonomy concepts in the definition linkbase.  Subtotals, which should be target of calculation relationship, are not required to be anchored.  If extension concept is found without anchor, it should fail.   

#### Steps to Test
CI

**review**:
@Arelle/arelle
