### PR TITLE
Try harder to use system certs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     'pyparsing==3.*',
     'python-dateutil==2.*',
     'regex',
+    'truststore==0.*; python_version>"3.9"',
     'typing-extensions==4.*',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # core modules
 certifi==2025.6.15
+truststore==0.10.1 ; python_version > "3.9"
 filelock==3.18.0
 jsonschema==4.24.0
 lxml==5.4.0


### PR DESCRIPTION
#### Reason for change
Resolves a support issue.

#### Description of change
Use [truststore](https://truststore.readthedocs.io/en/latest/) (requires Python 3.10+) to validate certs using native system certificate stores.

#### Steps to Test
* [x] frozen build tested by reporting user 
* [ ] CI

**review**:
@Arelle/arelle
