### PR TITLE
Use macOS 14 for ARM builds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       macos_version:
-        default: '15'
+        default: '14'
         description: 'MacOS version to use (15, 14, 13, latest, etc.)'
         required: false
         type: string
@@ -55,7 +55,7 @@ on:
         required: false
         type: string
       macos_version:
-        default: '15'
+        default: '14'
         description: 'MacOS version to use (15, 14, 13, latest, etc.)'
         required: true
         type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
   build-macos-arm64:
     uses: ./.github/workflows/build-macos.yml
     with:
-      macos_version: 15
+      macos_version: 14
       python_architecture: arm64
     secrets: inherit
   publish-macos-arm64:


### PR DESCRIPTION
#### Reason for change
Workaround for macOS ARM64 builds failing on macOS 15 runner: https://github.com/actions/runner-images/issues/12482

We also use macOS 14 for our test runners so it makes sense to be consistent anyway. Once the above issue is resolved we should switch both the build and test runners to macOS 15.

#### Description of change
Use macOS 14 runner for ARM64 macOS builds.

#### Steps to Test
* [x] Smoke test https://github.com/Arelle/Arelle/actions/runs/15981191746

**review**:
@Arelle/arelle
