### PR TITLE
Add support for logging image css selectors

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -1112,8 +1112,7 @@ def validateCssUrl(cssContent:str, normalizedUri:str, modelXbrl: ModelXbrl, val:
                             _("Fonts SHOULD be included in the XHTML document as a base64 encoded string: %(file)s."),
                             modelObject=elt, file=css_rule.value)
         if isinstance(css_element, tinycss2.ast.QualifiedRule):
-            cssSelectors = tinycss2.serialize(css_element.prelude).strip()
-            validateCssUrlContent(css_element.content, normalizedUri, modelXbrl, val, elt, params, cssSelectors)
+            validateCssUrlContent(css_element.content, normalizedUri, modelXbrl, val, elt, params, css_element.prelude)
 
 
 def validateCssUrlContent(
@@ -1123,7 +1122,7 @@ def validateCssUrlContent(
         val: ValidateXbrl,
         elt: ModelObject,
         params: ImageValidationParameters,
-        cssSelectors: str | None = None,
+        prelude: list[Any] | None = None,
 ) -> None:
     for css_rule in cssRules:
         if isinstance(css_rule, tinycss2.ast.FunctionBlock):
@@ -1131,8 +1130,8 @@ def validateCssUrlContent(
                 if len(css_rule.arguments):
                     css_rule_url = css_rule.arguments[0].value  # url or base64
                     evaluatedMsg = _('On line {line}').format(line=1) #css_element.source_line)
-                    validateImageAndLog(normalizedUri, css_rule_url, modelXbrl, val, elt, evaluatedMsg, params, cssSelectors)
+                    validateImageAndLog(normalizedUri, css_rule_url, modelXbrl, val, elt, evaluatedMsg, params, prelude)
         elif isinstance(css_rule, tinycss2.ast.URLToken):
             value = css_rule.value
             evaluatedMsg = _('On line {line}').format(line=1) #css_element.source_line)
-            validateImageAndLog(normalizedUri, value, modelXbrl, val, elt, evaluatedMsg, params, cssSelectors)
+            validateImageAndLog(normalizedUri, value, modelXbrl, val, elt, evaluatedMsg, params, prelude)

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -1112,18 +1112,27 @@ def validateCssUrl(cssContent:str, normalizedUri:str, modelXbrl: ModelXbrl, val:
                             _("Fonts SHOULD be included in the XHTML document as a base64 encoded string: %(file)s."),
                             modelObject=elt, file=css_rule.value)
         if isinstance(css_element, tinycss2.ast.QualifiedRule):
-            validateCssUrlContent(css_element.content, normalizedUri, modelXbrl, val, elt, params)
+            cssSelectors = tinycss2.serialize(css_element.prelude).strip()
+            validateCssUrlContent(css_element.content, normalizedUri, modelXbrl, val, elt, params, cssSelectors)
 
 
-def validateCssUrlContent(cssRules: list[Any], normalizedUri:str, modelXbrl: ModelXbrl, val: ValidateXbrl, elt: ModelObject, params: ImageValidationParameters) -> None:
+def validateCssUrlContent(
+        cssRules: list[Any],
+        normalizedUri:str,
+        modelXbrl: ModelXbrl,
+        val: ValidateXbrl,
+        elt: ModelObject,
+        params: ImageValidationParameters,
+        cssSelectors: str | None = None,
+) -> None:
     for css_rule in cssRules:
         if isinstance(css_rule, tinycss2.ast.FunctionBlock):
             if css_rule.lower_name == "url":
                 if len(css_rule.arguments):
                     css_rule_url = css_rule.arguments[0].value  # url or base64
                     evaluatedMsg = _('On line {line}').format(line=1) #css_element.source_line)
-                    validateImageAndLog(normalizedUri, css_rule_url, modelXbrl, val, elt, evaluatedMsg, params)
+                    validateImageAndLog(normalizedUri, css_rule_url, modelXbrl, val, elt, evaluatedMsg, params, cssSelectors)
         elif isinstance(css_rule, tinycss2.ast.URLToken):
             value = css_rule.value
             evaluatedMsg = _('On line {line}').format(line=1) #css_element.source_line)
-            validateImageAndLog(normalizedUri, value, modelXbrl, val, elt, evaluatedMsg, params)
+            validateImageAndLog(normalizedUri, value, modelXbrl, val, elt, evaluatedMsg, params, cssSelectors)

--- a/arelle/plugin/validate/UK/__init__.py
+++ b/arelle/plugin/validate/UK/__init__.py
@@ -454,7 +454,7 @@ def validateXbrlFinally(val, *args, **kwargs):
                         _("Image scope must be base-64 encoded string (starting with data:image/*;base64), *=gif, jpeg or png.  src disallowed: %(src)s."),
                         modelObject=elt, src=attrValue[:128])
         for elt in rootElt.iterdescendants(tag="{http://www.w3.org/1999/xhtml}style"):
-            _validateScriptElement(elt, modelXbrl)
+            _validateStyleElement(elt, modelXbrl)
         for elt in rootElt.xpath("//xhtml:*[@style]", namespaces={"xhtml": "http://www.w3.org/1999/xhtml"}):
             _validateStyleAttribute(elt, modelXbrl)
 
@@ -468,7 +468,7 @@ def validateXbrlFinally(val, *args, **kwargs):
     modelXbrl.modelManager.showStatus(None)
 
 
-def _validateScriptElement(elt, modelXbrl):
+def _validateStyleElement(elt, modelXbrl):
     cssElements = tinycss2.parse_stylesheet(elt.text)
     for css_element in cssElements:
         if isinstance(css_element, tinycss2.ast.QualifiedRule):
@@ -479,9 +479,10 @@ def _validateScriptElement(elt, modelXbrl):
                 elif _isExternalImageUrl(cssProperty, elem):
                         modelXbrl.error(
                             "HMRC.SG.3.8",
-                            _("Style element has disallowed image reference: %(styleImage)s."),
+                            _("Style element has disallowed image reference: %(cssSelectors)s, %(styleImage)s."),
                             modelObject=elt,
-                            styleImage=elem.arguments[0].value
+                            cssSelectors=tinycss2.serialize(css_element.prelude).strip(),
+                            styleImage=elem.arguments[0].value,
                         )
                         return
         elif isinstance(css_element, tinycss2.ast.ParseError):

--- a/arelle/utils/validate/ESEFImage.py
+++ b/arelle/utils/validate/ESEFImage.py
@@ -61,6 +61,7 @@ def validateImageAndLog(
     elts: _Element | list[_Element],
     evaluatedMsg: str,
     params: ImageValidationParameters,
+    cssSelectors: str | None = None,
 ) -> None:
     for validation in validateImage(
         baseUrl=baseUrl,
@@ -71,7 +72,13 @@ def validateImageAndLog(
         evaluatedMsg=evaluatedMsg,
         params=params,
     ):
-        modelXbrl.log(level=validation.level.name, codes=validation.codes, msg=validation.msg, **validation.args)
+        if cssSelectorsArg := validation.args.get("cssSelectors"):
+            raise ValueError(_("The 'cssSelectors' argument is reserved to record the CSS selector. It should not be present in the validation arguments: {}").format(cssSelectorsArg))
+
+        args = validation.args.copy()
+        if cssSelectors:
+            args["cssSelectors"] = cssSelectors
+        modelXbrl.log(level=validation.level.name, codes=validation.codes, msg=validation.msg, **args)
 
 # check image contents against mime/file ext and for Steganography
 def validateImage(

--- a/arelle/utils/validate/ESEFImage.py
+++ b/arelle/utils/validate/ESEFImage.py
@@ -7,9 +7,10 @@ import binascii
 import os
 
 from dataclasses import dataclass
-from typing import cast, Iterable
+from typing import Any, cast, Iterable
 from urllib.parse import unquote
 
+import tinycss2
 from lxml.etree import XML, XMLSyntaxError
 from lxml.etree import _Element
 
@@ -61,8 +62,9 @@ def validateImageAndLog(
     elts: _Element | list[_Element],
     evaluatedMsg: str,
     params: ImageValidationParameters,
-    cssSelectors: str | None = None,
+    prelude: list[Any] | None = None,
 ) -> None:
+    cssSelectors = None
     for validation in validateImage(
         baseUrl=baseUrl,
         image=image,
@@ -74,7 +76,8 @@ def validateImageAndLog(
     ):
         if cssSelectorsArg := validation.args.get("cssSelectors"):
             raise ValueError(_("The 'cssSelectors' argument is reserved to record the CSS selector. It should not be present in the validation arguments: {}").format(cssSelectorsArg))
-
+        if prelude and cssSelectors is None:
+            cssSelectors = tinycss2.serialize(prelude).strip()
         args = validation.args.copy()
         if cssSelectors:
             args["cssSelectors"] = cssSelectors

--- a/arelle/utils/validate/ESEFImage.py
+++ b/arelle/utils/validate/ESEFImage.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 from urllib.parse import unquote
 
-import tinycss2
+import tinycss2  # type: ignore[import-untyped]
 from lxml.etree import XML, XMLSyntaxError, _Element
 
 from arelle import ModelDocument

--- a/arelle/utils/validate/ESEFImage.py
+++ b/arelle/utils/validate/ESEFImage.py
@@ -5,23 +5,22 @@ from __future__ import annotations
 
 import binascii
 import os
-
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, cast, Iterable
+from typing import Any, cast
 from urllib.parse import unquote
 
 import tinycss2
-from lxml.etree import XML, XMLSyntaxError
-from lxml.etree import _Element
+from lxml.etree import XML, XMLSyntaxError, _Element
 
 from arelle import ModelDocument
 from arelle.ModelObjectFactory import parser
 from arelle.ModelXbrl import ModelXbrl
+from arelle.typing import TypeGetText
 from arelle.UrlUtil import decodeBase64DataImage, scheme
+from arelle.utils.validate.Validation import Validation
 from arelle.ValidateFilingText import parseImageDataURL, validateGraphicHeaderType
 from arelle.ValidateXbrl import ValidateXbrl
-from arelle.typing import TypeGetText
-from arelle.utils.validate.Validation import Validation
 
 _: TypeGetText  # Handle gettext
 


### PR DESCRIPTION
#### Reason for change
Handles a user request to log the CSS selector when validating CSS defined images so the consumer can determine which elements the offending image applies to.

#### Description of change
Include the CSS selectors as a log argument when validating CSS defined images.

#### Steps to Test
* [x] use a private testing doc to verify that the CSS selector is included in the logged args.

**review**:
@Arelle/arelle
