### PR TITLE
Use FileNamedBytesIO instead of sourceZipStreamFileName param

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -634,7 +634,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
         super().__init__(hasGui=False, uiLang=uiLang, disable_persistent_config=disable_persistent_config, logFileName=logFileName)
         self.preloadedPlugins =  {}
 
-    def run(self, options: RuntimeOptions, sourceZipStream=None, responseZipStream=None, sourceZipStreamFileName=None) -> bool:
+    def run(self, options: RuntimeOptions, sourceZipStream=None, responseZipStream=None) -> bool:
         """Process command line arguments or web service request, such as to load and validate an XBRL document, or start web server.
 
         When a web server has been requested, this method may be called multiple times, once for each web service (REST) request that requires processing.
@@ -998,7 +998,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         _entryPoints.append({"file":f})
         filesource = None # file source for all instances if not None
         if sourceZipStream:
-            filesource = FileSource.openFileSource(None, self, sourceZipStream=sourceZipStream, sourceZipStreamFileName=sourceZipStreamFileName)
+            filesource = FileSource.openFileSource(None, self, sourceZipStream)
         elif len(_entryPoints) == 1 and "file" in _entryPoints[0]: # check if an archive and need to discover entry points (and not IXDS)
             entryPath = PackageManager.mappedUrl(_entryPoints[0]["file"])
             filesource = FileSource.openFileSource(entryPath, self, checkIfXmlIsEis=_checkIfXmlIsEis)

--- a/arelle/api/Session.py
+++ b/arelle/api/Session.py
@@ -12,6 +12,7 @@ from typing import Any, BinaryIO
 
 from arelle import PackageManager, PluginManager
 from arelle.CntlrCmdLine import CntlrCmdLine, createCntlrAndPreloadPlugins
+from arelle.FileSource import FileNamedBytesIO
 from arelle.ModelXbrl import ModelXbrl
 from arelle.RuntimeOptions import RuntimeOptions
 
@@ -102,11 +103,10 @@ class Session:
     def run(
         self,
         options: RuntimeOptions,
-        sourceZipStream: BinaryIO | None = None,
+        sourceZipStream: BinaryIO | FileNamedBytesIO | None = None,
         responseZipStream: BinaryIO | None = None,
         logHandler: logging.Handler | None = None,
         logFilters: list[logging.Filter] | None = None,
-        sourceZipStreamFileName: str | None = None,
     ) -> bool:
         """
         Perform a run using the given options.
@@ -114,13 +114,10 @@ class Session:
         :param sourceZipStream: Optional stream to read source data from.
         :param responseZipStream: Options stream to write response data to.
         :param logHandler: Optional log handler to use for logging.
-        :param sourceZipStreamFileName: Optional file name to use for the passed zip stream.
         :return: True if the run was successful, False otherwise.
         """
         with _session_lock:
             self._check_thread()
-            if sourceZipStreamFileName is not None and sourceZipStream is None:
-                raise ValueError("sourceZipStreamFileName may only be provided if sourceZipStream is not None.")
             PackageManager.reset()
             PluginManager.reset()
             if self._cntlr is None:
@@ -174,5 +171,4 @@ class Session:
                     options,
                     sourceZipStream=sourceZipStream,
                     responseZipStream=responseZipStream,
-                    sourceZipStreamFileName=sourceZipStreamFileName,
                 )


### PR DESCRIPTION
#### Reason for change
Resolves #1753 

#### Description of change
PR #1538 introduced a filename parameter to support defining names for ZIP stream files in POST requests. However, this change inadvertently caused issues in plugin hooks, particularly with the EDGAR plugin, where the filename was not being passed through correctly.

After further review, it turns out this filename parameter was unnecessary. Arelle already has a BytesIO wrapper class that captures a filename. This update removes the filename parameter and replaces its usage with the existing wrapper class.

#### Steps to Test
* [x] verify the testing steps from #1538 to check for regressions.
* [x] verify that using a multi-part form upload with the EDGAR renderer no longer raises an exception as described in #1753.

**review**:
@Arelle/arelle
