### PR TITLE
Add check for extension taxonomy directory prefix within the report package for DK ESEF

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -1109,6 +1109,21 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                         _("Extension elements must not duplicate the existing elements from the core taxonomy and be identifiable %(qname)s."),
                         modelObject=(c,_i), qname=c.qname)
 
+        extensionTaxonomyDirectoryPrefix = val.authParam["reportPackageExtensionTaxonomyDirectoryPrefix"]
+        if extensionTaxonomyDirectoryPrefix is not None and val.modelXbrl.fileSource.dir is not None:
+            for filepath in val.modelXbrl.fileSource.dir:
+                filepath_parts = filepath.split('/')
+                if filepath_parts[1] in ['META-INF', 'reports']:
+                    continue
+                if not filepath_parts[1].startswith(extensionTaxonomyDirectoryPrefix):
+                    modelXbrl.error(
+                        'arelle.ESEF.reportPackageExtensionTaxonomyDirectoryPrefix',
+                        _('The XBRL linkbase files must live within the report package under a directory that starts '
+                          'with `{}`').format(extensionTaxonomyDirectoryPrefix),
+                        modelObject=val.modelXbrl
+                    )
+                    break
+
     modelXbrl.profileActivity(_statusMsg, minTimeToShow=0.0)
     modelXbrl.modelManager.showStatus(None)
 

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -42,6 +42,7 @@
         ],
         "comment": "default parameters where not specified by authority",
         "reportPackageMaxMB": null,
+        "reportPackageExtensionTaxonomyDirectoryPrefix": null,
         "identiferScheme": "http://standards.iso.org/iso/17442",
         "ixTargetUsage": "warning",
         "extensionAbstractContexts": "warning",
@@ -171,6 +172,7 @@
     },
     "DBA": {
         "name": "Danish Business Authority",
+        "reportPackageExtensionTaxonomyDirectoryPrefix": "xbrl.",
         "reportPackageMaxMB": "2000",
         "reportPackageMeasurement": "unzipped",
         "ixTargetUsage": "allowed",


### PR DESCRIPTION
#### Reason for change
Within the DK ESEF report package, we need to verify that the extension taxonomy directory is prefixed by xbrl.. Add this as an authoirity validation in the ESEF plugin.

#### Steps to Test
CI

**review**:
@Arelle/arelle
