### PR TITLE
Better handling of test case variations with only warnings

### DIFF
--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -764,7 +764,7 @@ class Validate:
             status = "pass" if numErrors == 0 else "fail"
         elif expected == "invalid":
             status = "fail" if numErrors == 0 else "pass"
-        elif expected in (None, []) and numErrors == 0:
+        elif expected in (None, []) and numErrors == 0 and not expectedWarnings:
             status = "pass"
         elif isinstance(expected, (QName, str, dict, list)) or expectedWarnings:
             status = "fail"

--- a/tests/integration_tests/validation/conformance_suite_configurations/edinet.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/edinet.py
@@ -6,6 +6,7 @@ config = ConformanceSuiteConfig(
     args=[
         '--baseTaxonomyValidation', 'none',
         '--disclosureSystem', 'EDINET',
+        '--testcaseResultsCaptureWarnings',
     ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(


### PR DESCRIPTION
#### Reason for change
Test case variations that expected *only* warnings were passing so long as no *errors* were fired. This results in false-positive test case results where an expected warning wasn't actually firing but the test case was passing regardless.

#### Description of change
- Update logic to not "pass" test case before checking expected warnings.
- Update formatting of conformance suite "expected" results output
- Update EDINET conformance suite runner to capture warnings

#### Steps to Test
CI

**review**:
@Arelle/arelle
