### PR TITLE
Add UKFRC Authority

### DIFF
--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -346,8 +346,7 @@
     "UKFRC-2023": {
         "name": "United Kingdom Multiple Targets",
         "authorityName": "FRC",
-        "comment": "Pertains to multi target UKSEF Guidance",
-        "comment2": "See UKFRC for reports prior to 2023 which did not use separate targets for FRC and ESEF",
+        "comment": "This is a deprecated authority that will be removed. Use UKFRC instead.",
         "reference": "https://media.frc.org.uk/documents/XBRL_Tagging_Guide_-_FRC_Taxonomies_2024_On9jOuS.pdf",
         "reportPackageMaxMB": "150",
         "reportPackageMeasurement": "zipped",

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -352,5 +352,15 @@
         "reportPackageMaxMB": "150",
         "reportPackageMeasurement": "zipped",
         "ixTargetUsage": "allowed"
+    },
+    "UKFRC": {
+        "name": "United Kingdom Multiple Targets",
+        "authorityName": "FRC",
+        "comment": "Pertains to multi target UKSEF Guidance",
+        "comment2": "See UKFRC-2022 for reports prior to 2023 which did not use separate targets for FRC and ESEF",
+        "reference": "https://media.frc.org.uk/documents/XBRL_Tagging_Guide_-_FRC_Taxonomies_2024_On9jOuS.pdf",
+        "reportPackageMaxMB": "150",
+        "reportPackageMeasurement": "zipped",
+        "ixTargetUsage": "allowed"
     }
 }


### PR DESCRIPTION
#### Reason for change
Resolves #1715

#### Description of change
`UKFRC-2023` was an unfortunate name choice for the authority. It is expected to be used for >= 2023. This adds a generic `UKFRC` for >= 2023 and adds a comment explaining that the 2023 authority is deprecated.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
