### PR TITLE
Identify duplicate contexts and units more carefully.

### DIFF
--- a/arelle/ModelInstanceObject.py
+++ b/arelle/ModelInstanceObject.py
@@ -1266,7 +1266,7 @@ class ModelContext(ModelObject):
 
     def isEntityIdentifierEqualTo(self, cntx2):
         """(bool) -- True if entityIdentifier values are equal (scheme and text value)"""
-        return self.entityIdentifierHash == cntx2.entityIdentifierHash
+        return self.entityIdentifier == cntx2.entityIdentifier
 
     def isEqualTo(self, cntx2, dimensionalAspectModel=None) -> bool:
         if dimensionalAspectModel is None: dimensionalAspectModel = self.modelXbrl.hasXDT

--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -12,6 +12,8 @@ from arelle import Locale, XbrlConst, XbrlUtil
 from arelle.ModelObject import ObjectPropertyViewWrapper
 from arelle.PythonUtil import flattenSequence, strTruncate
 from arelle.XmlValidateConst import UNVALIDATED, VALID
+from arelle.utils.Contexts import partitionModelXbrlContexts
+from arelle.utils.Units import partitionModelXbrlUnits
 
 if TYPE_CHECKING:
     from _decimal import Decimal
@@ -147,27 +149,15 @@ class ValidateXbrlCalcs:
 
         # identify equal contexts
         modelXbrl.profileActivity()
-        uniqueContextHashes = {}
-        for context in modelXbrl.contexts.values():
-            h = context.contextDimAwareHash
-            if h in uniqueContextHashes:
-                if context.isEqualTo(uniqueContextHashes[h]):
-                    self.mapContext[context] = uniqueContextHashes[h]
-            else:
-                uniqueContextHashes[h] = context
-        del uniqueContextHashes
+        for exemplar_context, *contexts in partitionModelXbrlContexts(modelXbrl).values():
+            for context in contexts:
+                self.mapContext[context] = exemplar_context
         modelXbrl.profileActivity("... identify equal contexts", minTimeToShow=1.0)
 
         # identify equal units
-        uniqueUnitHashes = {}
-        for unit in modelXbrl.units.values():
-            h = unit.hash
-            if h in uniqueUnitHashes:
-                if unit.isEqualTo(uniqueUnitHashes[h]):
-                    self.mapUnit[unit] = uniqueUnitHashes[h]
-            else:
-                uniqueUnitHashes[h] = unit
-        del uniqueUnitHashes
+        for exemplar_unit, *units in partitionModelXbrlUnits(modelXbrl).values():
+            for unit in units:
+                self.mapUnit[unit] = exemplar_unit
         modelXbrl.profileActivity("... identify equal units", minTimeToShow=1.0)
 
         # identify concepts participating in essence-alias relationships

--- a/arelle/plugin/validate/DBA/rules/__init__.py
+++ b/arelle/plugin/validate/DBA/rules/__init__.py
@@ -15,6 +15,7 @@ from arelle.ModelValue import QName
 from arelle.ModelXbrl import ModelXbrl
 from arelle.typing import TypeGetText
 from arelle.UrlUtil import scheme
+from arelle.utils.Contexts import ContextHashKey
 from arelle.utils.validate.Validation import Validation
 from arelle.ValidateFilingText import parseImageDataURL
 from arelle.ValidateXbrl import ValidateXbrl
@@ -267,15 +268,15 @@ def getFactsGroupedByContextId(modelXbrl: ModelXbrl, *conceptQns: QName) -> dict
     return dict(sorted(groupedFacts.items()))
 
 
-def groupFactsByContextHash(facts: set[ModelFact]) -> dict[int, list[ModelFact]]:
+def groupFactsByContextHash(facts: set[ModelFact]) -> dict[ContextHashKey, list[ModelFact]]:
     """
-    Groups facts by their contextDimAwareHash.
-    :return: A dictionary of contextDimAwareHashes to list of facts.
+    Groups facts by their context hash key.
+    :return: A dictionary of context hash keys to list of facts.
     """
-    groupedFacts: defaultdict[int, list[ModelFact]] = defaultdict(list)
+    groupedFacts: defaultdict[ContextHashKey, list[ModelFact]] = defaultdict(list)
     for fact in facts:
         if fact.xValid >= VALID:
-            contextHash = fact.context.contextDimAwareHash
+            contextHash = ContextHashKey(fact.context, dimensionalAspectModel=True)
             groupedFacts[contextHash].append(fact)
     groupedFacts.default_factory = None
     return groupedFacts

--- a/arelle/plugin/validate/DBA/rules/__init__.py
+++ b/arelle/plugin/validate/DBA/rules/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import datetime
 import itertools
+from collections import defaultdict
 from collections.abc import Callable, Iterable
 from typing import Optional, cast
 
@@ -271,12 +272,10 @@ def groupFactsByContextHash(facts: set[ModelFact]) -> dict[int, list[ModelFact]]
     Groups facts by their contextDimAwareHash.
     :return: A dictionary of contextDimAwareHashes to list of facts.
     """
-    groupedFacts: dict[int, list[ModelFact]] = {}
+    groupedFacts: dict[int, list[ModelFact]] = defaultdict(list)
     for fact in facts:
         if fact.xValid >= VALID:
             contextHash = fact.context.contextDimAwareHash
-            if contextHash not in groupedFacts:
-                groupedFacts[contextHash] = []
             groupedFacts[contextHash].append(fact)
     return dict(sorted(groupedFacts.items()))
 

--- a/arelle/plugin/validate/DBA/rules/__init__.py
+++ b/arelle/plugin/validate/DBA/rules/__init__.py
@@ -266,7 +266,7 @@ def getFactsGroupedByContextId(modelXbrl: ModelXbrl, *conceptQns: QName) -> dict
     return dict(sorted(groupedFacts.items()))
 
 
-def groupFactsByContextHash(facts: set[ModelFact] ) -> dict[str, list[ModelFact]]:
+def groupFactsByContextHash(facts: set[ModelFact]) -> dict[str, list[ModelFact]]:
     """
     Groups facts by their contextDimAwareHash.
     :return: A dictionary of contextDimAwareHashes to list of facts.

--- a/arelle/plugin/validate/DBA/rules/__init__.py
+++ b/arelle/plugin/validate/DBA/rules/__init__.py
@@ -266,12 +266,12 @@ def getFactsGroupedByContextId(modelXbrl: ModelXbrl, *conceptQns: QName) -> dict
     return dict(sorted(groupedFacts.items()))
 
 
-def groupFactsByContextHash(facts: set[ModelFact]) -> dict[str, list[ModelFact]]:
+def groupFactsByContextHash(facts: set[ModelFact]) -> dict[int, list[ModelFact]]:
     """
     Groups facts by their contextDimAwareHash.
     :return: A dictionary of contextDimAwareHashes to list of facts.
     """
-    groupedFacts: dict[str, list[ModelFact]] = {}
+    groupedFacts: dict[int, list[ModelFact]] = {}
     for fact in facts:
         if fact.xValid >= VALID:
             contextHash = fact.context.contextDimAwareHash

--- a/arelle/plugin/validate/DBA/rules/__init__.py
+++ b/arelle/plugin/validate/DBA/rules/__init__.py
@@ -272,12 +272,13 @@ def groupFactsByContextHash(facts: set[ModelFact]) -> dict[int, list[ModelFact]]
     Groups facts by their contextDimAwareHash.
     :return: A dictionary of contextDimAwareHashes to list of facts.
     """
-    groupedFacts: dict[int, list[ModelFact]] = defaultdict(list)
+    groupedFacts: defaultdict[int, list[ModelFact]] = defaultdict(list)
     for fact in facts:
         if fact.xValid >= VALID:
             contextHash = fact.context.contextDimAwareHash
             groupedFacts[contextHash].append(fact)
-    return dict(sorted(groupedFacts.items()))
+    groupedFacts.default_factory = None
+    return groupedFacts
 
 
 def lookup_namespaced_facts(modelXbrl: ModelXbrl, namespaceURI: str) -> set[ModelFact]:

--- a/arelle/plugin/validate/DBA/rules/fr.py
+++ b/arelle/plugin/validate/DBA/rules/fr.py
@@ -602,9 +602,9 @@ def rule_fr57(
     DBA.FR57.Equality(Error):
     Assets (fsa:Assets) must equal Liabilities (fsa:LiabilitiesAndEquity)
     """
-    currenStartDateFacts =  getFactsWithDimension(val,pluginData.reportingPeriodStartDateQn, pluginData.consolidatedSoloDimensionQn, [pluginData.consolidatedMemberQn, pluginData.soloMemberQn])
+    currentStartDateFacts = getFactsWithDimension(val, pluginData.reportingPeriodStartDateQn, pluginData.consolidatedSoloDimensionQn, [pluginData.consolidatedMemberQn, pluginData.soloMemberQn])
     currentEndDateFacts = getFactsWithDimension(val, pluginData.reportingPeriodEndDateQn, pluginData.consolidatedSoloDimensionQn, [pluginData.consolidatedMemberQn, pluginData.soloMemberQn])
-    currentGroupedFacts = groupFactsByContextHash(currenStartDateFacts.union(currentEndDateFacts))
+    currentGroupedFacts = groupFactsByContextHash(currentStartDateFacts.union(currentEndDateFacts))
     precedingEndDateFacts = getFactsWithDimension(val, pluginData.precedingReportingPeriodEndDateQn, pluginData.consolidatedSoloDimensionQn, [pluginData.consolidatedMemberQn, pluginData.soloMemberQn])
     precedingStartDateFacts = getFactsWithDimension(val, pluginData.precedingReportingPeriodStartDateQn, pluginData.consolidatedSoloDimensionQn, [pluginData.consolidatedMemberQn, pluginData.soloMemberQn])
     precedingGroupedFacts = groupFactsByContextHash(precedingEndDateFacts.union(precedingStartDateFacts))
@@ -635,7 +635,7 @@ def rule_fr57(
         equityFacts = getFactsWithoutDimension(val, pluginData.equityQn)
         profitLossFacts = getFactsWithoutDimension(val, pluginData.profitLossQn)
         liabilitiesAndEquityFacts = getFactsWithoutDimension(val, pluginData.liabilitiesAndEquityQn)
-        for context, facts in currentGroupedFacts.items():
+        for facts in currentGroupedFacts.values():
             if len(facts) == 2:
                 for fact in facts:
                     if fact.qname == pluginData.reportingPeriodStartDateQn:

--- a/arelle/plugin/validate/DBA/rules/tr.py
+++ b/arelle/plugin/validate/DBA/rules/tr.py
@@ -42,8 +42,10 @@ def rule_tr01(
         gsd_facts = lookup_namespaced_facts(val.modelXbrl, NAMESPACE_GSD)
         facts_in_error = []
         for fact in gsd_facts:
-            if (fact.context.entityIdentifier != cvr_fact.context.entityIdentifier or
-                    fact.context.periodHash != cvr_fact.context.periodHash):
+            if not (
+                fact.context.isEntityIdentifierEqualTo(cvr_fact.context) and
+                fact.context.isPeriodEqualTo(cvr_fact.context)
+            ):
                 facts_in_error.append(fact)
         if len(facts_in_error) > 0:
             yield Validation.error(

--- a/arelle/plugin/validate/EBA/__init__.py
+++ b/arelle/plugin/validate/EBA/__init__.py
@@ -17,7 +17,7 @@ from arelle.ValidateUtr import ValidateUtr
 from arelle.Version import authorLabel, copyrightLabel
 from arelle.XbrlConst import qnEnumerationItemTypes
 from arelle.ModelInstanceObject import ModelFact
-from arelle.utils.Contexts import getDuplicateContextPairs
+from arelle.utils.Contexts import getDuplicateContextGroups
 import regex as re
 from lxml import etree
 from collections import defaultdict
@@ -486,11 +486,11 @@ def validateFacts(val, factsToCheck):
     del unitHashes
 
     if not getattr(modelXbrl, "isStreamingMode", False):
-        for context1, context2 in getDuplicateContextPairs(modelXbrl):
+        for contexts in getDuplicateContextGroups(modelXbrl):
             modelXbrl.log("WARNING" if val.isEIOPAfullVersion else "ERROR",
                 "EIOPA.S.2.7.b",
                 _("Duplicate contexts MUST NOT be reported, contexts %(cntx1)s and %(cntx2)s are equivalent.'"),
-                modelObject=(context1, context2), cntx1=context1.id, cntx2=context2.id)
+                modelObject=contexts, cntx1=contexts[0].id, cntx2=contexts[1].id)
     for cntx in modelXbrl.contexts.values():
         for _dim in cntx.qnameDims.values():
             _dimQn = _dim.dimensionQname

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -30,6 +30,8 @@ from arelle.utils.validate.ESEFImage import ImageValidationParameters, checkSVGC
 from arelle.utils.validate.ValidationUtil import etreeIterWithDepth
 from arelle.PythonUtil import isLegacyAbs, normalizeSpace
 from arelle.PythonUtil import strTruncate
+from arelle.utils.Contexts import partitionModelXbrlContexts
+from arelle.utils.Units import partitionModelXbrlUnits
 from arelle.utils.validate.DetectScriptsInXhtml import containsScriptMarkers
 from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateUtr import ValidateUtr
@@ -629,27 +631,17 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
         # identify unique contexts and units
         mapContext = {}
         mapUnit = {}
-        uniqueContextHashes: dict[Any, Any] = {}
-        for context in modelXbrl.contexts.values():
-            h = context.contextDimAwareHash
-            if h in uniqueContextHashes:
-                if context.isEqualTo(uniqueContextHashes[h]):
-                    mapContext[context] = uniqueContextHashes[h]
-            else:
-                uniqueContextHashes[h] = context
-        del uniqueContextHashes
-        uniqueUnitHashes: dict[Any, Any] = {}
+        for exemplar_context, *contexts in partitionModelXbrlContexts(modelXbrl).values():
+            for context in contexts:
+                mapContext[context] = exemplar_context
         utrValidator = ValidateUtr(modelXbrl)
         utrUnitIds = set(u.unitId
                          for unitItemType in utrValidator.utrItemTypeEntries.values()
                          for u in unitItemType.values())
+        for exemplar_unit, *units in partitionModelXbrlUnits(modelXbrl).values():
+            for unit in units:
+                mapUnit[unit] = exemplar_unit
         for unit in modelXbrl.units.values():
-            h = unit.hash
-            if h in uniqueUnitHashes:
-                if unit.isEqualTo(uniqueUnitHashes[h]):
-                    mapUnit[unit] = uniqueUnitHashes[h]
-            else:
-                uniqueUnitHashes[h] = unit
             # check if any custom measure is in UTR
             for measureTerm in unit.measures:
                 for measure in measureTerm:
@@ -659,7 +651,6 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                             modelXbrl.warning("ESEF.RTS.III.1.G1-7-1.customUnitInUtr",
                                 _("Custom measure SHOULD NOT duplicate a UnitID of UTR: %(measure)s"),
                                 modelObject=unit, measure=measure)
-        del uniqueUnitHashes
 
         reportedMandatory: set[QName] = set()
         precisionFacts = set()

--- a/arelle/plugin/validate/FERC/__init__.py
+++ b/arelle/plugin/validate/FERC/__init__.py
@@ -33,7 +33,7 @@ from arelle.PrototypeDtsObject import LinkPrototype, LocPrototype, ArcPrototype
 from arelle.Version import authorLabel, copyrightLabel
 from arelle.XbrlConst import xbrli, xhtml
 from arelle.XmlValidateConst import VALID
-from arelle.utils.Contexts import getDuplicateContextPairs
+from arelle.utils.Contexts import getDuplicateContextGroups
 
 def dislosureSystemTypes(disclosureSystem, *args, **kwargs):
     # return ((disclosure system name, variable name), ...)
@@ -134,11 +134,11 @@ def validateXbrlFinally(val, *args, **kwargs):
         if XmlUtil.hasChild(c, xbrli, "segment"):
             segContexts.add(c)
         contextIDs.add(c.id)
-    for context1, context2 in getDuplicateContextPairs(modelXbrl):
+    for contexts in getDuplicateContextGroups(modelXbrl):
         modelXbrl.error("FERC.6.05.07",
             _("The instance document contained more than one context equivalent to %(context)s (%(context2)s).  "
                 "Please remove duplicate contexts from the instance."),
-            modelObject=(context1, context2), context=context1.id, context2=context2.id)
+            modelObject=contexts, context=contexts[0].id, context2=contexts[1].id)
 
     if segContexts:
         modelXbrl.error("FERC.6.05.04",

--- a/arelle/plugin/validate/FERC/__init__.py
+++ b/arelle/plugin/validate/FERC/__init__.py
@@ -133,6 +133,7 @@ def validateXbrlFinally(val, *args, **kwargs):
     for c in modelXbrl.contexts.values():
         if XmlUtil.hasChild(c, xbrli, "segment"):
             segContexts.add(c)
+        contextIDs.add(c.id)
         h = c.contextDimAwareHash
         if h in uniqueContextHashes:
             if c.isEqualTo(uniqueContextHashes[h]):
@@ -142,7 +143,6 @@ def validateXbrlFinally(val, *args, **kwargs):
                     modelObject=(c, uniqueContextHashes[h]), context=c.id, context2=uniqueContextHashes[h].id)
         else:
             uniqueContextHashes[h] = c
-        contextIDs.add(c.id)
 
     if segContexts:
         modelXbrl.error("FERC.6.05.04",

--- a/arelle/plugin/validate/NL/rules/fr_nl.py
+++ b/arelle/plugin/validate/NL/rules/fr_nl.py
@@ -18,6 +18,7 @@ from arelle.ModelObject import ModelObject, ModelComment
 from arelle.ModelValue import QName, qname
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.typing import TypeGetText
+from arelle.utils.Contexts import partitionModelXbrlContexts
 from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
@@ -579,10 +580,7 @@ def rule_fr_nl_3_04(
     """
     FR-NL-3.04: An XBRL instance document MUST NOT contain duplicate 'xbrli:context' elements
     """
-    duplicates = defaultdict(list)
-    for context in val.modelXbrl.contexts.values():
-        duplicates[context.contextDimAwareHash].append(context)
-    for duplicate_contexts in duplicates.values():
+    for duplicate_contexts in partitionModelXbrlContexts(val.modelXbrl).values():
         if len(duplicate_contexts) > 1:
             yield Validation.error(
                 codes='NL.FR-NL-3.04',

--- a/arelle/utils/Contexts.py
+++ b/arelle/utils/Contexts.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from arelle.utils.Equivalence import (
+    partitionIntoEquivalenceClasses,
+    getDuplicateItemPairs,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from arelle.ModelXbrl import ModelXbrl
+    from arelle.ModelInstanceObject import ModelContext
+
+class ContextHashKey:
+    __slots__ = ('context', 'dimensionalAspectModel', 'hash')
+    context: ModelContext
+    dimensionalAspectModel: bool
+    hash: int
+
+    def __init__(self, context: ModelContext, dimensionalAspectModel: bool) -> None:
+        self.context = context
+        self.dimensionalAspectModel = dimensionalAspectModel
+        self.hash = self.context.contextDimAwareHash if dimensionalAspectModel else self.context.contextNonDimAwareHash
+
+    def __eq__(self, o: Any) -> bool:
+        if isinstance(o, ContextHashKey):
+            return self.dimensionalAspectModel == o.dimensionalAspectModel and self.context.isEqualTo(o.context, self.dimensionalAspectModel)
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return self.hash
+
+def partitionContexts(contexts: Iterable[ModelContext], dimensionalAspectModel: bool) -> dict[ContextHashKey, tuple[ModelContext, ...]]:
+    return partitionIntoEquivalenceClasses(contexts, lambda c: ContextHashKey(c, dimensionalAspectModel))
+
+def partitionModelXbrlContexts(modelXbrl: ModelXbrl) -> dict[ContextHashKey, tuple[ModelContext, ...]]:
+    return partitionContexts(modelXbrl.contexts.values(), dimensionalAspectModel=modelXbrl.hasXDT)
+
+def getDuplicateContextPairs(modelXbrl: ModelXbrl) -> list[tuple[ModelContext, ModelContext]]:
+    return getDuplicateItemPairs(modelXbrl, partitionModelXbrlContexts)

--- a/arelle/utils/Contexts.py
+++ b/arelle/utils/Contexts.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from arelle.utils.Equivalence import (
-    partitionIntoEquivalenceClasses,
-    getDuplicateItemPairs,
-)
+from arelle.utils.Equivalence import partitionIntoEquivalenceClasses
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -37,5 +34,5 @@ def partitionContexts(contexts: Iterable[ModelContext], dimensionalAspectModel: 
 def partitionModelXbrlContexts(modelXbrl: ModelXbrl) -> dict[ContextHashKey, tuple[ModelContext, ...]]:
     return partitionContexts(modelXbrl.contexts.values(), dimensionalAspectModel=modelXbrl.hasXDT)
 
-def getDuplicateContextPairs(modelXbrl: ModelXbrl) -> list[tuple[ModelContext, ModelContext]]:
-    return getDuplicateItemPairs(modelXbrl, partitionModelXbrlContexts)
+def getDuplicateContextGroups(modelXbrl: ModelXbrl) -> list[tuple[ModelContext, ...]]:
+    return [partition for partition in partitionModelXbrlContexts(modelXbrl).values() if len(partition) > 1]

--- a/arelle/utils/Equivalence.py
+++ b/arelle/utils/Equivalence.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    TypeVar,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from arelle.ModelXbrl import ModelXbrl
+
+T = TypeVar('T')
+K = TypeVar('K')
+
+def partitionIntoEquivalenceClasses(items: Iterable[T], key: Callable[[T], K]) -> dict[K, tuple[T, ...]]:
+    d = defaultdict(list)
+    for item in items:
+        d[key(item)].append(item)
+    return {k: tuple(v) for k, v in d.items()}
+
+def getDuplicateItemPairs(modelXbrl: ModelXbrl, partition: Callable[[ModelXbrl], dict[Any, tuple[T, ...]]]) -> list[tuple[T, T]]:
+    return [
+        (context, exemplar)
+        for exemplar, *contexts in partition(modelXbrl).values()
+        for context in contexts
+    ]

--- a/arelle/utils/Equivalence.py
+++ b/arelle/utils/Equivalence.py
@@ -20,10 +20,3 @@ def partitionIntoEquivalenceClasses(items: Iterable[T], key: Callable[[T], K]) -
     for item in items:
         d[key(item)].append(item)
     return {k: tuple(v) for k, v in d.items()}
-
-def getDuplicateItemPairs(modelXbrl: ModelXbrl, partition: Callable[[ModelXbrl], dict[Any, tuple[T, ...]]]) -> list[tuple[T, T]]:
-    return [
-        (context, exemplar)
-        for exemplar, *contexts in partition(modelXbrl).values()
-        for context in contexts
-    ]

--- a/arelle/utils/Units.py
+++ b/arelle/utils/Units.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from arelle.utils.Equivalence import (
-    partitionIntoEquivalenceClasses,
-    getDuplicateItemPairs,
-)
+from arelle.utils.Equivalence import partitionIntoEquivalenceClasses
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -35,5 +32,5 @@ def partitionUnits(units: Iterable[ModelUnit]) -> dict[UnitHashKey, tuple[ModelU
 def partitionModelXbrlUnits(modelXbrl: ModelXbrl) -> dict[UnitHashKey, tuple[ModelUnit, ...]]:
     return partitionUnits(modelXbrl.units.values())
 
-def getDuplicateUnitPairs(modelXbrl: ModelXbrl) -> list[tuple[ModelUnit, ModelUnit]]:
-    return getDuplicateItemPairs(modelXbrl, partitionModelXbrlUnits)
+def getDuplicateUnitGroups(modelXbrl: ModelXbrl) -> list[tuple[ModelUnit, ...]]:
+    return [partition for partition in partitionModelXbrlUnits(modelXbrl).values() if len(partition) > 1]

--- a/arelle/utils/Units.py
+++ b/arelle/utils/Units.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from arelle.utils.Equivalence import (
+    partitionIntoEquivalenceClasses,
+    getDuplicateItemPairs,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from arelle.ModelXbrl import ModelXbrl
+    from arelle.ModelInstanceObject import ModelUnit
+
+class UnitHashKey:
+    __slots__ = ('unit', 'hash')
+    unit: ModelUnit
+    hash: int
+
+    def __init__(self, unit: ModelUnit) -> None:
+        self.unit = unit
+        self.hash = self.unit.hash
+
+    def __eq__(self, o: Any) -> bool:
+        if isinstance(o, UnitHashKey):
+            return self.unit.isEqualTo(o.unit)
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return self.hash
+
+def partitionUnits(units: Iterable[ModelUnit]) -> dict[UnitHashKey, tuple[ModelUnit, ...]]:
+    return partitionIntoEquivalenceClasses(units, UnitHashKey)
+
+def partitionModelXbrlUnits(modelXbrl: ModelXbrl) -> dict[UnitHashKey, tuple[ModelUnit, ...]]:
+    return partitionUnits(modelXbrl.units.values())
+
+def getDuplicateUnitPairs(modelXbrl: ModelXbrl) -> list[tuple[ModelUnit, ModelUnit]]:
+    return getDuplicateItemPairs(modelXbrl, partitionModelXbrlUnits)

--- a/tests/unit_tests/arelle/utils/test_contexts.py
+++ b/tests/unit_tests/arelle/utils/test_contexts.py
@@ -5,7 +5,7 @@ from arelle.ModelXbrl import ModelXbrl
 from arelle.utils.Contexts import (
     partitionContexts,
     partitionModelXbrlContexts,
-    getDuplicateContextPairs,
+    getDuplicateContextGroups,
 )
 
 def test_notEqualDifferentHash():
@@ -74,5 +74,5 @@ def test_detectAlternatingDuplicate():
     assert partitions1 == [(c1a, c1b), (c2,)]
     partitions2 = list(partitionModelXbrlContexts(modelXbrl).values())
     assert partitions2 == partitions1
-    duplicates = getDuplicateContextPairs(modelXbrl)
-    assert duplicates == [(c1b, c1a)]
+    duplicates = getDuplicateContextGroups(modelXbrl)
+    assert duplicates == [(c1a, c1b)]

--- a/tests/unit_tests/arelle/utils/test_contexts.py
+++ b/tests/unit_tests/arelle/utils/test_contexts.py
@@ -1,0 +1,78 @@
+from unittest.mock import Mock, patch
+
+from arelle.ModelInstanceObject import ModelContext
+from arelle.ModelXbrl import ModelXbrl
+from arelle.utils.Contexts import (
+    partitionContexts,
+    partitionModelXbrlContexts,
+    getDuplicateContextPairs,
+)
+
+def test_notEqualDifferentHash():
+    c1 = Mock(spec=ModelContext, contextDimAwareHash=1)
+    c2 = Mock(spec=ModelContext, contextDimAwareHash=2)
+    c1.isEqualTo.side_effect = lambda o, _: o is c1
+    c2.isEqualTo.side_effect = lambda o, _: o is c2
+    assert list(partitionContexts([c1, c2], True).values()) == [(c1,), (c2,)]
+
+def test_notEqualSameHash():
+    c1 = Mock(spec=ModelContext, contextDimAwareHash=1)
+    c2 = Mock(spec=ModelContext, contextDimAwareHash=1)
+    c1.isEqualTo.side_effect = lambda o, _: o is c1
+    c2.isEqualTo.side_effect = lambda o, _: o is c2
+    assert list(partitionContexts([c1, c2], True).values()) == [(c1,), (c2,)]
+
+def test_equal():
+    c1 = Mock(spec=ModelContext, contextDimAwareHash=1)
+    c2 = Mock(spec=ModelContext, contextDimAwareHash=1)
+    c1.isEqualTo.side_effect = lambda o, _: o is c1 or o is c2
+    c2.isEqualTo.side_effect = lambda o, _: o is c1 or o is c2
+    assert list(partitionContexts([c1, c2], True).values()) == [(c1, c2)]
+
+def test_id():
+    c1 = Mock(spec=ModelContext, contextDimAwareHash=1)
+    c1.isEqualTo.side_effect = lambda o, _: o is c1
+    assert list(partitionContexts([c1, c1], True).values()) == [(c1, c1)]
+
+
+def test_nonDim_notEqualDifferentHash():
+    c1 = Mock(spec=ModelContext, contextNonDimAwareHash=1)
+    c2 = Mock(spec=ModelContext, contextNonDimAwareHash=2)
+    c1.isEqualTo.side_effect = lambda o, _: o is c1
+    c2.isEqualTo.side_effect = lambda o, _: o is c2
+    assert list(partitionContexts([c1, c2], False).values()) == [(c1,), (c2,)]
+
+def test_nonDim_notEqualSameHash():
+    c1 = Mock(spec=ModelContext, contextNonDimAwareHash=1)
+    c2 = Mock(spec=ModelContext, contextNonDimAwareHash=1)
+    c1.isEqualTo.side_effect = lambda o, _: o is c1
+    c2.isEqualTo.side_effect = lambda o, _: o is c2
+    assert list(partitionContexts([c1, c2], False).values()) == [(c1,), (c2,)]
+
+def test_nonDim_equal():
+    c1 = Mock(spec=ModelContext, contextNonDimAwareHash=1)
+    c2 = Mock(spec=ModelContext, contextNonDimAwareHash=1)
+    c1.isEqualTo.side_effect = lambda o, _: o is c1 or o is c2
+    c2.isEqualTo.side_effect = lambda o, _: o is c1 or o is c2
+    assert list(partitionContexts([c1, c2], False).values()) == [(c1, c2)]
+
+def test_nonDim_id():
+    c1 = Mock(spec=ModelContext, contextNonDimAwareHash=1)
+    c1.isEqualTo.side_effect = lambda o, _: o is c1
+    assert list(partitionContexts([c1, c1], False).values()) == [(c1, c1)]
+
+
+def test_detectAlternatingDuplicate():
+    c1a = Mock(spec=ModelContext, contextDimAwareHash=1)
+    c2 = Mock(spec=ModelContext, contextDimAwareHash=1)
+    c1b = Mock(spec=ModelContext, contextDimAwareHash=1)
+    c1a.isEqualTo.side_effect = lambda o, _: o is c1a or o is c1b
+    c2.isEqualTo.side_effect = lambda o, _: o is c2
+    c1b.isEqualTo.side_effect = lambda o, _: o is c1a or o is c1b
+    modelXbrl = Mock(spec=ModelXbrl, contexts={1:c1a, 2:c2, 3:c1b}, hasXDT=True)
+    partitions1 = list(partitionContexts([c1a, c2, c1b], True).values())
+    assert partitions1 == [(c1a, c1b), (c2,)]
+    partitions2 = list(partitionModelXbrlContexts(modelXbrl).values())
+    assert partitions2 == partitions1
+    duplicates = getDuplicateContextPairs(modelXbrl)
+    assert duplicates == [(c1b, c1a)]

--- a/tests/unit_tests/arelle/utils/test_units.py
+++ b/tests/unit_tests/arelle/utils/test_units.py
@@ -5,7 +5,7 @@ from arelle.ModelXbrl import ModelXbrl
 from arelle.utils.Units import (
     partitionUnits,
     partitionModelXbrlUnits,
-    getDuplicateUnitPairs,
+    getDuplicateUnitGroups,
 )
 
 def test_notEqualDifferentHash():
@@ -47,5 +47,5 @@ def test_detectAlternatingDuplicate():
     assert partitions1 == [(u1a, u1b), (u2,)]
     partitions2 = list(partitionModelXbrlUnits(modelXbrl).values())
     assert partitions2 == partitions1
-    duplicates = getDuplicateUnitPairs(modelXbrl)
-    assert duplicates == [(u1b, u1a)]
+    duplicates = getDuplicateUnitGroups(modelXbrl)
+    assert duplicates == [(u1a, u1b)]

--- a/tests/unit_tests/arelle/utils/test_units.py
+++ b/tests/unit_tests/arelle/utils/test_units.py
@@ -1,0 +1,51 @@
+from unittest.mock import Mock, patch
+
+from arelle.ModelInstanceObject import ModelUnit
+from arelle.ModelXbrl import ModelXbrl
+from arelle.utils.Units import (
+    partitionUnits,
+    partitionModelXbrlUnits,
+    getDuplicateUnitPairs,
+)
+
+def test_notEqualDifferentHash():
+    u1 = Mock(spec=ModelUnit, hash=1)
+    u2 = Mock(spec=ModelUnit, hash=2)
+    u1.isEqualTo.side_effect = lambda o: o is u1
+    u2.isEqualTo.side_effect = lambda o: o is u2
+    assert list(partitionUnits([u1, u2]).values()) == [(u1,), (u2,)]
+
+def test_notEqualSameHash():
+    u1 = Mock(spec=ModelUnit, hash=1)
+    u2 = Mock(spec=ModelUnit, hash=1)
+    u1.isEqualTo.side_effect = lambda o: o is u1
+    u2.isEqualTo.side_effect = lambda o: o is u2
+    assert list(partitionUnits([u1, u2]).values()) == [(u1,), (u2,)]
+
+def test_equal():
+    u1 = Mock(spec=ModelUnit, hash=1)
+    u2 = Mock(spec=ModelUnit, hash=1)
+    u1.isEqualTo.side_effect = lambda o: o is u1 or o is u2
+    u2.isEqualTo.side_effect = lambda o: o is u1 or o is u2
+    assert list(partitionUnits([u1, u2]).values()) == [(u1, u2)]
+
+def test_id():
+    u1 = Mock(spec=ModelUnit, hash=1)
+    u1.isEqualTo.side_effect = lambda o: o is u1
+    assert list(partitionUnits([u1, u1]).values()) == [(u1, u1)]
+
+
+def test_detectAlternatingDuplicate():
+    u1a = Mock(spec=ModelUnit, hash=1)
+    u2 = Mock(spec=ModelUnit, hash=1)
+    u1b = Mock(spec=ModelUnit, hash=1)
+    u1a.isEqualTo.side_effect = lambda o: o is u1a or o is u1b
+    u2.isEqualTo.side_effect = lambda o: o is u2
+    u1b.isEqualTo.side_effect = lambda o: o is u1a or o is u1b
+    modelXbrl = Mock(spec=ModelXbrl, units={1:u1a, 2:u2, 3:u1b})
+    partitions1 = list(partitionUnits([u1a, u2, u1b]).values())
+    assert partitions1 == [(u1a, u1b), (u2,)]
+    partitions2 = list(partitionModelXbrlUnits(modelXbrl).values())
+    assert partitions2 == partitions1
+    duplicates = getDuplicateUnitPairs(modelXbrl)
+    assert duplicates == [(u1b, u1a)]


### PR DESCRIPTION
#### Description of change
Implement https://github.com/Arelle/Arelle/pull/1808#discussion_r2219717955.
Change some warnings about duplicate contexts/units from reporting duplicate pairs to reporting entire duplicate sets.

#### Steps to Test
CI.  Lightly tested EBA.

**review**:
@Arelle/arelle
