### PR TITLE
Check Session plugin import dependencies for args

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -620,7 +620,11 @@ class ParserForDynamicPlugins:
 
 
 def _pluginHasCliOptions(moduleInfo):
-    return "CntlrCmdLine.Options" in moduleInfo["classMethods"]
+    if "CntlrCmdLine.Options" in moduleInfo["classMethods"]:
+        return True
+    if imports := moduleInfo.get("imports"):
+        return any(_pluginHasCliOptions(importedModule) for importedModule in imports)
+    return False
 
 
 class CntlrCmdLine(Cntlr.Cntlr):

--- a/tests/integration_tests/scripts/tests/python_api_validate_esef.py
+++ b/tests/integration_tests/scripts/tests/python_api_validate_esef.py
@@ -60,8 +60,10 @@ options = RuntimeOptions(
     validate=True,
 )
 with Session() as session:
+    assert not hasattr(options, "saveTargetInstance"), "validate/ESEF plugin dependency inlineXbrlDocumentSet CLI args should not be loaded yet."
     session.run(options)
     log_xml = session.get_logs('xml')
+    assert hasattr(options, "saveTargetInstance"), "validate/ESEF plugin dependency inlineXbrlDocumentSet CLI args were not loaded."
 # include end
 
 print("Checking log XML for errors...")


### PR DESCRIPTION
#### Reason for change
The function that determines whether plugins passed to the Session API require loading CLI options (and applying their default values to RuntimeOptions) did not account for plugin dependencies.

As a result, the following would throw an attribute exception because `options.configFile` wasn't set by EDGAR/render.
```python
options = RuntimeOptions(
    entrypointFile="/Users/austinmatherne/Documents/xbrl/filings/workiva/0001445305-25-000091-xbrl.zip",
    disclosureSystemName='efm-pragmatic',
    logFile="/Users/austinmatherne/Desktop/arelle.log",
    plugins='EDGAR',
    validate=True,
)
with Session() as session:
    session.run(options)
```

Whereas this would not (note the addition of `EDGAR/render` which is already a dependency of `EDGAR`):
```python
options = RuntimeOptions(
    entrypointFile="/Users/austinmatherne/Documents/xbrl/filings/workiva/0001445305-25-000091-xbrl.zip",
    disclosureSystemName='efm-pragmatic',
    logFile="/Users/austinmatherne/Desktop/arelle.log",
    plugins='EDGAR|EDGAR/render',
    validate=True,
)
with Session() as session:
    session.run(options)
```

#### Description of change
For the Session API, also check whether plugins imported by user-specified plugins define CLI arguments that need to be loaded.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
