### PR TITLE
Include missing dependencies in EFM requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,9 @@ DB = [
     'rdflib>=5,<8',
 ]
 EFM = [
+    'aniso8601==10.*',
     'holidays==0.*',
+    'Matplotlib==3.*',
     'pytz',
 ]
 ESEF = [


### PR DESCRIPTION
#### Reason for change
EDGAR/XULE require matplotlib and aniso8601 to run. Discovered while responding to a support request.

#### Description of change
Add the missing dependencies to the optional python package EFM install target.

#### Steps to Test
1. In a fresh venv
2. `pip install .[EFM]`
3. Run (with your own paths to EDGAR/XULE/files):
```python
from arelle.RuntimeOptions import RuntimeOptions
from arelle.api.Session import Session


options = RuntimeOptions(
    entrypointFile="/Users/austinmatherne/Documents/xbrl/filings/workiva/0001445305-25-000091-xbrl.zip",
    disclosureSystemName="efm-pragmatic",
    logFile="/Users/austinmatherne/Desktop/arelle.log",
    plugins="/Users/austinmatherne/git/EDGAR|/Users/austinmatherne/git/EDGAR/transform|/Users/austinmatherne/git/EDGAR/validate|/Users/austinmatherne/git/xule/plugin/xule",
    pluginOptions={
        "excelXslt": "InstanceReport_XmlWorkbook.xslt",
        "reportsFolder": "/Users/austinmatherne/Desktop/reports"
    },
    validate=True,
)
with Session() as session:
    session.run(options)

```

**review**:
@Arelle/arelle
