### PR TITLE
Bump the dotnet-dependencies group with 4 updates

### DIFF
--- a/tests/integration_tests/ui_tests/ArelleGUITest/ArelleGUITest/ArelleGUITest.csproj
+++ b/tests/integration_tests/ui_tests/ArelleGUITest/ArelleGUITest/ArelleGUITest.csproj
@@ -16,10 +16,10 @@
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.7" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.8" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
**Dependabot created the branch, but failed to open a PR.**

Bumps Microsoft.Windows.Compatibility from 9.0.7 to 9.0.8 Bumps NUnit from 4.3.2 to 4.4.0
Bumps NUnit.Analyzers from 4.9.2 to 4.10.0
Bumps NUnit3TestAdapter from 5.0.0 to 5.1.0

---
updated-dependencies:
- dependency-name: Microsoft.Windows.Compatibility dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: dotnet-dependencies
- dependency-name: NUnit dependency-version: 4.4.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: dotnet-dependencies
- dependency-name: NUnit.Analyzers dependency-version: 4.10.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: dotnet-dependencies
- dependency-name: NUnit3TestAdapter dependency-version: 5.1.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: dotnet-dependencies ...

#### Reason for change


#### Description of change


#### Steps to Test

**review**:
@Arelle/arelle
