### PR TITLE
Compute test suite requires network setting

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -230,8 +230,8 @@ class ConformanceSuiteConfig:
             f'Testcase IDs in both expected failures and expected additional errors: {sorted(overlapping_expected_failure_testcase_ids)}'
 
     @property
-    def network_or_cache_required(self) -> bool:
-        return self.cache_version_id is not None or len(self.package_paths) > 0
+    def runs_without_network(self) -> bool:
+        return self.cache_version_id is None and len(self.package_paths) == 0
 
     @cached_property
     def entry_point_asset(self) -> ConformanceSuiteAssetConfig:

--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -201,7 +201,6 @@ class ConformanceSuiteConfig:
     shards: int = 1
     strict_testcase_index: bool = True
     url_replace: str | None = None
-    network_or_cache_required: bool = True
     required_locale_by_ids: dict[str, re.Pattern[str]] = field(default_factory=dict)
     test_case_result_options: Literal['match-all', 'match-any'] = 'match-all'
 
@@ -229,8 +228,10 @@ class ConformanceSuiteConfig:
         overlapping_expected_failure_testcase_ids = self.expected_failure_ids.intersection(self.expected_additional_testcase_errors.keys())
         assert not overlapping_expected_failure_testcase_ids, \
             f'Testcase IDs in both expected failures and expected additional errors: {sorted(overlapping_expected_failure_testcase_ids)}'
-        assert not self.network_or_cache_required or self.package_paths or self.cache_version_id, \
-            'If network or cache is required, either packages must be used or a cache version ID must be provided.'
+
+    @property
+    def network_or_cache_required(self) -> bool:
+        return self.cache_version_id is not None or len(self.package_paths) > 0
 
     @cached_property
     def entry_point_asset(self) -> ConformanceSuiteAssetConfig:

--- a/tests/integration_tests/validation/conformance_suite_configurations/dba_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/dba_current.py
@@ -16,7 +16,6 @@ config = ConformanceSuiteConfig(
     cache_version_id='gqg_wyX4Tx52sj4WljjDswZLJqH0zvaU',
     info_url='https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-aktuelle',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/DBA'}),
     shards=4,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/dba_multi_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/dba_multi_current.py
@@ -15,7 +15,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-aktuelle',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/DBA'}),
     shards=1,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/edinet.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/edinet.py
@@ -44,7 +44,6 @@ config = ConformanceSuiteConfig(
     expected_failure_ids=frozenset([]),
     info_url='https://disclosure2.edinet-fsa.go.jp/weee0020.aspx',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/EDINET', 'inlineXbrlDocumentSet'}),
     shards=4,
     test_case_result_options='match-all',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
@@ -22,7 +22,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.esma.europa.eu/document/conformance-suite-2021',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/ESEF'}),
     shards=8,
     test_case_result_options='match-any',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
@@ -27,7 +27,6 @@ config = ConformanceSuiteConfig(
     ]),
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2022',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/ESEF'}),
     shards=8,
     test_case_result_options='match-any',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
@@ -32,7 +32,6 @@ config = ConformanceSuiteConfig(
     ]),
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2023',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/ESEF'}),
     shards=8,
     test_case_result_options='match-any',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
@@ -31,7 +31,6 @@ config = ConformanceSuiteConfig(
     }.items()},
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2024',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/ESEF'}),
     shards=8,
     test_case_result_options='match-any',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2021.py
@@ -16,7 +16,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.esma.europa.eu/document/conformance-suite-2021',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/ESEF'}),
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
@@ -16,7 +16,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2022',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/ESEF'}),
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2023.py
@@ -16,7 +16,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2023',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/ESEF'}),
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2024.py
@@ -21,7 +21,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2024',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/ESEF'}),
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/hmrc_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/hmrc_current.py
@@ -30,7 +30,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.gov.uk/government/organisations/hm-revenue-customs',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/UK'}),
     shards=4,
     test_case_result_options='match-any',

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt16.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt16.py
@@ -28,7 +28,6 @@ config = ConformanceSuiteConfig(
     ]),
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT16%20-%2020210301_0.pdf',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=8,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt17.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt17.py
@@ -24,7 +24,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT17%20-%2020220301__.pdf',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=8,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt18.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt18.py
@@ -23,7 +23,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT18%20-%2020230301_.pdf',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=8,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt19.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt19.py
@@ -23,7 +23,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/20240301%20SBR%20Filing%20Rules%20NT19.pdf',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=8,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -184,7 +184,6 @@ config = ConformanceSuiteConfig(
     ]),
     info_url='https://www.sbr-nl.nl/sbr-domeinen/handelsregister/uitbreiding-elektronische-deponering-handelsregister',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=8,
     test_case_result_options='match-all',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024_gaap_other.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024_gaap_other.py
@@ -247,7 +247,6 @@ config = ConformanceSuiteConfig(
     ]),
     info_url='https://www.sbr-nl.nl/sbr-domeinen/handelsregister/uitbreiding-elektronische-deponering-handelsregister',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=8,
     test_case_result_options='match-all',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt16.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt16.py
@@ -17,7 +17,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT16%20-%2020210301_0.pdf',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=4,
     test_case_result_options='match-any',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt17.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt17.py
@@ -17,7 +17,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT17%20-%2020220301__.pdf',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=4,
     test_case_result_options='match-any',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt18.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt18.py
@@ -17,7 +17,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT18%20-%2020230301_.pdf',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=4,
     test_case_result_options='match-any',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt19.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt19.py
@@ -17,7 +17,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/20240301%20SBR%20Filing%20Rules%20NT19.pdf',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'validate/NL'}),
     shards=4,
     test_case_result_options='match-any',

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_2_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_2_1.py
@@ -27,6 +27,5 @@ config = ConformanceSuiteConfig(
     }.items()},
     info_url='https://specifications.xbrl.org/work-product-index-group-base-spec-base-spec.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     shards=3,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_calculations_1_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_calculations_1_1.py
@@ -14,7 +14,6 @@ config = ConformanceSuiteConfig(
     info_url='https://specifications.xbrl.org/work-product-index-calculations-2-calculations-1-1.html',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'../../tests/plugin/testcaseCalc11ValidateSetup.py'}),
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_dimensions_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_dimensions_1_0.py
@@ -29,6 +29,5 @@ config = ConformanceSuiteConfig(
     ]),
     info_url='https://specifications.xbrl.org/work-product-index-group-dimensions-dimensions.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_dtr_2024_01_31.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_dtr_2024_01_31.py
@@ -11,5 +11,4 @@ config = ConformanceSuiteConfig(
     info_url='https://gitlab.xbrl.org/base-spec/data-type-registry/-/tree/1.11.0-REC+registry+2024-01-31/conf',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_extensible_enumerations_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_extensible_enumerations_1_0.py
@@ -12,5 +12,4 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://specifications.xbrl.org/work-product-index-extensible-enumerations-extensible-enumerations-1.0.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_extensible_enumerations_2_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_extensible_enumerations_2_0.py
@@ -11,5 +11,4 @@ config = ConformanceSuiteConfig(
     info_url='https://specifications.xbrl.org/work-product-index-extensible-enumerations-extensible-enumerations-2.0.html',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_formula_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_formula_1_0.py
@@ -10,7 +10,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://specifications.xbrl.org/release-history-formula-1.0-formula-conf.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     shards=4,
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_formula_1_0_assertion_severity_2_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_formula_1_0_assertion_severity_2_0.py
@@ -10,6 +10,5 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://specifications.xbrl.org/release-history-formula-1.0-formula-conf.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_formula_1_0_function_registry.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_formula_1_0_function_registry.py
@@ -19,7 +19,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://specifications.xbrl.org/release-history-formula-1.0-formula-conf.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'formulaXPathChecker', 'functionsMath'}),
     strict_testcase_index=False,
     required_locale_by_ids={f'formula/function-registry/{t}': p for t, p in [

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_ixbrl_1_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_ixbrl_1_1.py
@@ -24,7 +24,6 @@ config = ConformanceSuiteConfig(
     capture_warnings=False,
     info_url='https://specifications.xbrl.org/work-product-index-inline-xbrl-inline-xbrl-1.1.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset({'inlineXbrlDocumentSet', '../../tests/plugin/testcaseIxExpectedHtmlFixup.py'}),
     shards=4,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_link_role_registry_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_link_role_registry_1_0.py
@@ -11,6 +11,5 @@ config = ConformanceSuiteConfig(
     info_url='https://specifications.xbrl.org/work-product-index-registries-lrr-1.0.html',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     url_replace='file:///c:/temp/conf/',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_oim_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_oim_1_0.py
@@ -18,6 +18,5 @@ config = ConformanceSuiteConfig(
     info_url='https://specifications.xbrl.org/work-product-index-open-information-model-open-information-model.html',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_report_packages_1_0.py
@@ -48,6 +48,5 @@ config = ConformanceSuiteConfig(
     info_url="https://specifications.xbrl.org/work-product-index-taxonomy-packages-report-packages-1.0.html",
     membership_url="https://www.xbrl.org/join",
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     plugins=frozenset(["inlineXbrlDocumentSet"]),
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_table_linkbase_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_table_linkbase_1_0.py
@@ -17,7 +17,6 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://specifications.xbrl.org/work-product-index-table-linkbase-table-linkbase-1.0.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     shards=4,
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_taxonomy_packages_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_taxonomy_packages_1_0.py
@@ -11,6 +11,5 @@ config = ConformanceSuiteConfig(
     info_url='https://specifications.xbrl.org/work-product-index-taxonomy-packages-taxonomy-packages-1.0.html',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
     test_case_result_options='match-any',
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_transformation_registry_3.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_transformation_registry_3.py
@@ -11,5 +11,4 @@ config = ConformanceSuiteConfig(
     info_url='https://specifications.xbrl.org/work-product-index-inline-xbrl-transformation-registry-3.html',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_transformation_registry_4.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_transformation_registry_4.py
@@ -11,5 +11,4 @@ config = ConformanceSuiteConfig(
     info_url='https://specifications.xbrl.org/work-product-index-inline-xbrl-transformation-registry-4.html',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_transformation_registry_5.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_transformation_registry_5.py
@@ -11,5 +11,4 @@ config = ConformanceSuiteConfig(
     info_url='https://specifications.xbrl.org/work-product-index-inline-xbrl-transformation-registry-5.html',
     membership_url='https://www.xbrl.org/join',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_malformed_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_malformed_1_0.py
@@ -33,7 +33,6 @@ configs = [
         expected_model_errors=frozenset(expected_model_errors),
         info_url='https://specifications.xbrl.org/work-product-index-registries-units-registry-1.0.html',
         name=PurePath(__file__).stem,
-        network_or_cache_required=False,
     )
     for malformed_utr_file, expected_model_errors in MALFORMED_UTR_FILES.items()
 ]

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_registry_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_registry_1_0.py
@@ -26,5 +26,4 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://specifications.xbrl.org/work-product-index-registries-units-registry-1.0.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_structure_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_utr_structure_1_0.py
@@ -20,5 +20,4 @@ config = ConformanceSuiteConfig(
     ],
     info_url='https://specifications.xbrl.org/work-product-index-registries-units-registry-1.0.html',
     name=PurePath(__file__).stem,
-    network_or_cache_required=False,
 )

--- a/tests/integration_tests/validation/discover_tests.py
+++ b/tests/integration_tests/validation/discover_tests.py
@@ -104,7 +104,7 @@ def main() -> None:
     private = False
     for config in CI_CONFORMANCE_SUITE_CONFIGS:
         if config.name in FAST_CONFIG_NAMES:
-            assert not config.network_or_cache_required
+            assert config.runs_without_network
             assert config.shards == 1
             config_names_seen.add(config.name)
             private |= config.has_private_asset

--- a/tests/integration_tests/validation/validation_util.py
+++ b/tests/integration_tests/validation/validation_util.py
@@ -276,7 +276,7 @@ def get_conformance_suite_arguments(config: ConformanceSuiteConfig, filename: st
             '--csvTestReport', f'conf-{config.name}{shard_str}-report.csv',
             '--logFile', f'conf-{config.name}{shard_str}-log.txt',
         ])
-    if offline or not config.network_or_cache_required:
+    if offline or config.runs_without_network:
         args.extend(['--internetConnectivity', 'offline'])
     for pattern in testcase_filters:
         args.extend(['--testcaseFilter', pattern])


### PR DESCRIPTION
#### Reason for change
Two test suites declare that they don't require network or cache, yet define a cache version ID to download from S3. When run without downloading the cache, these suites would fail because Arelle was forced into offline mode regardless of the offline argument passed to the test runner.

#### Description of change
Rather than relying on a manual declaration that a test suite requires network access, the setting is now inferred automatically based on whether taxonomy packages or a cache ID are used by the suite.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
