### PR TITLE
Dependency Cleanup

### DIFF
--- a/.github/actions/test_conformance_suite/action.yml
+++ b/.github/actions/test_conformance_suite/action.yml
@@ -48,7 +48,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements-test.txt
+        pip install -r requirements-test.txt${{ inputs.name == 'efm_current' && ' -r requirements-plugins.txt' || '' }}
     - name: Run integration tests with pytest
       shell: bash
       run: |

--- a/distro.py
+++ b/distro.py
@@ -55,14 +55,10 @@ for entryPoint in entryPoints:
     includeFiles.append((pluginDirectory, os.path.join('plugin', os.path.basename(pluginDirectory))))
 
 includeLibs = [
-    "aniso8601",
     "dateutil",
     "dateutil.relativedelta",
     "graphviz",
     "gzip",
-    "holidays",
-    "holidays.countries",
-    "holidays.financial",
     "isodate",
     "lxml._elementpath",
     "lxml.etree",
@@ -93,6 +89,10 @@ options = {
 }
 
 if os.path.exists("arelle/plugin/EDGAR"):
+    includeLibs.append("aniso8601")
+    includeLibs.append("holidays")
+    includeLibs.append("holidays.countries")
+    includeLibs.append("holidays.financial")
     includeLibs.append("matplotlib")
     includeLibs.append("matplotlib.pyplot")
     includeLibs.append("pytz")

--- a/distro.py
+++ b/distro.py
@@ -96,7 +96,6 @@ if os.path.exists("arelle/plugin/EDGAR"):
     includeLibs.append("matplotlib")
     includeLibs.append("matplotlib.pyplot")
     includeLibs.append("pytz")
-    includeLibs.append("six")
 
 if sys.platform == LINUX_PLATFORM:
     guiExecutable = Executable(script="arelleGUI.py", target_name="arelleGUI")

--- a/distro.py
+++ b/distro.py
@@ -88,8 +88,10 @@ options = {
     }
 }
 
-if os.path.exists("arelle/plugin/EDGAR"):
+if os.path.exists("arelle/plugin/EDGAR") or os.path.exists("arelle/plugin/xule"):
     includeLibs.append("aniso8601")
+
+if os.path.exists("arelle/plugin/EDGAR"):
     includeLibs.append("holidays")
     includeLibs.append("holidays.countries")
     includeLibs.append("holidays.financial")

--- a/distro.py
+++ b/distro.py
@@ -160,7 +160,7 @@ else:
 setup(
     executables=[guiExecutable, cliExecutable],
     options=options,
-    setup_requires=["setuptools_scm~=8.3"],
+    setup_requires=["setuptools_scm>=8.3,<9"],
     use_scm_version={
         "tag_regex": r"^(?:[\w-]+-?)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$",
         "write_to": os.path.normcase("arelle/_version.py"),

--- a/distro.py
+++ b/distro.py
@@ -56,6 +56,8 @@ for entryPoint in entryPoints:
 
 includeLibs = [
     "aniso8601",
+    "dateutil",
+    "dateutil.relativedelta",
     "graphviz",
     "gzip",
     "holidays",
@@ -74,10 +76,12 @@ includeLibs = [
     "PIL",
     "pycountry",
     "pymysql",
-    "regex",
+    "pyparsing",
     "rdflib",
+    "regex",
     "sqlite3",
     "tinycss2",
+    "tornado",
     "zlib",
 ]
 options = {
@@ -89,14 +93,10 @@ options = {
 }
 
 if os.path.exists("arelle/plugin/EDGAR"):
-    includeLibs.append("dateutil")
-    includeLibs.append("dateutil.relativedelta")
     includeLibs.append("matplotlib")
     includeLibs.append("matplotlib.pyplot")
-    includeLibs.append("pyparsing")
     includeLibs.append("pytz")
     includeLibs.append("six")
-    includeLibs.append("tornado")
 
 if sys.platform == LINUX_PLATFORM:
     guiExecutable = Executable(script="arelleGUI.py", target_name="arelleGUI")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ WebServer = [
     'cheroot>=8,<11',
     'tornado==6.*',
 ]
+XULE = [
+    'aniso8601==10.*',
+]
 
 [project.scripts]
 arelleCmdLine = "arelle.CntlrCmdLine:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
     'bottle>=0.13,<0.14',
     'certifi',
     'filelock',
-    'jsonschema>=4,<5',
     'isodate>=0,<1',
+    'jsonschema>=4,<5',
     'lxml>=4,<6',
     'numpy>=1,<3',
     'openpyxl>=3,<4',
@@ -57,7 +57,7 @@ DB = [
 EFM = [
     'aniso8601>=10,<11',
     'holidays>=0,<1',
-    'Matplotlib>=3,<4',
+    'matplotlib>=3,<4',
     'pytz',
 ]
 ESEF = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=79,<81", "wheel~=0.45", "setuptools_scm[toml]~=8.3"]
+requires = ["setuptools>=79,<81", "wheel>=0.45,<1", "setuptools_scm[toml]>=8.3,<9"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -31,47 +31,47 @@ dependencies = [
     'bottle>=0.13,<0.14',
     'certifi',
     'filelock',
-    'jsonschema==4.*',
-    'isodate==0.*',
+    'jsonschema>=4,<5',
+    'isodate>=0,<1',
     'lxml>=4,<6',
     'numpy>=1,<3',
-    'openpyxl==3.*',
+    'openpyxl>=3,<4',
     'pillow>=10,<12',
-    'pyparsing==3.*',
-    'python-dateutil==2.*',
+    'pyparsing>=3,<4',
+    'python-dateutil>=2,<3',
     'regex',
-    'truststore==0.*; python_version>"3.9"',
-    'typing-extensions==4.*',
+    'truststore>=0,<1; python_version>"3.9"',
+    'typing-extensions>=4,<5',
 ]
 
 [project.optional-dependencies]
 Crypto = [
-    'pycryptodome==3.*',
+    'pycryptodome>=3,<4',
 ]
 DB = [
-    'pg8000==1.*',
-    'PyMySQL==1.*',
+    'pg8000>=1,<2',
+    'PyMySQL>=1,<2',
     'pyodbc>=4,<6',
     'rdflib>=5,<8',
 ]
 EFM = [
-    'aniso8601==10.*',
-    'holidays==0.*',
-    'Matplotlib==3.*',
+    'aniso8601>=10,<11',
+    'holidays>=0,<1',
+    'Matplotlib>=3,<4',
     'pytz',
 ]
 ESEF = [
-    'tinycss2==1.*',
+    'tinycss2>=1,<2',
 ]
 ObjectMaker = [
-    'graphviz==0.*',
+    'graphviz>=0,<1',
 ]
 WebServer = [
     'cheroot>=8,<11',
-    'tornado==6.*',
+    'tornado>=6,<7',
 ]
 XULE = [
-    'aniso8601==10.*',
+    'aniso8601>=10,<11',
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,8 +5,8 @@ mypy==1.17.1
 
 boto3-stubs==1.40.12
 lxml-stubs==0.5.1
-types-PyMySQL==1.1.0.20250711
 types-openpyxl==3.1.5.20250809
+types-PyMySQL==1.1.0.20250711
 types-python-dateutil==2.9.0.20250809
 types-pytz==2025.2.0.20250809
 types-regex==2025.7.34.20250809

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -3,6 +3,6 @@ ixbrl-viewer==1.4.73
 # EDGAR & XULE plugins
 aniso8601==10.0.1
 holidays==0.79
-matplotlib==3.9.4 ; python_version <= "3.9"
 matplotlib==3.10.1 ; python_version > "3.9"
+matplotlib==3.9.4 ; python_version <= "3.9"
 pytz==2025.2

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -1,1 +1,8 @@
 ixbrl-viewer==1.4.73
+
+# EDGAR & XULE plugins
+aniso8601==10.0.1
+holidays==0.79
+matplotlib==3.9.4 ; python_version <= "3.9"
+matplotlib==3.10.1 ; python_version > "3.9"
+pytz==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,32 +1,32 @@
 # core modules
+bottle==0.13.4
 certifi==2025.8.3
-truststore==0.10.1 ; python_version > "3.9"
+cheroot==10.0.1
 filelock==3.19.1
+isodate==0.7.2
 jsonschema==4.25.1
 lxml==5.4.0
-OpenPyXL==3.1.5
-pyparsing==3.2.3
-regex==2025.7.34
-typing-extensions==4.14.1
-isodate==0.7.2
-bottle==0.13.4
-Cheroot==10.0.1
-python-dateutil==2.9.0.post0
+numpy==2.0.2 ; python_version <= "3.9"
+numpy==2.2.4 ; python_version > "3.9"
+openpyxl==3.1.5
 pycountry==24.6.1
+pyparsing==3.2.3
+python-dateutil==2.9.0.post0
+regex==2025.7.34
+tornado==6.5.2
+truststore==0.10.1 ; python_version > "3.9"
+typing-extensions==4.14.1
 # plugins
-NumPy==2.0.2 ; python_version <= "3.9"
-NumPy==2.2.4 ; python_version > "3.9"
-Tornado==6.5.2
 # security plugin
-PyCryptodome==3.23.0
+pycryptodome==3.23.0
 # xbrlDB plugin
 cx_Oracle==8.3.0
 pg8000==1.31.4
 PyMySQL==1.1.1
 pyodbc==5.2.0
-RDFLib==7.1.4
+rdflib==7.1.4
 # other
 graphviz==0.21
-Pillow==11.3.0
+pillow==11.3.0
 pywin32==311 ; sys_platform == "win32"
 tinycss2==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,19 +9,13 @@ pyparsing==3.2.3
 regex==2025.7.34
 typing-extensions==4.14.1
 isodate==0.7.2
-aniso8601==10.0.1
 bottle==0.13.4
 Cheroot==10.0.1
 python-dateutil==2.9.0.post0
 pycountry==24.6.1
 # plugins
-# EDGAR plugins
 NumPy==2.0.2 ; python_version <= "3.9"
 NumPy==2.2.4 ; python_version > "3.9"
-Matplotlib==3.9.4 ; python_version <= "3.9"
-Matplotlib==3.10.1 ; python_version > "3.9"
-holidays==0.79
-pytz==2025.2
 Tornado==6.5.2
 # security plugin
 PyCryptodome==3.23.0


### PR DESCRIPTION
#### Reason for change
Dependency definitions are duplicated across three places:
- pyproject.toml (for library users)
- requirements files (for dev, source, and builds)
- distro.py (for frozen build inclusions)

These had drifted out of sync, for example, some dependencies were marked as core in one place but EDGAR only in another, and vice versa.

#### Description of change
* Align dependency requirements
* Standardize dependency range formatting to match Dependabot’s update style
* Create arelle[XULE] target for library users who need XULE without EDGAR

#### Steps to Test
* CI

**review**:
@Arelle/arelle
