### PR TITLE
Update lxml to 6.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,6 @@ updates:
           - "*"
     ignore:
       - dependency-name: "cx_Freeze"
-      - dependency-name: "lxml"
-        versions:
-          - ">=6.0.0"
   - package-ecosystem: nuget
     directories:
       - /tests/integration_tests/ui_tests/ArelleGUITest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     'filelock',
     'isodate>=0,<1',
     'jsonschema>=4,<5',
-    'lxml>=4,<6',
+    'lxml>=4,<7,!=6.0.0',
     'numpy>=1,<3',
     'openpyxl>=3,<4',
     'pillow>=10,<12',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cheroot==10.0.1
 filelock==3.19.1
 isodate==0.7.2
 jsonschema==4.25.1
-lxml==5.4.0
+lxml==6.0.1
 numpy==2.0.2 ; python_version <= "3.9"
 numpy==2.2.4 ; python_version > "3.9"
 openpyxl==3.1.5


### PR DESCRIPTION
#### Reason for change
lxml 6.0.1 was released which includes a fix for a bug in 6.0.0 that previously prevented us from upgrading.

#### Description of change
* Update lxml to 6.0.1

#### Steps to Test
* CI

**review**:
@Arelle/arelle
