### PR TITLE
Fix timing of Validation.Complete plugin hook

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1171,10 +1171,6 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         for pluginXbrlMethod in PluginManager.pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
                             pluginXbrlMethod(self, options, modelXbrl, _entrypoint, sourceZipStream=sourceZipStream, responseZipStream=responseZipStream)
 
-                    if options.validate:
-                        for pluginXbrlMethod in PluginManager.pluginClassMethods("Validate.Complete"):
-                            pluginXbrlMethod(self, filesource)
-
                 except OSError as err:
                     self.addToLog(_("[IOError] Failed to save output:\n {0}").format(err),
                                   messageCode="IOError",
@@ -1222,6 +1218,11 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         self.modelManager.close(modelDiffReport)
                     elif modelXbrl:
                         self.modelManager.close(modelXbrl)
+
+        if options.validate:
+            for pluginXbrlMethod in PluginManager.pluginClassMethods("Validate.Complete"):
+                pluginXbrlMethod(self, filesource)
+
         if filesource is not None and not options.keepOpen:
             # Archive filesource potentially used by multiple reports may still be open.
             filesource.close()

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -488,13 +488,13 @@ class Validate:
                     self.instValidator.validate(model, parameters)
                     for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Xbrl.Validated"):
                         pluginXbrlMethod(self.modelXbrl, model)
-                    for pluginXbrlMethod in pluginClassMethods("Validate.Complete"):
-                        pluginXbrlMethod(self.modelXbrl.modelManager.cntlr, filesource)
                 except Exception as err:
                     model.error("exception:" + type(err).__name__,
                         _("Testcase variation validation exception: %(error)s, instance: %(instance)s"),
                         modelXbrl=model, instance=model.modelDocument.basename, error=err, exc_info=(type(err) is not AssertionError))
                 model.hasFormulae = _hasFormulae
+        for pluginXbrlMethod in pluginClassMethods("Validate.Complete"):
+            pluginXbrlMethod(self.modelXbrl.modelManager.cntlr, filesource)
         errors = [error for model in loadedModels for error in model.errors]
         for err in preLoadingErrors:
             if err not in errors:


### PR DESCRIPTION
#### Reason for change
#1893 and #1854 merged without having ever been tested together, causing EDINET failures on master. This fixes the underlying issue.

#### Description of change
`Validate.Complete` was being called within the per-entrypoint loop.

#### Steps to Test
CI

**review**:
@Arelle/arelle
