### PR TITLE
Use isOimTextFactType instead of isWgnStringFactType

### DIFF
--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -402,7 +402,7 @@ def getAspectEqualFacts(
                 fact.qname,
                 (
                     cast(str, fact.xmlLang or "").lower()
-                    if useLang and fact.concept.type.isWgnStringFactType
+                    if useLang and fact.concept.type.isOimTextFactType
                     else None
                 ),
             )


### PR DESCRIPTION
#### Reason for change
aspectEqualFacts key can be improved by using isOimTextFactType instead of isWgnStringFactType to indicate if xml:lang should be included.

#### Description of change
Replace isOimTextFactType with isWgnStringFactType

#### Steps to Test
* CI

**review**:
@Arelle/arelle
