### PR TITLE
Plugin Loading Improvements 

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -161,6 +161,7 @@ class Cntlr:
         disable_persistent_config: bool = False,
         betaFeatures: dict[str, bool] | None = None
     ) -> None:
+        self.logger = None
         if betaFeatures is None:
             betaFeatures = {}
         self.betaFeatures = {

--- a/arelle/DialogPluginManager.py
+++ b/arelle/DialogPluginManager.py
@@ -386,15 +386,17 @@ class DialogPluginManager(Toplevel):
         group = {
             "ixbrl-viewer": "1",  # pip installed Arelle viewer
             "iXBRLViewerPlugin": "2",  # git clone installed Arelle viewer
-            "Edgar Renderer": "3",
+            "EDGAR": "3",
+            "Inline XBRL Document Set": "4",
+            "XBRL rule processor (xule)": "5",
         }.get(key)
         if not group:
             if key.startswith("Validate"):
-                group = "4"
-            elif key.startswith("xbrlDB"):
-                group = "5"
-            else:
                 group = "6"
+            elif key.startswith("xbrlDB"):
+                group = "7"
+            else:
+                group = "8"
         return group + key.lower()
 
     @staticmethod

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -450,38 +450,38 @@ def moduleModuleInfo(
             del moduleInfo["importURLs"]
             moduleImports = moduleInfo["moduleImports"]
             del moduleInfo["moduleImports"]
-            _moduleImportsSubtree = False
+            moduleImportsSubtree = False
             mergedImportURLs = []
 
-            for _url in importURLs:
-                if _url.startswith("module_import"):
+            for url in importURLs:
+                if url.startswith("module_import"):
                     for moduleImport in moduleImports:
                         mergedImportURLs.append(moduleImport + ".py")
-                    if _url == "module_import_subtree":
-                        _moduleImportsSubtree = True
-                elif _url == "module_subtree":
+                    if url == "module_import_subtree":
+                        moduleImportsSubtree = True
+                elif url == "module_subtree":
                     for _dir in os.listdir(moduleDir):
-                        _subtreeModule = os.path.join(moduleDir,_dir)
-                        if os.path.isdir(_subtreeModule) and _dir != "__pycache__":
-                            mergedImportURLs.append(_subtreeModule)
+                        subtreeModule = os.path.join(moduleDir,_dir)
+                        if os.path.isdir(subtreeModule) and _dir != "__pycache__":
+                            mergedImportURLs.append(subtreeModule)
                 else:
-                    mergedImportURLs.append(_url)
-            if parentImportsSubtree and not _moduleImportsSubtree:
-                _moduleImportsSubtree = True
+                    mergedImportURLs.append(url)
+            if parentImportsSubtree and not moduleImportsSubtree:
+                moduleImportsSubtree = True
                 for moduleImport in moduleImports:
                     mergedImportURLs.append(moduleImport + ".py")
             imports = []
-            for _url in mergedImportURLs:
-                if isAbsolute(_url) or isLegacyAbs(_url):
-                    _importURL = _url # URL is absolute http or local file system
+            for url in mergedImportURLs:
+                if isAbsolute(url) or isLegacyAbs(url):
+                    importURL = url # URL is absolute http or local file system
                 else: # check if exists relative to this module's directory
-                    _importURL = os.path.join(os.path.dirname(moduleURL), os.path.normpath(_url))
-                    if not os.path.exists(_importURL): # not relative to this plugin, assume standard plugin base
-                        _importURL = _url # moduleModuleInfo adjusts relative URL to plugin base
-                _importModuleInfo = moduleModuleInfo(moduleURL=_importURL, reload=reload, parentImportsSubtree=_moduleImportsSubtree)
-                if _importModuleInfo:
-                    _importModuleInfo["isImported"] = True
-                    imports.append(_importModuleInfo)
+                    importURL = os.path.join(os.path.dirname(moduleURL), os.path.normpath(url))
+                    if not os.path.exists(importURL): # not relative to this plugin, assume standard plugin base
+                        importURL = url # moduleModuleInfo adjusts relative URL to plugin base
+                importModuleInfo = moduleModuleInfo(moduleURL=importURL, reload=reload, parentImportsSubtree=moduleImportsSubtree)
+                if importModuleInfo:
+                    importModuleInfo["isImported"] = True
+                    imports.append(importModuleInfo)
             moduleInfo["imports"] = imports
             logPluginTrace(f"Successful module plug-in info: {moduleFilename}", logging.INFO)
             return moduleInfo

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -1,26 +1,32 @@
 '''
 See COPYRIGHT.md for copyright information.
-
-based on pull request 4
-
 '''
 from __future__ import annotations
-import os, sys, types, time, ast, importlib, io, json, gettext, traceback
-from dataclasses import dataclass
-from importlib.metadata import entry_points, EntryPoint
-import importlib.util
-import logging
 
-from types import ModuleType
-from typing import TYPE_CHECKING, Any, cast
-from arelle.Locale import getLanguageCodes
-import arelle.FileSource
-from arelle.PythonUtil import isLegacyAbs
-from arelle.UrlUtil import isAbsolute
-from pathlib import Path
+import ast
+import gettext
+import importlib.util
+import io
+import json
+import logging
+import os
+import sys
+import time
+import traceback
+import types
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from importlib.metadata import EntryPoint, entry_points
+from numbers import Number
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, cast
 
+import arelle.FileSource
+from arelle.Locale import getLanguageCodes
+from arelle.PythonUtil import isLegacyAbs
+from arelle.UrlUtil import isAbsolute
 
 if TYPE_CHECKING:
     # Prevent potential circular import error

--- a/tests/unit_tests/arelle/test_pluginmanager.py
+++ b/tests/unit_tests/arelle/test_pluginmanager.py
@@ -1,13 +1,13 @@
 """Tests for the PluginManager module."""
 from __future__ import annotations
 import os
+from pathlib import Path
 import sys
 
 import pytest
 from unittest.mock import Mock
 
 from arelle import PluginManager
-from arelle.Cntlr import Cntlr
 
 
 def test_plugin_manager_init_first_pass():
@@ -84,50 +84,37 @@ def test_plugin_manager_reset():
 @pytest.mark.parametrize(
     "test_data, expected_result",
     [
-        # Test case 1
+        # Non-existent plugin
         (
-            # Test data
-            ("tests/unit_tests/arelle", "functionsMaths", "xyz"),
-            # Expected result
-            ("functionsMaths", "tests/unit_tests", "xyz")
+            (Path("arelle/plugin/non-existent-plugin"), "xyz"),
+            (None, None, None)
         ),
-        # Test case 2
+        # File plugin
         (
-            # Test data
-            ("arelle/plugin/", "xbrlDB/__init__.py", "xyz"),
-            # Expected result
+            (Path("arelle/plugin/CacheBuilder.py"), "xyz"),
+            ("CacheBuilder", "arelle/plugin", "xyz")
+        ),
+        # Module plugin with init file
+        (
+            (Path("arelle/plugin/xbrlDB/__init__.py"), "xyz"),
             ("xbrlDB", "arelle/plugin", "xbrlDB.")
         ),
-        # Test case 3
+        # Module plugin without init file
         (
-            # Test data
-            ("plugin/xbrlDB", None, "xyz"),
-            # Expected result
-            (None, None, None)
+            (Path("arelle/plugin/validate/ESEF"), "xyz"),
+            ("ESEF", "arelle/plugin/validate", "ESEF.")
         ),
     ]
 )
 def test_function_get_name_dir_prefix(
-    test_data: tuple[str, str, str],
+    test_data: tuple[str, str],
     expected_result: tuple[str, str, str],
     ):
     """Test util function get_name_dir_prefix."""
-    class Controller(Cntlr):
-        """Controller."""
-
-        pluginDir = test_data[0]
-
-        def __init__(self) -> None:
-            """Init controller with logging."""
-            super().__init__(logFileName="logToBuffer")
-
-    cntlr = Controller()
 
     moduleName, moduleDir, packageImportPrefix = PluginManager._get_name_dir_prefix(
-        controller=cntlr,
-        pluginBase=Controller.pluginDir,
-        moduleURL=test_data[1],
-        packagePrefix=test_data[2],
+        modulePath=test_data[0],
+        packagePrefix=test_data[1],
     )
 
     assert moduleName == expected_result[0]
@@ -144,25 +131,15 @@ def test_function_loadModule():
     the function.
     """
 
-    class Controller(Cntlr):
-        """Controller."""
-
-        pluginDir = "tests/unit_tests/arelle"
-
-        def __init__(self) -> None:
-            """Init controller with logging."""
-            super().__init__(logFileName="logToBuffer")
-
-    Controller()
-
     PluginManager.loadModule(
         moduleInfo={
             "name": "mock",
             "moduleURL": "functionsMath",
+            "path": "arelle/plugin/functionsMath.py",
         }
     )
 
-    all_modules_list: list[str] = [m.__name__ for m in sys.modules.values() if m]
+    all_modules_list = {m.__name__ for m in sys.modules.values() if m}
 
     assert "arelle.formula.XPathContext" in all_modules_list
     assert "arelle.FunctionUtil" in all_modules_list


### PR DESCRIPTION
#### Reason for change
Developers running Arelle from source and working with EDGAR plugins have faced issues handling dependencies on plugins defined in other repositories (EDGAR and XULE).

These changes target two common scenarios:
* Loading EDGAR plugins outside `arelle/plugin`: Relative imports (e.g., `EDGAR/render` → `EDGAR/validate`) currently fail, forcing developers to manually provide paths for all plugins including their plugin dependencies.
* Using the full XULE repo under arelle/plugin: Since the plugin isn’t located at `arelle/plugin/xule/__init__.py` but instead at `arelle/plugin/<repo-name>/plugin/xule/__init__.py`, it fails to load.

#### Description of change
* Support relative plugin dependency imports from plugins loaded outside of `arelle/plugin`.
* Fallback to a recursive search within the plugin directory to locate matching plugins.
* Update GUI plugin display priority:
  * Prefer the new EDGAR plugin over Edgar Renderer.
  * Move XULE and Inline XBRL Document Set plugins higher in the list.

#### Steps to Test
* Clone the [EDGAR plugin repo](https://github.com/Arelle/Edgar) into a directory outside of `arelle/plugin`.
* Modify the [EDGAR/validate plugin info import](https://github.com/Arelle/EDGAR/blob/0d42a79acebae3cc125b55d5762e790261d69138/validate/__init__.py#L950) to include `xule`.
* Clone the [XULE plugin repo](https://github.com/xbrlus/xule).
* Symlink or move the entire XULE repo under `arelle/plugin/<repo-name>`.
* Load the EDGAR plugin from the external directory and confirm validation runs with XULE rules:
  * `python arelleCmdLine.py --file <report-file> --plugins /path/to/repo/EDGAR --validate --disclosureSystem efm`

**review**:
@Arelle/arelle
