### PR TITLE
Fix iXDS ObjectPropertyViewWrapper href logging

### DIFF
--- a/arelle/ErrorManager.py
+++ b/arelle/ErrorManager.py
@@ -180,7 +180,10 @@ class ErrorManager:
                             objectUrl = arg
                         else:
                             try:
-                                objectUrl = arg.modelDocument.displayUri
+                                if isinstance(arg, ObjectPropertyViewWrapper):
+                                    objectUrl = arg.modelObject.modelDocument.displayUri
+                                else:
+                                    objectUrl = arg.modelDocument.displayUri
                             except AttributeError:
                                 try:
                                     objectUrl = arg.displayUri


### PR DESCRIPTION
#### Reason for change
When logging a validation message with an `ObjectPropertyViewWrapper`, the underlying `ModelObject` was not used to resolve the href. For iXDS models this caused a fallback to the source document’s display URI, producing an invalid pseudo-IXDS href string.

#### Description of change
If the modelObject being logged is an ObjectPropertyViewWrapper, use the underlying ModelObject displayUri instead of the nonexistent ObjectPropertyViewWrapper.displayUri.

#### Steps to Test
* Use [austin-2025-09-18-en.zip](https://github.com/user-attachments/files/22413919/austin-2025-09-18-en.zip)
* Run `python arelleCmdLine.py --plugins inlineXbrlDocumentSet --file austin-2025-09-18-en.zip --validate --formula=none --calc c10d --logFile log.xml`
* Verify ref hrefs are valid:
  * Should be:
    <img width="634" height="86" alt="fix" src="https://github.com/user-attachments/assets/75b61097-44a1-4e0c-87c0-d2170a74c6bc" />
  * Instead of:
    <img width="634" height="86" alt="master" src="https://github.com/user-attachments/assets/2c99fd3b-5286-40ac-91b8-d65a8db0ef13" />

**review**:
@Arelle/arelle
