### PR TITLE
EDINET: Merge fixes

### DIFF
--- a/tests/resources/conformance_suites/edinet/EC5710W.FRTA.4.2.2/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5710W.FRTA.4.2.2/index.xml
@@ -19,6 +19,7 @@
         <result>
             <warning>arelle:NoMatchingEdinetFormat</warning>
             <warning>EDINET.EC1057E</warning>
+            <warning>EDINET.EC5700W.GFM.1.1.6</warning>
             <warning>EDINET.EC5700W.GFM.1.2.8</warning>
             <warning>EDINET.EC5700W.GFM.1.2.27</warning>
             <warning>EDINET.EC5710W.FRTA.4.2.2</warning>

--- a/tests/resources/conformance_suites/edinet/EC5710W.FRTA.4.2.4/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5710W.FRTA.4.2.4/index.xml
@@ -18,7 +18,7 @@
             <instance readMeFirst="true">invalid01.zip</instance>
         </data>
         <result>
-            <warning>EDINET.FRTA.2.1.10</warning>
+            <warning>EDINET.EC5710W.FRTA.2.1.10</warning>
             <warning num="2">EDINET.EC5710W.FRTA.4.2.4</warning>
         </result>
     </variation>

--- a/tests/resources/conformance_suites/edinet/EC5710W.FRTA.4.2.7/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5710W.FRTA.4.2.7/index.xml
@@ -17,6 +17,8 @@
             <instance readMeFirst="true">invalid01.zip</instance>
         </data>
         <result>
+            <warning>EDINET.EC5700W.GFM.1.5.2</warning>
+            <warning>EDINET.EC5700W.GFM.1.5.3</warning>
             <warning>EDINET.EC5710W.FRTA.4.2.7</warning>
         </result>
     </variation>


### PR DESCRIPTION
#### Reason for change
A couple of EDINET validation updates merged without being tested together. This corrects the resulting conformance suite failures.

#### Steps to Test
CI

**review**:
@Arelle/arelle
