### PR TITLE
Package jaconv in frozen builds

### DIFF
--- a/distro.py
+++ b/distro.py
@@ -60,6 +60,7 @@ includeLibs = [
     "graphviz",
     "gzip",
     "isodate",
+    "jaconv",
     "lxml._elementpath",
     "lxml.etree",
     "lxml.html",


### PR DESCRIPTION
#### Reason for change
jaconv isn't automatically pulled into the frozen builds causing an exception when using the EDINET plugin.

```sh
/Applications/Arelle.app/Contents/MacOS/arelleCmdLine --plugins validate/EDINET --disclosureSystem edinet --validate --keepOpen --file report.zip
```
```bash
Unable to load module Validate EDINET
Exception loading plug-in Validate EDINET: No module named 'jaconv'
['  File "/Users/runner/work/Arelle/Arelle/arelle/PluginManager.py", line 586, in loadModule\n', '  File "/Users/runner/work/Arelle/Arelle/arelle/PluginManager.py", line 571, in _find_and_load_module\n', '  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module\n', '  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed\n', '  File "/Applications/Arelle.app/Contents/MacOS/plugin/validate/EDINET/__init__.py", line 14, in <module>\n    from .ValidationPluginExtension import ValidationPluginExtension\n', '  File "/Applications/Arelle.app/Contents/MacOS/plugin/validate/EDINET/ValidationPluginExtension.py", line 15, in <module>\n    from .ControllerPluginData import ControllerPluginData\n', '  File "/Applications/Arelle.app/Contents/MacOS/plugin/validate/EDINET/ControllerPluginData.py", line 23, in <module>\n    from .TableOfContentsBuilder import TableOfContentsBuilder\n', '  File "/Applications/Arelle.app/Contents/MacOS/plugin/validate/EDINET/TableOfContentsBuilder.py", line 9, in <module>\n    from jaconv import jaconv\n']
```

#### Description of change
Explicitly bundle jaconv in frozen builds.

#### Steps to Test
* [x] test [updated frozen build](https://github.com/Arelle/Arelle/actions/runs/18564508444) to make sure edinet plugin does not throw an exception on jaconv import.

**review**:
@Arelle/arelle
