### PR TITLE
Don't attempt to "align" period start values in non-tabular views

### DIFF
--- a/arelle/ViewFile.py
+++ b/arelle/ViewFile.py
@@ -18,6 +18,7 @@ XLSX  = 2
 HTML  = 3
 XML   = 4
 JSON  = 5
+TABULAR_VIEW_TYPES = {CSV, XLSX, HTML}
 TYPENAMES = ["NOOUT", "CSV", "XLSX", "HTML", "XML", "JSON"] # null means no output
 nonNameCharPattern =  re.compile(r"[^\w\-\.:]")
 

--- a/arelle/ViewFileFactTable.py
+++ b/arelle/ViewFileFactTable.py
@@ -3,7 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from arelle import ViewFile, ModelDtsObject, XbrlConst, XmlUtil
 from arelle.XbrlConst import conceptNameLabelRole, standardLabel, terseLabel, documentationLabel
-from arelle.ViewFile import CSV, XLSX, HTML, XML, JSON
+from arelle.ViewFile import CSV, XLSX, HTML, XML, JSON, TABULAR_VIEW_TYPES
 import datetime
 import regex as re
 from collections import defaultdict
@@ -324,7 +324,7 @@ class ViewFacts(ViewFile.View):
             try:
                 colId = self.contextColId[fact.context.objectId()]
                 # special case of start date, pick column corresponding
-                if preferredLabel == XbrlConst.periodStartLabel:
+                if self.type in TABULAR_VIEW_TYPES and preferredLabel == XbrlConst.periodStartLabel:
                     date = fact.context.instantDatetime
                     if date:
                         if date in self.startdatetimeColId:


### PR DESCRIPTION
#### Reason for change
Resolves #1968

In tabular views facts for concepts with period start labels are rendered as a roll-forward in duration context columns. However, when this same logic is applied to non-tabular views (XML and JSON) the values are simply output with the wrong context ID.

#### Description of change
If the requested view is non-tabular, don't "align"/change the rendered context ID.

#### Steps to Test
* See #1968 (can be tested with either XML or JSON fact table outputs).

**review**:
@Arelle/arelle
