### PR TITLE
Update Arelle S3 release upload auth

### DIFF
--- a/.github/workflows/publish-frozen-build.yml
+++ b/.github/workflows/publish-frozen-build.yml
@@ -23,6 +23,7 @@ jobs:
     environment: release
     permissions:
       contents: write
+      id-token: write
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/')
 
@@ -46,8 +47,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5.1.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+          role-to-assume: arn:aws:iam::494047596077:role/GitHubActionsArelleS3Upload
           aws-region: us-west-1
       - name: Upload build to AWS S3
         run: aws s3 cp --acl public-read ${{ inputs.build_name }} s3://arelle-us/${{ env.ARELLE_WEBSITE_BUILD_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
   publish-linux:
     permissions:
       contents: write
+      id-token: write
     needs: build-linux
     uses: ./.github/workflows/publish-frozen-build.yml
     with:
@@ -42,6 +43,7 @@ jobs:
   publish-macos-x64:
     permissions:
       contents: write
+      id-token: write
     needs: build-macos-x64
     uses: ./.github/workflows/publish-frozen-build.yml
     with:
@@ -59,6 +61,7 @@ jobs:
   publish-macos-arm64:
     permissions:
       contents: write
+      id-token: write
     needs: build-macos-arm64
     uses: ./.github/workflows/publish-frozen-build.yml
     with:
@@ -72,6 +75,7 @@ jobs:
   publish-windows-installer:
     permissions:
       contents: write
+      id-token: write
     needs: build-windows
     uses: ./.github/workflows/publish-frozen-build.yml
     with:
@@ -82,6 +86,7 @@ jobs:
   publish-windows-zip:
     permissions:
       contents: write
+      id-token: write
     needs: build-windows
     uses: ./.github/workflows/publish-frozen-build.yml
     with:


### PR DESCRIPTION
#### Reason for change
Our recent frozen releases [have failed to upload](https://github.com/Arelle/Arelle/actions/runs/18754570560) to the Arelle S3 bucket (what the arelle.org download links point to) because the token we were using is no longer valid.

#### Description of change
Use OIDC temporary credentials with an IAM Role to upload releases to S3. Access is restricted to workflows running in the release environment in the Arelle repo of the Arelle org.

#### Steps to Test
* [x] test that [a dummy workflow](https://github.com/Arelle/Arelle/actions/runs/18882599351/job/53889551568) can upload to S3.

**review**:
@Arelle/arelle
