### PR TITLE
Allow 2024 taxonomy for 2025 reporting year in KVK

### DIFF
--- a/arelle/plugin/validate/NL/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/NL/PluginValidationDataExtension.py
@@ -78,6 +78,11 @@ TAXONOMY_URLS_BY_YEAR = {
         'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-nlgaap-ext.xsd',
         'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-ifrs-ext.xsd',
         'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-other-gaap.xsd',
+    },
+    '2025': {
+        'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-nlgaap-ext.xsd',
+        'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-ifrs-ext.xsd',
+        'https://www.nltaxonomie.nl/kvk/2024-12-31/kvk-annual-report-other-gaap.xsd',
     }
 }
 


### PR DESCRIPTION
#### Reason for change
- Allow NT-19 for 2025 reporting year for KVK

#### Steps to Test
- CI

**review**:
@Arelle/arelle
