### PR TITLE
Use OpenID Connect for Python package publishing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,30 +49,3 @@ jobs:
           name: arelle.whl
           if-no-files-found: error
           path: dist/*.whl
-
-  publish-package:
-    needs: build-package
-    environment: release
-    permissions:
-      contents: write
-      id-token: write
-    runs-on: ubuntu-24.04
-    if: startsWith(github.ref, 'refs/tags')
-    steps:
-      - name: Download tar artifact
-        uses: actions/download-artifact@v6.0.0
-        with:
-          name: arelle.tar.gz
-          path: dist/
-      - name: Download wheel artifact
-        uses: actions/download-artifact@v6.0.0
-        with:
-          name: arelle.whl
-          path: dist/
-      - name: Publish package on release
-        uses: pypa/gh-action-pypi-publish@v1.13.0
-      - name: Upload release artifact
-        uses: softprops/action-gh-release@v2.4.2
-        with:
-          fail_on_unmatched_files: true
-          files: 'dist/*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,36 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yml
   python-package:
+    uses: ./.github/workflows/python-package.yml
+  publish-python-package:
+    # publish job is inline here because PyPI doesn't support trusted publishers from GitHub reusable workflows.
+    # https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
+    needs: 
+      - tests
+      - python-package
+    environment: release
     permissions:
       contents: write
       id-token: write
-    needs: tests
-    uses: ./.github/workflows/python-package.yml
-    secrets: inherit
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download tar artifact
+        uses: actions/download-artifact@v6.0.0
+        with:
+          name: arelle.tar.gz
+          path: dist/
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v6.0.0
+        with:
+          name: arelle.whl
+          path: dist/
+      - name: Publish package on release
+        uses: pypa/gh-action-pypi-publish@v1.13.0
+      - name: Upload release artifact
+        uses: softprops/action-gh-release@v2.4.2
+        with:
+          fail_on_unmatched_files: true
+          files: 'dist/*'
 
   build-linux:
     uses: ./.github/workflows/build-linux.yml


### PR DESCRIPTION
#### Description of change
Similar to #2002, replace secret workflow token with OIDC temporary credentials to [authenticate with PyPI](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-pypi).

#### Steps to Test
- [x] cut [a release using the modified workflow](https://github.com/Arelle/Arelle/actions/runs/19219551859) and verify that both the standard distribution and wheel [are published to PyPI](https://pypi.org/project/arelle-release/2.37.70/#files).

**review**:
@Arelle/arelle
