### PR TITLE
Fail gracefully when attempting to compare None values in Formula

### DIFF
--- a/arelle/FunctionUtil.py
+++ b/arelle/FunctionUtil.py
@@ -80,7 +80,9 @@ def testTypeCompatibility(
         a1: ContextItem,
         a2: ContextItem,
 ) -> None:
-    if (isinstance(a1,ModelValue.DateTime) and isinstance(a2,ModelValue.DateTime)):
+    if (a1 is None or a2 is None) and op not in ('eq', 'ne'):
+        pass # fail if either arg is None and op is not an equality check
+    elif (isinstance(a1,ModelValue.DateTime) and isinstance(a2,ModelValue.DateTime)):
         if a1.dateOnly == a2.dateOnly:
             return # can't interoperate between date and datetime
     elif isinstance(a1, bool) != isinstance(a2, bool):


### PR DESCRIPTION
#### Reason for change
```
...

  File "/usr/local/lib/python3.13/site-packages/arelle/formula/FormulaEvaluator.py", line 272, in evaluateVariableBindings
    result = xpCtx.evaluateBooleanValue(varSet.testProg)
  File "/usr/local/lib/python3.13/site-packages/arelle/formula/XPathContext.py", line 610, in evaluateBooleanValue
    return self.effectiveBooleanValue(progHeader, self.evaluate(exprStack, contextItem))
                                                  ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/arelle/formula/XPathContext.py", line 408, in evaluate
    result = op1 < op2 # type: ignore[operator]
             ^^^^^^^^^
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```

#### Description of change
Fail gracefully within `testTypeCompatibility` when `None` arguments are passed with invalid operators, rather than failing later when attempting the actual comparison.

#### Steps to Test
CI (unfortunately, the filing that triggered this error is not available to us and recreation is not straightforward)

**review**:
@Arelle/arelle
@hefischer 
