### PR TITLE
Pass Runtime Options JSON or File via command line argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ dist
 docs/_build
 docs/source/apidocs
 obj/
+runtime_options.json
 tests/resources/conformance_suites/*
 !tests/resources/conformance_suites/cipc/
 !tests/resources/conformance_suites/dba/

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -11,6 +11,7 @@ import datetime
 import fnmatch
 import gettext
 import glob
+import json
 import logging
 import multiprocessing
 import os
@@ -99,6 +100,7 @@ def parseAndRun(args):
 
 PREPARSE_ARG_CONFIGS = frozenset([
     (re.compile(r'^--plugins?.*$'), 'plugins'),
+    (re.compile(r'^--options(F|f)ile.*$'), 'optionsFile'),
 ])
 
 
@@ -445,17 +447,23 @@ def parseArgs(args):
     preparsedArgs = preparseArgs(args, parser)
 
     preloadPlugins = []
+    optionsFile = preparsedArgs.get('optionsFile')
+    optionsFileOptions = {}
+    if optionsFile:
+        optionsFileOptions = _parseOptionsFile(optionsFile, parser)
+        preloadPlugins.extend(optionsFileOptions.get('plugins', '').split('|'))
+
     preloadPlugins.extend(preparsedArgs.get('plugins', '').split('|'))
 
     # install any dynamic plugins so their command line options can be parsed if present
     arellePluginModules = {}
     for pluginCmd in preloadPlugins:
-                cmd = pluginCmd.strip()
-                if cmd not in ("show", "temp") and len(cmd) > 0 and cmd[0] not in ('-', '~', '+'):
-                    moduleInfo = PluginManager.addPluginModule(cmd)
-                    if moduleInfo:
-                        arellePluginModules[cmd] = moduleInfo
-                        PluginManager.reset()
+        cmd = pluginCmd.strip()
+        if cmd not in ("show", "temp") and len(cmd) > 0 and cmd[0] not in ('-', '~', '+'):
+            moduleInfo = PluginManager.addPluginModule(cmd)
+            if moduleInfo:
+                arellePluginModules[cmd] = moduleInfo
+                PluginManager.reset()
 
     # add plug-in options
     for optionsExtender in PluginManager.pluginClassMethods("CntlrCmdLine.Options"):
@@ -467,6 +475,10 @@ def parseArgs(args):
                       help=_("Show product version, copyright, and license."))
     parser.add_option("--diagnostics", action="store_true", dest="diagnostics",
                       help=_("output system diagnostics information"))
+    parser.add_option("--optionsFile", "--optionsfile",
+                      action="store", dest="optionsFile",
+                      help=_("Provide a path to a JSON file containing runtime options. "
+                             "These options will be overridden by any command line options provided."))
 
     if not args and isGAE():
         args = ["--webserver=::gae"]
@@ -545,9 +557,22 @@ def parseArgs(args):
     for optGroup in parser.option_groups[pluginOptionsGroupIndex:pluginLastOptionsGroupIndex]:
         for groupOption in optGroup.option_list:
             pluginOptionDestinations.add(groupOption.dest)
+
     baseOptions = {}
-    pluginOptions = {}
+    # Collect options from options file
+    for optionName, optionValue in optionsFileOptions.items():
+        if not hasattr(RuntimeOptions, optionName) and optionName not in pluginOptionDestinations:
+            parser.error(_("Unexpected name '{}' found in options file.").format(optionName))
+            continue
+        baseOptions[optionName] = optionValue
+    # Collect options from command line
     for optionName, optionValue in vars(options).items():
+        if optionName not in baseOptions or optionValue is not None:
+            baseOptions[optionName] = optionValue
+
+    pluginOptions = {}
+    finalOptions = {} # Validated options for RuntimeOptions
+    for optionName, optionValue in baseOptions.items():
         if optionName in pluginOptionDestinations:
             pluginOptions[optionName] = optionValue
         else:
@@ -559,9 +584,10 @@ def parseArgs(args):
                         parser.error(_("--testcaseExpectedErrors must be in the format '--testcaseExpectedErrors=testcase-index.xml:v-1|errorCode1,errorCode2,...'"))
                     expectedErrors[expectedErrorSplit[0]] = expectedErrorSplit[1].split(',')
                 optionValue = expectedErrors
-            baseOptions[optionName] = optionValue
+            if optionValue is not None or optionName not in finalOptions:
+                finalOptions[optionName] = optionValue
     try:
-        runtimeOptions = RuntimeOptions(pluginOptions=pluginOptions, **baseOptions)
+        runtimeOptions = RuntimeOptions(pluginOptions=pluginOptions, **finalOptions)
     except RuntimeOptionsException as e:
         parser.error(f"{e}, please try\n python CntlrCmdLine.py --help")
     if (
@@ -652,6 +678,28 @@ def _pluginHasCliOptions(moduleInfo):
     if imports := moduleInfo.get("imports"):
         return any(_pluginHasCliOptions(importedModule) for importedModule in imports)
     return False
+
+
+def _parseOptionsFile(optionsFile: str, parser: OptionParser) -> dict:
+    """
+    Parse the JSON options within the provided filepath.
+    :param optionsFile: The path to the JSON options file.
+    :param parser: The parser to log an error to if needed.
+    :return: The parsed options as a dictionary.
+    """
+    try:
+        with open(optionsFile) as f:
+            jsonOptions = json.load(f)
+    except OSError:
+        parser.error(_("Options file path does not exist: {}").format(optionsFile))
+        return {}
+    except Exception as e:
+        parser.error(_("Unable to parse options JSON file: {}").format(e))
+        return {}
+    if not isinstance(jsonOptions, dict):
+        parser.error(_("Options JSON file must contain a JSON object at its root."))
+        return {}
+    return jsonOptions
 
 
 class CntlrCmdLine(Cntlr.Cntlr):

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -106,6 +106,7 @@ class RuntimeOptions:
     logXmlMaxAttributeLength: Optional[int] = None
     monitorParentProcess: Optional[bool] = None
     noCertificateCheck: Optional[bool] = None
+    optionsFile: Optional[str] = None
     outputAttribution: Optional[str] = None
     packageManifestName: Optional[str] = None
     packages: Optional[list[str]] = None

--- a/tests/integration_tests/scripts/script_util.py
+++ b/tests/integration_tests/scripts/script_util.py
@@ -145,6 +145,24 @@ def validate_log_file(
     return validate_log_tree(tree, expected_results)
 
 
+def validate_log_text(
+        logfile_path: Path,
+        expected_results: dict[regex.Pattern[str], int] | None = None,
+) -> list[str]:
+    if not logfile_path.exists():
+        return [f'Log file "{logfile_path}" not found.']
+    expected_results = expected_results or {}
+    results = []
+    with open(logfile_path) as f:
+        logs = f.read()
+    for pattern, expected_count in expected_results.items():
+        matches = regex.findall(pattern, logs)
+        actual_count = len(matches)
+        if actual_count != expected_count:
+            results.append(f'Expected {expected_count} occurrence(s) of "{pattern}" but found {actual_count}.')
+    return results
+
+
 def validate_log_tree(
         tree: _ElementTree,
         expected_results: dict[str, dict[regex.Pattern[str], int]] | None = None,

--- a/tests/integration_tests/scripts/tests/options_file.py
+++ b/tests/integration_tests/scripts/tests/options_file.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import regex
+
+from tests.integration_tests.scripts.script_util import (
+    assert_result,
+    parse_args,
+    prepare_logfile, run_arelle, validate_log_text,
+)
+
+errors = []
+this_file = Path(__file__)
+args = parse_args(
+    this_file.stem,
+    "Confirm ESEF validation runs successfully using the webserver.",
+    arelle=False,
+)
+arelle_command = args.arelle
+arelle_offline = args.offline
+working_directory = Path(args.working_directory)
+test_directory = Path(args.test_directory)
+
+
+instance_files = [
+    test_directory / 'a.xml',
+    test_directory / 'b.xml',
+]
+
+test_cases: list[tuple[str, str, list[str], dict[regex.Pattern[str], int]]] = [
+    # Entry point only set in options file
+    (
+        'options_only',
+        json.dumps({
+            'validate': True,
+            'entrypointFile': str(instance_files[0]),
+        }),
+        [],
+        {
+            regex.compile(r'\[IOerror] .*a\.xml'): 1,
+        },
+    ),
+    # Entry point only set via command line arg
+    (
+        'cli_only',
+        json.dumps({
+            'validate': True
+        }),
+        [
+            "--file", str(instance_files[0]),
+        ],
+        {
+            regex.compile(r'\[IOerror] .*a\.xml'): 1,
+        },
+    ),
+    # Entry point set via both options file and command line arg (command line arg takes precedence)
+    (
+        'both',
+        json.dumps({
+            'validate': True,
+            'entrypointFile': str(instance_files[0]),
+        }),
+        [
+            "--file", str(instance_files[1]),
+        ],
+        {
+            regex.compile(r'\[IOerror] .*a\.xml'): 0,
+            regex.compile(r'\[IOerror] .*b\.xml'): 1,
+        },
+    ),
+    # Use option provided by plugin
+    (
+        'plugin_option',
+        json.dumps({
+            'validate': True,
+            'inlineTarget': 'value',
+            'plugins': 'inlineXbrlDocumentSet',
+            'entrypointFile': str(instance_files[0])
+        }),
+        [],
+        {
+            regex.compile(r'\[IOerror] .*a\.xml'): 2,
+        },
+    ),
+    # Invalid option name
+    (
+        'invalid_option',
+        json.dumps({
+            'validate': True,
+            'inlineTarget': 'value',
+            'entrypointFile': str(instance_files[0])
+        }),
+        [],
+        {
+            regex.compile(r"Unexpected name 'inlineTarget' found in options file."): 1,
+        },
+    ),
+    # Invalid JSON
+    (
+        'invalid_json',
+        '{ "validate": True }',
+        [],
+        {
+            regex.compile(r'Unable to parse options JSON file: Expecting value: line 1 column 15'): 1,
+        },
+    ),
+    # Duplicate optionsFile arg
+    (
+        'duplicate_arg',
+        json.dumps({
+            'validate': True,
+        }),
+        [
+            "--optionsFile", "another_options_file.json",
+        ],
+        {
+            regex.compile(r'Multiple \'optionsFile\' values found during argument preparsing.'): 1,
+        },
+    ),
+    # Missing options file
+    (
+        'missing',
+        '',
+        [],
+        {
+            regex.compile(r'Options file path does not exist: '): 1,
+        },
+    ),
+]
+options_files = []
+
+for name, options_json, additional_args, expected_results in test_cases:
+    print(f"Running testcase: {name}")
+    options_file = str(test_directory / f'{name}.json')
+    if name != 'missing':
+        with open(test_directory / f'{name}.json', 'w') as f:
+            f.write(options_json)
+    log_file = prepare_logfile(test_directory, this_file, name=name, ext='txt')
+    try:
+        run_arelle(
+            arelle_command,
+            additional_args=[
+                "--optionsFile", options_file,
+                *additional_args,
+            ],
+            offline=arelle_offline,
+            logFile=log_file,
+        )
+    except Exception as e:
+        with open(log_file, 'a') as f:
+            f.write(str(e))
+    errors += validate_log_text(log_file, expected_results=expected_results)
+    assert_result(errors)
+    options_files.append(options_file)
+
+assert_result(errors)
+
+print("Cleaning up")
+for options_file in options_files:
+    try:
+        os.unlink(options_file)
+    except OSError:
+        pass


### PR DESCRIPTION
#### Reason for change
Quickly convert a JSON representation of a RuntimeOptions object into an executable configuration file.

#### Description of change
Provide a path to a JSON file via `--optionsFile`. This can be combined with other CLI arguments, which will override the JSON values.

#### Steps to Test
The testcase I've chosen happens to fail validation with `'utf-8' codec can't decode byte 0x8a`.

JSON file ([runtime_options.json](https://github.com/user-attachments/files/23535774/runtime_options.json))

Basic:
```
python arelleCmdLine.py --optionsFile runtime_options.json
```

Override an option from the file:
```
python arelleCmdLine.py --optionsFile runtime_options.json -f
"tests/resources/conformance_suites/uksef-conformance-suite-v2.0/uksef-conformance-suite-v2.0/uksef-conformance-suite-v2.0.zip/uksef-conformance-suite/tests/FRC/FRC_18/TC1_valid.zip"
```

**review**:
@Arelle/arelle

