### PR TITLE
[ESEF] Add a validation to force the correct hidden style name

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -553,6 +553,11 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     if styleValue:
                         for declaration in tinycss2.parse_blocks_contents(styleValue):
                             if isinstance(declaration, tinycss2.ast.Declaration):
+                                disallowedHiddenStyle = val.authParam.get("disallowedHiddenStyle")
+                                if declaration.lower_name == disallowedHiddenStyle:
+                                    modelXbrl.error("ESEF.2.4.1.IxHiddenStyleDisallowed",
+                                                    _("Usage of disallowed hidden style: %(styleName)s"),
+                                                    modelObject=ixElt, styleName=disallowedHiddenStyle)
                                 validateCssUrlContent(declaration.value, ixElt.modelDocument.baseForElement(ixElt),
                                                       modelXbrl, val, ixElt, imageValidationParameters)
                             elif isinstance(declaration, tinycss2.ast.ParseError):

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -105,7 +105,8 @@
             "https://www.esma.europa.eu/taxonomy/2021-03-24/esef_cor.xsd"
         ],
 		"earliestTransformationRegistryVersion": 4,
-		"styleIxHiddenProperty": "-esef-ix-hidden"
+		"styleIxHiddenProperty": "-esef-ix-hidden",
+        "disallowedHiddenStyle": "-ix-hidden"
     },
     "ESEF-2022": {
         "outdatedTaxonomyURLs": [
@@ -129,7 +130,8 @@
             "https://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd"
 		],
 		"earliestTransformationRegistryVersion": 4,
-		"styleIxHiddenProperty": "-esef-ix-hidden"
+		"styleIxHiddenProperty": "-esef-ix-hidden",
+        "disallowedHiddenStyle": "-ix-hidden"
     },
     "ESEF-2023": {
         "outdatedTaxonomyURLs": [
@@ -153,7 +155,8 @@
             "https://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor.xsd"
 		],
 		"earliestTransformationRegistryVersion": 4,
-		"styleIxHiddenProperty": "-esef-ix-hidden"
+		"styleIxHiddenProperty": "-esef-ix-hidden",
+        "disallowedHiddenStyle": "-ix-hidden"
     },
     "ESEF-2024": {
         "outdatedTaxonomyURLs": [
@@ -181,7 +184,8 @@
             "https://www.esma.europa.eu/taxonomy/2024-03-27/esef_cor.xsd"
 		],
 		"earliestTransformationRegistryVersion": 4,
-		"styleIxHiddenProperty": "-esef-ix-hidden"
+		"styleIxHiddenProperty": "-esef-ix-hidden",
+        "disallowedHiddenStyle": "-ix-hidden"
     },
 	"ESEF-2025-DRAFT": {
 	    "outdatedTaxonomyURLs": [
@@ -211,7 +215,8 @@
 		    }
 		],
 		"earliestTransformationRegistryVersion": 5,
-		"styleIxHiddenProperty": "-ix-hidden"
+		"styleIxHiddenProperty": "-ix-hidden",
+        "disallowedHiddenStyle": "-esef-ix-hidden"
 	},
     "AT": {
         "name": "Austria",


### PR DESCRIPTION
#### Reason for change

The Esma updated the ESEF reporting manual 2025

#### Description of change

Add a validation on the ix-hidden style, that force the correct style, -esef-ix-hidden or -ix-hidden

#### Steps to Test

In a xhtml, use the -esef-ix-hidden style with the esef 2025 disclosure system, or the -ix-hidden with older disclosure

**review**:
@Arelle/arelle
