### PR TITLE
Minor updates for Netherlands iXBRL 2025

### DIFF
--- a/arelle/plugin/validate/NL/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/NL/PluginValidationDataExtension.py
@@ -106,6 +106,7 @@ STANDARD_TAXONOMY_URLS = frozenset((
 
 QN_DOMAIN_ITEM_TYPES = frozenset((
     qname("{http://www.xbrl.org/dtr/type/2022-03-31}nonnum:domainItemType"),
+    qname("{http://www.xbrl.org/dtr/type/2024-01-31}nonnum:domainItemType")
 ))
 
 SUPPORTED_IMAGE_TYPES_BY_IS_FILE = {

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -1245,7 +1245,8 @@ def rule_nl_kvk_4_2_2_2(
         **kwargs: Any,
 ) -> Iterable[Validation]:
     """
-    NL-KVK.4.2.2.2: Domain members MUST have domainItemType data type as defined in https://www.xbrl.org/dtr/type/2022-03-31/types.xsd.
+    NL-KVK.4.2.2.2: Domain members MUST have domainItemType data type as defined in
+    https://www.xbrl.org/dtr/type/2022-03-31/types.xsd or https://www.xbrl.org/dtr/type/2024-01-31/types.xsd
     """
     domainMembersWrongType = []
     domainMembers = pluginData.getDimensionalData(val.modelXbrl).domainMembers
@@ -1775,21 +1776,21 @@ def rule_nl_kvk_5_1_3_2(
     hook=ValidationHook.XBRL_FINALLY,
     disclosureSystems=ALL_NL_INLINE_DISCLOSURE_SYSTEMS,
 )
-def rule_nl_kvk_6_1_1_1(
+def rule_nl_kvk_8_1_1_1(
         pluginData: PluginValidationDataExtension,
         val: ValidateXbrl,
         *args: Any,
         **kwargs: Any,
 ) -> Iterable[Validation]:
     """
-    NL-KVK.6.1.1.1: The size of the report package MUST NOT exceed 100 MB.
+    NL-KVK.8.1.1.1: The size of the report package MUST NOT exceed 100 MB.
     """
     size = val.modelXbrl.fileSource.getBytesSize()
     if size is None:
         return  # File size is not available, cannot validate
     if size > MAX_REPORT_PACKAGE_SIZE_MBS * 1_000_000:  # Interpretting MB as megabytes (1,000,000 bytes)
         yield Validation.error(
-            codes='NL.NL-KVK.6.1.1.1.reportPackageMaximumSizeExceeded',
+            codes='NL.NL-KVK.8.1.1.1.reportPackageMaximumSizeExceeded',
             msg=_('The size of the report package must not exceed %(maxSize)s MBs, size is %(size)s MBs.'),
             modelObject=val.modelXbrl, maxSize=MAX_REPORT_PACKAGE_SIZE_MBS, size=int(size/1000000)
         )

--- a/arelle/utils/validate/ESEFImage.py
+++ b/arelle/utils/validate/ESEFImage.py
@@ -108,12 +108,12 @@ def validateImage(
     if isExternalUrl(image):
         yield Validation.error(("ESEF.4.1.6.xHTMLDocumentContainsExternalReferences" if not params.consolidated
                                else "ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences",
-                               "NL.NL-KVK.3.6.2.1.inlineXbrlDocumentContainsExternalReferences"),
+                               "NL.NL-KVK.3.6.2.1.inlineXbrlDocumentSetContainsExternalReferences"),
                                _("Inline XBRL instance documents MUST NOT contain any reference pointing to resources outside the reporting package: %(element)s"),
                                modelObject=elts, element=elts[0].tag, evaluatedMsg=evaluatedMsg,
                                messageCodes=("ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences",
                                              "ESEF.4.1.6.xHTMLDocumentContainsExternalReferences",
-                                             "NL.NL-KVK.3.6.2.1.inlineXbrlDocumentContainsExternalReferences"))
+                                             "NL.NL-KVK.3.6.2.1.inlineXbrlDocumentSetContainsExternalReferences"))
     elif image.startswith("data:image"):
         dataURLParts = parseImageDataURL(image)
         if not dataURLParts or not dataURLParts.isBase64:
@@ -278,6 +278,6 @@ def checkSVGContentElt(
                                        _("Inline XBRL images MUST NOT contain executable code: %(element)s"),
                                        modelObject=imgElts, element=eltTag)
             elif isExternalUrl(href):
-                yield Validation.error((f"{guidance}.referencesPointingOutsideOfTheReportingPackagePresent", "NL.NL-KVK.3.6.2.1.inlineXbrlDocumentContainsExternalReferences"),
+                yield Validation.error((f"{guidance}.referencesPointingOutsideOfTheReportingPackagePresent", "NL.NL-KVK.3.6.2.1.inlineXbrlDocumentSetContainsExternalReferences"),
                                        _("Inline XBRL instance document [image] MUST NOT contain any reference pointing to resources outside the reporting package: %(element)s"),
                                        modelObject=imgElts, element=eltTag)

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -165,7 +165,6 @@ config = ConformanceSuiteConfig(
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_2/index.xml:TC3_invalid',  # Expects an error code with a preceding double quote. G3-3-1_3 expects the same code without the typo.
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_1/index.xml:TC2_invalid',  # Produces: [err:XPTY0004] Variable set Het entity identifier scheme dat bij dit feit hoort MOET het standaard KVK identifier scheme zijn
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_2/index.xml:TC2_invalid',  # Expects fractionElementUsed”.  Note the double quote at the end.
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-2_1/index.xml:TC2_invalid',  # Expects inlineXbrlDocumentSetContainsExternalReferences.  Note incorrect "Set".
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_2/index.xml:TC2_invalid',  # Expects fractionElementUsed”.  Note the double quote at the end.
         'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-1_1/index.xml:TC2_invalid',  # Expects IncorrectSummationItemArcroleUsed.  Note the capital first character.
         'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_2_G3-1-1_1/index.xml:TC2_invalid',  # Expects NonIdenticalIdentifier instead of nonIdenticalIdentifier (note the cap N)

--- a/tests/unit_tests/arelle/plugin/validate/ESEF/ESEF_Current/test_validate_css_url.py
+++ b/tests/unit_tests/arelle/plugin/validate/ESEF/ESEF_Current/test_validate_css_url.py
@@ -11,7 +11,7 @@ class TestValidateCssUrl(TestCase):
             MagicMock(), modelXbrl, MagicMock(), MagicMock(), MagicMock())
         expected = dict(
             level='ERROR',
-            codes=('ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences', 'NL.NL-KVK.3.6.2.1.inlineXbrlDocumentContainsExternalReferences'),
+            codes=('ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences', 'NL.NL-KVK.3.6.2.1.inlineXbrlDocumentSetContainsExternalReferences'),
         )
         self.assertLessEqual(expected.items(), modelXbrl.log.call_args.kwargs.items())
 
@@ -22,6 +22,6 @@ class TestValidateCssUrl(TestCase):
             MagicMock(), modelXbrl, MagicMock(), MagicMock(), MagicMock())
         expected = dict(
             level='ERROR',
-            codes=('ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences', 'NL.NL-KVK.3.6.2.1.inlineXbrlDocumentContainsExternalReferences'),
+            codes=('ESEF.3.5.1.inlineXbrlDocumentContainsExternalReferences', 'NL.NL-KVK.3.6.2.1.inlineXbrlDocumentSetContainsExternalReferences'),
         )
         self.assertLessEqual(expected.items(), modelXbrl.log.call_args.kwargs.items())


### PR DESCRIPTION
#### Description of change
- Update NL.NL-KVK.3.6.2.1.inlineXbrlDocumentContainsExternalReferences to NL.NL-KVK.3.6.2.1.inlineXbrlDocumentSetContainsExternalReferences
- Update NL.NL-KVK.4.2.2.2 to include namespaces from https://www.xbrl.org/dtr/type/2024-01-31/types.xsd.
- Update NL.NL-KVK.6.1.1.1 to NL.NL-KVK.8.1.1.1

#### Steps to Test
CI

**review**:
@Arelle/arelle
