### PR TITLE
Update requirements-dev.txt for lxml type stubs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ flake8-noqa==1.4.0
 mypy==1.18.2
 
 boto3-stubs==1.40.74
-lxml-stubs==0.5.1
+types-lxml==2025.08.25
 types-openpyxl==3.1.5.20250919
 types-PyMySQL==1.1.0.20250916
 types-python-dateutil==2.9.0.20251115


### PR DESCRIPTION
Replaced lxml-stubs with types-lxml in requirements.

[lxml-stubs](https://github.com/lxml/lxml-stubs) has [been abandoned](https://github.com/lxml/lxml-stubs/blob/83f445da9ee27aacf4302a204baaede9b605c50e/README.md?plain=1#L12) in favour of [types-lxml](https://github.com/abelcheung/types-lxml)


**review**:
@Arelle/arelle
