### PR TITLE
Check disclosure system before running cntlr validations

### DIFF
--- a/arelle/utils/validate/ValidationPlugin.py
+++ b/arelle/utils/validate/ValidationPlugin.py
@@ -12,6 +12,7 @@ from arelle.Cntlr import Cntlr
 from arelle.DisclosureSystem import DisclosureSystem
 from arelle.FileSource import FileSource
 from arelle.ModelDocument import LoadingException, ModelDocument
+from arelle.ModelManager import ModelManager
 from arelle.ModelXbrl import ModelXbrl
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.utils.PluginData import PluginData
@@ -229,15 +230,16 @@ class ValidationPlugin:
             *args: Any,
             **kwargs: Any,
     ) -> None:
-        pluginData = self.newPluginData(
-            cntlr=cntlr,
-            validateXbrl=None
-        )
-        for rule in self._getValidations(cntlr.modelManager.disclosureSystem, pluginHook):
-            validations = rule(pluginData, cntlr, fileSource, *args, **kwargs)
-            if validations is not None:
-                for val in validations:
-                    cntlr.error(level=val.level.name, codes=val.codes, msg=val.msg, fileSource=fileSource, **val.args)
+        if self.disclosureSystemFromPluginSelected(cntlr.modelManager):
+            pluginData = self.newPluginData(
+                cntlr=cntlr,
+                validateXbrl=None
+            )
+            for rule in self._getValidations(cntlr.modelManager.disclosureSystem, pluginHook):
+                validations = rule(pluginData, cntlr, fileSource, *args, **kwargs)
+                if validations is not None:
+                    for val in validations:
+                        cntlr.error(level=val.level.name, codes=val.codes, msg=val.msg, fileSource=fileSource, **val.args)
 
     def _executeModelValidations(
         self,
@@ -263,9 +265,9 @@ class ValidationPlugin:
 
     def disclosureSystemFromPluginSelected(
         self,
-        model: ValidateXbrl | ModelXbrl,
+        model: ValidateXbrl | ModelManager | ModelXbrl,
     ) -> bool:
-        if isinstance(model, ValidateXbrl):
+        if isinstance(model, (ModelManager, ValidateXbrl)):
             disclosureSystem = model.disclosureSystem
         elif isinstance(model, ModelXbrl):
             disclosureSystem = model.modelManager.disclosureSystem


### PR DESCRIPTION
#### Reason for change
Plugin validations should only run when a disclosure system defined by the plugin is selected (it's common for GUI users to enable multiple validation plugins and switch between them using the disclosure system setting). The base validation plugin class already checks the disclosure system before running model XBRL validation rules, but this check isn't applied before running controller validations. As a result, enabling a plugin like EDINET without selecting a matching disclosure system throws an exception.

```sh
>python arelleCmdLine.py --plugins validate/EDINET --validate --file filing.zip

[info] Activation of plug-in Validate EDINET successful, version 0.0.1. - validate/EDINET
Traceback (most recent call last):
  File "Arelle/arelleCmdLine.py", line 46, in <module>
    CntlrCmdLine.main()
    ~~~~~~~~~~~~~~~~~^^
  File "Arelle/arelle/CntlrCmdLine.py", line 85, in main
    parseAndRun(args)
    ~~~~~~~~~~~^^^^^^
  File "Arelle/arelle/CntlrCmdLine.py", line 97, in parseAndRun
    cntlr = configAndRunCntlr(runtimeOptions, arellePluginModules)
  File "Arelle/arelle/CntlrCmdLine.py", line 647, in configAndRunCntlr
    cntlr.run(options)
    ~~~~~~~~~^^^^^^^^^
  File "Arelle/arelle/CntlrCmdLine.py", line 1071, in run
    ValidateFileSource(self, filesource).validate(options.reportPackage)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "Arelle/arelle/ValidateFileSource.py", line 24, in validate
    pluginXbrlMethod(self._cntrl, self._filesource)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Arelle/arelle/plugin/validate/EDINET/__init__.py", line 74, in validateFileSource
    return validationPlugin.validateFileSource(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "Arelle/arelle/utils/validate/ValidationPlugin.py", line 142, in validateFileSource
    self._executeCntlrValidations(ValidationHook.FILESOURCE, cntlr, fileSource, *args, **kwargs)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Arelle/arelle/utils/validate/ValidationPlugin.py", line 236, in _executeCntlrValidations
    for rule in self._getValidations(cntlr.modelManager.disclosureSystem, pluginHook):
                ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Arelle/arelle/utils/validate/ValidationPlugin.py", line 285, in _getValidations
    raise RuntimeError("Disclosure system not configured.")
RuntimeError: Disclosure system not configured.
```

#### Description of change
* Check disclosure system before running plugin controller validation rules.

#### Steps to Test
* CI
* `python arelleCmdLine.py --plugins validate/EDINET --validate --file any-filing.zip`

**review**:
@Arelle/arelle
