### PR TITLE
ESEF 2025 1.4.1 Extension Anchoring Validation

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -181,7 +181,15 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                         )
 
                         allAnchorTypes = widerTypes | narrowerTypes
-                        invalidAnchorTypes = any(t != modelConcept.typeQname for t in allAnchorTypes)
+                        if esefDisclosureSystemYear == 2024:
+                            invalidAnchorTypes = any(t != modelConcept.typeQname for t in allAnchorTypes)
+                            msg = _("Issuers should anchor their extension elements to ESEF core taxonomy "
+                                    "elements sharing the same data type.")
+                        else:
+                            invalidAnchorTypes = any(not modelConcept.instanceOfType(t) for t in allAnchorTypes)
+                            msg = _("Issuers should anchor their extension elements to ESEF core taxonomy "
+                                    "elements with the same data type or a data type derived from the "
+                                    "anchor's data type.")
                         if invalidAnchorTypes:
                             anchorTypeParts = []
                             if widerTypes:
@@ -193,9 +201,7 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
                             anchorTypeStr = " ".join(anchorTypeParts)
                             val.modelXbrl.warning(
                                 "ESEF.1.4.1.differentExtensionDataType",
-                                _("Issuers should anchor their extension elements to ESEF core taxonomy "
-                                  "elements sharing the same data type. "
-                                  "Concept: %(qname)s type: %(type)s %(anchorTypes)s"),
+                                msg + _(" Concept: %(qname)s type: %(type)s %(anchorTypes)s"),
                                 modelObject=modelConcept,
                                 qname=modelConcept.qname,
                                 type=modelConcept.typeQname.clarkNotation,


### PR DESCRIPTION
#### Reason for change
The [2025 ESEF filer manual](https://www.esma.europa.eu/sites/default/files/library/esma32-60-254_esef_reporting_manual.pdf) permits extension concepts to have either the same data type as the anchor concept or a data type derived from it. For example, a `nonNegativeMonetaryItemType` extension concept can be anchored to a `monetaryItemType` base concept.

#### Description of change
* Cleanup 2024 anchor validation code.
* Don't raise an error for derived data type anchors for 2025 draft disclosure system.

#### Steps to Test
* CI
* Download [TC1_valid.zip](https://github.com/user-attachments/files/23943300/TC1_valid.zip) and rename to `.xbri` extension (GitHub doesn't support uploading `.xbri` files directly).
* Run: `python arelleCmdLine.py --plugins validate/ESEF --disclosureSystem esef-2025-draft --validate --file TC1_valid.xbri`
* Confirm `ESEF.1.4.1.differentExtensionDataType` warning is not raised.

**review**:
@Arelle/arelle
