### PR TITLE
Fix ESEF disclosure system enabled check

### DIFF
--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -89,6 +89,11 @@ def esefDisclosureSystemSelected(modelXbrl: ModelXbrl) -> bool:
     return getattr(modelXbrl.modelManager.disclosureSystem, ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY, False)
 
 
+def shouldRunEsefValidationRules(val: ValidateXbrl) -> bool:
+    if not val.validateDisclosureSystem:
+        return False
+    return esefDisclosureSystemSelected(val.modelXbrl)
+
 class ESEFPlugin(PluginHooks):
     @staticmethod
     def disclosureSystemTypes(
@@ -217,7 +222,7 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if not esefDisclosureSystemSelected(val.modelXbrl) and val.validateDisclosureSystem:
+        if not shouldRunEsefValidationRules(val):
             return None
         modelXbrl = val.modelXbrl
         val.extensionImportedUrls = set()
@@ -282,7 +287,7 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if not esefDisclosureSystemSelected(val.modelXbrl) and val.validateDisclosureSystem:
+        if not shouldRunEsefValidationRules(val):
             return None
         disclosureSystemYear = getDisclosureSystemYear(val.modelXbrl)
         if disclosureSystemYear == 2021:
@@ -295,7 +300,7 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if not esefDisclosureSystemSelected(val.modelXbrl) and val.validateDisclosureSystem:
+        if not shouldRunEsefValidationRules(val):
             return None
         if val.unconsolidated:
             return None
@@ -338,7 +343,7 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if not esefDisclosureSystemSelected(val.modelXbrl) and val.validateDisclosureSystem:
+        if not shouldRunEsefValidationRules(val):
             return None
         modelXbrl = val.modelXbrl
         if hasattr(val, 'priorFormulaOptionsRunIDs'):  # reset environment formula run IDs if they were saved


### PR DESCRIPTION
#### Reason for change
Existing check incorrectly tried (it threw a value error) to run ESEF validation rules even if disclosure system rules were disabled.

<img width="917" height="126" alt="Screenshot 2025-12-09 at 12 25 58 AM" src="https://github.com/user-attachments/assets/0e429dd5-7602-43fb-92f8-153fbd013645" />


#### Description of change
* Only run ESEF validation rules if an ESEF disclosure system is selected and disclosure system checks are enabled.

#### Steps to Test
* Enable ESEF validation plugin
* Select a non-ESEF disclosure system
* Disable disclosure system checks
* Validate a filing
* Confirm `Unable to determine year of ESEF disclosure system` value error is no longer raised
* Confirm ESEF rules aren't executed
* Enable disclosure system checks
* Select an ESEF disclosure system
* Validate the filing
* Confirm ESEF rules are executed

**review**:
@Arelle/arelle
