### PR TITLE
ESEF 2025: minor improvements to the error messages

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -582,9 +582,10 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     requiredToDisplayFacts.append(ixElt)
             if requiredToDisplayFacts:
                 modelXbrl.error("ESEF.2.4.1.factInHiddenSectionNotInReport",
-                    _("The ix:hidden section contains %(countUnreferenced)s fact(s) whose @id is not applied on any \"-esef-ix- hidden\" style: %(elements)s"),
+                    _("The ix:hidden section contains %(countUnreferenced)s fact(s) whose @id is not applied on any \"%(styleIxHiddenProperty)s\" style: %(elements)s"),
                     modelObject=requiredToDisplayFacts,
                     countUnreferenced=len(requiredToDisplayFacts),
+                    styleIxHiddenProperty=styleIxHiddenProperty,
                     elements=", ".join(sorted(set(str(f.qname) for f in requiredToDisplayFacts))))
             del eligibleForTransformHiddenFacts, hiddenEltIds, presentedHiddenEltIds, requiredToDisplayFacts
         elif modelDocument.type == ModelDocument.Type.INSTANCE:


### PR DESCRIPTION
#### Reason for change
**Guidance 2.2.7**: there was only one error message for the error code `improperApplicationOfEscapeAttribute`. However,
it was only appropriate for the checks of the year 2024. For 2025, there are now three possible messages, depending on the encountered error.

**Guidance 2.4.1**: there was still a hard-coded reference to `-esef-ix- hidden`. It has been replaced by a `%(styleIxHiddenProperty)s` reference as for the other messages of the same kind.

#### Description of change
Only the error messages have been altered. The ESEF plug-in is otherwise unchanged.

#### Steps to Test
These changes will be fully testable when a new ESEF conformance test suite is published.

In the meantime, I have altered by hand two test cases from the 2024 EESF conformance test suite to already check some of the messages. They are attached to this pull request.

Please execute them with the 2024 and 2025 disclosure system to fully appreciate the changes.

* [2.2.7_TC4_invalid.zip](https://github.com/user-attachments/files/24079139/2.2.7_TC4_invalid.zip)
* [2.4.1_TC4_invalid_ix-hidden.zip](https://github.com/user-attachments/files/24079016/2.4.1_TC4_invalid_ix-hidden.zip)

**review**:
@Arelle/arelle
