### PR TITLE
Support GUI find dialog for inline document sets

### DIFF
--- a/arelle/DialogFind.py
+++ b/arelle/DialogFind.py
@@ -186,7 +186,7 @@ class DialogFind(Toplevel):
         else:
             if not self.modelManager.modelXbrl or not docType in (
                  ModelDocument.Type.SCHEMA, ModelDocument.Type.LINKBASE, ModelDocument.Type.INSTANCE, ModelDocument.Type.INLINEXBRL,
-                 ModelDocument.Type.RSSFEED):
+                 ModelDocument.Type.RSSFEED, ModelDocument.Type.INLINEXBRLDOCUMENTSET):
                 messagebox.showerror(_("Find cannot be completed"),
                          _("Find requires an opened DTS or RSS Feed"), parent=self.parent)
                 return


### PR DESCRIPTION
#### Reason for change
The find dialog is of limited usefulness (doesn't navigate to results unless they're already in view), but it should support iXDS filings.

#### Description of change
Add INLINEXBRLDOCUMENTSET to list of find dialog supported document types.

#### Steps to Test
* Open an ixds filing.
* Use the find dialog to search for a concept, label, etc.
* Confirm results are returned and `Find requires an opened DTS or RSS Feed` error is not displayed.

**review**:
@Arelle/arelle
