### PR TITLE
Use pull_request_target for integration test scripts

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -2,7 +2,7 @@ name: Run Integration Test Scripts
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths:
       - '.github/workflows/test-scripts.yml'
       - 'arelle/**'


### PR DESCRIPTION
#### Reason for change
Integration test scripts now include private suites that require AWS S3 access. The `pull_request` trigger doesn't provide fork PRs with access to environment secrets, causing CI failures.

#### Description of change
Switch from `pull_request` to `pull_request_target` trigger, matching the pattern already used by the conformance suites workflow. This allows fork PRs to access the `integration-tests` environment secrets after approval.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
