### PR TITLE
EDINET.EC8069W

### DIFF
--- a/arelle/plugin/validate/EDINET/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/EDINET/PluginValidationDataExtension.py
@@ -77,11 +77,15 @@ class PluginValidationDataExtension(PluginData):
     assetsIfrsQn: QName
     categoriesOfDirectorsAndOtherOfficersAxisQn: QName
     consolidatedOrNonConsolidatedAxisQn: QName
+    corporateGovernanceCompanyWithAuditAndSupervisoryCommitteeTextBlockQn: QName
+    corporateGovernanceCompanyWithCorporateAuditorsTextBlockQn: QName
+    corporateGovernanceCompanyWithNominatingAndOtherCommitteesTextBlockQn: QName
     documentTypeDeiQn: QName
     executiveOfficersMemberQn: QName
     jpcrpEsrFilingDateCoverPageQn: QName
     jpcrpFilingDateCoverPageQn: QName
     jpspsFilingDateCoverPageQn: QName
+    issuedSharesTotalNumberOfSharesEtcQn: QName
     nonConsolidatedMemberQn: QName
     ratioOfFemaleDirectorsAndOtherOfficersQn: QName
 
@@ -100,8 +104,11 @@ class PluginValidationDataExtension(PluginData):
         # QNames
         self.accountingStandardsDeiQn = qname(self.namespaces.jpdei, 'AccountingStandardsDEI')
         self.assetsIfrsQn = qname(self.namespaces.jpigp, 'AssetsIFRS')
-        self.consolidatedOrNonConsolidatedAxisQn = qname(self.namespaces.jppfs, 'ConsolidatedOrNonConsolidatedAxis')
         self.categoriesOfDirectorsAndOtherOfficersAxisQn = qname(self.namespaces.jpcrp, 'CategoriesOfDirectorsAndOtherOfficersAxis')
+        self.consolidatedOrNonConsolidatedAxisQn = qname(self.namespaces.jppfs, 'ConsolidatedOrNonConsolidatedAxis')
+        self.corporateGovernanceCompanyWithAuditAndSupervisoryCommitteeTextBlockQn = qname(self.namespaces.jpcrp, 'CorporateGovernanceCompanyWithAuditAndSupervisoryCommitteeTextBlock')
+        self.corporateGovernanceCompanyWithCorporateAuditorsTextBlockQn = qname(self.namespaces.jpcrp, 'CorporateGovernanceCompanyWithCorporateAuditorsTextBlock')
+        self.corporateGovernanceCompanyWithNominatingAndOtherCommitteesTextBlockQn = qname(self.namespaces.jpcrp, 'CorporateGovernanceCompanyWithNominatingAndOtherCommitteesTextBlock')
         self.documentTypeDeiQn = qname(self.namespaces.jpdei, 'DocumentTypeDEI')
         self.executiveOfficersMemberQn = qname(self.namespaces.jpcrp, 'ExecutiveOfficersMember')
         self.issuedSharesTotalNumberOfSharesEtcQn = qname(self.namespaces.jpcrp, 'IssuedSharesTotalNumberOfSharesEtcTextBlock')

--- a/tests/resources/conformance_suites/edinet/EC1057E/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC1057E/index.xml
@@ -22,6 +22,7 @@
             <warning>EDINET.EC8029W</warning> <!-- removed fact's concept still exists in pres/def linkbase -->
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5002E/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5002E/index.xml
@@ -21,6 +21,7 @@
             <error nonStandardErrorCodes="true">xbrl.4.8.2:sharesFactUnit-notSharesMeasure</error>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5032E/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5032E/index.xml
@@ -20,6 +20,7 @@
             <error>EDINET.EC5032E</error>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5611W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5611W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5611W</warning>
             <warning>EDINET.EC8043W</warning> <!-- base filing -->
             <warning>EDINET.EC8045W</warning> <!-- base filing -->
+            <warning>EDINET.EC8069W</warning> <!-- base filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5613E/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5613E/index.xml
@@ -18,6 +18,7 @@
         </data>
         <result>
             <warning>EDINET.EC5613E</warning>
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.1.7/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.1.7/index.xml
@@ -19,6 +19,7 @@
             <warning>EDINET.EC5700W.GFM.1.1.7</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.10.14/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.10.14/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.10.14</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.10.3/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.10.3/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.10.3</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.10/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.10/index.xml
@@ -19,6 +19,7 @@
             <warning>EDINET.EC5700W.GFM.1.2.10</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.13/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.13/index.xml
@@ -20,6 +20,7 @@
             <error>EDINET.EC1002E</error> <!--NameOfContactPersonNearestPlaceOfContactCoverPage duplicated.-->
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.14/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.14/index.xml
@@ -19,6 +19,7 @@
             <warning>EDINET.EC5700W.GFM.1.2.14</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.22/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.22/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.2.22</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.26/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.26/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.2.26</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.27/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.27/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.2.27</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.3/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.3/index.xml
@@ -19,6 +19,7 @@
             <warning>EDINET.EC5700W.GFM.1.2.3</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.4/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.4/index.xml
@@ -19,6 +19,7 @@
             <warning>EDINET.EC5700W.GFM.1.2.4</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.5/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.5/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8011W</warning> <!-- due to invalid "ID" context ID. -->
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.7/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.7/index.xml
@@ -19,6 +19,7 @@
             <warning>EDINET.EC5700W.GFM.1.2.7</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.8/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.8/index.xml
@@ -19,6 +19,7 @@
             <warning>EDINET.EC5700W.GFM.1.2.8</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.9/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.2.9/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8019W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.1/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.1/index.xml
@@ -20,6 +20,7 @@
             <warning num="3">EDINET.EC8031W</warning> <!-- 1 schema file added with incorrect date x 3 'FilingDateInstant' contexts -->
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.10/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.10/index.xml
@@ -22,6 +22,7 @@
             <warning num="2">EDINET.EC8007W</warning> <!-- invalid roleTypes defined -->
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.11/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.11/index.xml
@@ -22,6 +22,7 @@
             <warning>EDINET.EC8007W</warning> <!-- invalid roleType defined -->
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.13/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.13/index.xml
@@ -24,6 +24,7 @@
             <warning num="2">EDINET.EC8007W</warning> <!-- invalid roleTypes defined -->
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.16/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.16/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.16</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.17/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.17/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.17</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.18/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.18/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.18</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.19/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.19/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.19</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.2/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.2/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.2</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.20/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.20/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.20</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.21/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.21/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.21</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.22/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.22/index.xml
@@ -21,6 +21,7 @@
             <warning num="2">EDINET.EC5700W.GFM.2.3.5</warning> <!-- concepts with invalid names introduced -->
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.23/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.23/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.23</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.25/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.25/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.25</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.26/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.26/index.xml
@@ -23,6 +23,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.26</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.28/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.28/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.28</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.29/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.29/index.xml
@@ -25,6 +25,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.29</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.30/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.30/index.xml
@@ -22,6 +22,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.30</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.31/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.31/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC8029W</warning> <!-- removed fact's concept still exists in pres/def linkbase -->
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.8/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.3.8/index.xml
@@ -19,6 +19,7 @@
             <warning>EDINET.EC5700W.GFM.1.3.8</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.4.4/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.4.4/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.4.4</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.4.6/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.4.6/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.4.6</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.4.8/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.4.8/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.4.8</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.10/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.10/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC5700W.GFM.1.5.10</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.6/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.6/index.xml
@@ -22,6 +22,7 @@
             <warning>EDINET.EC5700W.GFM.1.5.6</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.7/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.7/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.5.7</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
     <variation id="invalid02" name="invalid02">
@@ -34,6 +35,7 @@
             <warning>EDINET.EC5700W.GFM.1.5.7</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.8/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.8/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.5.8</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
     <variation id="invalid02" name="invalid02">
@@ -34,6 +35,7 @@
             <warning>EDINET.EC5700W.GFM.1.5.8</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.6.1/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.6.1/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.6.1</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.6.2/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.6.2/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC5700W.GFM.1.6.2</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.6.5/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.6.5/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC5700W.GFM.1.6.5</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.1/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.1/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.7.1</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.2/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.2/index.xml
@@ -22,6 +22,7 @@
             <error nonStandardErrorCodes="true">xbrl.5.2.5.2.1:zeroWeight</error>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.3/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.3/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.7.3</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.4/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.4/index.xml
@@ -21,6 +21,7 @@
             <error>EDINET.EC5700W.GFM.1.7.4</error>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.5/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.5/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC8030W</warning> <!-- presentation arc removed -->
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.6/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.7.6/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.7.6</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.1/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.1/index.xml
@@ -30,6 +30,7 @@
             <warning>EDINET.EC5700W.GFM.1.8.1</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.10/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.10/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.8.10</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.11/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.11/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.8.11</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.3/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.3/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.8.3</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.5/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.8.5/index.xml
@@ -20,6 +20,7 @@
             <error>EDINET.EC5700W.GFM.1.8.5</error>
             <warning>EDINET.EC8043W</warning>
             <warning>EDINET.EC8045W</warning>
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.9.1/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.9.1/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC5700W.GFM.1.9.1</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.2.5.1/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.2.5.1/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC5700W.GFM.1.1.3</warning> <!-- due to blocked URL -->
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.2.6.1/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.2.6.1/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC5700W.GFM.1.1.3</warning> <!-- due to blocked URL -->
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.2.8.1/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.2.8.1/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC5700W.GFM.1.1.3</warning> <!-- due to blocked URL -->
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8001W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8001W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8001W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8004W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8004W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8004W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8009W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8009W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8009W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8013W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8013W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8013W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8014W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8014W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8014W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8023W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8023W/index.xml
@@ -20,6 +20,7 @@
             <warning num="2">EDINET.EC8023W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8034W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8034W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8034W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8038W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8038W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8038W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8040W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8040W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8040W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8042W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8042W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8042W</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8046W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8046W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8046W</warning>
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8047W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8047W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8047W</warning>
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8049W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8049W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8049W</warning>
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8050W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8050W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning>
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
     <variation id="invalid02" name="invalid02">

--- a/tests/resources/conformance_suites/edinet/EC8054W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8054W/index.xml
@@ -21,6 +21,7 @@
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8054W</warning>
             <warning>EDINET.EC5700W.GFM.1.2.8</warning>
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8057W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8057W/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8057W</warning>
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
         </result>
     </variation>
 </testcase>

--- a/tests/resources/conformance_suites/edinet/EC8060E/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8060E/index.xml
@@ -20,6 +20,7 @@
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8050W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8060W</warning>
+            <warning>EDINET.EC8069W</warning> <!-- from base sample filing -->
             <error nonStandardErrorCodes="true">xbrldie:DefaultValueUsedInInstanceError</error>
         </result>
     </variation>

--- a/tests/resources/conformance_suites/edinet/valid/index.xml
+++ b/tests/resources/conformance_suites/edinet/valid/index.xml
@@ -61,6 +61,7 @@
         <result>
             <warning>EDINET.EC8015W</warning>
             <warning>EDINET.EC8050W</warning>
+            <warning>EDINET.EC8069W</warning>
         </result>
     </variation>
     <variation id="valid05" name="valid05">
@@ -76,6 +77,7 @@
         <result>
             <warning>EDINET.EC8043W</warning>
             <warning>EDINET.EC8045W</warning>
+            <warning>EDINET.EC8069W</warning>
         </result>
     </variation>
     <variation id="valid06" name="valid06">


### PR DESCRIPTION
#### Reason for change
Added EDINET.EC8069W -     If IssuedSharesTotalNumberOfSharesEtcTextBlock is tagged and non-nil then the one or more of the below three elements must also be tagged and non-nil. 

- CorporateGovernanceCompanyWithCorporateAuditorsTextBlock
- CorporateGovernanceCompanyWithAuditAndSupervisoryCommitteeTextBlock
- CorporateGovernanceCompanyWithNominatingAndOtherCommitteesTextBlock

#### Steps to Test

CI

**review**:
@Arelle/arelle
