### PR TITLE
DBA TypeError between instances of 'datetime.datetime' and 'NoneType'

### DIFF
--- a/arelle/plugin/validate/DBA/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/DBA/PluginValidationDataExtension.py
@@ -153,6 +153,8 @@ class PluginValidationDataExtension(PluginData):
         for context in modelXbrl.contexts.values():
             if context.isInstantPeriod or context.isForeverPeriod:
                 continue  # Reporting period contexts can't be instant/forever contexts
+            if context.startDatetime is None or context.endDatetime is None:
+                continue  # Incomplete context
             if len(context.qnameDims) > 0:
                 if context.qnameDims.keys() != {self.consolidatedSoloDimensionQn}:
                     continue  # Context is dimensionalized with something other than consolidatedSoloDimensionQn

--- a/arelle/plugin/validate/DBA/rules/__init__.py
+++ b/arelle/plugin/validate/DBA/rules/__init__.py
@@ -201,6 +201,7 @@ def getFactsWithoutDimension(
         if fact is not None
         if fact.xValid >= VALID
         if fact.context is not None
+        if fact.context.endDatetime is not None
         if len(fact.context.qnameDims) == 0
         }
     return foundFacts


### PR DESCRIPTION
#### Reason for change
DBA plugin performs datetime operations without guarding against None (`profitLoss.context.endDatetime - datetime.timedelta(days=1)`). I expected `context.xValid >= VALID` to work, but it doesn't.

```sh
python arelleCmdLine.py --file ~/Downloads/valid-ixbrl-001.xhtml.zip --plugin validate/DBA --disclosureSystem arl-2025-preview --validate --package tests/resources/packages/ARL-XBRL20251001-20251120.zip
[info] Activation of plug-in Validate DBA successful, version 0.0.1. - validate/DBA
[info] Activation of package Danish generally accepted accounting principles (DKGAAP) successful. - tests/resources/packages/ARL-XBRL20251001-20251120.zip
[xmlSchema:valueError] Element xbrli:endDate type XBRLI_DATEUNION value error: 20253-12-31, lexical pattern mismatch - valid-ixbrl-001.xhtml 6544
[info] loaded in 0.60 secs at 2026-01-05T18:41:34 - /Users/austinmatherne/Downloads/valid-ixbrl-001.xhtml.zip/valid-ixbrl-001.xhtml
[exception:TypeError] Instance validation exception: '<' not supported between instances of 'datetime.datetime' and 'NoneType', instance: valid-ixbrl-001.xhtml - valid-ixbrl-001.xhtml
Traceback (most recent call last):
  File "/Users/austinmatherne/git/Arelle/arelle/Validate.py", line 130, in validate
    self.instValidator.validate(self.modelXbrl, self.modelXbrl.modelManager.formulaOptions.typedParameters(self.modelXbrl.prefixedNamespaces))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/austinmatherne/git/Arelle/arelle/ValidateXbrl.py", line 408, in validate
    pluginXbrlMethod(self)
    ~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/austinmatherne/git/Arelle/arelle/plugin/validate/DBA/__init__.py", line 36, in validateXbrlFinally
    return validationPlugin.validateXbrlFinally(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/austinmatherne/git/Arelle/arelle/utils/validate/ValidationPlugin.py", line 183, in validateXbrlFinally
    self._executeModelValidations(ValidationHook.XBRL_FINALLY, val, *args, **kwargs)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/austinmatherne/git/Arelle/arelle/utils/validate/ValidationPlugin.py", line 263, in _executeModelValidations
    for val in validations:
               ^^^^^^^^^^^
  File "/Users/austinmatherne/git/Arelle/arelle/plugin/validate/DBA/rules/fr.py", line 395, in rule_fr41
    contextIds = {c.id for c in pluginData.getCurrentAndPreviousReportingPeriodContexts(modelXbrl)}
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/Users/austinmatherne/git/Arelle/arelle/plugin/validate/DBA/PluginValidationDataExtension.py", line 139, in getCurrentAndPreviousReportingPeriodContexts
    contexts = self.getReportingPeriodContexts(modelXbrl)
  File "/Users/austinmatherne/git/Arelle/arelle/plugin/validate/DBA/PluginValidationDataExtension.py", line 162, in getReportingPeriodContexts
    self._reportingPeriodContexts = sorted(contexts, key=lambda c: c.endDatetime)
                                    ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'datetime.datetime' and 'NoneType'
[info] validated in 0.33 secs - /Users/austinmatherne/Downloads/valid-ixbrl-001.xhtml.zip/valid-ixbrl-001.xhtml
```

#### Description of change
Filter out contexts with XML invalid period end values from the DBA plugin validation code.

#### Steps to Test
* Use [valid-ixbrl-001.xhtml.zip](https://github.com/user-attachments/files/24442245/valid-ixbrl-001.xhtml.zip)
* `python arelleCmdLine.py --file valid-ixbrl-001.xhtml.zip --plugin validate/DBA --disclosureSystem arl-2025-preview --validate --package tests/resources/packages/ARL-XBRL20251001-20251120.zip`
* Validation errors are expected (including `xmlSchema:valueError` for the broken context), but no `TypeError` exceptions should be raised between instances of `datetime.datetime` and `NoneType`.

**review**:
@Arelle/arelle
