### PR TITLE
Standardize base taxonomy validation and disclosure system in CS configs

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -189,9 +189,11 @@ class ConformanceSuiteConfig:
     additional_plugins_by_prefix: list[tuple[str, frozenset[str]]] = field(default_factory=list)
     args: list[str] = field(default_factory=list)
     assets: list[ConformanceSuiteAssetConfig] = field(default_factory=list)
+    base_taxonomy_validation: Literal['disclosureSystem', 'none', 'all', None] = None
     cache_version_id: str | None = None
     capture_warnings: bool = True
     ci_enabled: bool = True
+    disclosure_system: str | None = None
     expected_additional_testcase_errors: dict[str, dict[str, int]] = field(default_factory=dict)
     expected_failure_ids: frozenset[str] = frozenset()
     expected_missing_testcases: frozenset[str] = frozenset()

--- a/tests/integration_tests/validation/conformance_suite_configurations/cipc_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/cipc_current.py
@@ -2,17 +2,15 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'cipc',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('cipc'),
             entry_point=Path('index.xml'),
         ),
     ],
+    base_taxonomy_validation='none',
     cache_version_id='..Az6BmYC3hVWE.2nH2SYPTWkPMFJYa_',
+    disclosure_system='cipc',
     info_url='https://www.cipc.co.za/?page_id=4400',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/CIPC'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/dba_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/dba_2022.py
@@ -3,10 +3,6 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'arl-2022-preview',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('dba_2022'),
@@ -14,6 +10,8 @@ config = ConformanceSuiteConfig(
         ),
         ConformanceSuiteAssetConfig.public_taxonomy_package(Path('ARL-XBRL20221001-20221117.zip')),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='arl-2022-preview',
     info_url='https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-aktuelle',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/DBA'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/dba_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/dba_2024.py
@@ -4,8 +4,6 @@ from tests.integration_tests.validation.conformance_suite_config import Conforma
 
 config = ConformanceSuiteConfig(
     args=[
-        '--disclosureSystem', 'arl-2024-preview',
-        '--baseTaxonomyValidation', 'none',
         '--formula', 'none',
     ],
     assets=[
@@ -15,6 +13,8 @@ config = ConformanceSuiteConfig(
         ),
         ConformanceSuiteAssetConfig.public_taxonomy_package(Path('ARL-XBRL20241001-20240930-3_U.zip')),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='arl-2024-preview',
     info_url='https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-aktuelle',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/DBA'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/dba_2025.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/dba_2025.py
@@ -3,8 +3,6 @@ from tests.integration_tests.validation.conformance_suite_config import Conforma
 
 config = ConformanceSuiteConfig(
     args=[
-        '--disclosureSystem', 'arl-2025-preview',
-        '--baseTaxonomyValidation', 'none',
         '--formula', 'none',
     ],
     assets=[
@@ -14,6 +12,8 @@ config = ConformanceSuiteConfig(
         ),
         ConformanceSuiteAssetConfig.public_taxonomy_package(Path('ARL-XBRL20251001-20251120.zip')),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='arl-2025-preview',
     info_url='https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-aktuelle',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/DBA'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/dba_multi_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/dba_multi_2024.py
@@ -2,10 +2,6 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'arl-2024-multi-target-preview',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('dba_multi_2024'),
@@ -13,6 +9,8 @@ config = ConformanceSuiteConfig(
         ),
         ConformanceSuiteAssetConfig.public_taxonomy_package(Path('ARL-XBRL20241001-20240930-3_U.zip')),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='arl-2024-multi-target-preview',
     info_url='https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-aktuelle',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/DBA'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/dba_multi_2025.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/dba_multi_2025.py
@@ -3,8 +3,6 @@ from tests.integration_tests.validation.conformance_suite_config import Conforma
 
 config = ConformanceSuiteConfig(
     args=[
-        '--disclosureSystem', 'arl-2025-multi-target-preview',
-        '--baseTaxonomyValidation', 'none',
         '--formula', 'none',
     ],
     assets=[
@@ -14,6 +12,8 @@ config = ConformanceSuiteConfig(
         ),
         ConformanceSuiteAssetConfig.public_taxonomy_package(Path('ARL-XBRL20251001-20251120.zip')),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='arl-2025-multi-target-preview',
     info_url='https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-aktuelle',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/DBA'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/edinet.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/edinet.py
@@ -245,18 +245,15 @@ for test_id, errors in ADDITIONAL_INVALID_ERRORS.items():
 
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--baseTaxonomyValidation', 'none',
-        '--disclosureSystem', 'EDINET',
-        '--testcaseResultsCaptureWarnings',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('edinet'),
             entry_point=Path('index.xml'),
         ),
     ],
+    base_taxonomy_validation='none',
     cache_version_id='cs2wODrDheJqDIm1kEU4Qwk8jwd7DfQu',
+    disclosure_system='EDINET',
     expected_additional_testcase_errors={f"*{s}": val for s, val in EXPECTED_ADDITIONAL_TESTCASE_ERRORS.items()},
     expected_failure_ids=frozenset([]),
     info_url='https://disclosure2.edinet-fsa.go.jp/weee0020.aspx',

--- a/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
@@ -16,9 +16,6 @@ config = ConformanceSuiteConfig(
         '626-rendering-syntax',
         '902-sdr/efm/62421-sdr-multiple',
     ]],
-    args=[
-        '--disclosureSystem', 'efm-pragmatic',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path(CONFORMANCE_SUITE_ZIP_NAME),
@@ -28,6 +25,7 @@ config = ConformanceSuiteConfig(
         )
     ],
     cache_version_id='bY6OmURBAtPB4UALKzz5aeeLlMSKxN9e',
+    disclosure_system='efm-pragmatic',
     info_url='https://www.sec.gov/structureddata/osdinteractivedatatestsuite',
     name=PurePath(__file__).stem,
     plugins=frozenset({

--- a/tests/integration_tests/validation/conformance_suite_configurations/efm_reg_dqc.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/efm_reg_dqc.py
@@ -3,9 +3,6 @@ from tests.integration_tests.validation.conformance_suite_config import Conforma
 
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'efm-pragmatic',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('efm_reg_dqc.zip'),
@@ -15,6 +12,7 @@ config = ConformanceSuiteConfig(
     ],
     cache_version_id='FR1AEVo5AdJcSAoSphxQbpGVsMLmXvIF',
     ci_enabled=False,
+    disclosure_system='efm-pragmatic',
     info_url='N/A',
     name=PurePath(__file__).stem,
     plugins=frozenset({'EDGAR/validate', 'inlineXbrlDocumentSet'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/efm_reg_pragmatic.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/efm_reg_pragmatic.py
@@ -2,9 +2,6 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'efm-pragmatic',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('efm_reg_pragmatic.zip'),
@@ -14,6 +11,7 @@ config = ConformanceSuiteConfig(
     ],
     cache_version_id='F3BNGfVAc7XKtWIwszoxv3QWVsDPlail',
     ci_enabled=False,
+    disclosure_system='efm-pragmatic',
     info_url='N/A',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/EFM', 'inlineXbrlDocumentSet'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
@@ -6,10 +6,6 @@ from tests.integration_tests.validation.conformance_suite_config import (
 )
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'esef-2021',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('esef_conformance_suite_2021.zip'),
@@ -20,6 +16,8 @@ config = ConformanceSuiteConfig(
     ] + [
         package for year in [2017, 2019, 2020, 2021] for package in ESEF_PACKAGES[year]
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='esef-2021',
     info_url='https://www.esma.europa.eu/document/conformance-suite-2021',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
@@ -5,10 +5,6 @@ from tests.integration_tests.validation.conformance_suite_config import (
     ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'esef-2022',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('esef_conformance_suite_2022.zip'),
@@ -19,6 +15,8 @@ config = ConformanceSuiteConfig(
     ] + [
         package for year in [2017, 2019, 2020, 2021, 2022] for package in ESEF_PACKAGES[year]
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='esef-2022',
     expected_failure_ids=frozenset(f'esef_conformance_suite_2022/tests/{s}' for s in [
         # The following test cases fail because of the `tech_duplicated_facts1` formula which fires
         # incorrectly because it does not take into account the language attribute on the fact.

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
@@ -5,10 +5,6 @@ from tests.integration_tests.validation.conformance_suite_config import (
     ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'esef-2023',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('esef_conformance_suite_2023.zip'),
@@ -19,6 +15,8 @@ config = ConformanceSuiteConfig(
     ] + [
         package for year in [2017, 2019, 2020, 2021, 2022] for package in ESEF_PACKAGES[year]
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='esef-2023',
     expected_failure_ids=frozenset(f'tests/inline_xbrl/{s}' for s in [
         # Test report uses older domain item type (http://www.xbrl.org/dtr/type/non-numeric) forbidden by ESEF.3.2.2.
         'G3-1-2/index.xml:TC2_valid',

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
@@ -8,10 +8,6 @@ from tests.integration_tests.validation.conformance_suite_config import (
 )
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'esef-2024',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('esef_conformance_suite_2024.zip'),
@@ -22,6 +18,8 @@ config = ConformanceSuiteConfig(
     ] + [
         package for year in [2017, 2019, 2020, 2021, 2022, 2024] for package in ESEF_PACKAGES[year]
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='esef-2024',
     expected_additional_testcase_errors={f"esef_conformance_suite_2024/tests/inline_xbrl/{s}": val for s, val in {
         # Typo in the test case namespace declaration: incorrectly uses the Extensible Enumeration 1 namespace with the
         # commonly used Extensible Enumeration 2 prefix: xmlns:enum2="http://xbrl.org/2014/extensible-enumerations"

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2021.py
@@ -2,10 +2,6 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'esef-unconsolidated-2021',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('esef_conformance_suite_2021.zip'),
@@ -14,6 +10,8 @@ config = ConformanceSuiteConfig(
             source=AssetSource.S3_PUBLIC,
         ),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='esef-unconsolidated-2021',
     info_url='https://www.esma.europa.eu/document/conformance-suite-2021',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
@@ -2,10 +2,6 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'esef-unconsolidated-2022',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('esef_conformance_suite_2022.zip'),
@@ -14,6 +10,8 @@ config = ConformanceSuiteConfig(
             source=AssetSource.S3_PUBLIC,
         ),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='esef-unconsolidated-2022',
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2022',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2023.py
@@ -2,10 +2,6 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'esef-unconsolidated-2023',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('esef_conformance_suite_2023.zip'),
@@ -14,6 +10,8 @@ config = ConformanceSuiteConfig(
             source=AssetSource.S3_PUBLIC,
         ),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='esef-unconsolidated-2023',
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2023',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2024.py
@@ -7,10 +7,6 @@ from tests.integration_tests.validation.conformance_suite_config import (
 )
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'esef-unconsolidated-2024',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('esef_conformance_suite_2024.zip'),
@@ -19,6 +15,8 @@ config = ConformanceSuiteConfig(
             source=AssetSource.S3_PUBLIC,
         ),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='esef-unconsolidated-2024',
     info_url='https://www.esma.europa.eu/document/esef-conformance-suite-2024',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ESEF'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/hmrc_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/hmrc_current.py
@@ -2,10 +2,6 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'hmrc',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('HMRC'),
@@ -28,6 +24,8 @@ config = ConformanceSuiteConfig(
             public_download_url='https://www.frc.org.uk/documents/3421/Charities_2023_Taxonomies_2023.zip'
         ),
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='hmrc',
     info_url='https://www.gov.uk/government/organisations/hm-revenue-customs',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/UK'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt16.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt16.py
@@ -7,10 +7,6 @@ ZIP_PATH = Path('NT16_KVK_20211208 Berichten_0.zip')
 # needs to be extracted because arelle can't load a taxonomy package ZIP from within a ZIP
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT16',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.nested_conformance_suite(
             ZIP_PATH,
@@ -26,6 +22,8 @@ config = ConformanceSuiteConfig(
         # message:valueAssertion_ConsolidatedCashFlowStatementInsurance_PrtFST1SumOfChildrenParentDebit6
         'testcase-kvk-rpt-jaarverantwoording-2021-all-entrypoints-valid.xml:V-30',
     ]),
+    base_taxonomy_validation='none',
+    disclosure_system='NT16',
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT16%20-%2020210301_0.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt17.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt17.py
@@ -7,10 +7,6 @@ ZIP_PATH = Path('NT17_KVK_20221214 Berichten.zip')
 # needs to be extracted because arelle can't load a taxonomy package ZIP from within a ZIP
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT17',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.nested_conformance_suite(
             ZIP_PATH,
@@ -22,6 +18,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NT17'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NT17',
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT17%20-%2020220301__.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt18.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt18.py
@@ -6,10 +6,6 @@ from tests.integration_tests.validation.conformance_suite_config import Conforma
 ZIP_PATH = Path('NT18_KVK_20231213 Berichten.zip')
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT18',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.nested_conformance_suite(
             ZIP_PATH,
@@ -21,6 +17,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NT18'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NT18',
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT18%20-%2020230301_.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt19.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt19.py
@@ -6,10 +6,6 @@ from tests.integration_tests.validation.conformance_suite_config import Conforma
 ZIP_PATH = Path('NT19_KVK_20241211 Berichten.zip')
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT19',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.nested_conformance_suite(
             ZIP_PATH,
@@ -21,6 +17,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NT19'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NT19',
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/20240301%20SBR%20Filing%20Rules%20NT19.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt20.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt20.py
@@ -6,10 +6,6 @@ from tests.integration_tests.validation.conformance_suite_config import Conforma
 ZIP_PATH = Path('NT20_KVK_20251210 Berichten.zip')
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT20',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.nested_conformance_suite(
             ZIP_PATH,
@@ -21,6 +17,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NT20'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NT20',
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/20251119%20SBR%20Filing%20Rules%20NT20_v1_1.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -4,11 +4,6 @@ from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NL-INLINE-2024',
-        '--baseTaxonomyValidation', 'none',
-        '--testcaseResultsCaptureWarnings',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('conformance-suite-2024-sbr-domein-handelsregister.zip'),
@@ -18,6 +13,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NL-INLINE-2024'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NL-INLINE-2024',
     expected_additional_testcase_errors={f"conformance-suite-2024-sbr-domein-handelsregister/tests/{s}": val for s, val in {
         'G3-1-3_1/index.xml:TC2_invalid': {
             'scenarioNotUsedInExtensionTaxonomy': 1,  # Also fails 4.2.1.1

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024_gaap_other.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024_gaap_other.py
@@ -4,11 +4,6 @@ from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NL-INLINE-2024-GAAP-OTHER',
-        '--baseTaxonomyValidation', 'none',
-        # '--testcaseResultsCaptureWarnings',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.conformance_suite(
             Path('conformance-suite-2024-sbr-domein-handelsregister.zip'),
@@ -18,6 +13,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NL-INLINE-2024'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NL-INLINE-2024-GAAP-OTHER',
     expected_additional_testcase_errors={f"conformance-suite-2024-sbr-domein-handelsregister/tests/{s}": val for s, val in {
         'G5-1-3_1/index.xml:TC1_valid': {
             'noInlineXbrlTags': 1,

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt16.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt16.py
@@ -4,10 +4,6 @@ from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT16',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('nl_nt16'),
@@ -15,6 +11,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NT16'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NT16',
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT16%20-%2020210301_0.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt17.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt17.py
@@ -4,10 +4,6 @@ from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT17',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('nl_nt17'),
@@ -15,6 +11,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NT17'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NT17',
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT17%20-%2020220301__.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt18.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt18.py
@@ -4,10 +4,6 @@ from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT18',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('nl_nt18'),
@@ -15,6 +11,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NT18'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NT18',
     info_url='https://sbr-nl.nl/sites/default/files/bestanden/taxonomie/SBR%20Filing%20Rules%20NT18%20-%2020230301_.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt19.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt19.py
@@ -4,10 +4,6 @@ from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT19',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('nl_nt19'),
@@ -15,6 +11,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NT19'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NT19',
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/20240301%20SBR%20Filing%20Rules%20NT19.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_nt20.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_nt20.py
@@ -4,10 +4,6 @@ from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'NT20',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('nl_nt20'),
@@ -15,6 +11,8 @@ config = ConformanceSuiteConfig(
         ),
         *NL_PACKAGES['NT20'],
     ],
+    base_taxonomy_validation='none',
+    disclosure_system='NT20',
     info_url='https://www.sbr-nl.nl/sites/default/files/bestanden/taxonomie/20251119%20SBR%20Filing%20Rules%20NT20_v1_1.pdf',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/NL'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/ros_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/ros_current.py
@@ -2,17 +2,15 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
 config = ConformanceSuiteConfig(
-    args=[
-        '--disclosureSystem', 'ros',
-        '--baseTaxonomyValidation', 'none',
-    ],
     assets=[
         ConformanceSuiteAssetConfig.local_conformance_suite(
             Path('ros'),
             entry_point=Path('index.xml'),
         ),
     ],
+    base_taxonomy_validation='none',
     cache_version_id='gPspBVScQHwC33yT88cQcOK7nR5u3IRx',
+    disclosure_system='ros',
     info_url='https://www.revenue.ie/en/companies-and-charities/corporation-tax-for-companies/submitting-financial-statements/index.aspx',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/ROS'}),

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -10,7 +10,6 @@ ZIP_PATH = Path('uksef-conformance-suite-v2.0.zip')
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     args=[
-        '--baseTaxonomyValidation', 'none',
         '--formula', 'none',
     ],
     assets=[
@@ -29,6 +28,7 @@ config = ConformanceSuiteConfig(
     ] + [
         package for year in [2022, 2024] for package in ESEF_PACKAGES[year]
     ],
+    base_taxonomy_validation='none',
     expected_additional_testcase_errors={f'uksef-conformance-suite/tests/FRC/{s}': val for s, val in {
         # Test case references TC2_valid.zip, but actual file in suite has .xbri extension.
         'FRC_09/index.xml:TC2_valid': {'IOerror': 1},

--- a/tests/integration_tests/validation/validation_util.py
+++ b/tests/integration_tests/validation/validation_util.py
@@ -251,6 +251,10 @@ def get_conformance_suite_arguments(config: ConformanceSuiteConfig, filename: st
         '--testcaseResultOptions', config.test_case_result_options,
         '--validate',
     ]
+    if config.base_taxonomy_validation:
+        args.extend(['--baseTaxonomyValidation', config.base_taxonomy_validation])
+    if config.disclosure_system:
+        args.extend(['--disclosureSystem', config.disclosure_system])
     if config.package_paths:
         args.extend(['--packages', '|'.join(sorted(p.as_posix() for p in config.package_paths))])
     if plugins:


### PR DESCRIPTION
#### Reason for change
The upcoming test engine uses `RuntimeOptions` rather than CLI args. In an effort to break off small pieces of that PR, this PR standardizes how we configure base taxonomy validation and disclosure systems in conformance suite configs in order to remove most uses of `args`.

#### Steps to Test
CI

**review**:
@Arelle/arelle
