### PR TITLE
Extract all nested conformance suites

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -54,7 +54,7 @@ class ConformanceSuiteAssetConfig:
     @cached_property
     def local_directory(self) -> Path:
         if self.type == AssetType.CONFORMANCE_SUITE:
-            return Path('tests/resources/conformance_suites')
+            return Path(CONFORMANCE_SUITE_PATH_PREFIX)
         if self.type == AssetType.TAXONOMY_PACKAGE:
             return Path('tests/resources/packages')
         return Path('tests/resources')
@@ -139,6 +139,24 @@ class ConformanceSuiteAssetConfig:
         )
 
     @staticmethod
+    def extracted_conformance_suite(
+            extract_sequence: tuple[tuple[Path, Path], ...],
+            entry_point_root: Path,
+            entry_point: Path,
+            public_download_url: str | None = None,
+            source: AssetSource = AssetSource.S3_PRIVATE) -> ConformanceSuiteAssetConfig:
+        return ConformanceSuiteAssetConfig(
+            local_filename=extract_sequence[0][0],
+            source=source,
+            type=AssetType.CONFORMANCE_SUITE,
+            entry_point=entry_point,
+            entry_point_root=entry_point_root,
+            extract_sequence=extract_sequence,
+            public_download_url=public_download_url,
+            s3_key=extract_sequence[0][0].as_posix() if source.is_s3() else None,
+        )
+
+    @staticmethod
     def local_conformance_suite(
             name: Path,
             entry_point: Path | None = None) -> ConformanceSuiteAssetConfig:
@@ -158,17 +176,13 @@ class ConformanceSuiteAssetConfig:
             entry_point: Path,
             public_download_url: str | None = None,
             source: AssetSource = AssetSource.S3_PRIVATE) -> ConformanceSuiteAssetConfig:
-        return ConformanceSuiteAssetConfig(
-            local_filename=name,
-            source=source,
-            type=AssetType.CONFORMANCE_SUITE,
-            entry_point=entry_point,
+        assert entry_point.parent == Path('.'), f'Entry point must be a path with no directories: {entry_point}'
+        return ConformanceSuiteAssetConfig.extracted_conformance_suite(
+            ((name, extract_to),),
             entry_point_root=entry_point_root,
-            extract_sequence=(
-                (name, extract_to),
-            ),
+            entry_point=entry_point,
             public_download_url=public_download_url,
-            s3_key=name.as_posix() if source.is_s3() else None,
+            source=source,
         )
 
     @staticmethod

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2021.py
@@ -5,11 +5,15 @@ from tests.integration_tests.validation.conformance_suite_config import (
     ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
 
+ZIP_PATH = Path('esef_conformance_suite_2021.zip')
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('esef_conformance_suite_2021.zip'),
-            entry_point=Path('esef_conformance_suite_2021/esef_conformance_suite_2021/index_inline_xbrl.xml'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH / 'esef_conformance_suite_2021/esef_conformance_suite_2021',
+            entry_point=Path('index_inline_xbrl.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2021.zip',
             source=AssetSource.S3_PUBLIC,
         ),

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2022.py
@@ -4,11 +4,16 @@ from tests.integration_tests.validation.assets import ESEF_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import (
     ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
+
+ZIP_PATH = Path('esef_conformance_suite_2022.zip')
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('esef_conformance_suite_2022.zip'),
-            entry_point=Path('esef_conformance_suite_2022/index_inline_xbrl.xml'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH / 'esef_conformance_suite_2022',
+            entry_point=Path('index_inline_xbrl.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2022.zip',
             source=AssetSource.S3_PUBLIC,
         ),
@@ -17,7 +22,7 @@ config = ConformanceSuiteConfig(
     ],
     base_taxonomy_validation='none',
     disclosure_system='esef-2022',
-    expected_failure_ids=frozenset(f'esef_conformance_suite_2022/tests/{s}' for s in [
+    expected_failure_ids=frozenset(f'tests/{s}' for s in [
         # The following test cases fail because of the `tech_duplicated_facts1` formula which fires
         # incorrectly because it does not take into account the language attribute on the fact.
         # A fact can not be a duplicate fact if the language attributes are different.

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
@@ -4,10 +4,15 @@ from tests.integration_tests.validation.assets import ESEF_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import (
     ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
+
+ZIP_PATH = Path('esef_conformance_suite_2023.zip')
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('esef_conformance_suite_2023.zip'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH,
             entry_point=Path('index_inline_xbrl.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/2023-12/esef_conformance_suite_2023.zip',
             source=AssetSource.S3_PUBLIC,

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2024.py
@@ -7,11 +7,15 @@ from tests.integration_tests.validation.conformance_suite_config import (
     ConformanceSuiteConfig,
 )
 
+ZIP_PATH = Path('esef_conformance_suite_2024.zip')
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('esef_conformance_suite_2024.zip'),
-            entry_point=Path('esef_conformance_suite_2024/index_inline_xbrl.xml'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH / 'esef_conformance_suite_2024',
+            entry_point=Path('index_inline_xbrl.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/2025-01/esef_conformance_suite_2024.zip',
             source=AssetSource.S3_PUBLIC,
         ),
@@ -20,7 +24,7 @@ config = ConformanceSuiteConfig(
     ],
     base_taxonomy_validation='none',
     disclosure_system='esef-2024',
-    expected_additional_testcase_errors={f"esef_conformance_suite_2024/tests/inline_xbrl/{s}": val for s, val in {
+    expected_additional_testcase_errors={f"*tests/inline_xbrl/{s}": val for s, val in {
         # Typo in the test case namespace declaration: incorrectly uses the Extensible Enumeration 1 namespace with the
         # commonly used Extensible Enumeration 2 prefix: xmlns:enum2="http://xbrl.org/2014/extensible-enumerations"
         'G2-4-1_1/index.xml:TC2_valid': {

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2022.py
@@ -1,11 +1,15 @@
 from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
+ZIP_PATH = Path('esef_conformance_suite_2022.zip')
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('esef_conformance_suite_2022.zip'),
-            entry_point=Path('esef_conformance_suite_2022/index_pure_xhtml.xml'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH / 'esef_conformance_suite_2022',
+            entry_point=Path('index_pure_xhtml.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/library/esef_conformance_suite_2022.zip',
             source=AssetSource.S3_PUBLIC,
         ),

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2023.py
@@ -1,10 +1,14 @@
 from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
+ZIP_PATH = Path('esef_conformance_suite_2023.zip')
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('esef_conformance_suite_2023.zip'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH,
             entry_point=Path('index_pure_xhtml.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/2023-12/esef_conformance_suite_2023.zip',
             source=AssetSource.S3_PUBLIC,

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_xhtml_2024.py
@@ -6,11 +6,15 @@ from tests.integration_tests.validation.conformance_suite_config import (
     ConformanceSuiteConfig,
 )
 
+ZIP_PATH = Path('esef_conformance_suite_2024.zip')
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('esef_conformance_suite_2024.zip'),
-            entry_point=Path('esef_conformance_suite_2024/index_pure_xhtml.xml'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH / 'esef_conformance_suite_2024',
+            entry_point=Path('index_pure_xhtml.xml'),
             public_download_url='https://www.esma.europa.eu/sites/default/files/2025-01/esef_conformance_suite_2024.zip',
             source=AssetSource.S3_PUBLIC,
         ),

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt16.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt16.py
@@ -4,7 +4,6 @@ from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 ZIP_PATH = Path('NT16_KVK_20211208 Berichten_0.zip')
-# needs to be extracted because arelle can't load a taxonomy package ZIP from within a ZIP
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[

--- a/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt17.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/kvk_nt17.py
@@ -4,7 +4,6 @@ from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
 ZIP_PATH = Path('NT17_KVK_20221214 Berichten.zip')
-# needs to be extracted because arelle can't load a taxonomy package ZIP from within a ZIP
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -3,11 +3,15 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
+ZIP_PATH = Path('conformance-suite-2024-sbr-domein-handelsregister.zip')
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('conformance-suite-2024-sbr-domein-handelsregister.zip'),
-            entry_point=Path('conformance-suite-2024-sbr-domein-handelsregister/index.xml'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH / 'conformance-suite-2024-sbr-domein-handelsregister',
+            entry_point=Path('index.xml'),
             public_download_url='https://www.sbr-nl.nl/sites/default/files/2025-04/conformance-suite-2024-sbr-domein-handelsregister.zip',
             source=AssetSource.S3_PUBLIC,
         ),
@@ -15,7 +19,7 @@ config = ConformanceSuiteConfig(
     ],
     base_taxonomy_validation='none',
     disclosure_system='NL-INLINE-2024',
-    expected_additional_testcase_errors={f"conformance-suite-2024-sbr-domein-handelsregister/tests/{s}": val for s, val in {
+    expected_additional_testcase_errors={f"*tests/{s}": val for s, val in {
         'G3-1-3_1/index.xml:TC2_invalid': {
             'scenarioNotUsedInExtensionTaxonomy': 1,  # Also fails 4.2.1.1
         },
@@ -157,26 +161,26 @@ config = ConformanceSuiteConfig(
             'message:existsOnlyOnce_FinancialStatementsConsolidated': 1,
         },
     }.items()},
-    expected_failure_ids=frozenset([
+    expected_failure_ids=frozenset(f"tests/{s}" for s in [
         # Conformance Suite Errors
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_2/index.xml:TC3_invalid',  # Expects an error code with a preceding double quote. G3-3-1_3 expects the same code without the typo.
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_1/index.xml:TC2_invalid',  # Produces: [err:XPTY0004] Variable set Het entity identifier scheme dat bij dit feit hoort MOET het standaard KVK identifier scheme zijn
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_2/index.xml:TC2_invalid',  # Expects fractionElementUsed”.  Note the double quote at the end.
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_2/index.xml:TC2_invalid',  # Expects fractionElementUsed”.  Note the double quote at the end.
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-1_1/index.xml:TC2_invalid',  # Expects IncorrectSummationItemArcroleUsed.  Note the capital first character.
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_2_G3-1-1_1/index.xml:TC2_invalid',  # Expects NonIdenticalIdentifier instead of nonIdenticalIdentifier (note the cap N)
+        'G3-3-1_2/index.xml:TC3_invalid',  # Expects an error code with a preceding double quote. G3-3-1_3 expects the same code without the typo.
+        'G3-4-1_1/index.xml:TC2_invalid',  # Produces: [err:XPTY0004] Variable set Het entity identifier scheme dat bij dit feit hoort MOET het standaard KVK identifier scheme zijn
+        'G3-4-1_2/index.xml:TC2_invalid',  # Expects fractionElementUsed”.  Note the double quote at the end.
+        'G4-2-0_2/index.xml:TC2_invalid',  # Expects fractionElementUsed”.  Note the double quote at the end.
+        'G4-4-1_1/index.xml:TC2_invalid',  # Expects IncorrectSummationItemArcroleUsed.  Note the capital first character.
+        'RTS_Annex_IV_Par_2_G3-1-1_1/index.xml:TC2_invalid',  # Expects NonIdenticalIdentifier instead of nonIdenticalIdentifier (note the cap N)
 
 
         # Not Implemented
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G5-1-3_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP Other
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G5-1-3_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP Other
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G5-1-3_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP Other
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G5-1-3_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP Other
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_II_Par_1/index.xml:TC3_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_III_Par_1/index.xml:TC2_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_III_Par_1/index.xml:TC3_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC4_invalid',
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_14_G3-5-1_1/index.xml:TC2_invalid',
+        'G5-1-3_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP Other
+        'G5-1-3_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP Other
+        'G5-1-3_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP Other
+        'G5-1-3_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP Other
+        'RTS_Annex_II_Par_1/index.xml:TC3_invalid',
+        'RTS_Annex_III_Par_1/index.xml:TC2_invalid',
+        'RTS_Annex_III_Par_1/index.xml:TC3_invalid',
+        'RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC4_invalid',
+        'RTS_Annex_IV_Par_14_G3-5-1_1/index.xml:TC2_invalid',
     ]),
     info_url='https://www.sbr-nl.nl/sbr-domeinen/handelsregister/uitbreiding-elektronische-deponering-handelsregister',
     name=PurePath(__file__).stem,

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024_gaap_other.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024_gaap_other.py
@@ -3,11 +3,15 @@ from pathlib import PurePath, Path
 from tests.integration_tests.validation.assets import NL_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 
+ZIP_PATH = Path('conformance-suite-2024-sbr-domein-handelsregister.zip')
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('conformance-suite-2024-sbr-domein-handelsregister.zip'),
-            entry_point=Path('conformance-suite-2024-sbr-domein-handelsregister/index.xml'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH / 'conformance-suite-2024-sbr-domein-handelsregister',
+            entry_point=Path('index.xml'),
             public_download_url='https://www.sbr-nl.nl/sites/default/files/2025-04/conformance-suite-2024-sbr-domein-handelsregister.zip',
             source=AssetSource.S3_PUBLIC,
         ),
@@ -15,7 +19,7 @@ config = ConformanceSuiteConfig(
     ],
     base_taxonomy_validation='none',
     disclosure_system='NL-INLINE-2024-GAAP-OTHER',
-    expected_additional_testcase_errors={f"conformance-suite-2024-sbr-domein-handelsregister/tests/{s}": val for s, val in {
+    expected_additional_testcase_errors={f"*tests/{s}": val for s, val in {
         'G5-1-3_1/index.xml:TC1_valid': {
             'noInlineXbrlTags': 1,
         },
@@ -31,216 +35,216 @@ config = ConformanceSuiteConfig(
             'requiredEntryPointOtherGaapNotReferenced': 1,
         },
     }.items()},
-    expected_failure_ids=frozenset([
+    expected_failure_ids=frozenset(f"tests/{s}" for s in [
         # Conformance Suite Errors
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_2/index.xml:TC3_invalid',  # Expects an error code with a preceding double quote. G3-3-1_3 expects the same code without the typo.
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_1/index.xml:TC2_invalid',  # Produces: [err:XPTY0004] Variable set Het entity identifier scheme dat bij dit feit hoort MOET het standaard KVK identifier scheme zijn
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_2/index.xml:TC2_invalid',  # Expects fractionElementUsed”.  Note the double quote at the end.
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-2_1/index.xml:TC2_invalid',  # Produces 'EFM.6.03.11' and 'NL.NL-KVK.3.4.2.1.htmlOrXmlBaseUsed'
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_2_G3-1-1_1/index.xml:TC2_invalid',  # Expects NonIdenticalIdentifier instead of nonIdenticalIdentifier (note the cap N)
+        'G3-3-1_2/index.xml:TC3_invalid',  # Expects an error code with a preceding double quote. G3-3-1_3 expects the same code without the typo.
+        'G3-4-1_1/index.xml:TC2_invalid',  # Produces: [err:XPTY0004] Variable set Het entity identifier scheme dat bij dit feit hoort MOET het standaard KVK identifier scheme zijn
+        'G3-4-1_2/index.xml:TC2_invalid',  # Expects fractionElementUsed”.  Note the double quote at the end.
+        'G3-4-2_1/index.xml:TC2_invalid',  # Produces 'EFM.6.03.11' and 'NL.NL-KVK.3.4.2.1.htmlOrXmlBaseUsed'
+        'RTS_Annex_IV_Par_2_G3-1-1_1/index.xml:TC2_invalid',  # Expects NonIdenticalIdentifier instead of nonIdenticalIdentifier (note the cap N)
 
 
         # Wont Run
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-1-2_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-1-2_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-1-2_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-1-2_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-1-2_2/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-1-3_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-1-3_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-1-3_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-1-3_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-3_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-3_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-3_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-3_1/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-4_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-4_2/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-4_2/index.xml:TC3_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-4_2/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC3_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC5_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC6_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-2-7_1/index.xml:TC7_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_2/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-3-1_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_4/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_4/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_5/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-1_5/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-2_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-4-2_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_1/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_4/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_4/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_5/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_5/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-1_5/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-2_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-2_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-2_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-2_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-2_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-2_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-2_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-3_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-3_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-4_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-5-4_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-2_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-2_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-3_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-3_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-3_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-3_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-3_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-6-3_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-7-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G3-7-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G6-1-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G6-1-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-1-2_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-1-2_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-1-2_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-1-2_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-1-2_2/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
+        'G3-1-3_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-1-3_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-1-3_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-1-3_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-2-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-2-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-2-3_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-2-3_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
+        'G3-2-3_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
+        'G3-2-3_1/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
+        'G3-2-4_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-2-4_2/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
+        'G3-2-4_2/index.xml:TC3_valid',  # Tested in NL-INLINE-2024
+        'G3-2-4_2/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
+        'G3-2-7_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-2-7_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
+        'G3-2-7_1/index.xml:TC3_valid',  # Tested in NL-INLINE-2024
+        'G3-2-7_1/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
+        'G3-2-7_1/index.xml:TC5_invalid',  # Tested in NL-INLINE-2024
+        'G3-2-7_1/index.xml:TC6_invalid',  # Tested in NL-INLINE-2024
+        'G3-2-7_1/index.xml:TC7_invalid',  # Tested in NL-INLINE-2024
+        'G3-3-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-3-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-3-1_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-3-1_2/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
+        'G3-3-1_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-3-1_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-4-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-4-1_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-4-1_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-4-1_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-4-1_4/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-4-1_4/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-4-1_5/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-4-1_5/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-4-2_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-4-2_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-1_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
+        'G3-5-1_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-1_1/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-1_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-1_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-1_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-1_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-1_4/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-1_4/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-1_5/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-1_5/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-1_5/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-2_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-2_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
+        'G3-5-2_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-2_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-2_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-2_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-2_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-3_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-3_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-5-4_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-5-4_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-6-2_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-6-2_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-6-3_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-6-3_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-6-3_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-6-3_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-6-3_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-6-3_3/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G3-7-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G3-7-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'G6-1-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'G6-1-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
 
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_1/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_1/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_1/index.xml:TC5_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_1/index.xml:TC6_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_1/index.xml:TC7_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-1_2/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-2_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-2_1/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-2_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-2_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-2_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-5_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-5_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-5_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-5_2/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-5_2/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-5_2/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-5_2/index.xml:TC5_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-5_2/index.xml:TC6_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-1-5_2/index.xml:TC7_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-0_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-1_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-1_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-2_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-2_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-3_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-2-3_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-1_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-1_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-1_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-1_1/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-2_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-3-2_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-1_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-1_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-2_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-2_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-2_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-2_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-2_3/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-2_3/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-2_4/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-2_4/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-3_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-3_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-3_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-3_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-3_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-3_2/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-4_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-4_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-5_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-5_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-5_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-5_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-5_2/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-6_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-6_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/G4-4-6_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_1/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_1/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_1/index.xml:TC5_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_1/index.xml:TC6_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_1/index.xml:TC7_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-1_2/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-2_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-2_1/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-2_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-2_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-2_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-5_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-5_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-5_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-5_2/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-5_2/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-5_2/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-5_2/index.xml:TC5_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-5_2/index.xml:TC6_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-1-5_2/index.xml:TC7_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-0_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-0_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-0_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-0_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-1_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-1_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-2_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-2_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-3_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-2-3_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-3-1_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-3-1_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-3-1_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-3-1_1/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-3-2_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-3-2_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-1_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-1_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-2_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-2_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-2_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-2_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-2_3/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-2_3/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-2_4/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-2_4/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-3_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-3_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-3_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-3_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-3_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-3_2/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-4_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-4_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-5_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-5_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-5_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-5_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-5_2/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-6_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-6_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'G4-4-6_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
 
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_II_Par_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_II_Par_1/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_II_Par_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_III_Par_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_III_Par_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_III_Par_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_11_G4-2-2_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_11_G4-2-2_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_11_G4-2-2_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC3_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_14_G3-5-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_14_G3-5-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_1_G3-1-4_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_1_G3-1-4_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_1_G3-1-4_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_1_G3-1-4_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_2_G3-1-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_2_G3-1-1_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_2_G3-1-1_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_4_3/index.xml:TC5_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_5/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_5/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_5/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_6/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_6/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_6/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_6/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_9_Par_10/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_9_Par_10/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Annex_IV_Par_9_Par_10/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Art_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Art_3/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Art_3/index.xml:TC3_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Art_3/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Art_6_a/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
-        'conformance-suite-2024-sbr-domein-handelsregister/tests/RTS_Art_6_a/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_II_Par_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_II_Par_1/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_II_Par_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_III_Par_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_III_Par_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_III_Par_1/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_11_G4-2-2_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_11_G4-2-2_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_11_G4-2-2_1/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC3_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_14_G3-5-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_14_G3-5-1_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_1_G3-1-4_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_1_G3-1-4_1/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_1_G3-1-4_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_1_G3-1-4_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_2_G3-1-1_1/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_2_G3-1-1_2/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_2_G3-1-1_2/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_4_1/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_4_1/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_4_2/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_4_2/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_4_3/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_4_3/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_4_3/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_4_3/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_4_3/index.xml:TC5_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_5/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_5/index.xml:TC2_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_5/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_6/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_6/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_6/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_6/index.xml:TC4_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_8_G4-4-5/index.xml:TC3_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Annex_IV_Par_9_Par_10/index.xml:TC1_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_9_Par_10/index.xml:TC2_valid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Annex_IV_Par_9_Par_10/index.xml:TC3_invalid',  # Must be run with different disclosure system for GAAP/IFRS
+        'RTS_Art_3/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Art_3/index.xml:TC2_valid',  # Tested in NL-INLINE-2024
+        'RTS_Art_3/index.xml:TC3_valid',  # Tested in NL-INLINE-2024
+        'RTS_Art_3/index.xml:TC4_invalid',  # Tested in NL-INLINE-2024
+        'RTS_Art_6_a/index.xml:TC1_valid',  # Tested in NL-INLINE-2024
+        'RTS_Art_6_a/index.xml:TC2_invalid',  # Tested in NL-INLINE-2024
     ]),
     info_url='https://www.sbr-nl.nl/sbr-domeinen/handelsregister/uitbreiding-elektronische-deponering-handelsregister',
     name=PurePath(__file__).stem,

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -8,16 +8,22 @@ from tests.integration_tests.validation.conformance_suite_config import (
 
 ZIP_PATH = Path('uksef-conformance-suite-v2.0.zip')
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
+EXTRACTED_ZIP_PATH = EXTRACTED_PATH / 'uksef-conformance-suite-v2.0' / 'uksef-conformance-suite-v2.0.zip'
+EXTRACTED_EXTRACTED_PATH = Path(EXTRACTED_ZIP_PATH.parent) / EXTRACTED_ZIP_PATH.stem
+
+
 config = ConformanceSuiteConfig(
     args=[
         '--formula', 'none',
     ],
     assets=[
-        ConformanceSuiteAssetConfig.nested_conformance_suite(
-            ZIP_PATH,
-            EXTRACTED_PATH,
-            entry_point_root=EXTRACTED_PATH / 'uksef-conformance-suite-v2.0' / 'uksef-conformance-suite-v2.0.zip',
-            entry_point=Path('uksef-conformance-suite/index.xml'),
+        ConformanceSuiteAssetConfig.extracted_conformance_suite(
+            (
+                (ZIP_PATH, EXTRACTED_PATH),
+                (EXTRACTED_ZIP_PATH, EXTRACTED_EXTRACTED_PATH),
+            ),
+            entry_point_root=EXTRACTED_EXTRACTED_PATH / "uksef-conformance-suite",
+            entry_point=Path('index.xml'),
             public_download_url='https://www.frc.org.uk/documents/8116/uksef-conformance-suite-v2.0.zip',
             source=AssetSource.S3_PUBLIC,
         ),
@@ -29,15 +35,21 @@ config = ConformanceSuiteConfig(
         package for year in [2022, 2024] for package in ESEF_PACKAGES[year]
     ],
     base_taxonomy_validation='none',
-    expected_additional_testcase_errors={f'uksef-conformance-suite/tests/FRC/{s}': val for s, val in {
+    expected_additional_testcase_errors={f'*tests/FRC/{s}': val for s, val in {
         # Test case references TC2_valid.zip, but actual file in suite has .xbri extension.
-        'FRC_09/index.xml:TC2_valid': {'IOerror': 1},
+        'FRC_09/index.xml:TC2_valid': {
+            'FileSourceError': 1,
+            'tpe:invalidArchiveFormat': 1
+        },
         # Test case references TC3_valid.zip, but actual file in suite has .xbri extension.
-        'FRC_09/index.xml:TC3_valid': {'IOerror': 1},
+        'FRC_09/index.xml:TC3_valid': {
+            'FileSourceError': 1,
+            'tpe:invalidArchiveFormat': 1
+        },
         # Report package uses CR document type URI instead of rec URI.
         'FRC_09/index.xml:TC4_valid': {'rpe:unsupportedReportPackageVersion': 1},
     }.items()},
-    expected_failure_ids=frozenset({f'uksef-conformance-suite/tests/FRC/{s}' for s in [
+    expected_failure_ids=frozenset({f'tests/FRC/{s}' for s in [
         # FRC XBRL Tagging Guide not yet implemented.
         'FRC_01/index.xml:TC6_invalid',
         'FRC_01/index.xml:TC7_invalid',

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_2_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_2_1.py
@@ -18,7 +18,7 @@ config = ConformanceSuiteConfig(
             source=AssetSource.S3_PUBLIC,
         ),
     ],
-    expected_additional_testcase_errors={f"XBRL-CONF-2025-07-16/Common/{s}": val for s, val in {
+    expected_additional_testcase_errors={f"*XBRL-CONF-2025-07-16/Common/{s}": val for s, val in {
         # 202.02b in the absence of source/target constraints, an empty href doesn't pose a problem
         # 202-02b-HrefResolutionCounterExample-custom.xml Expected: valid, Actual: arelle:hrefWarning
         '200-linkbase/202-xlinkLocator.xml:V-02b': {

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_ixbrl_1_1.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_ixbrl_1_1.py
@@ -5,7 +5,6 @@ from tests.integration_tests.validation.conformance_suite_config import (
 )
 
 ZIP_PATH = Path('inlineXBRL-1.1-conformanceSuite-2020-04-08.zip')
-# needs to be extracted because arelle can't load a taxonomy package ZIP from within a ZIP
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     args=[
@@ -15,8 +14,8 @@ config = ConformanceSuiteConfig(
         ConformanceSuiteAssetConfig.nested_conformance_suite(
             ZIP_PATH,
             EXTRACTED_PATH,
-            entry_point_root=EXTRACTED_PATH,
-            entry_point=Path('inlineXBRL-1.1-conformanceSuite-2020-04-08/index.xml'),
+            entry_point_root=EXTRACTED_PATH / 'inlineXBRL-1.1-conformanceSuite-2020-04-08',
+            entry_point=Path('index.xml'),
             public_download_url='https://www.xbrl.org/2020/inlineXBRL-1.1-conformanceSuite-2020-04-08.zip',
             source=AssetSource.S3_PUBLIC,
         ),

--- a/tests/integration_tests/validation/conformance_suite_configurations/xbrl_taxonomy_packages_1_0.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/xbrl_taxonomy_packages_1_0.py
@@ -1,11 +1,15 @@
 from pathlib import PurePath, Path
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 
+ZIP_PATH = Path("taxonomy-package-conformance.zip")
+EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
     assets=[
-        ConformanceSuiteAssetConfig.conformance_suite(
-            Path('taxonomy-package-conformance.zip'),
-            entry_point=Path('index.xml'),
+        ConformanceSuiteAssetConfig.nested_conformance_suite(
+            ZIP_PATH,
+            EXTRACTED_PATH,
+            entry_point_root=EXTRACTED_PATH,
+            entry_point=Path("index.xml"),
         ),
     ],
     info_url='https://specifications.xbrl.org/work-product-index-taxonomy-packages-taxonomy-packages-1.0.html',

--- a/tests/integration_tests/validation/download_assets.py
+++ b/tests/integration_tests/validation/download_assets.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from tests.integration_tests.download_cache import apply_cache
 from tests.integration_tests.integration_test_util import get_s3_uri
-from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteAssetConfig, AssetType, AssetSource
+from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteAssetConfig, AssetType, AssetSource, CONFORMANCE_SUITE_PATH_PREFIX
 
 
 def _download_asset(asset: ConformanceSuiteAssetConfig, download_private: bool) -> bool:
@@ -94,9 +94,10 @@ def _extract_asset(asset: ConformanceSuiteAssetConfig) -> None:
     For each element in the sequence, the zip at the `from` path
     is extracted to the `to` directory.
     """
+    root_path = Path(CONFORMANCE_SUITE_PATH_PREFIX)
     for extract_from, extract_to in asset.extract_sequence:
-        extract_from = Path('tests/resources/conformance_suites') / extract_from
-        extract_to = Path('tests/resources/conformance_suites') / extract_to
+        extract_from = root_path / extract_from
+        extract_to = root_path / extract_to
         with zipfile.ZipFile(extract_from, 'r') as zip_ref:
             os.makedirs(extract_to, exist_ok=True)
             zip_ref.extractall(extract_to)


### PR DESCRIPTION
#### Reason for change
Core Arelle does not support nested zips (zips within zips). This is only currently supported for conformance suites because of special logic within the current testcase variation runner. The new test engine does not incorporate special handling logic like this, so we need to unzip conformance suites in order to run testcases through the standard Arelle pathway.

*Note: the report packages conformance suite has been skipped here since it proved non-trivial to get working with the existing testcase runner, and doing so would not prove valuable since it would not be incorporated in the new test engine.*

#### Description of change
Update conformance suite configs to unzip nested conformance suite packages.

#### Steps to Test
CI

**review**:
@Arelle/arelle
