### PR TITLE
Fix for long test script artifact names

### DIFF
--- a/.github/actions/test_script/action.yml
+++ b/.github/actions/test_script/action.yml
@@ -1,6 +1,10 @@
 name: Test Script
 description: Runs pytest against test script using given inputs. Adds logs to workflow run.
 inputs:
+  artifact_name:
+    default: 'logs'
+    description: Name of the logs artifact to upload
+    required: true
   name:
     description: Name of the test script to run
     required: true
@@ -31,7 +35,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@v6.0.0
       with:
-        name: ${{ inputs.name }} ${{ runner.os }} ${{ inputs.python_version }} logs
+        name: ${{ inputs.artifact_name }}
         if-no-files-found: error
         include-hidden-files: true
         path: '.test/**/*.logfile.*'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -99,5 +99,6 @@ jobs:
       - name: Test Script
         uses: ./.github/actions/test_script
         with:
+          artifact_name: ${{ matrix.test.private && 'private' || '' }} scripts ${{ matrix.test.os }} ${{ matrix.test.python_version }} logs
           name: ${{ matrix.test.name }}
           python_version: ${{ matrix.test.python_version }}

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -44,5 +44,6 @@ jobs:
       - name: Test Script
         uses: ./.github/actions/test_script
         with:
+          artifact_name: ${{ matrix.test.private && 'private' || '' }} scripts ${{ matrix.test.os }} ${{ matrix.test.python_version }} logs
           name: ${{ matrix.test.name }}
           python_version: ${{ matrix.test.python_version }}


### PR DESCRIPTION
#### Reason for change
test_script CI runs failing due to lengthy artifact names ([example](https://github.com/Arelle/Arelle/actions/runs/21009059039/job/60399065274?pr=2103))

#### Description of change
Pass artifact name to test_script action

#### Steps to Test
- Test scripts on this PR will fail due to conflicting artifact names (the runner will use this PR's updated test_script `action.yml` but the `integration-tests.yml` from `master`)
- [This run](https://github.com/aaroncameron-wk/arelle-public/actions/runs/21014280180/job/60416013294?pr=171) on my fork demonstrates the fix

**review**:
@Arelle/arelle
