### PR TITLE
Remove network exclusion for fast conformance suites

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_configurations/dba_multi_2025.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/dba_multi_2025.py
@@ -17,5 +17,4 @@ config = ConformanceSuiteConfig(
     info_url='https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-aktuelle',
     name=PurePath(__file__).stem,
     plugins=frozenset({'validate/DBA'}),
-    shards=4,
 )

--- a/tests/integration_tests/validation/discover_tests.py
+++ b/tests/integration_tests/validation/discover_tests.py
@@ -73,7 +73,7 @@ def main() -> None:
     config_names_seen: set[str] = set()
     private = False
     for config in CI_CONFORMANCE_SUITE_CONFIGS:
-        if config.runs_without_network and config.shards == 1:
+        if config.shards == 1:
             config_names_seen.add(config.name)
             private |= config.has_private_asset
     for os in [LINUX, MACOS, WINDOWS]:


### PR DESCRIPTION
#### Reason for change
We have a few conformance suites that run very quickly but are excluded from "fast suites" because they rely on a web cache or taxonomy packages. These conditions were originally put in place for optimization but are no longer disqualifying factors for running quickly.
<img width="334" height="333" alt="image" src="https://github.com/user-attachments/assets/86e02b1f-17b9-40d8-8503-25c4d11964fb" />

#### Description of change
Remove `runs_without_network` condition when building fast suites.
This effectively brings `cipc_current`, `dba_multi_2024`, and `dba_multi_2025` into `fast suites` and reduces overall CS runner count by 3.

#### Steps to Test
CI

**review**:
@Arelle/arelle
