### PR TITLE
DBA.FR118: Use non-hash key

### DIFF
--- a/arelle/plugin/validate/DBA/rules/fr.py
+++ b/arelle/plugin/validate/DBA/rules/fr.py
@@ -1665,8 +1665,9 @@ def rule_fr118(
         # An "other rendering" and "reported value" context match if they are effectively duplicate contexts
         # when ignoring the "other rendering" dimension member
         key = (
-            context.periodHash,
-            context.entityIdentifierHash,
+            context.startDatetime,
+            context.endDatetime,
+            context.entityIdentifier,
             tuple(
                 (dimConcept, dimMember)
                 for dimConcept, dimMember in sorted(context.scenDimValues.items(), key=lambda item: item[0].localName)


### PR DESCRIPTION
#### Reason for change
Initial implementation was on hashes for equality without a true equality check.

#### Description of change
The performance gain of using hashes is likely not worth the extra comparisons later on, so compare the underlying values directly via key.

#### Steps to Test
CI

**review**:
@Arelle/arelle
