### PR TITLE
NL.NL-KVK.6.1.3.4

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2025.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2025.py
@@ -167,6 +167,14 @@ config = ConformanceSuiteConfig(
             'invalidIdentifierFormat': 1,
             'requiredEntryPointOtherNotReferenced': 1,
         },
+        'G6-1-3_4/index.xml:TC1_valid': {
+            'incorrectVersionEntryPointOtherReferenced': 1,
+            'requiredEntryPointOtherNotReferenced': 1,
+        },
+        'G6-1-3_4/index.xml:TC2_invalid': {
+            'incorrectVersionEntryPointOtherReferenced': 1,
+            'requiredEntryPointOtherNotReferenced': 1,
+        },
         'G7-1-4_1/index.xml:TC1_valid': {
             'arelle:nonIxdsDocument': 1,
         },
@@ -285,8 +293,6 @@ config = ConformanceSuiteConfig(
         'G6-1-3_2/index.xml:TC2_invalid',
         'G6-1-3_3/index.xml:TC1_valid',
         'G6-1-3_3/index.xml:TC2_invalid',
-        'G6-1-3_4/index.xml:TC1_valid',
-        'G6-1-3_4/index.xml:TC2_invalid',
 
         # Expects invalidInlineXbrl.  Instead, we depend on the underlying XML Schema and iXBRL validation errors.
         'RTS_Annex_III_Par_1/index.xml:TC2_invalid',


### PR DESCRIPTION
#### Reason for change
NL-KVK.6.1.3.4: The filename of the separate Inline XBRL document for filing purposes MUST match the "kvk-{date}-{lang}.{extension}" pattern.

#### Description of change
This is the ESEF combo version of NL-KVK.3.6.3.4. Similar implementation, but instead check for `filing-information` target facts to identify likely filing information documents in multi-target contexts.

#### Steps to Test
CI

**review**:
@Arelle/arelle
