### PR TITLE
Update NL.NL-KVK.RTS_Art_6_a for 2025

### DIFF
--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -2432,17 +2432,21 @@ def rule_nl_kvk_RTS_Art_6_a(
     NL-KVK.RTS_Art_6_a: Legal entities shall embed markups in the annual reports
     in XHTML format using the Inline XBRL specifications
     """
-    for modelDocument in val.modelXbrl.urlDocs.values():
-        if modelDocument.type != ModelDocument.Type.INLINEXBRL:
-            continue
-        factElements = list(modelDocument.xmlRootElement.iterdescendants(
-            modelDocument.ixNStag + "nonNumeric",
-            modelDocument.ixNStag + "nonFraction",
-            modelDocument.ixNStag + "fraction"
-        ))
-        if len(factElements) == 0:
-            yield Validation.error(
-                codes='NL.NL-KVK.RTS_Art_6_a.noInlineXbrlTags',
-                msg=_('Annual report is using xhtml extension, but there are no inline mark up tags identified.'),
-                modelObject=modelDocument,
-            )
+    inlineDocs = {
+        doc
+        for doc in val.modelXbrl.urlDocs.values()
+        if doc.type == ModelDocument.Type.INLINEXBRL
+    }
+    if len(inlineDocs) == 0:
+        return
+    factElements = [
+        fact
+        for fact in val.modelXbrl.facts
+        if fact.modelDocument in inlineDocs
+    ]
+    if len(factElements) == 0:
+        yield Validation.error(
+            codes='NL.NL-KVK.RTS_Art_6_a.noInlineXbrlTags',
+            msg=_('Annual report is using one or more files with an xhtml extension, but non have inline mark up tags.'),
+            modelObject=inlineDocs,
+        )

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -73,6 +73,7 @@ config = ConformanceSuiteConfig(
         'G3-5-3_1/index.xml:TC2_invalid': {
             'arelle:ixdsTargetNotDefined': 1,
             'extensionTaxonomyWrongFilesStructure': 2,
+            'noInlineXbrlTags': 1,
             # This test is looking at the usage of the target attribute and does not import the correct taxonomy urls
             'requiredEntryPointNotImported': 1,
             'incorrectKvkTaxonomyVersionUsed': 1,
@@ -124,20 +125,16 @@ config = ConformanceSuiteConfig(
             'usableConceptsNotIncludedInDefinitionLink': 1,
         },
         'G5-1-3_1/index.xml:TC1_valid': {
-            'noInlineXbrlTags': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
         },
         'G5-1-3_1/index.xml:TC2_invalid': {
-            'noInlineXbrlTags': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
         },
         'G5-1-3_2/index.xml:TC1_valid': {
-            'noInlineXbrlTags': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
         },
         'G5-1-3_2/index.xml:TC2_invalid': {
             'documentNameDoesNotFollowNamingConvention': 1,
-            'noInlineXbrlTags': 1,
             'requiredEntryPointOtherGaapNotReferenced': 1,
         },
         'RTS_Annex_II_Par_1_RTS_Annex_IV_par_7/index.xml:TC2_valid': {
@@ -177,18 +174,6 @@ config = ConformanceSuiteConfig(
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
             'extensionTaxonomyWrongFilesStructure': 1,
         },
-        'RTS_Art_6_a/index.xml:TC2_invalid': {
-            'usableConceptsNotAppliedByTaggedFacts': 1,
-            'message:existsAtLeastOnce_ChamberOfCommerceRegistrationNumber': 1,
-            'message:existsAtLeastOnce_FinancialReportingPeriod': 1,
-            'message:existsAtLeastOnce_FinancialReportingPeriodEndDate': 1,
-            'message:existsAtLeastOnce_LegalEntityLegalForm': 1,
-            'message:existsAtLeastOnce_LegalEntityName': 1,
-            'message:existsAtLeastOnce_LegalEntityRegisteredOffice': 1,
-            'message:existsOnlyOnce_AuditorsReportFinancialStatementsPresent': 1,
-            'message:existsOnlyOnce_DocumentAdoptionStatus': 1,
-            'message:existsOnlyOnce_FinancialStatementsConsolidated': 1,
-        },
     }.items()},
     expected_failure_ids=frozenset(f"tests/{s}" for s in [
         # Conformance Suite Errors
@@ -199,6 +184,7 @@ config = ConformanceSuiteConfig(
         'G4-4-6_1/index.xml:TC3_invalid',  # Expects UsableConceptsNotAppliedByTaggedFacts.  Note the capital first character.
         'RTS_Annex_III_Par_1/index.xml:TC3_invalid',  # Expects invalidInlineXbrl, but this is valid.
         'RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC4_invalid',  # Expects inconsistentDuplicateNonnumericFactInInlineXbrlDocumentSet, should be inconsistentDuplicateNumericFactInInlineXbrlDocument.
+        'RTS_Art_6_a/index.xml:TC2_invalid',  # Expects noInlineXbrlTags, but kvk-2024-12-31-nl.xhtml has a hidden nonNumeric fact.
 
         # Expects invalidInlineXbrl.  Instead, we depend on the underlying XML Schema and iXBRL validation errors.
         'RTS_Annex_III_Par_1/index.xml:TC2_invalid',

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2025.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2025.py
@@ -63,6 +63,7 @@ config = ConformanceSuiteConfig(
         'G3-5-3_1/index.xml:TC2_invalid': {
             'arelle:ixdsTargetNotDefined': 1,
             'extensionTaxonomyWrongFilesStructure': 2,
+            'noInlineXbrlTags': 1,
             # This test is looking at the usage of the target attribute and does not import the correct taxonomy urls
             'requiredEntryPointNotImported': 1,
             'incorrectKvkTaxonomyVersionUsed': 1,
@@ -130,19 +131,15 @@ config = ConformanceSuiteConfig(
             'usableConceptsNotIncludedInDefinitionLink': 1,
         },
         'G5-1-3_1/index.xml:TC1_valid': {
-            'noInlineXbrlTags': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 4,
         },
         'G5-1-3_1/index.xml:TC2_invalid': {
-            'noInlineXbrlTags': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 4,
         },
         'G5-1-3_2/index.xml:TC1_valid': {
-            'noInlineXbrlTags': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 4,
         },
         'G5-1-3_2/index.xml:TC2_valid': {
-            'noInlineXbrlTags': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,
         },
         'G6-1-3_1/index.xml:TC2_invalid': {
@@ -234,21 +231,9 @@ config = ConformanceSuiteConfig(
         'RTS_Annex_IV_Par_11_G4-2-2_1/index.xml:TC3_invalid': {
             'incompatibleDataTypeAnchoringRelationship': 1,
         },
+        # New variation for 2025
         'RTS_Art_6_a/index.xml:TC2_valid': {
-            'noInlineXbrlTags': 1,
             'usableConceptsNotAppliedByTaggedFacts': 1,
-        },
-        'RTS_Art_6_a/index.xml:TC3_invalid': {
-            'usableConceptsNotAppliedByTaggedFacts': 1,
-            'message:existsAtLeastOnce_ChamberOfCommerceRegistrationNumber': 1,
-            'message:existsAtLeastOnce_FinancialReportingPeriod': 1,
-            'message:existsAtLeastOnce_FinancialReportingPeriodEndDate': 1,
-            'message:existsAtLeastOnce_LegalEntityLegalForm': 1,
-            'message:existsAtLeastOnce_LegalEntityName': 1,
-            'message:existsAtLeastOnce_LegalEntityRegisteredOffice': 1,
-            'message:existsOnlyOnce_AuditorsReportFinancialStatementsPresent': 1,
-            'message:existsOnlyOnce_DocumentAdoptionStatus': 1,
-            'message:existsOnlyOnce_FinancialStatementsConsolidated': 1,
         },
     }.items()},
     expected_failure_ids=frozenset(f"tests/{s}" for s in [
@@ -263,6 +248,7 @@ config = ConformanceSuiteConfig(
         'G5-1-3_2/index.xml:TC3_invalid',  # Expects incorrectVersionEntryPointOtherGaapReferenced, should be incorrectVersionEntryPointOtherReferenced.
         'RTS_Annex_III_Par_1/index.xml:TC3_invalid',  # Expects invalidInlineXbrl, but this is valid.
         'RTS_Annex_IV_Par_12_G3-2-4_1/index.xml:TC4_invalid',  # Expects inconsistentDuplicateNonnumericFactInInlineXbrlDocumentSet, should be inconsistentDuplicateNumericFactInInlineXbrlDocument.
+        'RTS_Art_6_a/index.xml:TC3_invalid',  # Expects noInlineXbrlTags, but kvk-2025-12-31-nl.xhtml has a hidden nonNumeric fact.
 
         # Not Implemented: improperApplicationOfEscapeAttribute
         'G3-2-7_1/index.xml:TC1_valid',


### PR DESCRIPTION
#### Reason for change
The 2025 suite added a new valid testcase: "Annual report with multiple files, some with inline XBRL embedded". This suggests that a filing with inline facts in _any_ of the inline documents passes this validation, whereas the current implementation will fire for each individual inline document that does not contain facts. This correction aligns with the ESEF implementation.

This correction revealed that both the 2024 and 2025 invalid testcases for this rule have errors. Both include a hidden inline XBRL fact (making them logically identical to the valid testcase in the context of this rule), and so are not actually invalid.

#### Steps to Test
CI

**review**:
@Arelle/arelle
