### PR TITLE
Merge PR branch into master for integration tests

### DIFF
--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -1,0 +1,30 @@
+name: 'Merge'
+description: 'Fetches and merges a specific SHA from a fork or branch'
+inputs:
+  commit_sha:
+    description: 'The specific commit SHA to merge'
+    required: true
+  repository_full_name:
+    description: 'The full name of the repository to fetch from (e.g., owner/repo)'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Fetch Remote SHA
+      shell: bash
+      run: |
+        git config user.name "github-actions"
+        git config user.email "github-actions@github.com"
+        
+        echo "Fetching from ${{ inputs.repository_full_name }}..."
+        git fetch https://github.com/${{ inputs.repository_full_name }}.git ${{ inputs.commit_sha }}
+
+    - name: Merge
+      shell: bash
+      run: |
+        echo "Merging SHA ${{ inputs.commit_sha }}..."
+        git merge FETCH_HEAD || {
+          echo "::error::Merge conflict detected."
+          exit 1
+        }

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,8 +26,12 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      # pull_request_target runs in the context of the base repository, so we need to
+      # merge the head branch to test the correct code for the PR.
+      - uses: ./.github/actions/merge
+        with:
+          commit_sha: ${{ github.event.pull_request.head.sha }}
+          repository_full_name: ${{ github.event.pull_request.head.repo.full_name }}
       - id: build-conformance-suite-matrix
         uses: ./.github/actions/get_conformance_suites_matrix
 
@@ -39,8 +43,10 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: ./.github/actions/merge
+        with:
+          commit_sha: ${{ github.event.pull_request.head.sha }}
+          repository_full_name: ${{ github.event.pull_request.head.repo.full_name }}
       - id: build-test-script-matrix
         uses: ./.github/actions/get_test_scripts_matrix
 


### PR DESCRIPTION
#### Reason for change
Using `pull_request_target` means we don't automatically get a merged version of the code to test. 

#### Description of change
We can manually merge the PR head into the base branch to ensure we are testing a merged version of the code. 

Note: This doesn't fix the gap where CI does not re-run when master changes.

#### Steps to Test

- CI on this PR will not reflect these changes.
- Tested on a PR within my fork here: https://github.com/aaroncameron-wk/arelle-public/actions/runs/21638468226?pr=172
- This doesn't test the case of a PR between a fork and a base repo, but we'll know very quickly and can revert this change if that breaks.

**review**:
@Arelle/arelle
