### PR TITLE
Support capturing warnings as errors via Session API

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1038,8 +1038,10 @@ class CntlrCmdLine(Cntlr.Cntlr):
             fo.testcaseExpectedErrors = options.testcaseExpectedErrors
         if options.testcaseFilters:
             fo.testcaseFilters = options.testcaseFilters
+        errorCaptureLevel = None
         if options.testcaseResultsCaptureWarnings:
-            self.errorManager.setErrorCaptureLevel(logging._checkLevel("WARNING"))
+            errorCaptureLevel = logging._checkLevel("WARNING")
+            self.errorManager.setErrorCaptureLevel(errorCaptureLevel)
             fo.testcaseResultsCaptureWarnings = True
         if options.testcaseResultOptions:
             fo.testcaseResultOptions = options.testcaseResultOptions
@@ -1104,7 +1106,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
             modelXbrl = None
             try:
                 if filesource:
-                    modelXbrl = self.modelManager.load(filesource, _("views loading"), entrypoint=_entrypoint)
+                    modelXbrl = self.modelManager.load(filesource, _("views loading"), entrypoint=_entrypoint, errorCaptureLevel=errorCaptureLevel)
                     if filesource.isArchive:
                         # Keep archive filesource potentially used by multiple reports open.
                         modelXbrl.closeFileSource = False


### PR DESCRIPTION
#### Reason for change
While `testcaseResultsCaptureWarnings` is primarily intended for the testcase validation process to collect `WARNING` logs as errors in the `ErrorManager`, we should apply that logic consistently so that Session API users can also collect warnings as errors.

### Description of change
The [testcase validation logic](https://github.com/Arelle/Arelle/blob/bee125f3b600d68ca036675778c4f31c137223c9/arelle/Validate.py#L254-L269) results in `testcaseResultsCaptureWarnings` passing `WARNING` as `errorCaptureLevel` during instance loading, but the `CntlrCmdLine` logic [does not](https://github.com/Arelle/Arelle/blob/bee125f3b600d68ca036675778c4f31c137223c9/arelle/CntlrCmdLine.py#L1041-L1107).

#### Steps to Test
CI

**review**:
@Arelle/arelle
