### PR TITLE
EDINET: Correct EC8023W as warning rather than error

### DIFF
--- a/arelle/plugin/validate/EDINET/rules/upload.py
+++ b/arelle/plugin/validate/EDINET/rules/upload.py
@@ -1189,7 +1189,7 @@ def rule_EC8023W(
 
         if fact.sign == '-' :
             if precedingChar != negativeChar:
-                yield Validation.error(
+                yield Validation.warning(
                     codes='EDINET.EC8023W',
                     msg=_("In an inline XBRL file, if the sign attribute of the ix:nonFraction "
                           "element is set to \"-\" (minus), you must set \"△\" immediately "
@@ -1198,7 +1198,7 @@ def rule_EC8023W(
                 )
         else:
             if precedingChar == negativeChar:
-                yield Validation.error(
+                yield Validation.warning(
                     codes='EDINET.EC8023W',
                     msg=_("In an inline XBRL file, if the sign attribute of the ix:nonFraction "
                           "element is not set to \"-\" (minus), there is no need to set \"△\" "

--- a/tests/resources/conformance_suites/edinet/EC8063W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8063W/index.xml
@@ -18,7 +18,7 @@
         </data>
         <result>
             <error num="2">EDINET.EC5700W.GFM.1.8.4</error>
-            <error num="2">EDINET.EC8023W</error>
+            <warning num="2">EDINET.EC8023W</warning>
             <warning>EDINET.EC2002W</warning>
             <warning>EDINET.EC8027W</warning>
             <warning>EDINET.EC8049W</warning>

--- a/tests/resources/conformance_suites/edinet/EC8065W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8065W/index.xml
@@ -18,7 +18,7 @@
         </data>
         <result>
             <error num="2">EDINET.EC5700W.GFM.1.8.4</error>
-            <error num="2">EDINET.EC8023W</error>
+            <warning num="2">EDINET.EC8023W</warning>
             <warning>EDINET.EC2002W</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8027W</warning>

--- a/tests/resources/conformance_suites/edinet/EC8066W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8066W/index.xml
@@ -18,7 +18,7 @@
         </data>
         <result>
             <error num="2">EDINET.EC5700W.GFM.1.8.4</error>
-            <error num="2">EDINET.EC8023W</error>
+            <warning num="2">EDINET.EC8023W</warning>
             <warning>EDINET.EC2002W</warning>
             <warning>EDINET.EC8027W</warning>
             <warning>EDINET.EC8049W</warning>

--- a/tests/resources/conformance_suites/edinet/EC8067W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8067W/index.xml
@@ -18,7 +18,7 @@
         </data>
         <result>
             <error num="2">EDINET.EC5700W.GFM.1.8.4</error>
-            <error num="2">EDINET.EC8023W</error>
+            <warning num="2">EDINET.EC8023W</warning>
             <warning>EDINET.EC2002W</warning>
             <warning>EDINET.EC8015W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8027W</warning>

--- a/tests/resources/conformance_suites/edinet/EC8068W/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC8068W/index.xml
@@ -18,7 +18,7 @@
         </data>
         <result>
             <error num="2">EDINET.EC5700W.GFM.1.8.4</error>
-            <error num="2">EDINET.EC8023W</error>
+            <warning num="2">EDINET.EC8023W</warning>
             <warning>EDINET.EC2002W</warning>
             <warning>EDINET.EC8027W</warning>
             <warning>EDINET.EC8049W</warning>


### PR DESCRIPTION
#### Description of change
Correct EC8023W as warning rather than error

#### Steps to Test
CI

**review**:
@Arelle/arelle
