### PR TITLE
Fix integration-tests workflow for manual triggering

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,10 +26,11 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.base_ref }}  # Forces the tip of the branch, not the event SHA
+          ref: ${{ github.base_ref || github.ref_name }}  # Forces the tip of the branch, not the event SHA
       # pull_request_target runs in the context of the base repository, so we need to
       # merge the head branch to test the correct code for the PR.
       - uses: ./.github/actions/merge
+        if: github.base_ref != '' # Only run merge if this is a PR run
         with:
           commit_sha: ${{ github.event.pull_request.head.sha }}
           repository_full_name: ${{ github.event.pull_request.head.repo.full_name }}
@@ -44,8 +45,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.base_ref }}  # Forces the tip of the branch, not the event SHA
-      - uses: ./.github/actions/merge
+          ref: ${{ github.base_ref || github.ref_name }}  # Forces the tip of the branch, not the event SHA
+      - uses: ./.github/actions/merge # Only run merge if this is a PR run
+        if: github.base_ref != ''
         with:
           commit_sha: ${{ github.event.pull_request.head.sha }}
           repository_full_name: ${{ github.event.pull_request.head.repo.full_name }}
@@ -65,8 +67,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.base_ref }}  # Forces the tip of the branch, not the event SHA
-      - uses: ./.github/actions/merge
+          ref: ${{ github.base_ref || github.ref_name }}  # Forces the tip of the branch, not the event SHA
+      - uses: ./.github/actions/merge # Only run merge if this is a PR run
+        if: github.base_ref != ''
         with:
           commit_sha: ${{ github.event.pull_request.head.sha }}
           repository_full_name: ${{ github.event.pull_request.head.repo.full_name }}
@@ -98,8 +101,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.base_ref }}  # Forces the tip of the branch, not the event SHA
-      - uses: ./.github/actions/merge
+          ref: ${{ github.base_ref || github.ref_name }}  # Forces the tip of the branch, not the event SHA
+      - uses: ./.github/actions/merge # Only run merge if this is a PR run
+        if: github.base_ref != ''
         with:
           commit_sha: ${{ github.event.pull_request.head.sha }}
           repository_full_name: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
#### Reason for change
Recent changes to the integration-test workflow to support merging the PR branch into latest master broke the workflow for workflow_dispatch.

#### Description of change
- Add fallback checkout ref for non-PR runs
- Skip merge action on non-PR runs

#### Steps to Test
- Confirm subsequent PRs merge correctly ([test on fork with this change on master](https://github.com/aaroncameron-wk/arelle-public/actions/runs/22742092265/job/65957567646?pr=178))
- Run via workflow_dispatch ([test on fork](https://github.com/aaroncameron-wk/arelle-public/actions/runs/22741939967))

**review**:
@Arelle/arelle
