### PR TITLE
NL.NL-KVK.4.4.2.5: Add expected additional error for NL inline 2024

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -162,6 +162,11 @@ config = ConformanceSuiteConfig(
         'RTS_Annex_IV_Par_4_3/index.xml:TC4_invalid': {
             'extensionTaxonomyWrongFilesStructure': 1,
         },
+        'RTS_Annex_IV_Par_5/index.xml:TC3_invalid': {
+            # The circumstance introduced in this testcase that causes extensionTaxonomyLineItemNotLinkedToAnyHypercube
+            # to fire also causes extensionTaxonomyLineItemNotLinkedToDesignatedPlaceholder.
+            'extensionTaxonomyLineItemNotLinkedToDesignatedPlaceholder': 1,
+        },
         'RTS_Annex_IV_Par_6/index.xml:TC2_valid': {
             'undefinedLanguageForTextFact': 1,
             'taggedTextFactOnlyInLanguagesOtherThanLanguageOfAReport': 5,


### PR DESCRIPTION
#### Description of change
Same expected additional error as 2025, but missed due to unrelated CI workflow issue.

#### Steps to Test
CI

**review**:
@Arelle/arelle
