### PR TITLE
Configure EFM 26.1 Expected Failures

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/efm_current.py
@@ -24,7 +24,7 @@ config = ConformanceSuiteConfig(
             source=AssetSource.S3_PUBLIC,
         )
     ],
-    cache_version_id='bY6OmURBAtPB4UALKzz5aeeLlMSKxN9e',
+    cache_version_id='ShpWxxspdHtuQbCApZ2bwkO7.t66OMa3',
     disclosure_system='efm-pragmatic',
     # Failures expected to be resolved when EFM 26.1 conformance suite is published.
     expected_additional_testcase_errors={


### PR DESCRIPTION
#### Reason for change
EDGAR plugin was updated to 26.1 release. Test suite is expected to have failures until the corresponding EFM 26.1 conformance suite is release.

#### Description of change
Configure expected failures.

#### Steps to Test
*CI

**review**:
@Arelle/arelle
