### PR TITLE
Add installation instructions for external plugins

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -56,6 +56,13 @@ See the contributing documentation for [setting up your environment][setting-up-
 if you're comfortable setting up your own Python environment and would like to run
 Arelle from source.
 
+:::{note}
+Some plugins bundled with the [prepackaged distributions](#prepackaged-distributions),
+such as [XULE][xule], [EDGAR][edgar], and the [Arelle iXBRL Viewer][arelle-ixbrl-viewer], are maintained in separate
+repositories and are not included when running from source or when installing the Python package.
+See their documentation for installation instructions.
+:::
+
 [setting-up-your-environment]: project:contributor_guides/contributing.md#setting-up-your-environment
 
 ## Python Package

--- a/docs/source/plugins/popular/arelle_ixbrl_viewer.md
+++ b/docs/source/plugins/popular/arelle_ixbrl_viewer.md
@@ -9,6 +9,22 @@ The [Arelle iXBRL Viewer][github] is an interactive tool developed by the Arelle
 reports in web browsers. It enables users to access and interact with XBRL data embedded in iXBRL reports. This viewer
 is designed with extensibility in mind, allowing users to adapt it to their needs.
 
+## Installation
+
+The iXBRL Viewer is included in Arelle's [prepackaged distributions][prepackaged], so no additional
+installation steps are needed if you are using one of those.
+
+If you installed Arelle [from source][from-source] or via [pip][python-package],
+the iXBRL Viewer plugin is **not** included and must be installed separately:
+
+```shell
+pip install ixbrl-viewer
+```
+
+[prepackaged]: project:../../install.md#prepackaged-distributions
+[from-source]: project:../../install.md#from-python-source
+[python-package]: project:../../install.md#python-package
+
 ## Key Features
 
 - **Interactive Viewing**: Experience interactive viewing of iXBRL reports in any web browser.

--- a/docs/source/plugins/popular/edgar.md
+++ b/docs/source/plugins/popular/edgar.md
@@ -10,6 +10,31 @@ Commission (SEC), is designed to provide traditional and inline XBRL viewers for
 and extends the [EFM Validation plugin][github-validate-efm], offering EFM validation for SEC filings. For end-user support,
 please contact the SEC directly at: [StructuredData@sec.gov][sec-email].
 
+## Installation
+
+The EDGAR plugins are included in Arelle's [prepackaged distributions][prepackaged], so no additional
+installation steps are needed if you are using one of those.
+
+If you installed Arelle [from source][from-source] or via [pip][python-package],
+the EDGAR plugins are **not** included and must be installed separately.
+See the [EDGAR repository][github-edgar] for installation instructions.
+
+Additionally, EDGAR requires some extra Python dependencies. You can install them by running:
+
+```shell
+pip install arelle-release[EFM]
+```
+
+Or if running from source:
+
+```shell
+pip install -r requirements-plugins.txt
+```
+
+[prepackaged]: project:../../install.md#prepackaged-distributions
+[from-source]: project:../../install.md#from-python-source
+[python-package]: project:../../install.md#python-package
+
 ## Key Features
 
 - **XBRL Viewers**: Offers both traditional and inline XBRL viewers for SEC filings.
@@ -39,6 +64,7 @@ The Edgar Renderer can be easily configured through the graphical user interface
 - To access the Renderer, go to `View` > `Edgar Renderer`.
 - To select an EFM disclosure system, navigate to `Tools` > `Validation` > `Disclosure system checks`.
 
+[github-edgar]: https://github.com/Arelle/EDGAR/
 [github-edgar-renderer]: https://github.com/Arelle/EDGAR/tree/master/render
 [github-validate-efm]: https://github.com/Arelle/EDGAR/tree/master/validate
 [sec-email]: mailto:StructuredData@sec.gov

--- a/docs/source/plugins/popular/xule.md
+++ b/docs/source/plugins/popular/xule.md
@@ -11,6 +11,31 @@ rules for SEC filings and FERC rules available in XULE format. It also allows fo
 facts. Utilize the `DQC Rules Validator` and `ESEF DQC Rules Validator` plugins for specific XULE validation rules. For
 more details on XULE and its usage, visit the [XULE plugin readme][readme].
 
+## Installation
+
+XULE is included in Arelle's [prepackaged distributions][prepackaged], so no additional
+installation steps are needed if you are using one of those.
+
+If you installed Arelle [from source][from-source] or via [pip][python-package],
+the XULE plugin is **not** included and must be installed separately.
+See the [XULE plugin README][readme] for installation instructions.
+
+Additionally, XULE requires some extra Python dependencies. You can install them by running:
+
+```shell
+pip install arelle-release[XULE]
+```
+
+Or if running from source:
+
+```shell
+pip install -r requirements-plugins.txt
+```
+
+[prepackaged]: project:../../install.md#prepackaged-distributions
+[from-source]: project:../../install.md#from-python-source
+[python-package]: project:../../install.md#python-package
+
 ## Key Features
 
 - **XBRL Data Querying and Manipulation**: Provides a user-friendly syntax for interacting with XBRL data.


### PR DESCRIPTION
#### Reason for change
EDGAR/Arelle viewer/XULE all require separate plugin installation when running Arelle from source or from a python package install.

#### Description of change
Update docs to include info about external plugin installation.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
