### PR TITLE
Fix false-positive DORA formula filtering across handled dimensions

### DIFF
--- a/arelle/formula/FormulaEvaluator.py
+++ b/arelle/formula/FormulaEvaluator.py
@@ -748,11 +748,11 @@ def trialFilterFacts(xpCtx, vb, facts, filterRelationships, filterType, var=None
             # filter now with filter info
             outFacts = set()
             for fact in facts:
-                if fact.isItem:
-                    for varFilterRel, dimQname in noComplHandledFilterRels:
-                        dim = fact.context.qnameDims.get(dimQname)
-                        if dim is not None:
-                            outFacts.add(fact)
+                if (
+                    fact.isItem
+                    and all(fact.context.qnameDims.get(dimQname) is not None for _, dimQname in noComplHandledFilterRels)
+                ):
+                    outFacts.add(fact)
             facts = outFacts
             if len(facts) == 0:
                 return facts
@@ -799,11 +799,11 @@ def trialFilterFacts(xpCtx, vb, facts, filterRelationships, filterType, var=None
             # filter now with filter info
             outFacts = set()
             for fact in facts:
-                if fact.isItem:
-                    for varFilterRel, dimQname in complHandledFilterRels:
-                        dim = fact.context.qnameDims.get(dimQname)
-                        if dim is None:
-                            outFacts.add(fact)
+                if (
+                    fact.isItem
+                    and all(fact.context.qnameDims.get(dimQname) is None for _, dimQname in complHandledFilterRels)
+                ):
+                    outFacts.add(fact)
             facts = outFacts
     return facts
 

--- a/tests/unit_tests/arelle/formula/test_formula_evaluator.py
+++ b/tests/unit_tests/arelle/formula/test_formula_evaluator.py
@@ -1,0 +1,145 @@
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import arelle.ModelFormulaObject
+from arelle.ModelValue import qname
+from arelle.formula import FormulaEvaluator
+from arelle.formula.FormulaEvaluator import VariableBinding, trialFilterFacts
+
+
+@dataclass
+class DummyBoundFact:
+    context: str
+
+
+@dataclass
+class DummyContext:
+    qnameDims: dict
+
+
+class DummyItemFact:
+    def __init__(self, name: str, dims: dict) -> None:
+        self.name = name
+        self.isItem = True
+        self.context = DummyContext(dims)
+
+
+class DummyFilter:
+    def aspectsCovered(self, var_binding) -> set:
+        return set()
+
+
+def _handled_filter_rel(dim) -> tuple:
+    return (
+        SimpleNamespace(
+            toModelObject=DummyFilter(),
+            isCovered=False,
+        ),
+        dim,
+    )
+
+
+def _group_filter_var_set(no_compl_dims: tuple = (), compl_dims: tuple = ()) -> SimpleNamespace:
+    return SimpleNamespace(
+        filterInfo=True,
+        noComplHandledFilterRels=[_handled_filter_rel(dim) for dim in no_compl_dims],
+        complHandledFilterRels=[_handled_filter_rel(dim) for dim in compl_dims],
+        unHandledFilterRels=[],
+    )
+
+
+def test_fact_variable_evaluation_results_yield_fallback_after_facts_exist() -> None:
+    vb = VariableBinding.__new__(VariableBinding)
+    vb.isFactVar = True
+    vb.isBindAsSequence = False
+    vb.facts = [DummyBoundFact("c1")]
+    vb.values = ["fallback"]
+    vb.yieldedFact = None
+    vb.yieldedFactContext = None
+    vb.yieldedEvaluation = None
+    vb.isFallback = False
+
+    results = list(vb.evaluationResults)
+
+    assert results == [vb.facts[0], vb.values]
+
+
+def test_fact_variable_evaluation_results_yield_fallback_when_sequence_binding_has_no_matches(monkeypatch) -> None:
+    vb = VariableBinding.__new__(VariableBinding)
+    vb.isFactVar = True
+    vb.isBindAsSequence = True
+    vb.facts = [DummyBoundFact("c1")]
+    vb.values = ["fallback"]
+    vb.aspectsDefined = set()
+    vb.aspectsCovered = set()
+    vb.xpCtx = SimpleNamespace()
+    vb.matchesSubPartitions = lambda partition, aspects: iter(())
+    vb.yieldedFact = None
+    vb.yieldedFactContext = None
+    vb.yieldedEvaluation = None
+    vb.isFallback = False
+
+    monkeypatch.setattr(FormulaEvaluator, "factsPartitions", lambda xpCtx, facts, aspects: [facts])
+
+    results = list(vb.evaluationResults)
+
+    assert results == [vb.values]
+
+
+def test_fact_variable_evaluation_results_yield_fallback_for_sequence_binding_with_matches(monkeypatch) -> None:
+    fact = DummyBoundFact("c1")
+    vb = VariableBinding.__new__(VariableBinding)
+    vb.isFactVar = True
+    vb.isBindAsSequence = True
+    vb.facts = [fact]
+    vb.values = ["fallback"]
+    vb.aspectsDefined = set()
+    vb.aspectsCovered = set()
+    vb.xpCtx = SimpleNamespace()
+    vb.matchesSubPartitions = lambda partition, aspects: iter(((fact,),))
+    vb.yieldedFact = None
+    vb.yieldedFactContext = None
+    vb.yieldedEvaluation = None
+    vb.isFallback = False
+
+    monkeypatch.setattr(FormulaEvaluator, "factsPartitions", lambda xpCtx, facts, aspects: [facts])
+
+    results = list(vb.evaluationResults)
+
+    assert results == [(fact,), vb.values]
+
+
+def test_trial_filter_facts_requires_all_non_complement_dimensions() -> None:
+    dim_a = qname("{http://example.com}a")
+    dim_b = qname("{http://example.com}b")
+    fact_with_both = DummyItemFact("both", {dim_a: object(), dim_b: object()})
+    fact_with_one = DummyItemFact("one", {dim_a: object()})
+
+    result = trialFilterFacts(
+        xpCtx=SimpleNamespace(),
+        vb=SimpleNamespace(aspectsCovered=set()),
+        facts={fact_with_both, fact_with_one},
+        filterRelationships=[],
+        filterType="group",
+        varSet=_group_filter_var_set(no_compl_dims=(dim_a, dim_b)),
+    )
+
+    assert result == {fact_with_both}
+
+
+def test_trial_filter_facts_requires_all_complement_dimensions_to_be_absent() -> None:
+    dim_a = qname("{http://example.com}a")
+    dim_b = qname("{http://example.com}b")
+    fact_with_none = DummyItemFact("none", {})
+    fact_with_one = DummyItemFact("one", {dim_a: object()})
+
+    result = trialFilterFacts(
+        xpCtx=SimpleNamespace(),
+        vb=SimpleNamespace(aspectsCovered=set()),
+        facts={fact_with_none, fact_with_one},
+        filterRelationships=[],
+        filterType="group",
+        varSet=_group_filter_var_set(compl_dims=(dim_a, dim_b)),
+    )
+
+    assert result == {fact_with_none}


### PR DESCRIPTION
#### Reason for change

Arelle was producing false-positive DORA validation failures on xBRL-CSV reports for `B_05.01` assertions such as `v8851_m_0` through `v8855_m_0`, even when the row data satisfied the rules.

The reproduced pattern was that facts expected for a single `B_05.01` row were present in the instance, but formula evaluation was allowing facts from a different dimensional signature to survive filtering and interfere with the assertion bindings.

#### Description of change

This PR makes one formula-evaluator change and adds focused unit coverage around related fallback behavior.

In `trialFilterFacts()`:
- require all non-complement handled dimensions to be present for the optimized handled-dimension path
- require all complement handled dimensions to be absent for the optimized complement path

This changes the optimized path from effectively matching any handled dimension to matching the full handled-dimension signature intended by the group filters.

The PR also adds focused unit tests covering:
- fallback after a non-sequence fact variable already yields a fact evaluation
- fallback use when sequence binding has candidate facts but yields no matching evaluation
- fallback preservation when sequence binding yields a matching sequence evaluation
- handled-dimension optimization requiring all non-complement dimensions
- handled-dimension complement optimization requiring all complemented dimensions to be absent

These fallback-related tests are included as regression guards for existing Formula 1.0 bind-empty behavior. After the CI-guided removals of the earlier `implicitFilter()` and `evaluationResults()` experiments, the `trialFilterFacts()` handled-dimension change is the only net-new formula-evaluator behavior change.

#### Steps to Test

1. Run the focused unit tests:
   ```bash
   .venv/bin/python -m pytest tests/unit_tests/arelle/formula/test_formula_evaluator.py -q
   ```
2. Validate a DORA xBRL-CSV report that previously showed false-positive `B_05.01` assertion failures:
   ```bash
   .venv/bin/python arelleCmdLine.py \
     -f report.json \
     -v \
     --internetConnectivity offline \
     --logFile /tmp/arelle-validation.log \
     --logFileMode w \
     --logFormat '[%(messageCode)s] %(message)s'
   ```
3. Confirm that the report no longer produces false-positive `v8851_m_0` through `v8855_m_0` messages.
4. As a regression control, run the Formula 1.0 conformance shard covering `22180 Bind To Empty Sequence` and confirm those cases still pass.

**review**:
@Arelle/arelle
