### PR TITLE
Add descriptive prefix error messages

### DIFF
--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -117,7 +117,10 @@ def qname(
             namespaceURI = "http://www.w3.org/XML/1998/namespace"
     if not namespaceURI:
         if prefix:
-            if prefixException: raise prefixException
+            if prefixException:
+                if isinstance(prefixException, type):
+                    raise prefixException(f"prefix '{prefix}' is not defined in namespace map.")
+                raise prefixException
             return None  # error, prefix not found
         namespaceURI = None # cancel namespace if it is a zero length string
     return QName(prefix, namespaceURI, localName)
@@ -146,7 +149,7 @@ def qnameEltPfxName(
     | ModelInlineFact
     | ModelObject,
     prefixedName: str,
-    prefixException: type[Exception] | None = None,
+    prefixException: Exception | type[Exception] | None = None,
 ) -> QName | None:
     prefix: str | None
     namespaceURI: str | None
@@ -166,7 +169,10 @@ def qnameEltPfxName(
             if prefix == 'xml':
                 namespaceURI = "http://www.w3.org/XML/1998/namespace"
             else:
-                if prefixException: raise prefixException
+                if prefixException:
+                    if isinstance(prefixException, type):
+                        raise prefixException(f"prefix '{prefix}' is not defined in namespace map.")
+                    raise prefixException
                 return None
         else:
             namespaceURI = None # cancel namespace if it is a zero length string


### PR DESCRIPTION
#### Reason for change
Unmapped prefix errors aren't informative:

```
[xmlSchema:valueError] Element xbrli:measure type QName value error: p:testPure,  - p-20260318.htm 4
```

#### Description of change
Updated `qname` and `qnameEltPfxName` in `ModelValue.py` to include a descriptive message when raising a `prefixException` that is passed as a type (e.g. `ValueError`), indicating which prefix was not found in the namespace map.

#### Steps to Test
* Use [filing_documents.zip](https://github.com/user-attachments/files/26095261/filing_documents.zip)
* `python arelleCmdLine.py --file filing_documents.zip --validate`
* Confirm prefix map info is included in error message:

```
[xmlSchema:valueError] Element xbrli:measure type QName value error: p:testPure, prefix 'p' is not defined in namespace map. - p-20260318.htm 4
```

**review**:
@Arelle/arelle
