### PR TITLE
Fix TypeError in CALC 1.1 validation

### DIFF
--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -138,7 +138,7 @@ class ValidateXbrlCalcs:
             oimErrs = set()
             for i in range(len(modelXbrl.errors) - 1, -1, -1):
                 e = modelXbrl.errors[i]
-                if e in oimXbrlxeBlockingErrorCodes:
+                if isinstance(e, str) and e in oimXbrlxeBlockingErrorCodes:
                     del modelXbrl.errors[i] # remove the oim errors from modelXbrl.errors
                 oimErrs.add(e)
             if any(e == "xbrlxe:unsupportedTuple" for e in oimErrs):


### PR DESCRIPTION
#### Reason for change
Fixes #2253

#### Description of change
`modelXbrl.errors` can contain dict objects, filter errors by str types before checking if in set of strings.

#### Steps to Test
* CI
* No test doc, but this is a straightforward error

**review**:
@Arelle/arelle
