### PR TITLE
Merge action: --deepen instead of --depth

### DIFF
--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -26,10 +26,10 @@ runs:
         git config user.email "github-actions@github.com"
         
         echo "Fetching $SHA from $REPO with depth $DEPTH..."
-        git fetch --quiet --deepen="$DEPTH" "https://github.com/$REPO.git" "$SHA"
+        git fetch --deepen="$DEPTH" "https://github.com/$REPO.git" "$SHA"
 
         echo "Deepening base branch history to depth $DEPTH..."
-        git fetch --quiet --deepen="$DEPTH" origin
+        git fetch --deepen="$DEPTH" origin
 
         git merge "$SHA" --no-edit || {
           echo "::error::Merge failed. Ancestor not found within $DEPTH commits or a conflict exists."


### PR DESCRIPTION
#### Reason for change
`--depth` gives git some flexibility in whether or not it will actually deepen commit history. `--deepen` is more explicit.

#### Steps to Test
- [x] Recreated [merge failure](https://github.com/Arelle/Arelle/actions/runs/23501391828/job/68397113182?pr=2271) locally, confirmed `--deepen` fixes the issue.

**review**:
@Arelle/arelle
