### PR TITLE
Fix HMRC conformance suite case mismatch in ignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,7 +33,7 @@ tests/resources/conformance_suites/*
 !tests/resources/conformance_suites/cipc/
 !tests/resources/conformance_suites/dba_*
 !tests/resources/conformance_suites/edinet/
-!tests/resources/conformance_suites/hmrc/
+!tests/resources/conformance_suites/HMRC/
 !tests/resources/conformance_suites/nl_*/
 !tests/resources/conformance_suites/ros/
 tests/resources/packages/

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ tests/resources/conformance_suites/*
 !tests/resources/conformance_suites/cipc/
 !tests/resources/conformance_suites/dba_*
 !tests/resources/conformance_suites/edinet/
-!tests/resources/conformance_suites/hmrc/
+!tests/resources/conformance_suites/HMRC/
 !tests/resources/conformance_suites/nl_*/
 !tests/resources/conformance_suites/ros/
 tests/resources/packages/


### PR DESCRIPTION
#### Reason for change
The negation pattern used lowercase `hmrc` but the actual directory is `HMRC`. On Linux filesystems, this caused the Docker build to exclude tracked HMRC test files from the build context, making the git working tree appear dirty to `setuptools-scm` and producing [a dev version instead of tagged release](https://github.com/Arelle/Arelle/actions/runs/23512349337/job/68440406154) versions.

#### Description of change
Fix `.gitignore` and `.dockerignore` entry.

#### Steps to Test
* `git tag 9.9.9`
* `docker build --build-arg OPENSSL_VERSION=3.6.0 --build-arg PYTHON_VERSION=3.14.3 --load --tag arelle:test --file docker/ubuntu.Dockerfile .`
* `docker create --name arelle-test arelle:test`
* `docker cp arelle-test:/build/dist/ dist/`
* `test -f dist/arelle-ubuntu-9.9.9.tgz && echo "PASS" || echo "FAIL"`

**review**:
@Arelle/arelle
