### PR TITLE
Tcl/Tk 9.0 Compatibility

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -201,13 +201,13 @@ class CntlrWinMain (Cntlr.Cntlr):
         validateMenu.add_command(label=_("Validate"), underline=0, command=self.validate)
         self.modelManager.validateDisclosureSystem = self.config.setdefault("validateDisclosureSystem",False)
         self.validateDisclosureSystem = BooleanVar(value=self.modelManager.validateDisclosureSystem)
-        self.validateDisclosureSystem.trace("w", self.setValidateDisclosureSystem)
+        self.validateDisclosureSystem.trace_add("write", self.setValidateDisclosureSystem)
         validateMenu.add_checkbutton(label=_("Disclosure system checks"), underline=0, variable=self.validateDisclosureSystem, onvalue=True, offvalue=False)
         validateMenu.add_command(label=_("Select disclosure system..."), underline=0, command=self.selectDisclosureSystem)
         calcMenu = Menu(self.menubar, tearoff=0)
         self.modelManager.validateCalcs = self.config.setdefault("validateCalcsEnum", CalcsMode.NONE)
         self.calcChoiceEnumVar = IntVar(self.parent, value=self.modelManager.validateCalcs)
-        self.calcChoiceEnumVar.trace("w", self.setCalcChoiceEnumVar)
+        self.calcChoiceEnumVar.trace_add("write", self.setCalcChoiceEnumVar)
         for calcChoiceMenuLabel, calcChoiceEnumValue in CalcsMode.menu().items():
             calcMenu.add_radiobutton(label=calcChoiceMenuLabel, underline=0, var=self.calcChoiceEnumVar, value=calcChoiceEnumValue)
         toolsMenu.add_cascade(label=_("Calc linkbase"), menu=calcMenu, underline=0)
@@ -216,29 +216,29 @@ class CntlrWinMain (Cntlr.Cntlr):
         baseValidationModeName = self.config.setdefault("baseTaxonomyValidationMode", ValidateBaseTaxonomiesMode.DISCLOSURE_SYSTEM.value)
         self.modelManager.baseTaxonomyValidationMode = ValidateBaseTaxonomiesMode.fromName(baseValidationModeName)
         self.baseTaxonomyValidationModeEnumVar = StringVar(self.parent, value=baseValidationModeName)
-        self.baseTaxonomyValidationModeEnumVar.trace("w", self.setBaseTaxonomyValidationModeEnumVar)
+        self.baseTaxonomyValidationModeEnumVar.trace_add("write", self.setBaseTaxonomyValidationModeEnumVar)
         for modeLabel, modeValue in ValidateBaseTaxonomiesMode.menu().items():
             baseValidateModeMenu.add_radiobutton(label=modeLabel, underline=0, var=self.baseTaxonomyValidationModeEnumVar, value=modeValue)
         validateMenu.add_cascade(label=_("Base taxonomy validation"), menu=baseValidateModeMenu, underline=0)
 
         self.modelManager.validateUtr = self.config.setdefault("validateUtr",True)
         self.validateUtr = BooleanVar(value=self.modelManager.validateUtr)
-        self.validateUtr.trace("w", self.setValidateUtr)
+        self.validateUtr.trace_add("write", self.setValidateUtr)
         validateMenu.add_checkbutton(label=_("Unit Type Registry validation"), underline=0, variable=self.validateUtr, onvalue=True, offvalue=False)
 
         self.modelManager.validateXmlOim = self.config.setdefault("validateXmlOim", False)
         self.validateXmlOim = BooleanVar(value=self.modelManager.validateXmlOim)
-        self.validateXmlOim.trace("w", self.setValidateXmlOim)
+        self.validateXmlOim.trace_add("write", self.setValidateXmlOim)
         validateMenu.add_checkbutton(label=_("OIM validate xBRL-XML documents"), underline=0, variable=self.validateXmlOim, onvalue=True, offvalue=False)
 
         self.modelManager.validateAllFilesAsReportPackages = self.config.setdefault("validateAllFilesAsReportPackages", False)
         self.validateAllFilesAsReportPackages = BooleanVar(value=self.modelManager.validateAllFilesAsReportPackages)
-        self.validateAllFilesAsReportPackages.trace("w", self.setValidateAllFilesAsReportPackages)
+        self.validateAllFilesAsReportPackages.trace_add("write", self.setValidateAllFilesAsReportPackages)
         validateMenu.add_checkbutton(label=_("Validate all files as Report Packages"), underline=0, variable=self.validateAllFilesAsReportPackages, onvalue=True, offvalue=False)
 
         self.modelManager.validateAllFilesAsTaxonomyPackages = self.config.setdefault("validateAllFilesAsTaxonomyPackages", False)
         self.validateAllFilesAsTaxonomyPackages = BooleanVar(value=self.modelManager.validateAllFilesAsTaxonomyPackages)
-        self.validateAllFilesAsTaxonomyPackages.trace("w", self.setValidateAllFilesAsTaxonomyPackages)
+        self.validateAllFilesAsTaxonomyPackages.trace_add("write", self.setValidateAllFilesAsTaxonomyPackages)
         validateMenu.add_checkbutton(label=_("Validate all files as Taxonomy Packages"), underline=0, variable=self.validateAllFilesAsTaxonomyPackages, onvalue=True, offvalue=False)
 
         self.validateDuplicateFacts = None
@@ -267,20 +267,20 @@ class CntlrWinMain (Cntlr.Cntlr):
         toolsMenu.add_cascade(label=_("Internet"), menu=cacheMenu, underline=0)
         self.webCache.workOffline  = self.config.setdefault("workOffline",False)
         self.workOffline = BooleanVar(value=self.webCache.workOffline)
-        self.workOffline.trace("w", self.setWorkOffline)
+        self.workOffline.trace_add("write", self.setWorkOffline)
         cacheMenu.add_checkbutton(label=_("Work offline"), underline=0, variable=self.workOffline, onvalue=True, offvalue=False)
         self.webCache.noCertificateCheck = self.config.setdefault("noCertificateCheck",False) # resets proxy handler stack if true
         self.noCertificateCheck = BooleanVar(value=self.webCache.noCertificateCheck)
-        self.noCertificateCheck.trace("w", self.setNoCertificateCheck)
+        self.noCertificateCheck.trace_add("write", self.setNoCertificateCheck)
         cacheMenu.add_checkbutton(label=_("No certificate check"), underline=0, variable=self.noCertificateCheck, onvalue=True, offvalue=False)
         '''
         self.webCache.recheck  = self.config.setdefault("webRecheck",False)
         self.webRecheck = BooleanVar(value=self.webCache.webRecheck)
-        self.webRecheck.trace("w", self.setWebRecheck)
+        self.webRecheck.trace_add("write", self.setWebRecheck)
         cacheMenu.add_checkbutton(label=_("Recheck file dates weekly"), underline=0, variable=self.workOffline, onvalue=True, offvalue=False)
         self.webCache.notify  = self.config.setdefault("",False)
         self.downloadNotify = BooleanVar(value=self.webCache.retrievalNotify)
-        self.downloadNotify.trace("w", self.setRetrievalNotify)
+        self.downloadNotify.trace_add("write", self.setRetrievalNotify)
         cacheMenu.add_checkbutton(label=_("Notify file downloads"), underline=0, variable=self.workOffline, onvalue=True, offvalue=False)
         '''
 
@@ -289,7 +289,7 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.internetRecheckVar = StringVar(value=self.webCache.recheck)
         self._internetRecheckLabel = _("Internet recheck Interval")
         _recheck_initial = 'disable' if self.webCache.workOffline else 'normal'
-        self.internetRecheckVar.trace("w", self.setInternetRecheck)
+        self.internetRecheckVar.trace_add("write", self.setInternetRecheck)
 
         _internetRecheckEntries = ((_("daily"), "daily"), (_("weekly"), "weekly"), (_("monthly"), "monthly"), (_("never"), "never"))
 
@@ -317,12 +317,12 @@ class CntlrWinMain (Cntlr.Cntlr):
         logmsgMenu.add_command(label=_("Save to file"), underline=0, command=self.logSaveToFile)
         self.modelManager.collectProfileStats = self.config.setdefault("collectProfileStats",False)
         self.collectProfileStats = BooleanVar(value=self.modelManager.collectProfileStats)
-        self.collectProfileStats.trace("w", self.setCollectProfileStats)
+        self.collectProfileStats.trace_add("write", self.setCollectProfileStats)
         logmsgMenu.add_checkbutton(label=_("Collect profile stats"), underline=0, variable=self.collectProfileStats, onvalue=True, offvalue=False)
         logmsgMenu.add_command(label=_("Log profile stats"), underline=0, command=self.showProfileStats)
         logmsgMenu.add_command(label=_("Clear profile stats"), underline=0, command=self.clearProfileStats)
         self.showDebugMessages = BooleanVar(value=self.config.setdefault("showDebugMessages",False))
-        self.showDebugMessages.trace("w", self.setShowDebugMessages)
+        self.showDebugMessages.trace_add("write", self.setShowDebugMessages)
         logmsgMenu.add_checkbutton(label=_("Show debug messages"), underline=0, variable=self.showDebugMessages, onvalue=True, offvalue=False)
 
         toolsMenu.add_command(label=_("Language..."), underline=0, command=lambda: DialogLanguage.askLanguage(self))
@@ -541,7 +541,7 @@ class CntlrWinMain (Cntlr.Cntlr):
             duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(defaultArg)
         self.modelManager.validateDuplicateFacts = duplicateTypeArg.duplicateType()
         self.validateDuplicateFacts = StringVar(value=duplicateTypeArg.value)
-        self.validateDuplicateFacts.trace("w", self.setValidateDuplicateFacts)
+        self.validateDuplicateFacts.trace_add("write", self.setValidateDuplicateFacts)
         duplicateFactWarningMenu = Menu(validateMenu, tearoff=0)
         for duplicateTypeArg in ValidateDuplicateFacts.DuplicateTypeArg:
             duplicateFactWarningMenu.add_checkbutton(

--- a/arelle/DialogUserPassword.py
+++ b/arelle/DialogUserPassword.py
@@ -153,7 +153,7 @@ class DialogUserPassword(Toplevel):
                                          "       with user and password (if provided)"
                                          ).format(hostProxy), wraplength=360)
             self.useOsProxyCb = useOsProxyCb
-            useOsProxyCb.valueVar.trace("w", self.setEnabledState)
+            useOsProxyCb.valueVar.trace_add("write", self.setEnabledState)
 
             y += 1
         if showUrl:

--- a/arelle/UiUtil.py
+++ b/arelle/UiUtil.py
@@ -173,7 +173,7 @@ class gridCell(Entry):
     def __init__(self, master, x, y, value="", width=None, justify=None, objectId=None, onClick=None):
         Entry.__init__(self, master=master)
         self.valueVar = StringVar()
-        self.valueVar.trace('w', self.valueChanged)
+        self.valueVar.trace_add('write', self.valueChanged)
         self.config(textvariable=self.valueVar,
                     #relief="ridge",
                     #bg="#ff8ff8ff8", fg="#000000000",
@@ -217,7 +217,7 @@ class gridCombobox(_Combobox):
         _Combobox.__init__(self, master=master)
         self.attr = attr
         self.valueVar = StringVar()
-        self.valueVar.trace('w', self.valueChanged)
+        self.valueVar.trace_add('write', self.valueChanged)
         self.config(textvariable=self.valueVar,
                     background="#ff8ff8ff8", foreground="#000000000",
                    # justify='center'
@@ -282,7 +282,7 @@ class checkbox(Checkbutton):
         self.attr = attr
         self.onclick = onclick
         self.valueVar = StringVar()
-        self.valueVar.trace('w', self.valueChanged)
+        self.valueVar.trace_add('write', self.valueChanged)
         Checkbutton.__init__(self, master=master, text=text, variable=self.valueVar)
         self.grid(column=x, row=y, sticky=W, padx=24)
         if columnspan:

--- a/arelle/ViewWinFactGrid.py
+++ b/arelle/ViewWinFactGrid.py
@@ -20,9 +20,9 @@ def viewFactsGrid(modelXbrl, tabWin, header="Fact Grid", arcrole=XbrlConst.paren
         # context menu
         menu = view.contextMenu()
         optionsMenu = Menu(view.viewFrame, tearoff=0)
-        view.ignoreDims.trace("w", view.view)
+        view.ignoreDims.trace_add("write", view.view)
         optionsMenu.add_checkbutton(label=_("Ignore Dimensions"), underline=0, variable=view.ignoreDims, onvalue=True, offvalue=False)
-        view.showDimDefaults.trace("w", view.view)
+        view.showDimDefaults.trace_add("write", view.view)
         optionsMenu.add_checkbutton(label=_("Show Dimension Defaults"), underline=0, variable=view.showDimDefaults, onvalue=True, offvalue=False)
         menu.add_cascade(label=_("Options"), menu=optionsMenu, underline=0)
         menu.add_cascade(label=_("Close"), underline=0, command=view.close)

--- a/arelle/ViewWinFactTable.py
+++ b/arelle/ViewWinFactTable.py
@@ -27,7 +27,7 @@ def viewFacts(modelXbrl, tabWin, header="Fact Table", arcrole=XbrlConst.parentCh
     # languages menu
     menu = view.contextMenu()
     optionsMenu = Menu(view.viewFrame, tearoff=0)
-    view.ignoreDims.trace("w", view.viewReloadDueToMenuAction)
+    view.ignoreDims.trace_add("write", view.viewReloadDueToMenuAction)
     optionsMenu.add_checkbutton(label=_("Ignore Dimensions"), underline=0, variable=view.ignoreDims, onvalue=True, offvalue=False)
     menu.add_cascade(label=_("Options"), menu=optionsMenu, underline=0)
     view.menuAddExpandCollapse()

--- a/arelle/ViewWinRenderedGrid.py
+++ b/arelle/ViewWinRenderedGrid.py
@@ -70,7 +70,7 @@ def viewRenderedGrid(modelXbrl, tabWin, lang=None):
     optionsMenu = Menu(view.viewFrame, tearoff=0)
     optionsMenu.add_command(label=_("New fact item options"), underline=0, command=lambda: getNewFactItemOptions(modelXbrl.modelManager.cntlr, view.newFactItemOptions))
     optionsMenu.add_command(label=_("Open breakdown entry rows"), underline=0, command=view.setOpenBreakdownEntryRows)
-    view.ignoreDimValidity.trace("w", view.viewReloadDueToMenuAction)
+    view.ignoreDimValidity.trace_add("write", view.viewReloadDueToMenuAction)
     optionsMenu.add_checkbutton(label=_("Ignore Dimensional Validity"), underline=0, variable=view.ignoreDimValidity, onvalue=True, offvalue=False)
     menu.add_cascade(label=_("Options"), menu=optionsMenu, underline=0)
     view.tablesMenu = Menu(view.viewFrame, tearoff=0)

--- a/arelle/archive/plugin/validateTableInfoset.py
+++ b/arelle/archive/plugin/validateTableInfoset.py
@@ -14,7 +14,7 @@ def validateTableInfosetMenuEntender(cntlr, validateMenu):
     generateTableInfoset = BooleanVar(value=cntlr.modelManager.generateTableInfoset)
     def setTableInfosetOption(*args):
         cntlr.config["generateTableInfoset"] = cntlr.modelManager.generateTableInfoset = generateTableInfoset.get()
-    generateTableInfoset.trace("w", setTableInfosetOption)
+    generateTableInfoset.trace_add("write", setTableInfosetOption)
     validateMenu.add_checkbutton(label=_("Generate table infosets (instead of diffing them)"),
                                  underline=0,
                                  variable=generateTableInfoset, onvalue=True, offvalue=False)


### PR DESCRIPTION
#### Reason for change
The Arelle GUI silently crashes on startup with Tcl/Tk 9.0, which removed the deprecated trace variable function. Python's `tkinter.Variable.trace("w", ...)` relies on this command.

#### Description of change
Replace all `.trace("w", ...)` calls with `.trace_add("write", ...)` across the GUI codebase. `trace_add` has been available since Python 3.6 and works with both Tcl/Tk 8.6 and 9.0.

#### Steps to Test
* [x] Confirm GUI doesn't crash on Tcl/Tk 8.6 or 9.0

**review**:
@Arelle/arelle
