### PR TITLE
Fix No Entry Points in Archive Error Message

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -878,9 +878,6 @@ class CntlrWinMain (Cntlr.Cntlr):
             entrypointFiles = entrypointParseResult.entrypointFiles
             # check for archive files
             if filesource.isArchive:
-                filenameWithoutFakeIxdsPrefix = UrlUtil.stripIxdsSurrogatePrefix(filename)
-                if all(e.get("file") == filenameWithoutFakeIxdsPrefix for e in entrypointFiles):
-                    entrypointFiles = []
                 if (
                     len(entrypointFiles) == 0 and
                     not filesource.selection and

--- a/arelle/plugin/loadFromExcel.py
+++ b/arelle/plugin/loadFromExcel.py
@@ -1866,6 +1866,11 @@ def loadFromExcel(cntlr, modelXbrl, excelFile, mappedUri):
 def isExcelPath(filepath):
     return os.path.splitext(filepath)[1] in (".xlsx", ".xls", ".xlsm")
 
+def excelEntrypointFiles(filesource, inlineOnly):
+    if not inlineOnly and isExcelPath(filesource.url):
+        return [{"file": filesource.url}]
+    return None
+
 def isExcelLoadable(modelXbrl, mappedUri, normalizedUri, filepath, **kwargs):
     return isExcelPath(filepath)
 
@@ -2009,6 +2014,7 @@ __pluginInfo__ = {
     'author': authorLabel,
     'copyright': copyrightLabel,
     # classes of mount points (required)
+    'FileSource.EntrypointFiles': excelEntrypointFiles,
     'ModelDocument.IsPullLoadable': isExcelLoadable,
     'ModelDocument.PullLoader': excelLoader,
     'CntlrWinMain.Xbrl.Loaded': guiXbrlLoaded,

--- a/arelle/utils/EntryPointDetection.py
+++ b/arelle/utils/EntryPointDetection.py
@@ -79,9 +79,8 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False
         if filesource.isTaxonomyPackage:  # if archive is also a taxonomy package, activate mappings
             filesource.loadTaxonomyPackageMappings()
         # HF note: a web api request to load a specific file from archive is ignored, is this right?
-        discoveredEntrypointFiles = []
+        del entrypointFiles[:]
         if reportPackage := filesource.reportPackage:
-            del entrypointFiles[:]
             assert isinstance(filesource.basefile, str)
             for report in reportPackage.reports or []:
                 if report.isInline:
@@ -92,9 +91,9 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False
                         ixdsDiscovered = True
                     if not ixdsDiscovered and len(reportEntries) > 1:
                         raise RuntimeError(_("Loading error. Inline document set encountered. Enable 'InlineXbrlDocumentSet' plug-in to load this filing: {0}").format(filesource.url))
-                    discoveredEntrypointFiles.extend(reportEntries)
+                    entrypointFiles.extend(reportEntries)
                 elif not inlineOnly:
-                    discoveredEntrypointFiles.append({"file": report.fullPathPrimary})
+                    entrypointFiles.append({"file": report.fullPathPrimary})
         elif fallbackSelect:
             # attempt to find inline XBRL files before instance files, .xhtml before probing others (ESMA)
             urlsByType = {}
@@ -106,25 +105,20 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False
             # use inline instances, if any, else non-inline instances
             for identifiedType in ((ModelDocumentType.INLINEXBRL,) if inlineOnly else (ModelDocumentType.INLINEXBRL, ModelDocumentType.INSTANCE)):
                 for url in urlsByType.get(identifiedType, []):
-                    discoveredEntrypointFiles.append({"file":url})
-                if discoveredEntrypointFiles:
+                    entrypointFiles.append({"file":url})
+                if entrypointFiles:
                     if identifiedType == ModelDocumentType.INLINEXBRL:
                         for pluginXbrlMethod in filesource.pluginClassMethods("InlineDocumentSet.Discovery"):
-                            pluginXbrlMethod(filesource, discoveredEntrypointFiles) # group into IXDS if plugin feature is available
+                            pluginXbrlMethod(filesource, entrypointFiles) # group into IXDS if plugin feature is available
                     break # found inline (or non-inline) entrypoint files, don't look for any other type
             # for ESEF non-consolidated xhtml documents accept an xhtml entry point
-            if not discoveredEntrypointFiles and not inlineOnly:
+            if not entrypointFiles and not inlineOnly:
                 for url in urlsByType.get(ModelDocumentType.HTML, []):
-                    discoveredEntrypointFiles.append({"file":url})
-            if not discoveredEntrypointFiles and filesource.taxonomyPackage is not None:
+                    entrypointFiles.append({"file":url})
+            if not entrypointFiles and filesource.taxonomyPackage is not None:
                 for packageEntry in filesource.taxonomyPackage.get('entryPoints', {}).values():
                     for _resolvedUrl, remappedUrl, _closest in packageEntry:
-                        discoveredEntrypointFiles.append({"file": remappedUrl})
-        if discoveredEntrypointFiles:
-            # Only clear archive entry points if we discovered new ones.
-            # This could be a plugin loaded archive, such as an Excel file.
-            del entrypointFiles[:]
-            entrypointFiles.extend(discoveredEntrypointFiles)
+                        entrypointFiles.append({"file": remappedUrl})
 
 
     elif os.path.isdir(filesource.url):

--- a/tests/integration_tests/scripts/tests/no_entrypoints_zip.py
+++ b/tests/integration_tests/scripts/tests/no_entrypoints_zip.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+import zipfile
+from pathlib import Path
+
+import regex
+
+from tests.integration_tests.scripts.script_util import (
+    assert_result,
+    parse_args,
+    prepare_logfile,
+    run_arelle,
+    validate_log_file,
+)
+
+errors = []
+this_file = Path(__file__)
+args = parse_args(
+    this_file.stem,
+    "Verify error message when loading a zip file with no XBRL entry points.",
+)
+arelle_command = args.arelle
+arelle_offline = args.offline
+test_directory = Path(args.test_directory)
+arelle_log_file = prepare_logfile(test_directory, this_file)
+
+no_entrypoints_zip_path = test_directory / "no_entrypoints.zip"
+print(f"Creating zip file with no XBRL entry points: {no_entrypoints_zip_path}")
+with zipfile.ZipFile(no_entrypoints_zip_path, "w") as zf:
+    zf.writestr("readme.md", "This archive has no XBRL entry points.")
+
+run_arelle(
+    arelle_command,
+    additional_args=[
+        "--file",
+        str(no_entrypoints_zip_path),
+    ],
+    offline=arelle_offline,
+    logFile=arelle_log_file,
+)
+
+print(f"Checking for expected error in log: {arelle_log_file}")
+errors += validate_log_file(
+    arelle_log_file,
+    expected_results={
+        "error": {
+            regex.compile(r".*No XBRL entry points could be loaded from provided file.*"): 1,
+        },
+    },
+)
+assert_result(errors)
+
+print("Cleaning up")
+os.unlink(no_entrypoints_zip_path)


### PR DESCRIPTION
#### Reason for change

Archives without XBRL entry points show a confusing `[IOerror]` instead of `No XBRL entry points could be loaded`. This was a regression introduced in #2023 when `filesourceEntrypointFiles` was changed to preserve `entrypointFiles` when no new entry points were discovered.

Master:
```sh
> python arelleCmdLine.py --file empty.zip
[IOerror] empty.zip: file error: [Errno 2] Archive /Users/austinmatherne/git/Arelle/empty.zip: '' - empty.zip
```
PR:
```sh
> python arelleCmdLine.py --file empty.zip
[error] No XBRL entry points could be loaded from provided file: empty.zip -
```


#### Description of change

The loadFromExcel plugin now uses the `FileSource.EntrypointFiles` hook to declare its entry points. This lets the archive block safely clear `entrypointFiles` unconditionally again, restoring the error message for archives that both can't be loaded by a plugin and contain no detectable entry points.

#### Steps to Test

* CI (`no_entrypoints_zip.py` and `load_from_excel.py` test scripts)

**review**:
@Arelle/arelle
