### PR TITLE
Add --esefAuthority CLI option and GUI dropdown for ESEF

### DIFF
--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -31,6 +31,13 @@ _: TypeGetText
 YEAR_GROUP = "year"
 DISCLOSURE_SYSTEM_YEAR_PATTERN = re.compile(rf"esef-(?:unconsolidated-)?(?P<{YEAR_GROUP}>20\d\d)(?:-draft)?")
 
+AUTHORITY_CODES: frozenset[str] = frozenset({
+    "AT", "BE", "BG", "CY", "CZ", "DBA", "DE", "DK", "EE", "EL", "ES",
+    "FI", "FR", "GB", "HR", "HU", "IE", "IS", "IT", "LI", "LT", "LU",
+    "LV", "MT", "NL", "NO", "PL", "PT", "RO", "SE", "SI", "SK",
+    "UKFRC", "UKFRC-2022", "UKFRC-2023",
+})
+
 
 def getDisclosureSystemYear(modelXbrl: ModelXbrl) -> int:
     for name in modelXbrl.modelManager.disclosureSystem.names:

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -7,20 +7,29 @@ Filer Guidelines:
 
 GUI operation:
 - Enable the validate/ESEF plugin and optionally install ESEF taxonomy packages.
-- From the `Tools` menu > `Formula` > `Parameters` set the eps_threshold and optionally the authority.
+- Optionally select an authority from `Tools` > `Validation` > `ESEF authority`.
 
 Command line operation:
 `python arelleCmdLine.py --plugins validate/ESEF --packages {my-package-directory}/esef_taxonomy.zip --disclosureSystem esef --validate --file {my-report-package-zip-file}`
 
-Adding checks for formulas not automatically included:
-`--parameters "eps_threshold=.01"`
+Authority-specific configuration:
+The --esefAuthority option configures jurisdiction-specific behavior within the ESEF Filer Manual
+rules (e.g. target attribute handling). Valid authority codes are defined in resources/authority-validations.json.
+- `--esefAuthority DK`
+- `--esefAuthority UKFRC`
+
+Python API:
+`RuntimeOptions(pluginOptions={"esefAuthority": "DK"})`
+
+Supplementary formula assertions:
+The esef_all-for.xml formula linkbase contains additional assertions (e.g. EPS calculations) that
+are not loaded by default. To use them, import the linkbase and provide the required eps_threshold
+parameter:
+`--import http://www.esma.europa.eu/taxonomy/2020-03-16/esef_all-for.xml --parameters "eps_threshold=.01"`
 Dimensional validations required by some auditors may require
 `--import http://www.esma.europa.eu/taxonomy/2020-03-16/esef_all-for.xml`
-and likely `--skipLoading *esef_all-cal.xml` because the esef_all-cal.xml calculations are reported to be problematic for some filings.
-
-Authority specific validations are enabled by formula parameter authority, e.g. for Denmark or UKSEF and eps_threshold specify:
-- `--parameters "eps_threshold=.01,authority=DK"`
-- `--parameters "eps_threshold=.01,authority=UK"`
+and likely `--skipLoading *esef_all-cal.xml` because the esef_all-cal.xml calculations are reported
+to be problematic for some filings.
 
 Using arelle as a web server:
 
@@ -31,11 +40,13 @@ python arelleCmdLine.py --webserver localhost:8080:cheroot --plugins validate/ES
 Client with curl:
 
 ```bash
-curl -X POST "-HContent-type: application/zip" -T TC1_valid.zip "http://localhost:8080/rest/xbrl/validation?disclosureSystem=esef&media=text"
+curl -X POST "-HContent-type: application/zip" -T TC1_valid.zip "http://localhost:8080/rest/xbrl/validation?disclosureSystem=esef&esefAuthority=DK&media=text"
 ```
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
+from optparse import OptionParser
 from pathlib import Path
 from typing import Any, cast
 
@@ -43,24 +54,28 @@ import regex as re
 from lxml.etree import XMLParser, XMLSyntaxError, parse
 
 from arelle import ModelDocument, XhtmlValidate
+from arelle.Cntlr import Cntlr
 from arelle.DisclosureSystem import DisclosureSystem
 from arelle.FileSource import FileSource
 from arelle.ModelDocument import LoadingException, ModelDocument as ModelDocumentClass
 from arelle.ModelValue import qname
 from arelle.ModelXbrl import ModelXbrl
 from arelle.PackageManager import validateTaxonomyPackage
+from arelle.RuntimeOptions import RuntimeOptions
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.Version import authorLabel, copyrightLabel
 from arelle.XbrlConst import xhtml
 from arelle.formula.XPathContext import XPathContext
 from arelle.typing import TypeGetText
+from arelle.utils.PluginData import PluginData
 from arelle.utils.PluginHooks import PluginHooks
 from .ESEF_2021.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinally2021
 from .ESEF_Current.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinallyCurrent
-from .Util import getDisclosureSystemYear, loadAuthorityValidations
+from .Util import AUTHORITY_CODES, getDisclosureSystemYear, loadAuthorityValidations
 
 _: TypeGetText
 
+ESEF_PLUGIN_NAME = "Validate ESMA ESEF"
 ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY = "ESEFplugin"
 
 ixErrorPattern = re.compile(r"ix11[.]|xmlSchema[:]|(?!xbrl.5.2.5.2|xbrl.5.2.6.2)xbrl[.]|xbrld[ti]e[:]|utre[:]")
@@ -94,6 +109,51 @@ def shouldRunEsefValidationRules(val: ValidateXbrl) -> bool:
         return False
     return esefDisclosureSystemSelected(val.modelXbrl)
 
+
+def getEsefAuthority(
+    modelXbrl: ModelXbrl,
+    parameters: dict[Any, Any] | None,
+) -> str | None:
+    cntlr = modelXbrl.modelManager.cntlr
+    pluginData = cntlr.getPluginData(ESEF_PLUGIN_NAME)
+    esefAuthority = pluginData.esefAuthority if isinstance(pluginData, ESEFPluginData) else None
+    if not esefAuthority and cntlr.hasGui and cntlr.config is not None:
+        esefAuthority = cntlr.config.get("esefAuthority") or None
+    formulaAuthority = None
+    if parameters:
+        # formula parameter backwards compatibility for legacy users.
+        p = parameters.get(qname("authority", noPrefixIsNoNamespace=True))
+        if p and len(p) == 2 and p[1] not in ("null", "None", None):
+            formulaAuthority = p[1]
+    if esefAuthority and formulaAuthority and esefAuthority != formulaAuthority:
+        modelXbrl.error(
+            "Arelle.conflictingESEFAuthorityParameters",
+            _(
+                "ESEF Authority '%(esefAuthority)s' conflicts with formula parameter authority '%(formulaAuthority)s'."
+                " Continuing with '%(esefAuthority)s'."
+            ),
+            modelObject=modelXbrl,
+            esefAuthority=esefAuthority,
+            formulaAuthority=formulaAuthority,
+        )
+    authority = esefAuthority or formulaAuthority
+    if authority and authority not in AUTHORITY_CODES:
+        modelXbrl.error(
+            "Arelle.invalidESEFAuthority",
+            _("Invalid authority '%(authority)s'. Valid values: %(validValues)s."),
+            modelObject=modelXbrl,
+            authority=authority,
+            validValues=", ".join(sorted(AUTHORITY_CODES)),
+        )
+        return None
+    return authority
+
+
+@dataclass
+class ESEFPluginData(PluginData):
+    esefAuthority: str | None = None
+
+
 class ESEFPlugin(PluginHooks):
     @staticmethod
     def disclosureSystemTypes(
@@ -110,6 +170,55 @@ class ESEFPlugin(PluginHooks):
         **kwargs: Any,
     ) -> str:
         return str(Path(__file__).parent / "resources" / "config.xml")
+
+    @staticmethod
+    def cntlrCmdLineOptions(
+        parser: OptionParser,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        parser.add_option(
+            "--esefAuthority",
+            action="store",
+            dest="esefAuthority",
+            choices=sorted(AUTHORITY_CODES),
+            help=_("Select ESEF authority for jurisdiction-specific validation configuration."),
+        )
+
+    @staticmethod
+    def cntlrCmdLineUtilityRun(
+        cntlr: Cntlr,
+        options: RuntimeOptions,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        esefAuthority = getattr(options, "esefAuthority", None)
+        if esefAuthority:
+            cntlr.setPluginData(ESEFPluginData(name=ESEF_PLUGIN_NAME, esefAuthority=esefAuthority))
+
+    @staticmethod
+    def cntlrWinMainMenuValidation(
+        cntlr: Any,
+        menu: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        from tkinter import Menu as TkMenu, StringVar
+
+        jurisdictionMenu = TkMenu(menu, tearoff=0)
+        cntlr.config.setdefault("esefAuthority", "")
+        esefAuthorityVar = StringVar(value=cntlr.config.get("esefAuthority", ""))
+
+        def setEsefAuthority(*args: Any) -> None:
+            cntlr.config["esefAuthority"] = esefAuthorityVar.get()
+            cntlr.saveConfig()
+
+        esefAuthorityVar.trace_add("write", setEsefAuthority)
+        jurisdictionMenu.add_radiobutton(label=_("None"), variable=esefAuthorityVar, value="")
+        jurisdictionMenu.add_separator()
+        for code in sorted(AUTHORITY_CODES):
+            jurisdictionMenu.add_radiobutton(label=code, variable=esefAuthorityVar, value=code)
+        menu.add_cascade(label=_("ESEF authority"), menu=jurisdictionMenu, underline=0)
 
     @staticmethod
     def modelDocumentPullLoader(
@@ -228,12 +337,7 @@ class ESEFPlugin(PluginHooks):
         val.extensionImportedUrls = set()
         val.unconsolidated = any("unconsolidated" in n for n in val.disclosureSystem.names)
         val.consolidated = not val.unconsolidated
-        val.authority = None
-        if parameters:
-            p = parameters.get(qname("authority",noPrefixIsNoNamespace=True))
-            if p and len(p) == 2 and p[1] not in ("null", "None", None):
-                v = p[1] # formula dialog and cmd line formula parameters may need type conversion
-                val.authority = v
+        val.authority = getEsefAuthority(modelXbrl, parameters)
 
         authorityValidations = loadAuthorityValidations(val.modelXbrl)
         # loadAuthorityValidations returns either a list or a dict but in this context, we expect a dict.
@@ -389,6 +493,9 @@ __pluginInfo__ = {
     "license": "Apache-2",
     "author": authorLabel,
     "copyright": copyrightLabel,
+    "CntlrCmdLine.Options": ESEFPlugin.cntlrCmdLineOptions,
+    "CntlrCmdLine.Utility.Run": ESEFPlugin.cntlrCmdLineUtilityRun,
+    "CntlrWinMain.Menu.Validation": ESEFPlugin.cntlrWinMainMenuValidation,
     "ModelDocument.PullLoader": ESEFPlugin.modelDocumentPullLoader,
     "import": ("inlineXbrlDocumentSet",),  # import dependent modules
     # classes of mount points (required)

--- a/docs/source/esef.md
+++ b/docs/source/esef.md
@@ -35,6 +35,15 @@ Arelle's validation plugins can provide multiple collections of validation rules
 
 > **Important**: Always select the appropriate disclosure system version that matches your reporting period requirements, as validation rules evolve between reporting years.
 
+## Authority-Specific Configuration
+
+Some ESEF Filer Manual rules allow jurisdiction specific behavior. The `--esefAuthority` option configures this behavior.
+
+- Report package size limits and measurement method (zipped vs unzipped)
+- Whether iXBRL target attributes are allowed, warned, or treated as errors
+- Identifier scheme requirements (e.g., LEI vs Companies House)
+- Formula filtering (e.g., skipping LEI checks)
+
 ## GUI Validation
 
 To enable ESEF validation in the Arelle graphical user interface:
@@ -49,11 +58,9 @@ To enable ESEF validation in the Arelle graphical user interface:
      - For reports with Inline XBRL: Select year-specific system matching your requirements (e.g., `ESMA RTS on ESEF-2023`)
      - For reports without XBRL tagging: Select `ESMA RTS on ESEF-2023 Unconsolidated` or equivalent for your reporting year
 
-3. **Set Formula Parameters (Optional)**:
-   - Navigate to `Tools` > `Formula` > `Parameters...`
-   - Set parameters as needed:
-     - `authority`: For country-specific validations (e.g., `DK` for Denmark or `UK` for UKSEF)
-     - `eps_threshold`: Custom calculation tolerance for numeric accuracy checks
+3. **Set Authority (Optional)**:
+   - Navigate to `Tools` > `Validation` > `ESEF authority`
+   - Select the appropriate authority for your jurisdiction
 
 4. **Open the ESEF Report**:
    - Use `File` > `Open File...` to open the ESEF report (can be .zip package, or .xbri report package.)
@@ -82,12 +89,16 @@ python arelleCmdLine.py --plugin validate/ESEF --disclosureSystem esef --validat
 python arelleCmdLine.py --plugin validate/ESEF --disclosureSystem esef-2023 --validate --file report.zip
 ```
 
-#### Country-Specific Validation Rules
-
-For authority-specific validations (e.g., Denmark or United Kingdom):
+#### Authority Specific Configuration
 
 ```bash
-python arelleCmdLine.py --plugin validate/ESEF --disclosureSystem esef-2023 --parameters "authority=DK" --validate --file report.zip
+python arelleCmdLine.py --plugin validate/ESEF --disclosureSystem esef-2023 --esefAuthority DK --validate --file report.zip
+```
+
+For UKFRC (UK Financial Reporting Council) validation:
+
+```bash
+python arelleCmdLine.py --plugin validate/ESEF --disclosureSystem esef-2023 --esefAuthority UKFRC --validate --file report.zip
 ```
 
 ### Including ESEF Taxonomy Packages

--- a/tests/unit_tests/arelle/plugin/validate/ESEF/test_authority_codes.py
+++ b/tests/unit_tests/arelle/plugin/validate/ESEF/test_authority_codes.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+import regex
+
+from arelle.plugin.validate import ESEF
+from arelle.plugin.validate.ESEF.Util import AUTHORITY_CODES
+
+_AUTHORITY_VALIDATIONS_PATH = Path(ESEF.__file__).parent / "resources" / "authority-validations.json"
+
+_NON_AUTHORITY_KEY_PATTERN = regex.compile(r"copyright|description|default|ESEF-\d{4}(?:-DRAFT)?")
+
+
+class TestAuthorityCodes:
+    def test_authority_codes_match_json(self) -> None:
+        with open(_AUTHORITY_VALIDATIONS_PATH, encoding="utf-8") as f:
+            validations = json.load(f)
+        jsonAuthorityCodes = {
+            key
+            for key, value in validations.items()
+            if isinstance(value, dict) and not _NON_AUTHORITY_KEY_PATTERN.fullmatch(key)
+        }
+        assert jsonAuthorityCodes == AUTHORITY_CODES, (
+            f"AUTHORITY_CODES mismatch with authority-validations.json. "
+            f"Missing from AUTHORITY_CODES: {jsonAuthorityCodes - AUTHORITY_CODES}, "
+            f"Extra in AUTHORITY_CODES: {AUTHORITY_CODES - jsonAuthorityCodes}"
+        )


### PR DESCRIPTION
#### Reason for change

The authority parameter for jurisdiction specific ESEF validation was buried in formula parameters (`--parameters "authority=DK"`), making it tricky to discover and poorly documented. This adds a proper `--esefAuthority` CLI option with a choice list, a GUI dropdown menu under `Tools` > `Validation` > `ESEF authority`, and Python API support via `RuntimeOptions(pluginOptions={"esefAuthority": "DK"})`.

The legacy `--parameters "authority=..."` approach is preserved for backward compatibility. Conflicts between the two raise an error. Invalid authority values are also reported as errors.

#### Description of change

- Added `--esefAuthority` CLI option with choice validation
- Added ESEF authority dropdown selection to GUI validation menu

#### Steps to Test
* Toggle and validate ESEF authority selections in GUI
* Validate `--esefAuthority` from command line 

**review**:
@Arelle/arelle
