### PR TITLE
Fix bug in variable naming when inserting facts into the sql db

### DIFF
--- a/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
@@ -1091,7 +1091,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                                   fact.decimals,
                                   roundValue(fact.value, fact.precision, fact.decimals) if fact.isNumeric and not fact.isNil else None,
                                   fact.xmlLang if not fact.isNumeric and not fact.isNil else None,
-                                  collapseWhitespace(value) if fact.value is not None else None,
+                                  collapseWhitespace(fact.value) if fact.value is not None else None,
                                   fact.value,
                                   ))
             table = self.getTable('fact', 'fact_pk',


### PR DESCRIPTION
#### Reason for change
Properly allow facts to be populated into the connected database via the arelle plugin.

#### Description of change
properly use 'fact.value' instead of an undefined 'value'

#### Steps to Test
Discovered in a personal project when attempting to ingest various xbrl filings into a postgres database. 


**review**:
@Arelle/arelle
