### PR TITLE
Optimize Arelle startup time by avoiding subprocess for locale detection (Windows), caching valid locales and deferring imports

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -40,7 +40,7 @@ from arelle import (
     ModelDocument,
     PackageManager,
     PluginManager,
-    ValidateDuplicateFacts,
+    ValidateDuplicateFactsConst,
     Version,
     ViewFileConcepts,
     ViewFileDTS,
@@ -330,11 +330,11 @@ def parseArgs(args: list[str]) -> tuple[RuntimeOptions, dict[str, Any]]:
     validationGroup.add_option(
         "--validateDuplicateFacts",
         "--validateduplicatefacts",
-        choices=[a.value for a in ValidateDuplicateFacts.DUPLICATE_TYPE_ARG_MAP],
+        choices=[a.value for a in ValidateDuplicateFactsConst.DUPLICATE_TYPE_ARG_MAP],
         dest="validateDuplicateFacts",
         help=_(
             "Select which types of duplicates should trigger warnings "
-            f"({' ,'.join([f'`{a.value}`' for a in ValidateDuplicateFacts.DUPLICATE_TYPE_ARG_MAP])})"
+            f"({' ,'.join([f'`{a.value}`' for a in ValidateDuplicateFactsConst.DUPLICATE_TYPE_ARG_MAP])})"
 
             )
         )
@@ -730,11 +730,11 @@ def parseArgs(args: list[str]) -> tuple[RuntimeOptions, dict[str, Any]]:
     outputFileGroup.add_option(
         "--deduplicateFacts",
         "--deduplicatefacts",
-        choices=[a.value for a in ValidateDuplicateFacts.DeduplicationType],
+        choices=[a.value for a in ValidateDuplicateFactsConst.DeduplicationType],
         dest="deduplicateFacts",
         help=_(
             "When using `--saveDeduplicatedInstance` to save a deduplicated instance, check for duplicates of this type"
-            f" ({' ,'.join([f'`{a.value}`' for a in ValidateDuplicateFacts.DeduplicationType])})."
+            f" ({' ,'.join([f'`{a.value}`' for a in ValidateDuplicateFactsConst.DeduplicationType])})."
             )
         )
     outputFileGroup.add_option(
@@ -1811,7 +1811,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
             self.modelManager.baseTaxonomyValidationMode = ValidateBaseTaxonomiesMode.fromName(options.baseTaxonomyValidationMode)
         self.modelManager.validateXmlOim = options.validateXmlOim
         if options.validateDuplicateFacts:
-            duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(options.validateDuplicateFacts)
+            duplicateTypeArg = ValidateDuplicateFactsConst.DuplicateTypeArg(options.validateDuplicateFacts)
             duplicateType = duplicateTypeArg.duplicateType()
             self.modelManager.validateDuplicateFacts = duplicateType
         self.modelManager.validateAllFilesAsReportPackages = options.reportPackage
@@ -2231,9 +2231,9 @@ class CntlrCmdLine(Cntlr.Cntlr):
                 if success:
                     if options.saveDeduplicatedInstance:
                         if options.deduplicateFacts:
-                            deduplicateFactsArg = ValidateDuplicateFacts.DeduplicationType(options.deduplicateFacts)
+                            deduplicateFactsArg = ValidateDuplicateFactsConst.DeduplicationType(options.deduplicateFacts)
                         else:
-                            deduplicateFactsArg = ValidateDuplicateFacts.DeduplicationType.COMPLETE
+                            deduplicateFactsArg = ValidateDuplicateFactsConst.DeduplicationType.COMPLETE
                         if modelXbrl.modelDocument.type != ModelDocument.Type.INSTANCE:
                             self.addToLog(_("Provided file must be a traditional XBRL instance document to save a deduplicated instance."),
                                           messageCode="error", file=modelXbrl.modelDocument.uri)
@@ -2241,6 +2241,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                             # Deduplication modifies the underlying lxml tree and leaves the model in an undefined state.
                             # Anything depending on the ModelXbrl that runs after this may encounter unexpected behavior,
                             # so we'll run it as a final step in the CLI controller flow.
+                            from arelle import ValidateDuplicateFacts
                             ValidateDuplicateFacts.saveDeduplicatedInstance(
                                 modelXbrl,
                                 deduplicateFactsArg,

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -23,10 +23,9 @@ import time
 import traceback
 from optparse import SUPPRESS_HELP, Option, OptionGroup, OptionParser
 from pprint import pprint
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import regex as re
-from bottle import Bottle  # type: ignore[import-untyped]
 from lxml import etree
 
 try:
@@ -70,6 +69,9 @@ from arelle.typing import TypeGetText
 from arelle.utils.EntryPointDetection import parseEntrypointFileInput
 from arelle.ValidateXbrlDTS import ValidateBaseTaxonomiesMode
 from arelle.WebCache import proxyTuple
+
+if TYPE_CHECKING:
+    from bottle import Bottle
 
 STILL_ACTIVE = 259 # MS Windows process status constants
 PROCESS_QUERY_INFORMATION = 0x400
@@ -1495,7 +1497,7 @@ def _configAndRunCntlr(
         cntlr.postLoggingInit()
         from arelle import CntlrWebMain
         app = CntlrWebMain.startWebserver(cntlr, options)
-        if options.webserver == "::wsgi":
+        if options.webserver == "::wsgi" and app is not None:
             return app, None
 
         return None, None

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -71,7 +71,7 @@ from arelle.ValidateXbrlDTS import ValidateBaseTaxonomiesMode
 from arelle.WebCache import proxyTuple
 
 if TYPE_CHECKING:
-    from bottle import Bottle
+    from bottle import Bottle # type: ignore[import-untyped]
 
 STILL_ACTIVE = 259 # MS Windows process status constants
 PROCESS_QUERY_INFORMATION = 0x400

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -18,7 +18,8 @@ from typing import Any
 
 import regex as re
 
-from arelle import UrlUtil, ValidateDuplicateFacts
+from arelle import UrlUtil, ViewUtil
+from arelle.ValidateDuplicateFactsConst import DuplicateTypeArg
 from arelle.ValidateFileSource import ValidateFileSource
 from arelle.logging.formatters.LogFormatter import LogFormatter, logRefsFileLines
 from arelle.typing import TypeGetText
@@ -545,17 +546,17 @@ class CntlrWinMain(Cntlr.Cntlr):
         self.setValidateTooltipText()
 
     def buildValidateDuplicateFactsMenu(self, validateMenu: Menu) -> None:
-        defaultArg = ValidateDuplicateFacts.DuplicateTypeArg.NONE.value
+        defaultArg = DuplicateTypeArg.NONE.value
         validateDuplicateFactsStr = self.config.setdefault("validateDuplicateFacts", defaultArg)
         try:
-            duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(validateDuplicateFactsStr)
+            duplicateTypeArg = DuplicateTypeArg(validateDuplicateFactsStr)
         except ValueError:
-            duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(defaultArg)
+            duplicateTypeArg = DuplicateTypeArg(defaultArg)
         self.modelManager.validateDuplicateFacts = duplicateTypeArg.duplicateType()
         self.validateDuplicateFacts = StringVar(value=duplicateTypeArg.value)
         self.validateDuplicateFacts.trace_add("write", self.setValidateDuplicateFacts)
         duplicateFactWarningMenu = Menu(validateMenu, tearoff=0)
-        for duplicateTypeArg in ValidateDuplicateFacts.DuplicateTypeArg:
+        for duplicateTypeArg in DuplicateTypeArg:
             duplicateFactWarningMenu.add_checkbutton(
                 label=duplicateTypeArg.value.title(),
                 variable=self.validateDuplicateFacts,
@@ -1337,7 +1338,7 @@ class CntlrWinMain(Cntlr.Cntlr):
     def setValidateDuplicateFacts(self, *args: Any) -> None:
         assert self.validateDuplicateFacts is not None
         value = self.validateDuplicateFacts.get()
-        duplicateTypeArg = ValidateDuplicateFacts.DuplicateTypeArg(value)
+        duplicateTypeArg = DuplicateTypeArg(value)
         self.modelManager.validateDuplicateFacts = duplicateTypeArg.duplicateType()
         self.config["validateDuplicateFacts"] = value
         self.addToLog('ModelManager.validateDuplicateFacts = {}'.format(

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -9,6 +9,7 @@ See COPYRIGHT.md for copyright information.
 from __future__ import annotations
 
 import ctypes
+import functools
 import locale
 import sys
 import unicodedata
@@ -53,37 +54,36 @@ POSIX_LOCALE_ENCODING_SEPARATOR = '.'
 BCP47_LANGUAGE_TAG = re.compile(r"^[a-zA-Z]{2,3}(-[a-zA-Z]{2,3}(\-[a-zA-Z0-9]{1,8})*)?$")
 
 
-def _getUserLocaleUnsafe(posixLocale: str = '') -> tuple[LocaleDict, str | None]:
+@functools.lru_cache(maxsize=None)
+def _probeLocale(localeStr: str) -> LocaleDict | None:
     """
-    Get locale conventions dictionary. May change the global locale if called directly.
-    :param posixLocale: The locale code to use to retrieve conventions. Defaults to system default.
-    :return: Tuple of local conventions dictionary and a user-directed setup message
+    Try to activate localeStr and return its localeconv dict.
+    Returns None if the locale is not available on this system.
+    Result is cached — setlocale is only called once per unique localeStr.
+    Not thread-safe (Python's locale module uses global C state).
     """
-    localeSetupMessage = None
+    saved = locale.setlocale(locale.LC_ALL)
     try:
-        locale.setlocale(locale.LC_ALL, posixLocale)
+        locale.setlocale(locale.LC_ALL, localeStr)
+        return cast(LocaleDict, locale.localeconv())
     except locale.Error:
-        locale.setlocale(locale.LC_ALL, 'C')
-        localeSetupMessage = _('Locale code "{}" is not available on this system.').format(posixLocale)
+        return None
     finally:
-        conv = locale.localeconv()
-    return cast(LocaleDict, conv), localeSetupMessage
+        locale.setlocale(locale.LC_ALL, saved)
 
 
 def getUserLocale(posixLocale: str | None = None) -> tuple[LocaleDict, str | None]:
     """
-    Get locale conventions dictionary. Ensures that the locale (global to the process) is reset afterwards.
+    Get locale conventions dictionary.
     :param posixLocale: The locale code to use to retrieve conventions. Defaults to system default.
-    :return: Tuple of local conventions dictionary and a user-directed setup message
+    :return: Tuple of (locale conventions dict, optional error message for the user)
     """
-    if posixLocale is None:
-        # Empty string is system default.
-        posixLocale = ''
-    currentLocale = locale.setlocale(locale.LC_ALL)
-    try:
-        return _getUserLocaleUnsafe(posixLocale)
-    finally:
-        locale.setlocale(locale.LC_ALL, currentLocale)
+    localeStr = posixLocale or ''
+    if (conv := _probeLocale(localeStr)) is not None:
+        return conv, None
+    # Locale not available — fall back to C and report it
+    return cast(LocaleDict, _probeLocale('C') or locale.localeconv()), \
+        _('Locale code "{}" is not available on this system.').format(posixLocale)
 
 
 def getLanguageCode() -> str:
@@ -116,46 +116,22 @@ def getLanguageCodes(configLang: str | None = None) -> list[str]:
     return [lang]
 
 
-def _unsafeIsLocaleCompatible(localeValue: str) -> bool:
-    """
-    Checks if locale can be set by python on the system.
-    May change the global locale if called directly.
-    """
-    try:
-        locale.setlocale(locale.LC_ALL, localeValue)
-        return True
-    except locale.Error:
-        return False
-
-
-def _unsafeFindCompatibleLocale(localeValue: str) -> str | None:
-    """
-    Attempts to find a system compatible locale (checks default regions and possible encodings) based on the user provided locale value.
-    May change the global locale if called directly.
-    """
-    if _unsafeIsLocaleCompatible(localeValue):
-        return localeValue
-    formattedLocaleCode = bcp47LangToPosixLocale(localeValue)
-    if formattedLocaleCode != localeValue and _unsafeIsLocaleCompatible(formattedLocaleCode):
-        return formattedLocaleCode
-    candidateLocaleCodes = _candidateLocaleCodes(formattedLocaleCode)
-    for candidateLocaleCode in candidateLocaleCodes:
-        if _unsafeIsLocaleCompatible(candidateLocaleCode):
-            return candidateLocaleCode
-    return None
-
-
 def findCompatibleLocale(localeValue: str | None) -> str | None:
     """
-    Attempts to find a system compatible locale (checks default regions and possible encodings) based on the user provided locale value.
+    Attempts to find a system-compatible locale based on the provided value.
+    Checks default regions and possible encodings.
     """
     if localeValue is None:
         return None
-    currentLocale = locale.setlocale(locale.LC_ALL)
-    try:
-        return _unsafeFindCompatibleLocale(localeValue)
-    finally:
-        locale.setlocale(locale.LC_ALL, currentLocale)
+    if _probeLocale(localeValue) is not None:
+        return localeValue
+    formattedLocaleCode = bcp47LangToPosixLocale(localeValue)
+    if formattedLocaleCode != localeValue and _probeLocale(formattedLocaleCode) is not None:
+        return formattedLocaleCode
+    for candidate in _candidateLocaleCodes(formattedLocaleCode):
+        if _probeLocale(candidate) is not None:
+            return candidate
+    return None
 
 
 def _candidateLocaleCodes(posixLocale: str) -> list[str]:

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -44,8 +44,6 @@ defaultLocaleCodes = {
     "sk": "SK", "sl": "SI", "sq": "AL", "sr": "RS", "sv": "SE", "th": "TH",
     "tr": "TR", "uk": "UA", "ur": "PK", "vi": "VN", "zh": "CN"}
 
-MACOS_PLATFORM = "darwin"
-WINDOWS_PLATFORM = "win32"
 
 BCP47_LANGUAGE_REGION_SEPARATOR = '-'
 POSIX_LANGUAGE_REGION_SEPARATOR = '_'
@@ -200,24 +198,26 @@ def _getPosixLocaleLangRegionAndEncoding(posixLocale: str) -> tuple[str, str | N
     return language, region or None, encoding or None
 
 
-_locale = None
+_locale: str | None = None
 
 
 def getLocale() -> str | None:
     global _locale
     if _locale:
         return _locale
+
     # Try getting locale language code from system on macOS and Windows before resorting to the less reliable locale.getlocale.
-    systemLocale = None
-    if sys.platform == MACOS_PLATFORM:
+    systemLocale: str | None = None
+    if sys.platform == "darwin":
         systemLocale = tryRunCommand("defaults", "read", "-g", "AppleLocale")
-    elif sys.platform == WINDOWS_PLATFORM:
+    elif sys.platform == "win32":
         # https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getuserdefaultlocalename
         # https://learn.microsoft.com/en-us/windows/win32/intl/locale-name-constants
         LOCALE_NAME_MAX_LENGTH = 85
         buf = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
         if ctypes.windll.kernel32.GetUserDefaultLocaleName(buf, LOCALE_NAME_MAX_LENGTH):
             systemLocale = buf.value
+
     if pythonCompatibleLocale := findCompatibleLocale(systemLocale):
         _locale = pythonCompatibleLocale
     elif sys.version_info < (3, 12) or (3, 13, 3) <= sys.version_info[:3] <= (3, 13, 4):
@@ -269,7 +269,7 @@ iso3region = {
 "US": "usa"}
 
 
-_systemLocales = None
+_systemLocales: list[str] | None = None
 
 
 def getLocaleList() -> list[str]:
@@ -279,7 +279,7 @@ def getLocaleList() -> list[str]:
     global _systemLocales
     if _systemLocales is not None:
         return _systemLocales
-    if sys.platform != WINDOWS_PLATFORM and (locales := tryRunCommand("locale", "-a")):
+    if sys.platform != "win32" and (locales := tryRunCommand("locale", "-a")):
         _systemLocales = locales.splitlines()
     else:
         _systemLocales = []
@@ -297,7 +297,7 @@ def availableLocales() -> set[str]:
     }
 
 
-_languageCodes = None
+_languageCodes: dict[str, str] | None = None
 
 
 def languageCodes() -> dict[str, str]:  # dynamically initialize after gettext is loaded

--- a/arelle/Locale.py
+++ b/arelle/Locale.py
@@ -8,6 +8,7 @@ See COPYRIGHT.md for copyright information.
 
 from __future__ import annotations
 
+import ctypes
 import locale
 import sys
 import unicodedata
@@ -235,7 +236,12 @@ def getLocale() -> str | None:
     if sys.platform == MACOS_PLATFORM:
         systemLocale = tryRunCommand("defaults", "read", "-g", "AppleLocale")
     elif sys.platform == WINDOWS_PLATFORM:
-        systemLocale = tryRunCommand("pwsh", "-Command", "Get-Culture | Select -ExpandProperty IetfLanguageTag")
+        # https://learn.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getuserdefaultlocalename
+        # https://learn.microsoft.com/en-us/windows/win32/intl/locale-name-constants
+        LOCALE_NAME_MAX_LENGTH = 85
+        buf = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
+        if ctypes.windll.kernel32.GetUserDefaultLocaleName(buf, LOCALE_NAME_MAX_LENGTH):
+            systemLocale = buf.value
     if pythonCompatibleLocale := findCompatibleLocale(systemLocale):
         _locale = pythonCompatibleLocale
     elif sys.version_info < (3, 12) or (3, 13, 3) <= sys.version_info[:3] <= (3, 13, 4):

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 import gc, sys, traceback, logging
-from arelle import ModelXbrl, Validate, DisclosureSystem, PackageManager, ValidateXbrlCalcs, ValidateDuplicateFacts
+from arelle import ModelXbrl, Validate, DisclosureSystem, PackageManager, ValidateXbrlCalcs, ValidateDuplicateFactsConst
 from arelle.ModelFormulaObject import FormulaOptions
 from arelle.ValidateXbrlDTS import ValidateBaseTaxonomiesMode
 from arelle.typing import LocaleDict
@@ -70,7 +70,7 @@ class ModelManager:
         self.baseTaxonomyValidationMode = ValidateBaseTaxonomiesMode.DISCLOSURE_SYSTEM
         self.validateAllFilesAsReportPackages = False
         self.validateAllFilesAsTaxonomyPackages = False
-        self.validateDuplicateFacts = ValidateDuplicateFacts.DuplicateType.NONE
+        self.validateDuplicateFacts = ValidateDuplicateFactsConst.DuplicateType.NONE
         self.validateXmlOim = False
         self.setLocale()
         ValidateXbrlCalcs.init() # required due to circular dependencies in module

--- a/arelle/PythonUtil.py
+++ b/arelle/PythonUtil.py
@@ -368,6 +368,8 @@ def tryRunCommand(*args: str) -> str | None:
             text=True,
             # A call to get std handle throws an OSError if stdin is not specified when run on Windows as a service.
             stdin=subprocess.PIPE,
+            # Prevent a console window flashing briefly when spawning console-subsystem processes from a GUI app.
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         ).stdout.strip()
     except (OSError, subprocess.SubprocessError):
         return None

--- a/arelle/RuntimeOptions.py
+++ b/arelle/RuntimeOptions.py
@@ -10,7 +10,7 @@ import regex as re
 
 from arelle.FileSource import FileNamedStringIO
 from arelle.SystemInfo import hasWebServer
-from arelle.ValidateDuplicateFacts import DeduplicationType
+from arelle.ValidateDuplicateFactsConst import DeduplicationType
 
 RuntimeOptionValue = Union[bool, int, str, None]
 

--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from enum import Enum, Flag, auto
 from functools import cached_property
 from math import isnan
 from typing import Any, SupportsFloat, cast
@@ -19,6 +18,14 @@ from arelle.ModelInstanceObject import ModelContext, ModelFact, ModelUnit
 from arelle.ModelValue import DateTime, QName, TypeXValue
 from arelle.ModelXbrl import ModelXbrl
 from arelle.typing import TypeGetText
+from arelle.ValidateDuplicateFactsConst import (
+    DUPLICATE_TYPE_ARG_MAP,
+    DeduplicationType,
+    DuplicateType,
+    DuplicateTypeArg,
+    FactValueEqualityType,
+    TypeFactValueEqualityKey,
+)
 from arelle.ValidateXbrlCalcs import inferredDecimals, rangeValue
 
 _: TypeGetText
@@ -294,56 +301,6 @@ class DuplicateFactSet:
         return self._ranges[fact]
 
 
-class DuplicateType(Flag):
-    NONE = 0
-    INCONSISTENT = auto()
-    CONSISTENT = auto()
-    INCOMPLETE = auto()
-    COMPLETE = auto()
-
-    # Flags before 3.11 did not support iterating Flag values,
-    # so we have to override with our own iterator. Remove when we no longer support 3.10
-    def __iter__(self) -> Iterator[DuplicateType]:
-        # num must be a positive integer
-        num = self.value
-        while num:
-            b = num & (~num + 1)
-            yield DuplicateType(b)
-            num ^= b
-
-    @property
-    def description(self) -> str:
-        return "|".join([str(n.name) for n in self if n.name]).lower()
-
-
-class DuplicateTypeArg(Enum):
-    NONE = "none"
-    INCONSISTENT = "inconsistent"
-    CONSISTENT = "consistent"
-    INCOMPLETE = "incomplete"
-    COMPLETE = "complete"
-    ALL = "all"
-
-    def duplicateType(self) -> DuplicateType:
-        return DUPLICATE_TYPE_ARG_MAP.get(self, DuplicateType.NONE)
-
-
-class DeduplicationType(Enum):
-    COMPLETE = "complete"
-    CONSISTENT_PAIRS = "consistent-pairs"
-    CONSISTENT_SETS = "consistent-sets"
-
-
-DUPLICATE_TYPE_ARG_MAP = {
-    DuplicateTypeArg.NONE: DuplicateType.NONE,
-    DuplicateTypeArg.INCONSISTENT: DuplicateType.INCONSISTENT,
-    DuplicateTypeArg.CONSISTENT: DuplicateType.CONSISTENT,
-    DuplicateTypeArg.INCOMPLETE: DuplicateType.INCOMPLETE,
-    DuplicateTypeArg.COMPLETE: DuplicateType.COMPLETE,
-    DuplicateTypeArg.ALL: DuplicateType.INCONSISTENT | DuplicateType.CONSISTENT,
-}
-
-
 def _isNanOrNone(value: TypeXValue) -> bool:
     if value is None:
         return True
@@ -496,15 +453,6 @@ def getDuplicateFactSetsWithType(
     for duplicateFactSet in getDuplicateFactSets(facts, includeSingles=False):
         if doesSetHaveDuplicateType(duplicateFactSet, duplicateType):
             yield duplicateFactSet
-
-
-class FactValueEqualityType(Enum):
-    DEFAULT = "default"
-    DATETIME = "datetime"
-    LANGUAGE = "language"
-
-
-TypeFactValueEqualityKey = tuple[FactValueEqualityType, tuple[Any, ...]]
 
 
 def getFactValueEqualityKey(fact: ModelFact) -> TypeFactValueEqualityKey:

--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -19,12 +19,12 @@ from arelle.ModelValue import DateTime, QName, TypeXValue
 from arelle.ModelXbrl import ModelXbrl
 from arelle.typing import TypeGetText
 from arelle.ValidateDuplicateFactsConst import (
-    DUPLICATE_TYPE_ARG_MAP,
-    DeduplicationType,
-    DuplicateType,
-    DuplicateTypeArg,
-    FactValueEqualityType,
-    TypeFactValueEqualityKey,
+    DUPLICATE_TYPE_ARG_MAP as DUPLICATE_TYPE_ARG_MAP,
+    DeduplicationType as DeduplicationType,
+    DuplicateType as DuplicateType,
+    DuplicateTypeArg as DuplicateTypeArg,
+    FactValueEqualityType as FactValueEqualityType,
+    TypeFactValueEqualityKey as TypeFactValueEqualityKey,
 )
 from arelle.ValidateXbrlCalcs import inferredDecimals, rangeValue
 

--- a/arelle/ValidateDuplicateFactsConst.py
+++ b/arelle/ValidateDuplicateFactsConst.py
@@ -1,0 +1,72 @@
+"""
+Constants and enums for duplicate fact validation.
+Kept in a separate module so that API and Cntlr* code can import these lightweight types
+without pulling in the heavy model/validation imports of ValidateDuplicateFacts.
+
+See COPYRIGHT.md for copyright information.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from enum import Enum, Flag, auto
+from typing import Any
+
+
+class DuplicateType(Flag):
+    NONE = 0
+    INCONSISTENT = auto()
+    CONSISTENT = auto()
+    INCOMPLETE = auto()
+    COMPLETE = auto()
+
+    # Flags before 3.11 did not support iterating Flag values,
+    # so we have to override with our own iterator. Remove when we no longer support 3.10
+    def __iter__(self) -> Iterator[DuplicateType]:
+        # num must be a positive integer
+        num = self.value
+        while num:
+            b = num & (~num + 1)
+            yield DuplicateType(b)
+            num ^= b
+
+    @property
+    def description(self) -> str:
+        return "|".join([str(n.name) for n in self if n.name]).lower()
+
+
+class DuplicateTypeArg(Enum):
+    NONE = "none"
+    INCONSISTENT = "inconsistent"
+    CONSISTENT = "consistent"
+    INCOMPLETE = "incomplete"
+    COMPLETE = "complete"
+    ALL = "all"
+
+    def duplicateType(self) -> DuplicateType:
+        return DUPLICATE_TYPE_ARG_MAP.get(self, DuplicateType.NONE)
+
+
+class DeduplicationType(Enum):
+    COMPLETE = "complete"
+    CONSISTENT_PAIRS = "consistent-pairs"
+    CONSISTENT_SETS = "consistent-sets"
+
+
+DUPLICATE_TYPE_ARG_MAP = {
+    DuplicateTypeArg.NONE: DuplicateType.NONE,
+    DuplicateTypeArg.INCONSISTENT: DuplicateType.INCONSISTENT,
+    DuplicateTypeArg.CONSISTENT: DuplicateType.CONSISTENT,
+    DuplicateTypeArg.INCOMPLETE: DuplicateType.INCOMPLETE,
+    DuplicateTypeArg.COMPLETE: DuplicateType.COMPLETE,
+    DuplicateTypeArg.ALL: DuplicateType.INCONSISTENT | DuplicateType.CONSISTENT,
+}
+
+
+class FactValueEqualityType(Enum):
+    DEFAULT = "default"
+    DATETIME = "datetime"
+    LANGUAGE = "language"
+
+
+TypeFactValueEqualityKey = tuple[FactValueEqualityType, tuple[Any, ...]]

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -26,13 +26,7 @@ from urllib import request as proxyhandlers
 from urllib.error import ContentTooShortError, HTTPError, URLError
 from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
-import certifi
 import regex as re
-import truststore
-from filelock import FileLock, Timeout
-
-from arelle.PythonUtil import isLegacyAbs
-from arelle.typing import TypeGetText
 
 try:
     import ssl
@@ -40,6 +34,8 @@ except ImportError:
     ssl = None  # type: ignore[assignment]
 
 from arelle.FileSource import SERVER_WEB_CACHE, archiveFilenameParts
+from arelle.PythonUtil import isLegacyAbs
+from arelle.typing import TypeGetText
 from arelle.UrlUtil import isHttpUrl
 from arelle.Version import __version__
 
@@ -295,6 +291,11 @@ class WebCache:
         if self._opener is None:
             handlers = list(self._baseProxyHandlers)
             if ssl:
+                # Both imports are slow to load, so we do them lazily here when
+                # we know we'll need them.
+                import certifi
+                import truststore
+
                 context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
                 # Include certifi certificates (Mozilla's carefully curated
                 # collection) for systems with outdated certs.
@@ -653,6 +654,10 @@ class WebCache:
             retrievingDueToRecheckInterval: bool = False,
             retryCount: int = 5
         ) -> bool:
+        # Defer import of filelock until here since it is not needed for other
+        # operations and is slow to import
+        from filelock import FileLock, Timeout
+
         before_timestamp = WebCache._getFileTimestamp(filepath)
         fileInCache = False
         lock = FileLock(filepath + ".lock", timeout=FILE_LOCK_TIMEOUT)

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -130,9 +130,9 @@ class WebCache:
         self._httpUserAgent: str = HTTP_USER_AGENT # default user agent for product
         self._httpsRedirect: bool = False
         self._redirectFallbackMap: dict[re.Pattern[str], str] = {}
+        self._baseProxyHandlers: list[proxyhandlers.BaseHandler] = []
+        self._opener: proxyhandlers.OpenerDirector | None = None
         self.resetProxies(httpProxyTuple)
-
-        self.opener.addheaders = [("User-agent", self.httpUserAgent)]
 
         if cntlr.isGAE:
             self.cacheDir: str = SERVER_WEB_CACHE # GAE type servers
@@ -285,24 +285,30 @@ class WebCache:
             self.http_auth_handler = proxyhandlers.HTTPBasicAuthHandler()
             proxyHandlers = [self.proxy_handler, self.proxy_auth_handler, self.http_auth_handler]
 
-        if ssl:
-            context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            # Include certifi certificates (Mozilla’s carefully curated
-            # collection) for systems with outdated certs.
-            context.load_verify_locations(cafile=certifi.where())
-            if self.noCertificateCheck:  # this is required in some Akamai environments, such as sec.gov
-                context.check_hostname = False
-                context.verify_mode = ssl.CERT_NONE
-            proxyHandlers.append(proxyhandlers.HTTPSHandler(context=context))
+        # Store handlers without SSL and invalidate the cached opener.
+        # The SSL context and opener are built lazily on first network request.
+        self._baseProxyHandlers = list(proxyHandlers)
+        self._opener = None
 
-        self.opener = proxyhandlers.build_opener(*proxyHandlers)
-        self.opener.addheaders = [
-            ("User-Agent", self.httpUserAgent),
-            ("Accept-Encoding", "gzip, deflate")
-        ]
-
-        #self.opener.close()
-        #self.opener = WebCacheUrlOpener(self.cntlr, proxyDirFmt(httpProxyTuple))
+    @property
+    def opener(self) -> proxyhandlers.OpenerDirector:
+        if self._opener is None:
+            handlers = list(self._baseProxyHandlers)
+            if ssl:
+                context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                # Include certifi certificates (Mozilla's carefully curated
+                # collection) for systems with outdated certs.
+                context.load_verify_locations(cafile=certifi.where())
+                if self.noCertificateCheck:  # this is required in some Akamai environments, such as sec.gov
+                    context.check_hostname = False
+                    context.verify_mode = ssl.CERT_NONE
+                handlers.append(proxyhandlers.HTTPSHandler(context=context))
+            self._opener = proxyhandlers.build_opener(*handlers)
+            self._opener.addheaders = [
+                ("User-Agent", self.httpUserAgent),
+                ("Accept-Encoding", "gzip, deflate"),
+            ]
+        return self._opener
 
     def normalizeFilepath(self, filepath: str, url: str, cacheDir: str | None = None) -> str:
         """


### PR DESCRIPTION
#### Reason for change
Arelle GUI was unreasonably slow to open and on Windows flashed open a console/terminal/dos box running:
```python
tryRunCommand("pwsh", "-Command", "Get-Culture | Select -ExpandProperty IetfLanguageTag")
```

#### Description of change

- Fix `tryRunCommand` to not create pop-up console boxes on Windows any more
- Fix Locale.py to query kernel32.dll directly on Windows rather than invoking and capturing pwsh.exe's output to try to find the system's current locale
- Reduce the amount of setlocale() required to start up Arelle and reduce the methods calling it down to one, `probeLocale`
- Reduce the time to load Webcache.py from 300ms to 4ms by lazily building the SSL context and deferring slow imports until required
- Remove the cascade of imports triggered by importing ValidateDuplicateFacts when all we need is a few enums to make the command line duplicate option work.
- Bottle is only needed in `CntlrCmdLine.py` for type checking so guard its import with `TYPE_CHECKING`

Reduce start up time for the command line by about 1 second, the GUI (on Windows) by perhaps 3 seconds.

#### Steps to Test
Windows:
```
arelle-dev) PS C:\b\Arelle> Measure-Command { arelleCmdLine.exe --version | Out-Host }
Arelle(r) 2.39.4.dev31+gb3a955a40.d20260327 (64bit)

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 697
Ticks             : 6973598
TotalDays         : 8.07129398148148E-06
TotalHours        : 0.000193711055555556
TotalMinutes      : 0.0116226633333333
TotalSeconds      : 0.6973598
TotalMilliseconds : 697.3598

(arelle-dev) PS C:\b\Arelle> Measure-Command { & 'C:\Program Files\Arelle\arelleCmdLine.exe' --version | Out-Host }
Arelle(r) 2.39.5 (64bit)

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 1
Milliseconds      : 793
Ticks             : 17938011
TotalDays         : 2.07615868055556E-05
TotalHours        : 0.000498278083333333
TotalMinutes      : 0.029896685
TotalSeconds      : 1.7938011
TotalMilliseconds : 1793.8011
```

For the GUI, the above also works but it won't stop the timer until you quit Arelle. Better to add instrumentation/logging and launch the relevant pair of `arelleGUI.exe` to compare.

**review**:
@Arelle/arelle
