### PR TITLE
base must be specified, otherwise glob will look in the current directory

### DIFF
--- a/arelle/plugin_system/_plugin_manager.py
+++ b/arelle/plugin_system/_plugin_manager.py
@@ -316,7 +316,7 @@ class PluginManager:
             # Handles cases where a plugin exists in a nested structure, such as
             # when a developer clones an entire repository into the plugin directory.
             # Example: arelle/plugin/xule/plugin/xule/__init__.py
-            for path in glob("**/" + moduleURL.replace('\\', '/'), recursive=True):
+            for path in glob(base + "**/" + moduleURL.replace('\\', '/'), recursive=True):
                 if normalizedPath := self.normalizeModuleFilename(path):
                     return normalizedPath, None
         # `moduleFilename` did not map to a local filepath or did not normalize to a script


### PR DESCRIPTION
#### Reason for change
The XULE plugin is not being loaded in the EDGAR workflow. After investigating i found that the getModuleFilename method is missing the base when calling glob so it defaults to the directory where arelleCmdLine is being called from (working directory).

#### Description of change
added the base directory to the glob function call

#### Steps to Test

- Your setup should have the xule repository cloned into the plugin directory

- Run the following command(MUST SET VARIABLES ACCORDINGLY) from a directory which is not a parent of where the xule plugin is stored. In the logs you will see the following message "[arelle.xulePluginNotLoaded] Xule plugin is not loaded. Xule plugin is required to run DQC rules. This plugin should be automatically loaded." because the plugin manager was unable to locate the xule plugin

`python $PATH_TO_ARELLECMDLINE/arelleCmdLine.py --xdgConfigHome $XDG_CONFIG_HOME --file https://www.sec.gov/Archives/edgar/data/1374328/000143774926012937/0001437749-26-012937-xbrl.zip -v --disclosureSystem efm-pragmatic --plugins EdgarRenderer --logFile arelleLog.xml --logFileMode w`
**review**:
@Arelle/arelle
