### PR TITLE
Implement `PackageSource`

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -530,7 +530,7 @@ class Cntlr:
         self._pluginManager.save(self)
 
         if self.hasGui:
-            PackageManager.save(self)
+            self._packageManager.save(self)
         if saveConfig:
             self.saveConfig()
         if self.logger is not None:

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import regex
 
-from arelle import Locale, ModelManager, PackageManager, XbrlConst
+from arelle import Locale, ModelManager, XbrlConst
 from arelle.BetaFeatures import BETA_FEATURES_AND_DESCRIPTIONS
 from arelle.ErrorManager import ErrorManager
 from arelle.FileSource import FileSource
@@ -33,6 +33,8 @@ from arelle.logging.handlers.LogToPrintHandler import LogToPrintHandler
 from arelle.logging.handlers.LogToXmlHandler import LogToXmlHandler
 from arelle.logging.handlers.StructuredMessageLogHandler import StructuredMessageLogHandler
 from arelle.SystemInfo import PlatformOS, getSystemWordSize, hasFileSystem, hasWebServer, isCGI, isGAE
+from arelle.packages._package_manager import PackageManager
+from arelle.packages.package_registry import PackageRegistry
 from arelle.plugin_system._plugin_manager import PluginManager
 from arelle.plugin_system.plugin_provider import PluginProvider
 from arelle.typing import TypeGetText
@@ -127,6 +129,7 @@ class Cntlr:
 
     """
     __version__ = "1.6.0"
+    _packageManager: PackageManager
     _pluginManager: PluginManager
     betaFeatures: dict[str, bool]
     errorManager: ErrorManager | None
@@ -135,6 +138,7 @@ class Cntlr:
     hasFileSystem: bool
     isGAE: bool
     isCGI: bool
+    packages: PackageRegistry
     systemWordSize: int
     uiLang: str
     configDir: str
@@ -300,7 +304,10 @@ class Cntlr:
         self.modelManager = ModelManager.initialize(self)
 
         # start taxonomy package server (requres web cache initialized, but not logger)
-        PackageManager.init(self, loadPackagesConfig=hasGui)
+        from arelle.PackageManager import getInstance as _getPackageManagerInstance
+        self._packageManager = _getPackageManagerInstance()
+        self._packageManager.init(self, loadPackagesConfig=hasGui)
+        self.packages = PackageRegistry(self._packageManager)
 
         self.startLogging(logFileName, logFileMode, logFileEncoding, logFormat)
         self.errorManager = ErrorManager(self.modelManager, logging._checkLevel("INCONSISTENCY")) # type: ignore[attr-defined]

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -2382,11 +2382,11 @@ class CntlrCmdLine(Cntlr.Cntlr):
             self._packageManager.packagesConfigChanged = False
         if showPackages:
             self.addToLog(_("Taxonomy packages:"), messageCode="info")
-            for packageInfo in self._packageManager.orderedPackagesConfig()["packages"]:
+            for packageMeta in self.packages.get_packages():
                 self.addToLog(_("Package: {0}; version: {1}; status: {2}; date: {3}; description: {4}.").format(
-                    packageInfo.get("name"), packageInfo.get("version"), packageInfo.get("status"),
-                    packageInfo.get("fileDate"), packageInfo.get("description")),
-                    messageCode="info", file=packageInfo.get("URL"))
+                    packageMeta.name, packageMeta.version, packageMeta.status,
+                    packageMeta.file_date, packageMeta.description),
+                    messageCode="info", file=packageMeta.url)
 
 if __name__ == "__main__":
     if getattr(sys, 'frozen', False):

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -37,7 +37,6 @@ from arelle import (
     Cntlr,
     FileSource,
     ModelDocument,
-    PackageManager,
     PluginManager,
     ValidateDuplicateFactsConst,
     Version,
@@ -1994,7 +1993,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
             if filesource and filesource.isArchive:
                 filesource.select(_entrypointFile)
             else:
-                _entrypointFile = PackageManager.getInstance().mappedUrl(_entrypointFile)
+                _entrypointFile = self._packageManager.mappedUrl(_entrypointFile)
                 filesource = FileSource.openFileSource(_entrypointFile, self, sourceZipStream)
                 if options.validate:
                     ValidateFileSource(self, filesource).validate(options.reportPackage, options.taxonomyPackage)
@@ -2325,8 +2324,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                 sys.exit()
 
     def loadPackage(self, package: str, packageManifestName: str) -> None:
-        from arelle import PackageManager
-        packageInfo = PackageManager.getInstance().addPackage(self, package, packageManifestName)
+        packageInfo = self._packageManager.addPackage(self, package, packageManifestName)
         if packageInfo:
             self.addToLog(_("Activation of package {0} successful.").format(packageInfo.get("name")),
                           messageCode="info", file=packageInfo.get("URL", ""))
@@ -2342,10 +2340,8 @@ class CntlrCmdLine(Cntlr.Cntlr):
         :param packages: Pipe-separated list of options. See CLI documentation for 'packages'.
         :param packageManifestName: Unix shell style pattern used to find package manifest.
         """
-        from arelle import PackageManager
         savePackagesChanges = True
         showPackages = False
-        packageManager = PackageManager.getInstance()
         # For backwards compatibility, we allow '|' separated filenames/URLs
         # within a single --packages option.
         for packageCmd in [cmd for p in packages for cmd in p.split("|")]:
@@ -2355,19 +2351,19 @@ class CntlrCmdLine(Cntlr.Cntlr):
             elif cmd == "temp":
                 savePackagesChanges = False
             elif cmd.startswith("+"):
-                packageInfo = packageManager.addPackage(self, cmd[1:], packageManifestName)
+                packageInfo = self._packageManager.addPackage(self, cmd[1:], packageManifestName)
                 if packageInfo:
                     self.addToLog(_("Addition of package {0} successful.").format(packageInfo.get("name")),
                                   messageCode="info", file=packageInfo.get("URL", ""))
                 else:
                     self.addToLog(_("Unable to load package."), messageCode="info", file=cmd[1:])
             elif cmd.startswith("~"):
-                if packageManager.reloadPackageModule(self, cmd[1:]):
+                if self._packageManager.reloadPackageModule(self, cmd[1:]):
                     self.addToLog(_("Reload of package successful."), messageCode="info", file=cmd[1:])
                 else:
                     self.addToLog(_("Unable to reload package."), messageCode="info", file=cmd[1:])
             elif cmd.startswith("-"):
-                if packageManager.removePackageModule(self, cmd[1:]):
+                if self._packageManager.removePackageModule(self, cmd[1:]):
                     self.addToLog(_("Deletion of package successful."), messageCode="info", file=cmd[1:])
                 else:
                     self.addToLog(_("Unable to delete package."), messageCode="info", file=cmd[1:])
@@ -2378,15 +2374,15 @@ class CntlrCmdLine(Cntlr.Cntlr):
             else: # assume it is a module or package
                 savePackagesChanges = False
                 self.loadPackage(cmd, packageManifestName)
-        if packageManager.packagesConfigChanged:
-            packageManager.rebuildRemappings(self)
+        if self._packageManager.packagesConfigChanged:
+            self._packageManager.rebuildRemappings(self)
         if savePackagesChanges:
-            packageManager.save(self)
+            self._packageManager.save(self)
         else:
-            packageManager.packagesConfigChanged = False
+            self._packageManager.packagesConfigChanged = False
         if showPackages:
             self.addToLog(_("Taxonomy packages:"), messageCode="info")
-            for packageInfo in PackageManager.orderedPackagesConfig()["packages"]:
+            for packageInfo in self._packageManager.orderedPackagesConfig()["packages"]:
                 self.addToLog(_("Package: {0}; version: {1}; status: {2}; date: {3}; description: {4}.").format(
                     packageInfo.get("name"), packageInfo.get("version"), packageInfo.get("status"),
                     packageInfo.get("fileDate"), packageInfo.get("description")),

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -2324,10 +2324,10 @@ class CntlrCmdLine(Cntlr.Cntlr):
                 sys.exit()
 
     def loadPackage(self, package: str, packageManifestName: str) -> None:
-        packageInfo = self._packageManager.addPackage(self, package, packageManifestName)
-        if packageInfo:
-            self.addToLog(_("Activation of package {0} successful.").format(packageInfo.get("name")),
-                          messageCode="info", file=packageInfo.get("URL", ""))
+        packageMeta = self.packages.add(package, packageManifestName)
+        if packageMeta:
+            self.addToLog(_("Activation of package {0} successful.").format(packageMeta.name),
+                          messageCode="info", file=packageMeta.url)
         else:
             self.addToLog(_("Unable to load package \"%(name)s\". "),
                           messageCode="arelle:packageLoadingError",
@@ -2351,10 +2351,10 @@ class CntlrCmdLine(Cntlr.Cntlr):
             elif cmd == "temp":
                 savePackagesChanges = False
             elif cmd.startswith("+"):
-                packageInfo = self._packageManager.addPackage(self, cmd[1:], packageManifestName)
-                if packageInfo:
-                    self.addToLog(_("Addition of package {0} successful.").format(packageInfo.get("name")),
-                                  messageCode="info", file=packageInfo.get("URL", ""))
+                packageMeta = self.packages.add(cmd[1:], packageManifestName)
+                if packageMeta:
+                    self.addToLog(_("Addition of package {0} successful.").format(packageMeta.name),
+                                  messageCode="info", file=packageMeta.url)
                 else:
                     self.addToLog(_("Unable to load package."), messageCode="info", file=cmd[1:])
             elif cmd.startswith("~"):

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1993,7 +1993,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
             if filesource and filesource.isArchive:
                 filesource.select(_entrypointFile)
             else:
-                _entrypointFile = self._packageManager.mappedUrl(_entrypointFile)
+                _entrypointFile = self.packages.map(_entrypointFile)
                 filesource = FileSource.openFileSource(_entrypointFile, self, sourceZipStream)
                 if options.validate:
                     ValidateFileSource(self, filesource).validate(options.reportPackage, options.taxonomyPackage)

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -593,15 +593,15 @@ class CntlrWinMain(Cntlr.Cntlr):
         self.fileMenu.add_cascade(label=_("Recent imports"), menu=self.recentAttachMenu, underline=0)
         self.packagesMenu = Menu(self.menubar, tearoff=0)
         hasPackages = False
-        for i, packageInfo in enumerate(sorted(self._packageManager.packagesConfig.get("packages", []),
-                                               key=lambda packageInfo: (packageInfo.get("name",""),packageInfo.get("version",""))),
+        for i, packageMeta in enumerate(sorted(self.packages.get_packages(),
+                                               key=lambda packageMeta: (packageMeta.name,packageMeta.version)),
                                         start=1):
-            name = packageInfo.get("name", "package{}".format(i))
-            version = packageInfo.get("version")
+            name = packageMeta.name if packageMeta.name is not None else "package{}".format(i)
+            version = packageMeta.version
             if version:
                 name = "{} ({})".format(name, version)
-            URL = packageInfo.get("URL")
-            if name and URL and packageInfo.get("status") == "enabled":
+            URL = packageMeta.url
+            if name and URL and packageMeta.status == "enabled":
                 self.packagesMenu.add_command(
                      label=name,
                      command=lambda url=URL: self.fileOpenFile(url))  # type: ignore[misc]

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -593,9 +593,7 @@ class CntlrWinMain(Cntlr.Cntlr):
         self.fileMenu.add_cascade(label=_("Recent imports"), menu=self.recentAttachMenu, underline=0)
         self.packagesMenu = Menu(self.menubar, tearoff=0)
         hasPackages = False
-        for i, packageMeta in enumerate(sorted(self.packages.get_packages(),
-                                               key=lambda packageMeta: (packageMeta.name,packageMeta.version)),
-                                        start=1):
+        for i, packageMeta in enumerate(self.packages.get_packages(), start=1):
             name = packageMeta.name if packageMeta.name is not None else "package{}".format(i)
             version = packageMeta.version
             if version:

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -78,7 +78,6 @@ from arelle import (
     DialogPluginManager,
     DialogURL,
     ModelDocument,
-    PackageManager,
     TableStructure,
     Updater,
     ViewFileConcepts,
@@ -594,7 +593,7 @@ class CntlrWinMain(Cntlr.Cntlr):
         self.fileMenu.add_cascade(label=_("Recent imports"), menu=self.recentAttachMenu, underline=0)
         self.packagesMenu = Menu(self.menubar, tearoff=0)
         hasPackages = False
-        for i, packageInfo in enumerate(sorted(PackageManager.packagesConfig.get("packages", []),
+        for i, packageInfo in enumerate(sorted(self._packageManager.packagesConfig.get("packages", []),
                                                key=lambda packageInfo: (packageInfo.get("name",""),packageInfo.get("version",""))),
                                         start=1):
             name = packageInfo.get("name", "package{}".format(i))
@@ -921,7 +920,7 @@ class CntlrWinMain(Cntlr.Cntlr):
             return
         url = DialogURL.askURL(self.parent, buttonSEC=True, buttonRSS=True)
         if url:
-            url = PackageManager.mappedUrl(url)
+            url = self._packageManager.mappedUrl(url)
             self.updateFileHistory(url, False)
             for xbrlLoadedMethod in self.plugins.hooks("CntlrWinMain.Xbrl.Open"):
                 url = xbrlLoadedMethod(self, url) # runs in GUI thread, allows mapping url, mult return url
@@ -952,7 +951,7 @@ class CntlrWinMain(Cntlr.Cntlr):
             return False
         url = DialogURL.askURL(self.parent, buttonSEC=False, buttonRSS=False)
         if url:
-            url = PackageManager.mappedUrl(url)
+            url = self._packageManager.mappedUrl(url)
             self.fileOpenFile(url, importToDTS=True)
         return None
 
@@ -969,7 +968,7 @@ class CntlrWinMain(Cntlr.Cntlr):
                 if filesource and filesource.isArchive:
                     filesource.select(entrypointFile)
                 else:
-                    entrypointFile = PackageManager.mappedUrl(entrypointFile)
+                    entrypointFile = self._packageManager.mappedUrl(entrypointFile)
                     filesource = openFileSource(entrypointFile, self)
                 if importToDTS:
                     action = _("imported")

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -920,7 +920,7 @@ class CntlrWinMain(Cntlr.Cntlr):
             return
         url = DialogURL.askURL(self.parent, buttonSEC=True, buttonRSS=True)
         if url:
-            url = self._packageManager.mappedUrl(url)
+            url = self.packages.map(url)
             self.updateFileHistory(url, False)
             for xbrlLoadedMethod in self.plugins.hooks("CntlrWinMain.Xbrl.Open"):
                 url = xbrlLoadedMethod(self, url) # runs in GUI thread, allows mapping url, mult return url
@@ -951,7 +951,7 @@ class CntlrWinMain(Cntlr.Cntlr):
             return False
         url = DialogURL.askURL(self.parent, buttonSEC=False, buttonRSS=False)
         if url:
-            url = self._packageManager.mappedUrl(url)
+            url = self.packages.map(url)
             self.fileOpenFile(url, importToDTS=True)
         return None
 
@@ -968,7 +968,7 @@ class CntlrWinMain(Cntlr.Cntlr):
                 if filesource and filesource.isArchive:
                     filesource.select(entrypointFile)
                 else:
-                    entrypointFile = self._packageManager.mappedUrl(entrypointFile)
+                    entrypointFile = self.packages.map(entrypointFile)
                     filesource = openFileSource(entrypointFile, self)
                 if importToDTS:
                     action = _("imported")

--- a/arelle/DialogPackageManager.py
+++ b/arelle/DialogPackageManager.py
@@ -23,17 +23,18 @@ def dialogPackageManager(mainWin):
 
 def backgroundCheckForUpdates(cntlr):
     cntlr.showStatus(_("Checking for updates to packages")) # clear web loading status
-    packageNamesWithNewerFileDates = PackageManager.packageNamesWithNewerFileDates()
+    packageManager = PackageManager.getInstance()
+    packageNamesWithNewerFileDates = packageManager.packageNamesWithNewerFileDates()
     if packageNamesWithNewerFileDates:
         cntlr.showStatus(_("Updates are available for these packages: {0}")
                               .format(', '.join(packageNamesWithNewerFileDates)), clearAfter=5000)
     else:
         cntlr.showStatus(_("No updates found for packages."), clearAfter=5000)
     time.sleep(0.1) # Mac locks up without this, may be needed for empty ui queue?
-    cntlr.uiThreadQueue.put((DialogPackageManager, [cntlr, packageNamesWithNewerFileDates]))
+    cntlr.uiThreadQueue.put((DialogPackageManager, [cntlr, packageManager, packageNamesWithNewerFileDates]))
 
 class DialogPackageManager(Toplevel):
-    def __init__(self, mainWin, packageNamesWithNewerFileDates):
+    def __init__(self, mainWin, packageManager, packageNamesWithNewerFileDates):
         super(DialogPackageManager, self).__init__(mainWin.parent)
 
         self.ENABLE = _("Enable")
@@ -43,7 +44,7 @@ class DialogPackageManager(Toplevel):
         self.webCache = mainWin.webCache
 
         # copy plugins for temporary display
-        self._packageManager = PackageManager.getInstance()
+        self._packageManager = packageManager
         self.packagesConfig = self._packageManager.packagesConfig
         self.packagesConfigChanged = False
         self.packageNamesWithNewerFileDates = packageNamesWithNewerFileDates

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -13,17 +13,13 @@ from typing import Any, cast, TYPE_CHECKING
 from typing_extensions import Self
 from lxml import etree
 from xml.sax import SAXParseException
-
-from arelle import (
-    PackageManager, XbrlConst, XmlUtil, UrlUtil, ValidateFilingText,
-    XhtmlValidate, XmlValidateSchema, FunctionIxt,
-    )
-
-from arelle.ModelXbrl import ModelXbrl
+from arelle import (XbrlConst, XmlUtil, UrlUtil, ValidateFilingText,
+                    XhtmlValidate, XmlValidateSchema, FunctionIxt)
 from arelle.conformance.CSVTestcaseLoader import CSVTestcaseException, loadCsvTestcase
 from arelle.FileSource import FileSource
 from arelle.ModelObject import ModelObject
 from arelle.ModelValue import qname, QName
+from arelle.ModelXbrl import ModelXbrl
 from arelle.ModelDtsObject import ModelLink
 from arelle.ModelInstanceObject import ModelFact, ModelContext, ModelUnit, ModelInlineFact
 from arelle.ModelObjectFactory import parser, KnownNamespacesModelObjectClassLookup, DiscoveringClassLookup
@@ -115,10 +111,11 @@ def load(modelXbrl: ModelXbrl, uri: str, base: str | None = None, referringEleme
     if modelXbrl.modelManager.skipLoading and modelXbrl.modelManager.skipLoading.match(normalizedUri):
         return None
 
+    mappedUri: str | None
     if modelXbrl.fileSource.isMappedUrl(normalizedUri):
         mappedUri = modelXbrl.fileSource.mappedUrl(normalizedUri)
-    elif PackageManager.isMappedUrl(normalizedUri):
-        mappedUri = PackageManager.mappedUrl(normalizedUri)  # type: ignore[assignment]
+    elif modelXbrl.modelManager.cntlr.packages.is_mapped(normalizedUri):
+        mappedUri = modelXbrl.modelManager.cntlr.packages.map(normalizedUri)
     else:
         mappedUri = modelXbrl.modelManager.disclosureSystem.mappedUrl(normalizedUri)
 
@@ -130,7 +127,7 @@ def load(modelXbrl: ModelXbrl, uri: str, base: str | None = None, referringEleme
     if modelXbrl.fileSource.isInArchive(mappedUri):
         filepath = mappedUri
     else:
-        filepath = modelXbrl.modelManager.cntlr.webCache.getfilename(mappedUri, reload=reloadCache, checkModifiedTime=kwargs.get("checkModifiedTime",False))  # type: ignore[assignment]
+        filepath = modelXbrl.modelManager.cntlr.webCache.getfilename(mappedUri, reload=reloadCache, checkModifiedTime=kwargs.get("checkModifiedTime",False))
         if filepath:
             uri = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(filepath)
     if filepath is None: # error such as HTTPerror is already logged

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -150,10 +150,10 @@ class ModelManager:
         if taxonomyPackages:
             resetPackageMappings = False
             for pkgUrl in taxonomyPackages:
-                if PackageManager.addPackage(self.cntlr, pkgUrl):
+                if self.cntlr.packages.add(pkgUrl):
                     resetPackageMappings = True
             if resetPackageMappings:
-                PackageManager.rebuildRemappings(self.cntlr)
+                self.cntlr.packages.rebuild()
         modelXbrl: ModelXbrl | None = None # loaded modelXbrl
         if isinstance(filesource, FileSource):
             if isinstance(filesource.url, str) and filesource.url.startswith("urn:uuid:"): # request for an open modelXbrl

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -287,7 +287,7 @@ class ModelXbrl:
 
     closeFileSource: bool
     dimensionDefaultConcepts: dict[ModelConcept, ModelConcept]
-    entryLoadingUrl: str
+    entryLoadingUrl: str | None
     fileSource: FileSourceClass
     ixdsDocUrls: list[str]
     ixdsHtmlElements: list[Any]

--- a/arelle/ValidateFileSource.py
+++ b/arelle/ValidateFileSource.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from arelle import PackageManager
 from arelle.packages.report.ReportPackageValidator import ReportPackageValidator
 
 if TYPE_CHECKING:

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -18,7 +18,7 @@ import isodate
 import regex as re
 from lxml import etree
 
-from arelle import (ModelDocument, ModelXbrl, PackageManager, UrlUtil,
+from arelle import (ModelDocument, ModelXbrl, UrlUtil,
                     ValidateXbrlDimensions, XbrlConst, XmlUtil, XmlValidate)
 from arelle.ModelValue import (DATETIME, dateTime, dayTimeDuration, qname,
                                yearMonthDuration)
@@ -828,8 +828,8 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
             normalizedUrl = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(oimFile, extendingFile)
             if modelXbrl.fileSource.isMappedUrl(normalizedUrl):
                 mappedUrl = modelXbrl.fileSource.mappedUrl(normalizedUrl)
-            elif PackageManager.isMappedUrl(normalizedUrl):
-                mappedUrl = PackageManager.mappedUrl(normalizedUrl)
+            elif cntlr.packages.is_mapped(normalizedUrl):
+                mappedUrl = cntlr.packages.map(normalizedUrl)
             else:
                 mappedUrl = modelXbrl.modelManager.disclosureSystem.mappedUrl(normalizedUrl)
             if modelXbrl.fileSource.isInArchive(mappedUrl):

--- a/arelle/packages/_package_manager.py
+++ b/arelle/packages/_package_manager.py
@@ -532,12 +532,13 @@ class PackageManager:
 
     def packageInfo(
         self,
-        cntlr: Cntlr,
+        cntlr: Cntlr | None,
         URL: str,
         reload: bool = False,
         packageManifestName: str | None = None,
         errors: list[str] | None = None,
     ) -> dict[str, Any] | None:
+        cntlr = cntlr or self._getCntlr()
         if errors is None:
             errors = []
         #TODO several directories, eg User Application Data
@@ -671,7 +672,8 @@ class PackageManager:
                 filesource.close()
         return None
 
-    def rebuildRemappings(self, cntlr: Cntlr) -> None:
+    def rebuildRemappings(self, cntlr: Cntlr | None = None) -> None:
+        cntlr = cntlr or self._getCntlr()
         remappings = self._getPackagesConfig()["remappings"]
         remappings.clear()
         remapOverlapUrls: list[tuple[str, str, str]] = []  # (prefix, packageURL, rewriteString)
@@ -727,10 +729,11 @@ class PackageManager:
 
     def addPackage(
         self,
-        cntlr: Cntlr,
+        cntlr: Cntlr | None,
         url: str,
         packageManifestName: str | None = None,
     ) -> dict[str, Any] | None:
+        cntlr = cntlr or self._getCntlr()
         newPackageInfo = self.packageInfo(cntlr, url, packageManifestName=packageManifestName)
         if newPackageInfo and newPackageInfo.get("identifier"):
             identifier = newPackageInfo.get("identifier")

--- a/arelle/packages/package_meta.py
+++ b/arelle/packages/package_meta.py
@@ -1,0 +1,62 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, Set
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PackageMeta:
+    description: str | None
+    entry_points: Mapping[str, Set[tuple[str, str, str]]] # Path, URL, Description
+    file_date: str | None
+    identifier: str | None
+    license: str | None
+    manifest_name: str | None
+    name: str | None
+    publication_date: str | None
+    publisher: str | None
+    publisher_country: str | None
+    publisher_url: str | None
+    remappings: Mapping[str, str]
+    status: str | None
+    superseded_taxonomy_packages: Set[str]
+    url: str
+    version: str | None
+    versioning_reports: Set[str]
+
+    @staticmethod
+    def from_config(config: dict[str, Any]) -> PackageMeta:
+        return PackageMeta(
+            description=config.get("description"),
+            entry_points=MappingProxyType({
+                name: frozenset(
+                    (path, url, description)
+                    for path, url, description in entry_points
+                )
+                for name, entry_points in config.get("entryPoints", {}).items()
+            }),
+            file_date=config.get("fileDate"),
+            identifier=config.get("identifier"),
+            license=config.get("license"),
+            manifest_name=config.get("manifestName"),
+            name=config.get("name"),
+            publication_date=config.get("publicationDate"),
+            publisher=config.get("publisher"),
+            publisher_country=config.get("publisherCountry"),
+            publisher_url=config.get("publisherURL"),
+            remappings=MappingProxyType({
+                prefix: remapping
+                for prefix, remapping in config.get("remappings", {}).items()
+                if isinstance(prefix, str) and isinstance(remapping, str)
+            }),
+            status=config.get("status"),
+            superseded_taxonomy_packages=frozenset(config.get("supersededTaxonomyPackages", [])),
+            url=config.get("URL") or "",
+            version=config.get("version"),
+            versioning_reports=frozenset(config.get("versioningReports", [])),
+        )

--- a/arelle/packages/package_registry.py
+++ b/arelle/packages/package_registry.py
@@ -1,0 +1,52 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+from arelle.packages._package_manager import PackageManager
+from arelle.packages.package_meta import PackageMeta
+
+
+class PackageRegistry:
+
+    def __init__(self, package_manager: PackageManager) -> None:
+        self._package_manager = package_manager
+
+    def add(
+            self,
+            url: str,
+            manifest_name: str | None = None,
+    ) -> PackageMeta | None:
+        package_config = self._package_manager.addPackage(
+            cntlr=None,
+            url=url,
+            packageManifestName=manifest_name
+        )
+        if package_config is None:
+            return None
+        return PackageMeta.from_config(package_config)
+
+    def get_mappings(self) -> dict[str, str]:
+        config = self._package_manager.orderedPackagesConfig()
+        return {
+            prefix: remapping
+            for prefix, remapping in config.get("remappings", {}).items()
+            if isinstance(prefix, str) and isinstance(remapping, str)
+        }
+
+    def get_packages(self) -> tuple[PackageMeta, ...]:
+        config = self._package_manager.orderedPackagesConfig()
+        package_configs = config.get("packages", [])
+        return tuple(
+            PackageMeta.from_config(package_config)
+            for package_config in package_configs
+        )
+
+    def is_mapped(self, url: str | None) -> bool:
+        return self._package_manager.isMappedUrl(url)
+
+    def map(self, url: str | None) -> str | None:
+        return self._package_manager.mappedUrl(url)
+
+    def rebuild(self) -> None:
+        return self._package_manager.rebuildRemappings()

--- a/arelle/plugin/formulaXPathChecker.py
+++ b/arelle/plugin/formulaXPathChecker.py
@@ -39,7 +39,7 @@ from arelle.formula.XPathParser import (VariableRef, QNameDef, OperationDef, Ran
 from arelle.formula.XPathContext import (XPathException, VALUE_OPS, GENERALCOMPARISON_OPS, NODECOMPARISON_OPS,
                                  COMBINING_OPS, LOGICAL_OPS, UNARY_OPS, FORSOMEEVERY_OPS, PATH_OPS,
                                  SEQUENCE_TYPES, GREGORIAN_TYPES)
-from arelle import FileSource, PackageManager, XbrlConst, XmlUtil, ValidateXbrlDimensions
+from arelle import FileSource, XbrlConst, XmlUtil, ValidateXbrlDimensions
 from arelle.formula import ValidateFormula, XPathParser
 from arelle.Version import authorLabel, copyrightLabel
 import os, datetime, logging
@@ -290,16 +290,16 @@ def validateUtilityRun(cntlr, options, *args, **kwargs):
 def setupPackageEntrypoints(cntlr, options, filesource, entrypointFiles, *args, **kwargs):
     # check package entries formula code
     if getattr(options, "checkPackageEntries", False) and not entrypointFiles:
-        for packageInfo in sorted(PackageManager.packagesConfig.get("packages", []),
-                                  key=lambda packageInfo: (packageInfo.get("name",""),packageInfo.get("version",""))):
+        for packageMeta in sorted(cntlr.packages.get_packages(),
+                                  key=lambda packageMeta: (packageMeta.name ,packageMeta.version)):
             cntlr.addToLog(_("Package %(package)s Version %(version)s"),
-                           messageArgs={"package": packageInfo["name"], "version": packageInfo["version"]},
+                           messageArgs={"package": packageMeta.name, "version": packageMeta.version},
                            messageCode="info",
                            level=logging.INFO)
-            filesource = FileSource.openFileSource(packageInfo["URL"], cntlr)
+            filesource = FileSource.openFileSource(packageMeta.url, cntlr)
             if filesource.isTaxonomyPackage:  # if archive is also a taxonomy package, activate mappings
                 filesource.loadTaxonomyPackageMappings()
-            for name, urls in packageInfo.get("entryPoints",{}).items():
+            for name, urls in packageMeta.entry_points.items():
                 for url in urls:
                     if filesource and filesource.isArchive:
                         cntlr.addToLog(_("   EntryPont %(entryPoint)s: %(url)s"),

--- a/arelle/plugin/formulaXPathChecker.py
+++ b/arelle/plugin/formulaXPathChecker.py
@@ -290,8 +290,7 @@ def validateUtilityRun(cntlr, options, *args, **kwargs):
 def setupPackageEntrypoints(cntlr, options, filesource, entrypointFiles, *args, **kwargs):
     # check package entries formula code
     if getattr(options, "checkPackageEntries", False) and not entrypointFiles:
-        for packageMeta in sorted(cntlr.packages.get_packages(),
-                                  key=lambda packageMeta: (packageMeta.name ,packageMeta.version)):
+        for packageMeta in cntlr.packages.get_packages():
             cntlr.addToLog(_("Package %(package)s Version %(version)s"),
                            messageArgs={"package": packageMeta.name, "version": packageMeta.version},
                            messageCode="info",

--- a/arelle/utils/EntryPointDetection.py
+++ b/arelle/utils/EntryPointDetection.py
@@ -9,9 +9,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING, BinaryIO, cast
 
-from arelle import (
-    FileSource, PackageManager,
-)
+from arelle import FileSource
 from arelle.FileSource import FileNamedBytesIO
 from arelle.ModelDocumentType import ModelDocumentType
 from arelle.UrlUtil import isHttpUrl
@@ -55,7 +53,7 @@ def parseEntrypointFileInput(cntlr: Cntlr, entrypointFile: str | None, sourceZip
     if sourceZipStream:
         filesource = FileSource.openFileSource(None, cntlr, sourceZipStream)
     elif len(_entryPoints) == 1 and "file" in _entryPoints[0]: # check if an archive and need to discover entry points (and not IXDS)
-        entryPath = PackageManager.mappedUrl(_entryPoints[0]["file"])
+        entryPath = cntlr.packages.map(_entryPoints[0]["file"])
         filesource = FileSource.openFileSource(entryPath, cntlr, checkIfXmlIsEis=_checkIfXmlIsEis)
     _entrypointFiles = _entryPoints
     if filesource and not filesource.selection and not (sourceZipStream and len(_entrypointFiles) > 0):

--- a/tests/unit_tests/arelle/packages/test_package_meta.py
+++ b/tests/unit_tests/arelle/packages/test_package_meta.py
@@ -1,0 +1,110 @@
+from arelle.packages.package_meta import PackageMeta
+
+_PACKAGE_CONFIG = {
+    "URL": "tests/resources/packages/example.zip",
+    "description": "Example taxonomy package.",
+    "entryPoints": {
+        "Example entry point #1": [
+            (
+                "/example/all1.xsd",
+                "https://www.example.com/all1.xsd",
+                "Example entry point."
+            )
+        ],
+        "Example entry point #2": [
+            (
+                "https://www.example.com/all2.xsd",
+                "https://www.example.com/all2.xsd",
+                "Example entry point with URL instead of file path."
+            )
+        ]
+    },
+    "fileDate": "2025-05-20T19:45:47 UTC",
+    "identifier": "https://www.example.com/all",
+    "license": "The IFRS Taxonomy - Terms and Conditions",
+    "manifestName": "META-INF/taxonomyPackage.xml",
+    "name": "Example taxonomy",
+    "publicationDate": "2024-12-31",
+    "publisher": "Example publisher",
+    "publisherCountry": "NL",
+    "publisherURL": "https://www.example.com/publisher",
+    "remappings": {
+        "https://www.example.com/2024-12-31/": "/example/2024-12-31/"
+    },
+    "status": "enabled",
+    "supersededTaxonomyPackages": [],
+    "version": "31 december 2024",
+    "versioningReports": [
+        "https://www.example.com/versioning1.xml",
+        "https://www.example.com/versioning2.xml",
+    ]
+}
+
+
+def test_parse_package_config_empty():
+    """
+    Test that PackageMeta is correctly parsed from minimal config.
+    """
+    package_meta = PackageMeta.from_config({})
+
+    assert package_meta.description is None
+    assert len(package_meta.entry_points) == 0
+    assert package_meta.file_date is None
+    assert package_meta.identifier is None
+    assert package_meta.license is None
+    assert package_meta.manifest_name is None
+    assert package_meta.name is None
+    assert package_meta.publication_date is None
+    assert package_meta.publisher is None
+    assert package_meta.publisher_country is None
+    assert package_meta.publisher_url is None
+    assert len(package_meta.remappings) == 0
+    assert package_meta.status is None
+    assert len(package_meta.superseded_taxonomy_packages) == 0
+    assert len(package_meta.url) == 0
+    assert package_meta.version is None
+    assert len(package_meta.versioning_reports) == 0
+
+
+def test_parse_package_config_full():
+    """
+    Test that PackageMeta is correctly parsed from maximal config.
+    """
+    package_meta = PackageMeta.from_config(_PACKAGE_CONFIG)
+    assert package_meta.description == "Example taxonomy package."
+    assert package_meta.entry_points == {
+        "Example entry point #1": frozenset([
+            (
+                "/example/all1.xsd",
+                "https://www.example.com/all1.xsd",
+                "Example entry point."
+            )
+        ]),
+        "Example entry point #2":  frozenset([
+            (
+                "https://www.example.com/all2.xsd",
+                "https://www.example.com/all2.xsd",
+                "Example entry point with URL instead of file path."
+            )
+        ])
+    }
+    assert package_meta.file_date == "2025-05-20T19:45:47 UTC"
+    assert package_meta.identifier == "https://www.example.com/all"
+    assert package_meta.license == "The IFRS Taxonomy - Terms and Conditions"
+    assert package_meta.manifest_name == "META-INF/taxonomyPackage.xml"
+    assert package_meta.name == "Example taxonomy"
+    assert package_meta.publication_date == "2024-12-31"
+    assert package_meta.publisher == "Example publisher"
+    assert package_meta.publisher_country == "NL"
+    assert package_meta.publisher_url == "https://www.example.com/publisher"
+    assert package_meta.remappings == {
+        "https://www.example.com/2024-12-31/": "/example/2024-12-31/"
+    }
+    assert package_meta.status == "enabled"
+    assert package_meta.superseded_taxonomy_packages == frozenset()
+    assert package_meta.url == "tests/resources/packages/example.zip"
+    assert package_meta.version == "31 december 2024"
+    assert package_meta.versioning_reports == frozenset({
+        "https://www.example.com/versioning1.xml",
+        "https://www.example.com/versioning2.xml",
+    })


### PR DESCRIPTION
#### Reason for change
Part of the non-breaking phase of #2269.
Establish the official public API for package mapping and interaction.

#### Description of change
Introduce a new component of the package mapping system: `PackageSource`. This component serves as a public API wrapper for interacting with the internal package mapping system.

Migrate most internal package mapping use to new API. Remaining `PackageManager` uses will be addressed in subsequent PRs.

#### Steps to Test
CI

**review**:
@Arelle/arelle
