### PR TITLE
Handle DockerHub Username and Namespace Separately

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             PYTHON_VERSION=${{ inputs.python_version }}
           push: true
@@ -125,6 +126,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             PYTHON_VERSION=${{ inputs.python_version }}
             INCLUDE_EDGAR=true

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -40,6 +40,8 @@ on:
         required: false
         type: string
 
+permissions: {}
+
 jobs:
   push-to-registry:
     name: Push Docker images

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -52,6 +52,8 @@ jobs:
       contents: read
       attestations: write
       id-token: write
+    env:
+      DOCKERHUB_IMAGE: ${{ vars.DOCKER_NAMESPACE || secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}
     steps:
       - name: Checkout Arelle
         uses: actions/checkout@v6.0.2
@@ -77,17 +79,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.0.0
 
-      - name: Extract repository name to ENV
-        id: repository_name
-        run: |
-          echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> "$GITHUB_OUTPUT"
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6.0.0
         with:
           images: |
-            ${{ secrets.DOCKER_USERNAME }}/${{ steps.repository_name.outputs.REPO_NAME }}
+            ${{ env.DOCKERHUB_IMAGE }}
             ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
@@ -99,7 +96,7 @@ jobs:
         uses: docker/metadata-action@v6.0.0
         with:
           images: |
-            ${{ secrets.DOCKER_USERNAME }}/${{ steps.repository_name.outputs.REPO_NAME }}
+            ${{ env.DOCKERHUB_IMAGE }}
             ghcr.io/${{ github.repository }}
           flavor: |
             latest=false
@@ -142,13 +139,13 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest@v4.1.0
         with:
-          subject-name: index.docker.io/${{ secrets.DOCKER_USERNAME }}/${{ steps.repository_name.outputs.REPO_NAME }}
+          subject-name: index.docker.io/${{ env.DOCKERHUB_IMAGE }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
       - name: Generate artifact attestation slim
         uses: actions/attest@v4.1.0
         with:
-          subject-name: index.docker.io/${{ secrets.DOCKER_USERNAME }}/${{ steps.repository_name.outputs.REPO_NAME }}
+          subject-name: index.docker.io/${{ env.DOCKERHUB_IMAGE }}
           subject-digest: ${{ steps.push-slim.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -42,7 +42,7 @@ on:
 
 jobs:
   push-to-registry:
-    name: Push Docker images to Docker Hub
+    name: Push Docker images
     runs-on: ubuntu-24.04
     environment: release
     permissions:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -53,7 +53,7 @@ jobs:
       attestations: write
       id-token: write
     env:
-      DOCKERHUB_IMAGE: ${{ vars.DOCKER_NAMESPACE || secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}
+      DOCKERHUB_IMAGE: ${{ vars.DOCKER_NAMESPACE || vars.DOCKER_USERNAME }}/${{ github.event.repository.name }}
     steps:
       - name: Checkout Arelle
         uses: actions/checkout@v6.0.2
@@ -63,7 +63,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v4.0.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Log in to GHCR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,4 +130,3 @@ jobs:
       id-token: write
     uses: ./.github/workflows/publish-docker.yml
     secrets: inherit
-


### PR DESCRIPTION
#### Reason for change

This didn't come up while testing on forks where the username and namespace matched.

#### Description of change

* Decouple DockerHub username and image namespace (the Arelle team account and image namespace don't match).
* Build images for both amd64 and arm64 (increases workflow execution time, but still nowhere near the longest running job in the release workflow).

#### Steps to Test
* CI

**review**:
@Arelle/arelle @ryangeiser1 
