### PR TITLE
Exclude test files from frozen builds

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           cache: 'pip'
           check-latest: true
-          python-version: '3.14.2'
+          python-version: '3.14.4'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: false
         type: string
@@ -40,7 +40,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       openssl_version:
-        default: '3.6.0'
+        default: '3.6.2'
         description: 'OpenSSL version to use'
         required: false
         type: string
@@ -35,7 +35,7 @@ on:
         required: false
         type: string
       openssl_version:
-        default: '3.6.0'
+        default: '3.6.2'
         description: 'OpenSSL version to use'
         required: true
         type: string

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,8 +13,8 @@ on:
         required: false
         type: string
       macos_version:
-        default: '15'
-        description: 'MacOS version to use (15, 15-intel, 26, latest, etc.)'
+        default: '26'
+        description: 'MacOS version to use (26, 26-intel, latest, etc.)'
         required: false
         type: string
       python_version:
@@ -50,8 +50,8 @@ on:
         required: false
         type: string
       macos_version:
-        default: '15'
-        description: 'MacOS version to use (15, 15-intel, 26, latest, etc.)'
+        default: '26'
+        description: 'MacOS version to use (26, 26-intel, latest, etc.)'
         required: true
         type: string
       python_version:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: false
         type: string
@@ -55,7 +55,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/build-tktable.yml
+++ b/.github/workflows/build-tktable.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   build-macos-arm64:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -39,7 +39,7 @@ jobs:
           path: output/
 
   build-macos-x86_64:
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     steps:
       - uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: false
         type: string
@@ -36,7 +36,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/conformance-suite.yml
+++ b/.github/workflows/conformance-suite.yml
@@ -21,7 +21,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: Python version to use
         required: true
         type: string

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: false
         type: string
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
     inputs:
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -9,12 +9,13 @@ on:
   #   types: [published]
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   winget:
-    runs-on: windows-latest
+    permissions:
+      contents: read
+    runs-on: windows-2025
     steps:
       - uses: vedantmgoyal9/winget-releaser@v2
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,14 +4,14 @@ on:
   workflow_call:
     inputs:
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: false
         type: string
   workflow_dispatch:
     inputs:
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
   build-macos-x64:
     uses: ./.github/workflows/build-macos.yml
     with:
-      macos_version: 15-intel
+      macos_version: 26-intel
       python_architecture: x64
     secrets: inherit
   publish-macos-x64:
@@ -80,7 +80,7 @@ jobs:
   build-macos-arm64:
     uses: ./.github/workflows/build-macos.yml
     with:
-      macos_version: 15
+      macos_version: 26
       python_architecture: arm64
     secrets: inherit
   publish-macos-arm64:

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.14.2'
+        default: '3.14.4'
         description: 'Python version to use'
         required: false
         type: string
@@ -82,7 +82,7 @@ jobs:
         with:
           cache: 'pip'
           check-latest: true
-          python-version: ${{ github.event_name == 'workflow_dispatch' && inputs.python_version || '3.14.2' }}
+          python-version: ${{ github.event_name == 'workflow_dispatch' && inputs.python_version || '3.14.4' }}
       - name: Install Python dependencies
         if: matrix.build-type == 'source'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-15
+          - macos-26
           - ubuntu-24.04
           - windows-2025
         python-version:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
-          - '3.14.2'
+          - '3.14.4'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,12 +68,12 @@ Here's how to set up your environment:
   2. Install a supported version of Python.
     For example, 
     
-    pyenv install 3.14.2
+    pyenv install 3.14.4
 
   3. Create a virtual env using the Python version you just installed.
     For example, 
 
-    PYENV_VERSION=3.14.2 pyenv exec python -m venv venv
+    PYENV_VERSION=3.14.4 pyenv exec python -m venv venv
   4. Activate your environment: 
     
     source venv/bin/activate

--- a/distro.py
+++ b/distro.py
@@ -53,6 +53,8 @@ for entryPoint in entryPoints:
 includeLibs = [
     "dateutil",
     "dateutil.relativedelta",
+    "email",
+    "email.header",
     "graphviz",
     "gzip",
     "isodate",

--- a/distro.py
+++ b/distro.py
@@ -16,7 +16,7 @@ MACOS_PLATFORM = "darwin"
 WINDOWS_PLATFORM = "win32"
 
 cliExecutable = Executable(script="arelleCmdLine.py")
-packages = find_packages()
+packages = find_packages(include=["arelle*"])
 includeFiles = [
     (os.path.normcase("arelle/archive"), "archive"),
     (os.path.normcase("arelle/config"), "config"),

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ## --------------------- Build Stage ---------------------
-ARG PYTHON_VERSION="3.14.2"
+ARG PYTHON_VERSION="3.14.4"
 FROM python:${PYTHON_VERSION} AS builder
 
 WORKDIR /usr/src/app

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@ autodoc2_packages = [
 autodoc2_render_plugin = "myst"
 suppress_warnings = [
     "autodoc2.dup_item", # bottle and tkinter warnings
+    "ref.python", # ambiguous `type` xref vs ModelConcept.type / ModelAttribute.type
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,4 @@
-cx-Freeze==8.5.2
+cx-Freeze==8.6.4
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 setuptools-scm==10.0.5
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,9 @@
 furo==2025.12.19
-myst-parser==4.0.1
+myst-parser==4.0.1 ; python_version == "3.10"
+myst-parser==5.0.0 ; python_version > "3.10"
 sphinx==8.1.3 ; python_version == "3.10"
-sphinx==8.2.3 ; python_version > "3.10"
-sphinx-autobuild==2024.10.3
+sphinx==8.2.3 ; python_version == "3.11"
+sphinx==9.1.0 ; python_version > "3.11"
+sphinx-autobuild==2025.8.25
 sphinx-autodoc2==0.5.0
 sphinx-copybutton==0.5.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,6 +2,6 @@ boto3==1.42.91
 packaging==26.1
 pytest==9.0.3
 requests==2.33.1
-tomli==2.3.0 ; python_version <= "3.10"
+tomli==2.4.1 ; python_version == "3.10"
 
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jaconv==0.5.0
 jsonschema==4.26.0
 lxml==6.1.0
 numpy==2.2.6 ; python_version == "3.10"
-numpy==2.4.0 ; python_version > "3.10"
+numpy==2.4.4 ; python_version > "3.10"
 openpyxl==3.1.5
 pyparsing==3.3.2
 python-dateutil==2.9.0.post0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,2 +1,2 @@
 # https://github.com/dependabot/dependabot-core/blob/8ab4d78efe7cf9a75bef76dd883d7ee3fffffb40/python/lib/dependabot/python/file_parser/python_requirement_parser.rb#L76-L85
-python-3.10.19
+python-3.10.20

--- a/tests/integration_tests/github.py
+++ b/tests/integration_tests/github.py
@@ -1,5 +1,5 @@
 LINUX = 'ubuntu-24.04'
-MACOS = 'macos-15'
+MACOS = 'macos-26'
 WINDOWS = 'windows-2025'
 
 # number of cores on the runners

--- a/tests/integration_tests/scripts/discover_tests.py
+++ b/tests/integration_tests/scripts/discover_tests.py
@@ -16,9 +16,9 @@ ALL_PYTHON_VERSIONS = (
     '3.11',
     '3.12',
     '3.13',
-    '3.14.2',
+    '3.14.4',
 )
-LATEST_PYTHON_VERSION = '3.14.2'
+LATEST_PYTHON_VERSION = '3.14.4'
 PRIMARY_OPERATING_SYSTEM = LINUX
 FUNCTION_REGISTRY_TESTS = frozenset({
     'xbrl_formula_1_0_function_registry',

--- a/tests/integration_tests/validation/discover_tests.py
+++ b/tests/integration_tests/validation/discover_tests.py
@@ -16,9 +16,9 @@ ALL_PYTHON_VERSIONS = (
     '3.11',
     '3.12',
     '3.13',
-    '3.14.2',
+    '3.14.4',
 )
-LATEST_PYTHON_VERSION = '3.14.2'
+LATEST_PYTHON_VERSION = '3.14.4'
 
 
 class Entry(TypedDict, total=False):


### PR DESCRIPTION
#### Reason for change
Testing #2306 made me realize that we're bundling our conformance suite test files in the frozen builds contributing significant size to the build artifacts. This PR reduces the macOS Arelle.app size from ~850MB to ~450MB. Other platforms see similar size reductions.

#### Description of change
* Exclude test files from frozen builds.
* While we're testing builds, bump other dependencies and runner images which require manual testing of frozen builds.
* Bump other dependencies not managed by dependabot.

#### Steps to Test
* Regression test frozen builds:
  * [x] [Windows](https://github.com/Arelle/Arelle/actions/runs/24874715930)
  * [x] [macOS arm64](https://github.com/Arelle/Arelle/actions/runs/24874723526)
  * [x] [macOS amd64](https://github.com/Arelle/Arelle/actions/runs/24874729408)
  * [x] [Linux](https://github.com/Arelle/Arelle/actions/runs/24874720583)

**review**:
@Arelle/arelle
