### PR TITLE
Preserve fact value namespace prefixes in saveLoadableOIM

### DIFF
--- a/arelle/plugin/saveLoadableOIM.py
+++ b/arelle/plugin/saveLoadableOIM.py
@@ -220,9 +220,15 @@ def saveLoadableOIM(
     linkTypeAliases = {}
     groupAliases = {}
 
-    def compileQname(qname: QName) -> None:
+    def compileQname(qname: QName, nsmap: dict[str | None, str] | None = None) -> None:
         if qname.namespaceURI is not None and qname.namespaceURI not in namespacePrefixes:
-            namespacePrefixes.addNamespace(qname.namespaceURI, qname.prefix or "")
+            prefix = qname.prefix
+            if not prefix and nsmap:
+                for mapPrefix, mapNamespace in nsmap.items():
+                    if qname.namespaceURI == mapNamespace:
+                        prefix = mapPrefix
+                        break
+            namespacePrefixes.addNamespace(qname.namespaceURI, prefix or "")
 
     aspectsDefined = {qnOimConceptAspect, qnOimEntityAspect, qnOimPeriodAspect}
 
@@ -304,9 +310,14 @@ def saveLoadableOIM(
                 hasNumeric = True
             if concept.baseXbrliType in ("string", "normalizedString", "token") and fact.xmlLang:
                 hasLang = True
-        compileQname(fact.qname)
-        if hasattr(fact, "xValue") and isinstance(fact.xValue, QName):
-            compileQname(fact.xValue)
+        compileQname(fact.qname, fact.nsmap)
+        xValue = getattr(fact, "xValue", None)
+        if isinstance(xValue, QName):
+            compileQname(xValue, fact.nsmap)
+        elif isinstance(xValue, list):
+            for q in xValue:
+                if isinstance(q, QName):
+                    compileQname(q, fact.nsmap)
         unit = fact.unit
         if unit is not None:
             hasUnits = True


### PR DESCRIPTION
#### Reason for change

Resolves #2322.

#### Description of change

In the saveLoadableOIM plugin, "compile" (register) fact value/enum qname prefixes so that they survive into the output OIM instance.

#### Steps to Test
* Using [enum-save-oim.zip](https://github.com/user-attachments/files/27043204/enum-save-oim.zip)
* `python arelleCmdLine.py --file enum-save-oim.zip --plugin saveLoadableOIM --saveLoadableOIM oim.json`
* Verify `country` is in the namespaces uri map and used for the fact.

master:
```json
{
 "documentInfo": {
  "documentType": "https://xbrl.org/2021/xbrl-json",
  "features": {
   "xbrl:canonicalValues": true
  },
  "namespaces": {
   "ex": "http://example.com/taxonomy",
   "scheme": "http://www.example.com",
   "xbrl": "https://xbrl.org/2021"
  },
  "taxonomy": [
   "https://example.com/taxonomy.xsd"
  ]
 },
 "facts": {
  "f1250": {
   "value": "_:CA",
   "dimensions": {
    "concept": "ex:MyEnum",
    "entity": "scheme:example",
    "period": "2026-01-01T00:00:00"
   }
  }
 }
}
```

PR branch:
```json
{
 "documentInfo": {
  "documentType": "https://xbrl.org/2021/xbrl-json",
  "features": {
   "xbrl:canonicalValues": true
  },
  "namespaces": {
   "country": "http://example.com/countries",
   "ex": "http://example.com/taxonomy",
   "scheme": "http://www.example.com",
   "xbrl": "https://xbrl.org/2021"
  },
  "taxonomy": [
   "https://example.com/taxonomy.xsd"
  ]
 },
 "facts": {
  "f1250": {
   "value": "country:CA",
   "dimensions": {
    "concept": "ex:MyEnum",
    "entity": "scheme:example",
    "period": "2026-01-01T00:00:00"
   }
  }
 }
}
```

**review**:
@Arelle/arelle
