### PR TITLE
Fix AttributeError for --xdgConfigHome with missing directory

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -216,7 +216,7 @@ class Cntlr:
                         configHomeDir = os.path.abspath(configHomeDir)  # make into a full path if relative
                 except EnvironmentError:
                     configHomeDir = None
-        if self.hasFileSystem and configHomeDir and os.path.exists(configHomeDir):
+        if self.hasFileSystem and configHomeDir:
             # check if a cache exists in this directory (e.g. from XPE or other tool)
             impliedAppDir = os.path.join(configHomeDir, "arelle")
             if os.path.exists(impliedAppDir):


### PR DESCRIPTION
#### Reason for change

Arelle crashes with `AttributeError` if `--xdgConfigHome` is used with a directory that doesn't exist.

I was torn between creating the directory (what this PR does) and raising an error telling users to create the directory.

#### Description of change

Accept the user supplied config home even if it does not yet exist. The existing `os.makedirs(exist_ok=True)` creates it. Previously the existence check at init time meant none of the `userAppDir` assignment branches ran and `Cntlr.__init__` crashed with `AttributeError`.

#### Steps to Test
* `rm -rf /tmp/arelle-cache-test`
* `python arelleCmdLine.py --xdgConfigHome /tmp/arelle-cache-test --about`
* Verify `AttributeError` isn't raised.

master:
```sh
❯ rm -rf /tmp/arelle-cache-test
❯ python arelleCmdLine.py --xdgConfigHome /tmp/arelle-cache-test --about
Traceback (most recent call last):
  File "/Users/austinmatherne/git/open-source/Arelle/arelleCmdLine.py", line 40, in <module>
    CntlrCmdLine.main()
    ~~~~~~~~~~~~~~~~~^^
  File "/Users/austinmatherne/git/open-source/Arelle/arelle/CntlrCmdLine.py", line 95, in main
    cntlr, options, result = _parseAndRun(args)
                             ~~~~~~~~~~~~^^^^^^
  File "/Users/austinmatherne/git/open-source/Arelle/arelle/CntlrCmdLine.py", line 111, in _parseAndRun
    runtimeOptions, arellePluginModules = parseArgs(args)
                                          ~~~~~~~~~^^^^^^
  File "/Users/austinmatherne/git/open-source/Arelle/arelle/CntlrCmdLine.py", line 181, in parseArgs
    cntlr = CntlrCmdLine(uiLang=uiLang, disable_persistent_config=disable_persistent_config)
  File "/Users/austinmatherne/git/open-source/Arelle/arelle/CntlrCmdLine.py", line 1593, in __init__
    super().__init__(
    ~~~~~~~~~~~~~~~~^
        hasGui=False,
        ^^^^^^^^^^^^^
    ...<2 lines>...
        logFileName=logFileName
        ^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/austinmatherne/git/open-source/Arelle/arelle/Cntlr.py", line 272, in __init__
    os.makedirs(self.userAppDir, exist_ok=True)
                ^^^^^^^^^^^^^^^
AttributeError: 'CntlrCmdLine' object has no attribute 'userAppDir
```

branch:
```sh
❯ rm -rf /tmp/arelle-cache-test
❯ python arelleCmdLine.py --xdgConfigHome /tmp/arelle-cache-test --about

arelle(r) 2.39.7.dev22+g8b04b7b61 (64bit arm64)

An open source XBRL platform
(c) Copyright 2011-present Workiva, Inc., All rights reserved.
http://www.arelle.org
support@arelle.org

Licensed under the Apache License, Version 2.0 (the "License"); you may not
use this file except in compliance with the License.  You may obtain a copy
of the License at 'http://www.apache.org/licenses/LICENSE-2.0'

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.

Includes:
   Python(r) 3.14.4 (c) 2001-2013 Python Software Foundation
   PyParsing (c) 2003-2013 Paul T. McGuire
   lxml 6.1.0 (c) 2004 Infrae, ElementTree (c) 1999-2004 by Fredrik Lundh
   Bottle (c) 2009-2024 Marcel Hellkamp
   May include installable plug-in modules with author-specific license terms
```

**review**:
@Arelle/arelle
