### PR TITLE
Skip non-str entries when filtering OIM errors in calc 1.1

### DIFF
--- a/arelle/ValidateXbrlCalcs.py
+++ b/arelle/ValidateXbrlCalcs.py
@@ -140,14 +140,14 @@ class ValidateXbrlCalcs:
                 e = modelXbrl.errors[i]
                 if isinstance(e, str) and e in oimXbrlxeBlockingErrorCodes:
                     del modelXbrl.errors[i] # remove the oim errors from modelXbrl.errors
-                oimErrs.add(e)
-            if any(e == "xbrlxe:unsupportedTuple" for e in oimErrs):
+                    oimErrs.add(e)
+            if "xbrlxe:unsupportedTuple" in oimErrs:
                 # ignore this error and change to warning
                 yield Validation.warning(
                     "calc11e:tuplesInReportWarning",
                     _("Validating of calculations ignores tuples."),
                 )
-            if any(e in oimXbrlxeBlockingErrorCodes for e in oimErrs if e != "xbrlxe:unsupportedTuple"):
+            if oimErrs - {"xbrlxe:unsupportedTuple"}:
                 yield Validation.warning(
                     "calc11e:oimIncompatibleReportWarning",
                     _("Validating of calculations is skipped due to OIM errors."),


### PR DESCRIPTION
#### Reason for change

Resolves #2287. I was overconfident in #2260 and didn't spend the time coming up with a doc to reproduce the error... which just moved the exception down one line.

#### Description of change

The `isinstance(e, str)` guard from #2260 only covered the `oimXbrlxeBlockingErrorCodes` membership check, `oimErrs.add(e)` on the next line was still unconditional. Skip non-str entries outright so neither the check nor the set insertion sees a dict.

#### Steps to Test
1. Use the Arelle GUI (we need to validate the report twice to trigger the exception)
2. Add taxonomy packages from the repo:
  - `tests/resources/packages/NT20_20251128_Taxonomie_SBR.zip`
  - `tests/resources/packages/nltaxonomie-nl-20240326.zip`
3. Enable `validate/NL` plugin and `NT20` disclosure system
3. Enable Calc 1.1 round-to-nearest mode
4. Open `tests/resources/conformance_suites/nl_nt20/fr_kvk/5-01-invalid-decimals.xbrl`.
5. Validate
6. Validate again
7. Confirm `exception:TypeError` isn't in the messages log from the second validation

Master message log:
```sh
[NL.FG-NL-04] "unit" elements should not appear after "fact" elements. - 5-01-invalid-decimals.xbrl 37
[NL.FG-NL-04] "context" elements should not appear after "fact" elements. - 5-01-invalid-decimals.xbrl 40
[NL.FG-NL-05] Unused namespaces found in an instance document: bzk-wnt-i: http://www.nltaxonomie.nl/nt20/bzk/20251210/dictionary/bzk-wnt-data, jenv-bw2-dim: http://www.nltaxonomie.nl/nt20/jenv/20251210/dictionary/jenv-bw2-axes, jenv-bw2-dm: http://www.nltaxonomie.nl/nt20/jenv/20251210/dictionary/jenv-bw2-domains, rj-dim: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-axes, rj-dm: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-domains, rj-i: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-data, xbrldi: http://xbrl.org/2006/xbrldi - 5-01-invalid-decimals.xbrl 18
[NL.FR-KVK-5.01] The attribute "decimals" on monetary values MUST be filled with allowed values: ('INF', '-9', '-6', '-3', '0', '2'). Provided: 1 - 5-01-invalid-decimals.xbrl 48
[info:profileActivity] ... assertion and formula checks and compilation 1.624 secs
 - 5-01-invalid-decimals.xbrl 
[message:existenceAssertion_DocumentInformation_PrtExistOnce10] `FinancialStatementsDateOfPreparation` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 290
[message:existenceAssertion_DocumentInformation_PrtExistOnce6] `DocumentAdoptionStatus` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 288
[message:existenceAssertion_DocumentInformation_PrtExistOnce2] `BasisOfPreparation` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k-for.xml 47
[message:existenceAssertion_EntityAddress_PrtExist02XOR2] `PostalCodeNL` or `PlaceOfResidenceAbroad` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-entity-address-for.xml 167
[message:existenceAssertion_EntityAddress_PrtExist02XOR1] `PlaceOfResidenceNL` or `PlaceOfResidenceAbroad` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-entity-address-for.xml 166
[message:existenceAssertion_DocumentInformation_PrtExistOnce4] `DocumentPresentationCurrency` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 286
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'jenv-bw2-i:LegalEntityRegisteredOffice', value:'Address', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 32, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'jenv-bw2-i:RightsGrantedExercisePrice', value:'100.0', @contextRef:'ctx-2', @unitRef:'usd' |  - 5-01-invalid-decimals.xbrl 48, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'nl-cd:LegalEntityName', value:'Testing Entity Name', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 31, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'kvk-i:LegalSizeCriteriaClassificationSmall', value:'Klein', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 35, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'kvk-i:BusinessNames', value:'Testing Entity Name', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 34, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'nl-cd:ChamberOfCommerceRegistrationNumber', value:'12345678', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 33, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:existenceAssertion_DocumentInformation_PrtExistOnce5] `FinancialReportingPeriodDifferentThanAnnualStatus` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 287
[message:existenceAssertion_DocumentInformation_PrtExistOnce1] `EmailAddressFull` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 284
[message:existenceAssertion_DocumentInformation_PrtExistOnce3] `FinancialReportingPeriodCurrentEndDate` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 285
[message:existenceAssertion_SigningFinancialStatements_PrtExistence1] `DirectorSignedStatus` SHOULD exist at least once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-signing-financial-statements-for.xml 86
[message:existenceAssertion_ConsolidatedBalanceSheet_PrtExistence1] `BalanceSheetBeforeAfterAppropriationResults` MUST exist at least once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-consolidated-balance-sheet_k_m_g-for.xml 20
[message:existenceAssertion_EntityInformation_PrtExistOnce5] `LegalEntityLegalForm` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-entity-information-_k-m-g-for.xml 20
[message:existenceAssertion_NotesAverageNumberOfEmployeesBreakdown_PrtExistence1] `AverageNumberEmployees` SHOULD exist at least once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-notes-average-number-of-employees-breakdown-for.xml 80
[message:existenceAssertion_DocumentInformation_PrtExistOnce8] `FinancialReportingPeriodCurrentStartDate` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 289
validated in 13.80 secs: /Users/austinmatherne/git/open-source/Arelle/tests/resources/conformance_suites/nl_nt20/fr_kvk/5-01-invalid-decimals.xbrl
[NL.FG-NL-04] "unit" elements should not appear after "fact" elements. - 5-01-invalid-decimals.xbrl 37
[NL.FG-NL-04] "context" elements should not appear after "fact" elements. - 5-01-invalid-decimals.xbrl 40
[NL.FG-NL-05] Unused namespaces found in an instance document: bzk-wnt-i: http://www.nltaxonomie.nl/nt20/bzk/20251210/dictionary/bzk-wnt-data, jenv-bw2-dim: http://www.nltaxonomie.nl/nt20/jenv/20251210/dictionary/jenv-bw2-axes, jenv-bw2-dm: http://www.nltaxonomie.nl/nt20/jenv/20251210/dictionary/jenv-bw2-domains, rj-dim: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-axes, rj-dm: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-domains, rj-i: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-data, xbrldi: http://xbrl.org/2006/xbrldi - 5-01-invalid-decimals.xbrl 18
[NL.FR-KVK-5.01] The attribute "decimals" on monetary values MUST be filled with allowed values: ('INF', '-9', '-6', '-3', '0', '2'). Provided: 1 - 5-01-invalid-decimals.xbrl 48
[exception:TypeError] Instance validation exception: cannot use 'dict' as a set element (unhashable type: 'dict'), instance: 5-01-invalid-decimals.xbrl - 5-01-invalid-decimals.xbrl 
Traceback (most recent call last):
  File "/Users/austinmatherne/git/open-source/Arelle/arelle/Validate.py", line 130, in validate
    self.instValidator.validate(self.modelXbrl, self.modelXbrl.modelManager.formulaOptions.typedParameters(self.modelXbrl.prefixedNamespaces))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/austinmatherne/git/open-source/Arelle/arelle/ValidateXbrl.py", line 423, in validate
    for val in ValidateXbrlCalcs.validate(modelXbrl, self.validateCalcs):
               ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/austinmatherne/git/open-source/Arelle/arelle/ValidateXbrlCalcs.py", line 97, in validate
    yield from ValidateXbrlCalcs(modelXbrl, validateCalcs).validate()
  File "/Users/austinmatherne/git/open-source/Arelle/arelle/ValidateXbrlCalcs.py", line 143, in validate
    oimErrs.add(e)
    ~~~~~~~~~~~^^^
TypeError: cannot use 'dict' as a set element (unhashable type: 'dict')
validated in 1.82 secs: /Users/austinmatherne/git/open-source/Arelle/tests/resources/conformance_suites/nl_nt20/fr_kvk/5-01-invalid-decimals.xbrl
```

Branch message log:
```sh
[NL.FG-NL-04] "unit" elements should not appear after "fact" elements. - 5-01-invalid-decimals.xbrl 37
[NL.FG-NL-04] "context" elements should not appear after "fact" elements. - 5-01-invalid-decimals.xbrl 40
[NL.FG-NL-05] Unused namespaces found in an instance document: bzk-wnt-i: http://www.nltaxonomie.nl/nt20/bzk/20251210/dictionary/bzk-wnt-data, jenv-bw2-dim: http://www.nltaxonomie.nl/nt20/jenv/20251210/dictionary/jenv-bw2-axes, jenv-bw2-dm: http://www.nltaxonomie.nl/nt20/jenv/20251210/dictionary/jenv-bw2-domains, rj-dim: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-axes, rj-dm: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-domains, rj-i: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-data, xbrldi: http://xbrl.org/2006/xbrldi - 5-01-invalid-decimals.xbrl 18
[NL.FR-KVK-5.01] The attribute "decimals" on monetary values MUST be filled with allowed values: ('INF', '-9', '-6', '-3', '0', '2'). Provided: 1 - 5-01-invalid-decimals.xbrl 48
[info:profileActivity] ... assertion and formula checks and compilation 1.641 secs
 - 5-01-invalid-decimals.xbrl 
[message:existenceAssertion_DocumentInformation_PrtExistOnce6] `DocumentAdoptionStatus` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 288
[message:existenceAssertion_DocumentInformation_PrtExistOnce2] `BasisOfPreparation` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k-for.xml 47
[message:existenceAssertion_EntityAddress_PrtExist02XOR2] `PostalCodeNL` or `PlaceOfResidenceAbroad` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-entity-address-for.xml 167
[message:existenceAssertion_EntityAddress_PrtExist02XOR1] `PlaceOfResidenceNL` or `PlaceOfResidenceAbroad` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-entity-address-for.xml 166
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'jenv-bw2-i:LegalEntityRegisteredOffice', value:'Address', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 32, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'kvk-i:LegalSizeCriteriaClassificationSmall', value:'Klein', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 35, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'nl-cd:ChamberOfCommerceRegistrationNumber', value:'12345678', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 33, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'nl-cd:LegalEntityName', value:'Testing Entity Name', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 31, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'jenv-bw2-i:RightsGrantedExercisePrice', value:'100.0', @contextRef:'ctx-2', @unitRef:'usd' |  - 5-01-invalid-decimals.xbrl 48, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'kvk-i:BusinessNames', value:'Testing Entity Name', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 34, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:existenceAssertion_DocumentInformation_PrtExistOnce4] `DocumentPresentationCurrency` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 286
[message:existenceAssertion_DocumentInformation_PrtExistOnce5] `FinancialReportingPeriodDifferentThanAnnualStatus` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 287
[message:existenceAssertion_DocumentInformation_PrtExistOnce1] `EmailAddressFull` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 284
[message:existenceAssertion_DocumentInformation_PrtExistOnce3] `FinancialReportingPeriodCurrentEndDate` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 285
[message:existenceAssertion_ConsolidatedBalanceSheet_PrtExistence1] `BalanceSheetBeforeAfterAppropriationResults` MUST exist at least once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-consolidated-balance-sheet_k_m_g-for.xml 20
[message:existenceAssertion_SigningFinancialStatements_PrtExistence1] `DirectorSignedStatus` SHOULD exist at least once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-signing-financial-statements-for.xml 86
[message:existenceAssertion_EntityInformation_PrtExistOnce5] `LegalEntityLegalForm` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-entity-information-_k-m-g-for.xml 20
[message:existenceAssertion_DocumentInformation_PrtExistOnce10] `FinancialStatementsDateOfPreparation` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 290
[message:existenceAssertion_NotesAverageNumberOfEmployeesBreakdown_PrtExistence1] `AverageNumberEmployees` SHOULD exist at least once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-notes-average-number-of-employees-breakdown-for.xml 80
[message:existenceAssertion_DocumentInformation_PrtExistOnce8] `FinancialReportingPeriodCurrentStartDate` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 289
validated in 13.24 secs: /Users/austinmatherne/git/open-source/Arelle/tests/resources/conformance_suites/nl_nt20/fr_kvk/5-01-invalid-decimals.xbrl
[NL.FG-NL-04] "unit" elements should not appear after "fact" elements. - 5-01-invalid-decimals.xbrl 37
[NL.FG-NL-04] "context" elements should not appear after "fact" elements. - 5-01-invalid-decimals.xbrl 40
[NL.FG-NL-05] Unused namespaces found in an instance document: bzk-wnt-i: http://www.nltaxonomie.nl/nt20/bzk/20251210/dictionary/bzk-wnt-data, jenv-bw2-dim: http://www.nltaxonomie.nl/nt20/jenv/20251210/dictionary/jenv-bw2-axes, jenv-bw2-dm: http://www.nltaxonomie.nl/nt20/jenv/20251210/dictionary/jenv-bw2-domains, rj-dim: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-axes, rj-dm: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-domains, rj-i: http://www.nltaxonomie.nl/nt20/rj/20251210/dictionary/rj-data, xbrldi: http://xbrl.org/2006/xbrldi - 5-01-invalid-decimals.xbrl 18
[NL.FR-KVK-5.01] The attribute "decimals" on monetary values MUST be filled with allowed values: ('INF', '-9', '-6', '-3', '0', '2'). Provided: 1 - 5-01-invalid-decimals.xbrl 48
[message:existenceAssertion_DocumentInformation_PrtExistOnce6] `DocumentAdoptionStatus` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 288
[message:existenceAssertion_DocumentInformation_PrtExistOnce2] `BasisOfPreparation` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k-for.xml 47
[message:existenceAssertion_EntityAddress_PrtExist02XOR2] `PostalCodeNL` or `PlaceOfResidenceAbroad` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-entity-address-for.xml 167
[message:existenceAssertion_EntityAddress_PrtExist02XOR1] `PlaceOfResidenceNL` or `PlaceOfResidenceAbroad` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-entity-address-for.xml 166
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'jenv-bw2-i:LegalEntityRegisteredOffice', value:'Address', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 32, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'kvk-i:LegalSizeCriteriaClassificationSmall', value:'Klein', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 35, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'nl-cd:ChamberOfCommerceRegistrationNumber', value:'12345678', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 33, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'nl-cd:LegalEntityName', value:'Testing Entity Name', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 31, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'jenv-bw2-i:RightsGrantedExercisePrice', value:'100.0', @contextRef:'ctx-2', @unitRef:'usd' |  - 5-01-invalid-decimals.xbrl 48, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:valueAssertion_DocumentInformation_AllPeriodAspectCondParamPEtCE1] Instant facts SHOULD be reported with instant 2024-12-31 or 2025-12-31 and duration facts SHOULD be reported with startDate 2025-01-01 and endDate 2025-12-31. | name:'kvk-i:BusinessNames', value:'Testing Entity Name', @contextRef:'ctx-1', @unitRef:'' |  - 5-01-invalid-decimals.xbrl 34, http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information_u_k_m_g-for.xml 62
[message:existenceAssertion_DocumentInformation_PrtExistOnce4] `DocumentPresentationCurrency` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 286
[message:existenceAssertion_DocumentInformation_PrtExistOnce5] `FinancialReportingPeriodDifferentThanAnnualStatus` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 287
[message:existenceAssertion_DocumentInformation_PrtExistOnce1] `EmailAddressFull` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 284
[message:existenceAssertion_DocumentInformation_PrtExistOnce3] `FinancialReportingPeriodCurrentEndDate` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 285
[message:existenceAssertion_ConsolidatedBalanceSheet_PrtExistence1] `BalanceSheetBeforeAfterAppropriationResults` MUST exist at least once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-consolidated-balance-sheet_k_m_g-for.xml 20
[message:existenceAssertion_SigningFinancialStatements_PrtExistence1] `DirectorSignedStatus` SHOULD exist at least once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-signing-financial-statements-for.xml 86
[message:existenceAssertion_EntityInformation_PrtExistOnce5] `LegalEntityLegalForm` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-entity-information-_k-m-g-for.xml 20
[message:existenceAssertion_DocumentInformation_PrtExistOnce10] `FinancialStatementsDateOfPreparation` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 290
[message:existenceAssertion_NotesAverageNumberOfEmployeesBreakdown_PrtExistence1] `AverageNumberEmployees` SHOULD exist at least once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-notes-average-number-of-employees-breakdown-for.xml 80
[message:existenceAssertion_DocumentInformation_PrtExistOnce8] `FinancialReportingPeriodCurrentStartDate` MUST exist once. - http://www.nltaxonomie.nl/nt20/kvk/20251210/validation/kvk-document-information-for.xml 289
validated in 1.84 secs: /Users/austinmatherne/git/open-source/Arelle/tests/resources/conformance_suites/nl_nt20/fr_kvk/5-01-invalid-decimals.xbrl
```

**review**:
@Arelle/arelle
