### PR TITLE
Update dockerhub auth secret name

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/login-action@v4.0.0
         with:
           username: ${{ vars.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v4.0.0


### PR DESCRIPTION
#### Reason for change
Workflow secret name doesn't match what was configured by infre.

#### Description of change
Update auth secret name in workflow to reflect what's actually configured.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
