### PR TITLE
Move macOS x64 builds back to macOS 15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
   build-macos-x64:
     uses: ./.github/workflows/build-macos.yml
     with:
-      macos_version: 26-intel
+      macos_version: 15-intel
       python_architecture: x64
     secrets: inherit
   publish-macos-x64:


### PR DESCRIPTION
#### Reason for change

The 26-intel runner is demonstrating the same inconsistent "[hdiutil: create failed - Resource busy](https://github.com/Arelle/Arelle/actions/runs/24913239384/job/72959575988)" behavior that [required a retry loop](https://github.com/Arelle/Arelle/pull/2026) when building with the macOS 13 intel runner.

#### Description of change

Roll back to macOS 15 for the x64 runner to avoid a long retry loop in the DMG CI build step.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
