### PR TITLE
Fix Proxy Support

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -38,7 +38,7 @@ from arelle.plugin_system.plugin_provider import PluginProvider
 from arelle.typing import TypeGetText
 from arelle.utils.PluginData import PluginData
 from arelle.utils.validate.Validation import Validation
-from arelle.WebCache import WebCache
+from arelle.WebCache import ProxyTuple, WebCache
 
 _: TypeGetText
 
@@ -288,7 +288,7 @@ class Cntlr:
         self.setUiLanguage(uiLang or self.config.get("userInterfaceLangOverride",None), fallbackToDefault=True)
         Locale.setDisableRTL(self.config.get('disableRtl', False))
 
-        self.webCache = WebCache(self, self.config.get("proxySettings"))
+        self.webCache = WebCache(self, ProxyTuple.coerce(self.config.get("proxySettings")))
 
         # start plug in server (requres web cache initialized, but not logger)
         from arelle.PluginManager import getInstance as _getPluginManagerInstance

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -288,13 +288,19 @@ class Cntlr:
         self.setUiLanguage(uiLang or self.config.get("userInterfaceLangOverride",None), fallbackToDefault=True)
         Locale.setDisableRTL(self.config.get('disableRtl', False))
 
-        self.webCache = WebCache(self, ProxyTuple.coerce(self.config.get("proxySettings")))
-
-        # start plug in server (requres web cache initialized, but not logger)
+        # Order is load-bearing:
+        # PluginManager initialization can load plugins using the WebCache, but the WebCache uses plugin hooks.
+        # We first create the PluginManager and PluginProvider so that initial plugin hook lookups in the WebCache
+        # won't find anything, but also won't crash on AttributeError. We then create the WebCache before calling
+        # PluginManager.init() so that plugin paths can be loaded via the WebCache. Lastly, we call
+        # webCache.resetProxies() to pick up plugin hook defined proxy settings that weren't available when WebCache
+        # was first created.
         from arelle.PluginManager import getInstance as _getPluginManagerInstance
         self._pluginManager = _getPluginManagerInstance()
-        self._pluginManager.init(self, loadPluginConfig=hasGui)
         self.plugins = PluginProvider(self._pluginManager)
+        self.webCache = WebCache(self, ProxyTuple.coerce(self.config.get("proxySettings")))
+        self._pluginManager.init(self, loadPluginConfig=hasGui)
+        self.webCache.resetProxies(self.webCache._httpProxyTuple)
 
         # requires plug ins initialized
         self.modelManager = ModelManager.initialize(self)

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -68,7 +68,7 @@ from arelle.SystemInfo import PlatformOS, getSystemInfo, getSystemWordSize, hasW
 from arelle.typing import TypeGetText
 from arelle.utils.EntryPointDetection import parseEntrypointFileInput
 from arelle.ValidateXbrlDTS import ValidateBaseTaxonomiesMode
-from arelle.WebCache import proxyTuple
+from arelle.WebCache import ProxyTuple, proxyTuple
 
 if TYPE_CHECKING:
     from bottle import Bottle # type: ignore[import-untyped]
@@ -1681,7 +1681,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                 self.config["proxySettings"] = proxySettings  # type: ignore[index]
                 self.saveConfig()
                 self.addToLog(_("Proxy configuration has been set."), messageCode="info")
-            useOsProxy, urlAddr, urlPort, user, password = self.config.get("proxySettings", proxyTuple("none"))  # type: ignore[union-attr]
+            useOsProxy, urlAddr, urlPort, user, password = ProxyTuple.coerce(self.config.get("proxySettings")) or proxyTuple("none")  # type: ignore[union-attr]
             if useOsProxy:
                 self.addToLog(_("Proxy configured to use {0}.").format(
                     _("Microsoft Windows Internet Settings") if sys.platform.startswith("win")

--- a/arelle/DialogUserPassword.py
+++ b/arelle/DialogUserPassword.py
@@ -247,8 +247,7 @@ class DialogUserPassword(Toplevel):
     def ok(self, event=None):
         if hasattr(self, "useOsProxyCb"):
             self.useOsProxy = self.useOsProxyCb.value
-        self.urlAddr = self.urlAddrVar.get()
-        if self.urlAddr.startswith("http://"): self.urlAddr = self.ulrAddr[7:] # take of protocol part if any
+        self.urlAddr = self.urlAddrVar.get().removeprefix("https://").removeprefix("http://")
         self.urlPort = self.urlPortVar.get()
         self.user = self.userVar.get()
         self.password = self.passwordVar.get()

--- a/arelle/DialogUserPassword.py
+++ b/arelle/DialogUserPassword.py
@@ -8,6 +8,7 @@ except ImportError:
     from ttk import Frame, Button, Label, Entry
 from arelle.CntlrWinTooltip import ToolTip
 from arelle.UiUtil import checkbox, gridCombobox
+from arelle.WebCache import ProxyTuple
 import sys
 import regex as re
 
@@ -23,14 +24,10 @@ def askUserPassword(parent, host, realm, untilDoneEvent, result):
     untilDoneEvent.set()
 
 def askProxy(parent, priorProxySettings):
-    if isinstance(priorProxySettings,(tuple,list)) and len(priorProxySettings) == 5:
-        useOsProxy, urlAddr, urlPort, user, password = priorProxySettings
-    else:
-        useOsProxy = True
-        urlAddr = urlPort = user = password = None
-    dialog = DialogUserPassword(parent, _("Proxy Server"), urlAddr=urlAddr, urlPort=urlPort, useOsProxy=useOsProxy, user=user, password=password, showHost=False, showUrl=True, showUser=True, showRealm=False)
+    proxy = ProxyTuple.coerce(priorProxySettings) or ProxyTuple(useOsProxy=True)
+    dialog = DialogUserPassword(parent, _("Proxy Server"), urlAddr=proxy.urlAddr, urlPort=proxy.urlPort, useOsProxy=proxy.useOsProxy, user=proxy.user, password=proxy.password, showHost=False, showUrl=True, showUser=True, showRealm=False)
     if dialog.accepted:
-        return (dialog.useOsProxyCb.value, dialog.urlAddr, dialog.urlPort, dialog.user, dialog.password)
+        return ProxyTuple(dialog.useOsProxyCb.value, dialog.urlAddr, dialog.urlPort, dialog.user, dialog.password)
     return None
 
 def askSmtp(parent, priorSmtpSettings):

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -108,15 +108,22 @@ def proxyDirFmt(httpProxyTuple: ProxyTuple | None) -> dict[str, str] | None:
     return {"http": proxyUrl}
 
 
-def proxyTuple(url: str) -> ProxyTuple: # system, none, or http:[user[:password]@]host[:port]
+def proxyTuple(url: str) -> ProxyTuple: # system, none, or [scheme://][user[:password]@]host[:port]
     if url == "none":
         return ProxyTuple(useOsProxy=False)
     if url == "system":
         return ProxyTuple(useOsProxy=True)
-    userpwd, sep, hostport = url.rpartition("://")[2].rpartition("@")
-    urlAddr, sep, urlPort = hostport.partition(":")
-    user, sep, password = userpwd.partition(":")
-    return ProxyTuple(False, urlAddr or None, urlPort or None, user or None, password or None)
+    # urlparse needs a scheme to recognize user:password@host:port.
+    if "://" not in url:
+        url = "http://" + url
+    parsed = urlparse(url)
+    return ProxyTuple(
+        useOsProxy=False,
+        urlAddr=parsed.hostname,
+        urlPort=str(parsed.port) if parsed.port else None,
+        user=parsed.username,
+        password=parsed.password,
+    )
 
 
 def lastModifiedTime(headers: dict[str, str]) -> float | None:

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -105,7 +105,7 @@ def proxyDirFmt(httpProxyTuple: ProxyTuple | None) -> dict[str, str] | None:
         # block use of any proxy
         return {}
     proxyUrl = f"http://{httpProxyTuple.authority}"
-    return {"http": proxyUrl}
+    return {"http": proxyUrl, "https": proxyUrl}
 
 
 def proxyTuple(url: str) -> ProxyTuple: # system, none, or [scheme://][user[:password]@]host[:port]

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -145,6 +145,10 @@ class WebCache:
     ) -> None:
 
         self.cntlr = cntlr
+        # WebCache is constructed inside Cntlr.__init__, so cntlr is a live object but its
+        # attributes are only assigned as __init__ progresses. WebCache uses plugin hooks, so
+        # cntlr.plugins must already be assigned.
+        assert hasattr(cntlr, "plugins"), "cntlr.plugins must be assigned"
         self._timeout: float | int | None = None
 
         self._noCertificateCheck: bool = False

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -18,13 +18,14 @@ import shutil
 import sys
 import time
 import zlib
+from collections.abc import Callable
 from email.utils import parsedate as email_parsedate
 from http.client import IncompleteRead
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, NamedTuple
 from urllib import request as proxyhandlers
 from urllib.error import ContentTooShortError, HTTPError, URLError
-from urllib.parse import quote, unquote, urlsplit, urlunsplit
+from urllib.parse import quote, unquote, urlparse, urlsplit, urlunsplit
 
 import regex as re
 
@@ -66,39 +67,56 @@ XBRL_ORG_CACHE_REDIRECTS = {
 }
 
 
-def proxyDirFmt(httpProxyTuple: tuple[bool, str, str, str, str] | list[bool | str] | None) -> dict[str, str] | None:
-    if not isinstance(httpProxyTuple, (tuple, list)) or len(httpProxyTuple) != 5:
-        return None # use system proxy
+class ProxyTuple(NamedTuple):
+    useOsProxy: bool
+    urlAddr: str | None = None
+    urlPort: str | None = None
+    user: str | None = None
+    password: str | None = None
 
-    useOsProxy, urlAddr, urlPort, user, password = httpProxyTuple
-    if useOsProxy:
+    @classmethod
+    def coerce(cls, value: Any) -> ProxyTuple | None:
+        if value is None:
+            return None
+        if isinstance(value, cls):
+            return value
+        # Config persists proxy settings as JSON, so they come back as a 5-element list.
+        if isinstance(value, (tuple, list)) and len(value) == 5:
+            return cls(*value)
         return None
 
-    elif urlAddr:
-        if user and password:
-            userPart = "{0}:{1}@".format(user, password)
-        else:
-            userPart = ""
-        if urlPort:
-            portPart = ":{0}".format(urlPort)
-        else:
-            portPart = ""
-        return {"http": "http://{0}{1}{2}".format(userPart, urlAddr, portPart)}
-
-    return {}  # block use of any proxy
+    @property
+    def authority(self) -> str:
+        parts = ""
+        if self.user and self.password:
+            parts += f"{self.user}:{self.password}@"
+        if self.urlAddr:
+            parts += self.urlAddr
+        if self.urlPort:
+            parts += f":{self.urlPort}"
+        return parts
 
 
-def proxyTuple(url: str) -> tuple[bool, str, str, str, str]: # system, none, or http:[user[:passowrd]@]host[:port]
+def proxyDirFmt(httpProxyTuple: ProxyTuple | None) -> dict[str, str] | None:
+    if httpProxyTuple is None or httpProxyTuple.useOsProxy:
+        # let ProxyHandler fall back to OS / environment proxy
+        return None
+    if not httpProxyTuple.urlAddr:
+        # block use of any proxy
+        return {}
+    proxyUrl = f"http://{httpProxyTuple.authority}"
+    return {"http": proxyUrl}
+
+
+def proxyTuple(url: str) -> ProxyTuple: # system, none, or http:[user[:password]@]host[:port]
     if url == "none":
-        return False, "", "", "", ""
-
-    elif url == "system":
-        return True, "", "", "", ""
-
+        return ProxyTuple(useOsProxy=False)
+    if url == "system":
+        return ProxyTuple(useOsProxy=True)
     userpwd, sep, hostport = url.rpartition("://")[2].rpartition("@")
     urlAddr, sep, urlPort = hostport.partition(":")
     user, sep, password = userpwd.partition(":")
-    return False, urlAddr, urlPort, user, password
+    return ProxyTuple(False, urlAddr or None, urlPort or None, user or None, password or None)
 
 
 def lastModifiedTime(headers: dict[str, str]) -> float | None:
@@ -116,7 +134,7 @@ class WebCache:
 
     def __init__(
         self, cntlr: Cntlr,
-        httpProxyTuple: tuple[bool, str, str, str, str] | None
+        httpProxyTuple: ProxyTuple | None
     ) -> None:
 
         self.cntlr = cntlr
@@ -241,34 +259,32 @@ class WebCache:
     def redirectFallback(self, matchPattern: re.Pattern[str], replaceFormat: str) -> None:
         self._redirectFallbackMap[matchPattern] = replaceFormat
 
-    def resetProxies(self, httpProxyTuple: tuple[bool, str, str, str, str] | list[bool | str] | None) -> None:
+    def resetProxies(self, httpProxyTuple: ProxyTuple | None) -> None:
         # for ntlm user and password are required
         self.hasNTLM = False
-        self._httpProxyTuple = httpProxyTuple # save for resetting in noCertificateCheck setter
-        if isinstance(httpProxyTuple,(tuple, list)) and len(httpProxyTuple) == 5:
-            useOsProxy, _urlAddr, _urlPort, user, password = httpProxyTuple
-            _proxyDirFmt = proxyDirFmt(httpProxyTuple)
-            # only try ntlm if user and password are provided because passman is needed
-            if user and not useOsProxy:
-                for pluginXbrlMethod in self.cntlr.plugins.hooks("Proxy.HTTPAuthenticate"):
-                    pluginXbrlMethod(self.cntlr)
+        # save for resetting in noCertificateCheck setter
+        self._httpProxyTuple = httpProxyTuple
+        if httpProxyTuple is not None and httpProxyTuple.user and not httpProxyTuple.useOsProxy:
+            for pluginXbrlMethod in self.cntlr.plugins.hooks("Proxy.HTTPAuthenticate"):
+                pluginXbrlMethod(self.cntlr)
 
-                for pluginXbrlMethod in self.cntlr.plugins.hooks("Proxy.HTTPNtlmAuthHandler"):
-                    HTTPNtlmAuthHandler = pluginXbrlMethod()
-                    if HTTPNtlmAuthHandler is not None:
-                        self.hasNTLM = True
+            for pluginXbrlMethod in self.cntlr.plugins.hooks("Proxy.HTTPNtlmAuthHandler"):
+                HTTPNtlmAuthHandler = pluginXbrlMethod()
+                if HTTPNtlmAuthHandler is not None:
+                    self.hasNTLM = True
 
-                if not self.hasNTLM: # try for python site-packages ntlm
-                    try:
-                        from ntlm import HTTPNtlmAuthHandler # type: ignore[import-not-found,no-redef]
-                        self.hasNTLM = True
-                    except ImportError:
-                        pass
+            if not self.hasNTLM: # try for python site-packages ntlm
+                try:
+                    from ntlm import HTTPNtlmAuthHandler # type: ignore[import-not-found,no-redef]
+                    self.hasNTLM = True
+                except ImportError:
+                    pass
 
             if self.hasNTLM:
-                pwrdmgr = proxyhandlers.HTTPPasswordMgrWithDefaultRealm()
+                _proxyDirFmt = proxyDirFmt(httpProxyTuple)
                 assert _proxyDirFmt is not None
-                pwrdmgr.add_password(None, _proxyDirFmt["http"], str(user), str(password))
+                pwrdmgr = proxyhandlers.HTTPPasswordMgrWithDefaultRealm()
+                pwrdmgr.add_password(None, _proxyDirFmt["http"], httpProxyTuple.user or "", httpProxyTuple.password or "")
                 self.proxy_handler = proxyhandlers.ProxyHandler({})
                 self.proxy_auth_handler = proxyhandlers.ProxyBasicAuthHandler(pwrdmgr)
                 self.http_auth_handler = proxyhandlers.HTTPBasicAuthHandler(pwrdmgr)

--- a/arelle/plugin_system/_plugin_manager.py
+++ b/arelle/plugin_system/_plugin_manager.py
@@ -55,6 +55,10 @@ class PluginManager:
         return self._isInitialized
 
     def init(self, cntlr: Cntlr, loadPluginConfig: bool = True) -> None:
+        # PluginManager.init is called inside Cntlr.__init__, so cntlr is a live object but its
+        # attributes are only assigned as __init__ progresses. Plugin loading uses the
+        # WebCache, so cntlr.webCache must already be assigned.
+        assert hasattr(cntlr, "webCache"), "cntlr.webCache must be assigned"
         self._isInitialized = True
         self.pluginJsonFile: str | None = None
         self._cntlr: Cntlr = cntlr


### PR DESCRIPTION
#### Reason for change

Resolves #1784 along with other bugs uncovered while testing.

#### Description of change

- Fix `AttributeError` on `http://` prefixed proxy URLs. Extended the same stripping to also handle `https://` prefixes entered in the URL field.
- Fix `AttributeError` that prevents Arelle GUI from starting if user saved a proxy username to the config on last run.
- HTTPS traffic now routes through the configured proxy.
- Refactor proxy settings to a `ProxyTuple` `NamedTuple`. Replaces the anonymous (bool, str, str, str, str) tuple.
- Rewrite `proxyTuple()` fragile rpartition based URL parsing with `urlparse`.

#### Steps to Test

1. Set up a local proxy to observe traffic (I used charles).
2. In Arelle GUI: Tools > Internet > Proxy Server.
3. http:// prefix in URL field, enter http://<proxy-host> in the URL field and click OK. Before this fix: AttributeError. After: dialog accepts it and strips the prefix.
4. https:// prefix in URL field, same as above with https://. Should also be stripped cleanly.
5. HTTP requests route through proxy. Load an http:// URL, confirm the request appears in the proxy log.
6. HTTPS requests route through proxy. Load an https:// URL, confirm it now appears in the proxy log.
7. Credentials forwarded, configure proxy with user/password, confirm auth headers reach the proxy.
8. Configure an OS system level proxy.
9. Toggle on "Use OS proxy", confirm system proxy is used.
10. Config persistence:
    1. set proxy, including a username
    2. restart Arelle
    3. reopen proxy dialog
    4. confirm settings were saved and restored correctly.

**review**:
@Arelle/arelle
