### PR TITLE
Windows installer: pre-calculate installation size and update GitHub Action

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -125,7 +125,8 @@ jobs:
     - name: Make installer
       run: |
         $installer_version = ("${{ env.BUILD_VERSION }}" -replace '[^0-9.].*$', '' -replace '\.$', '') + ".${{ github.run_number }}"
-        makensis /INPUTCHARSET UTF8 /DINSTALLER_VERSION=$installer_version /DAPP_VERSION=${{ env.BUILD_VERSION }} installWin64.nsi
+        $size_kb = [math]::Ceiling((Get-ChildItem -Path (Resolve-Path "${{ env.BUILD_PATH }}") -Recurse -Force -File | Measure-Object -Property Length -Sum).Sum / 1KB)
+        makensis /INPUTCHARSET UTF8 /DINSTALLER_VERSION=$installer_version /DAPP_VERSION=${{ env.BUILD_VERSION }} /DAPP_INSTALL_SIZE_KB=$size_kb installWin64.nsi
     - name: Version installer
       run: mv dist\arelle-win-x64.exe ${{ steps.define-artifact-names.outputs.exe_build_artifact_path }}
     - name: Zip distribution

--- a/installWin64.nsi
+++ b/installWin64.nsi
@@ -21,6 +21,11 @@ Unicode true
   !define APP_VERSION "0.0.0"
 !endif
 
+!ifndef APP_INSTALL_SIZE_KB
+  ; Pick a reasonable default of 500 MB 
+  !define APP_INSTALL_SIZE_KB 512000
+!endif
+
 ;--------------------------------
 ; Include Modern UI
 
@@ -67,7 +72,6 @@ SetCompressor /SOLID lzma
 
   Var StartMenuFolder
   Var InstallDate
-  Var InstalledSizeKB
 
 ;--------------------------------
 ; Interface Settings
@@ -136,10 +140,10 @@ Section "Arelle" SecArelle
   WriteRegStr   HKLM  "${ARELLE_UNINSTALL_KEY}" "URLInfoAbout"      "https://arelle.org"
   WriteRegStr   HKLM  "${ARELLE_UNINSTALL_KEY}" "URLUpdateInfo"     "https://github.com/Arelle/Arelle/releases"
 
-  ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
-  ; $0 = total size in KB, $1 = file count (unused), $2 = subdirectory count (unused)
-  StrCpy $InstalledSizeKB $0
-  WriteRegDWORD HKLM  "${ARELLE_UNINSTALL_KEY}" "EstimatedSize"     $InstalledSizeKB
+  ; Use a pre-calculated size (in KB) rather than using ${GetSize} to calculate
+  ; a precise size at installation time. ${GetSize} is incredibly slow as it has
+  ; to stat every file.
+  WriteRegDWORD HKLM  "${ARELLE_UNINSTALL_KEY}" "EstimatedSize"     ${APP_INSTALL_SIZE_KB}
 
   ${GetTime} "" "L" $0 $1 $2 $3 $4 $5 $6
   ; GetTime outputs: $0=day(DD) $1=month(MM) $2=year(YYYY)


### PR DESCRIPTION
#### Reason for change
I just tried out the new installer for 2.39.10 and there is now a step (introduced by me in #2306) at the end of the install where it calculates the installation size. This step just took ages (~ 2 minutes) to complete. I'm not sure why I didn't notice it being slow at the time of the PR, but it is definitely slow now.

#### Description of change
Remove use of installer's `${GetSize}` command (which stats every file in the installation directory). Replace with a build time estimated size which can be passed in on the command line.

Update the GitHub actions to calculate the BUILD_PATH size in kb and pass it in.

#### Steps to Test

master spend time towards the end of the installation displaying "Size: x Kb Files: y Folders: z"
<img width="372" height="50" alt="image" src="https://github.com/user-attachments/assets/d8631319-cc5f-476c-88dd-f7591fbc158f" />

The PR should not display that step at all.

**review**:
@Arelle/arelle
