### PR TITLE
Remove "draft" from ESEF disclosure systems

### DIFF
--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -187,7 +187,7 @@
 		"styleIxHiddenProperty": "-esef-ix-hidden",
         "disallowedHiddenStyle": "-ix-hidden"
     },
-	"ESEF-2025-DRAFT": {
+	"ESEF-2025": {
 	    "outdatedTaxonomyURLs": [
 	        "http://www.esma.europa.eu/taxonomy/2017-03-31/esef_cor.xsd",
 	        "https://www.esma.europa.eu/taxonomy/2017-03-31/esef_cor.xsd",

--- a/arelle/plugin/validate/ESEF/resources/config.xml
+++ b/arelle/plugin/validate/ESEF/resources/config.xml
@@ -5,7 +5,7 @@
     <!-- see ../../../../config/disclosuresystem.xml for full comments -->
 
     <DisclosureSystem
-        names="Draft ESMA RTS on ESEF-2025|ESEF-2025-DRAFT|esef-2025-draft|ESEF-2025|esef-2025|ESEF|esef"
+        names="ESMA RTS on ESEF-2025|ESEF-2025|esef-2025|ESEF|esef"
         description="ESMA RTS on ESEF-2025 Validation Checks for Consolidated Financial Statements"
         validationType="ESEF"
         exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
@@ -15,7 +15,7 @@
     />
 
     <DisclosureSystem
-        names="Draft ESMA RTS on ESEF-2025 Unconsolidated|ESEF-Unconsolidated-2025-DRAFT|esef-unconsolidated-2025-draft|ESEF-Unconsolidated-2025|esef-unconsolidated-2025|ESEF-Unconsolidated|esef-unconsolidated"
+        names="ESMA RTS on ESEF-2025 Unconsolidated|ESEF-Unconsolidated-2025|esef-unconsolidated-2025|ESEF-Unconsolidated|esef-unconsolidated"
         description="ESMA RTS on ESEF-2025 Validation Checks for Unconsolidated Financial Statements"
         validationType="ESEF"
         exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
@@ -25,7 +25,7 @@
      />
 
     <DisclosureSystem
-        names="ESMA RTS on ESEF-2024|ESEF-2024-DRAFT|esef-2024-draft|ESEF-2024|esef-2024"
+        names="ESMA RTS on ESEF-2024|ESEF-2024|esef-2024"
         description="ESMA RTS on ESEF-2024 Validation Checks for Consolidated Financial Statements"
         validationType="ESEF"
         exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"

--- a/arelle/plugin/validate/ESEF/resources/config.xml
+++ b/arelle/plugin/validate/ESEF/resources/config.xml
@@ -6,7 +6,7 @@
 
     <DisclosureSystem
         names="Draft ESMA RTS on ESEF-2025|ESEF-2025-DRAFT|esef-2025-draft|ESEF-2025|esef-2025|ESEF|esef"
-        description="ESMA RTS on ESEF-2025 Validation Checks for Consolidated Financial Statements (DRAFT)"
+        description="ESMA RTS on ESEF-2025 Validation Checks for Consolidated Financial Statements"
         validationType="ESEF"
         exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
         blockDisallowedReferences="false"
@@ -16,7 +16,7 @@
 
     <DisclosureSystem
         names="Draft ESMA RTS on ESEF-2025 Unconsolidated|ESEF-Unconsolidated-2025-DRAFT|esef-unconsolidated-2025-draft|ESEF-Unconsolidated-2025|esef-unconsolidated-2025|ESEF-Unconsolidated|esef-unconsolidated"
-        description="ESMA RTS on ESEF-2025 Validation Checks for Unconsolidated Financial Statements (DRAFT)"
+        description="ESMA RTS on ESEF-2025 Validation Checks for Unconsolidated Financial Statements"
         validationType="ESEF"
         exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
         blockDisallowedReferences="false"


### PR DESCRIPTION
#### Reason for change
ESEF 2025 support is final. We can remove all the draft options and language.

#### Description of change
Update ESEF disclosure system names and descriptions.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
