### PR TITLE
avoid exceptions when an invalid typed member is used

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -699,7 +699,7 @@ class ModelXbrl:
                     dimElt = XmlUtil.addChild(contextElt, XbrlConst.xbrldi, "xbrldi:typedMember",
                                               attributes=dimAttr)
                     if isinstance(dimValue, (arelle.ModelInstanceObject.ModelDimensionValue, DimValuePrototype)) and dimValue.isTyped and dimValue.typedMember is not None:
-                        XmlUtil.copyNodes(dimElt, cast(ModelObject, dimValue.typedMember))
+                        XmlUtil.copyNodes(dimElt, dimValue.typedMember)
                 elif dimMemberQname:
                     dimElt = XmlUtil.addChild(contextElt, XbrlConst.xbrldi, "xbrldi:explicitMember",
                                               attributes=dimAttr,

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -698,7 +698,7 @@ class ModelXbrl:
                 if cast('DimValuePrototype | ModelDimensionValue', dimValue).isTyped:  #Typing thinks that this can also be a QName
                     dimElt = XmlUtil.addChild(contextElt, XbrlConst.xbrldi, "xbrldi:typedMember",
                                               attributes=dimAttr)
-                    if isinstance(dimValue, (arelle.ModelInstanceObject.ModelDimensionValue, DimValuePrototype)) and dimValue.isTyped and dimValue.typedMember:
+                    if isinstance(dimValue, (arelle.ModelInstanceObject.ModelDimensionValue, DimValuePrototype)) and dimValue.isTyped and dimValue.typedMember is not None:
                         XmlUtil.copyNodes(dimElt, cast(ModelObject, dimValue.typedMember))
                 elif dimMemberQname:
                     dimElt = XmlUtil.addChild(contextElt, XbrlConst.xbrldi, "xbrldi:explicitMember",
@@ -866,7 +866,7 @@ class ModelXbrl:
                         fbdq[NONDEFAULT].add(fact) # set of all facts that have non-default value for dimension
                         if dimValue.isExplicit:
                             fbdq[dimValue.memberQname].add(fact) # set of facts that have this dim and mem
-                        elif dimValue.isTyped and dimValue.typedMember:
+                        elif dimValue.isTyped and dimValue.typedMember is not None:
                             fbdq[dimValue.typedMember.textValue].add(fact) # set of facts that have this dim and mem
                     else: # default typed dimension
                         fbdq[DEFAULT].add(fact)

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -698,7 +698,7 @@ class ModelXbrl:
                 if cast('DimValuePrototype | ModelDimensionValue', dimValue).isTyped:  #Typing thinks that this can also be a QName
                     dimElt = XmlUtil.addChild(contextElt, XbrlConst.xbrldi, "xbrldi:typedMember",
                                               attributes=dimAttr)
-                    if isinstance(dimValue, (arelle.ModelInstanceObject.ModelDimensionValue, DimValuePrototype)) and dimValue.isTyped:
+                    if isinstance(dimValue, (arelle.ModelInstanceObject.ModelDimensionValue, DimValuePrototype)) and dimValue.isTyped and dimValue.typedMember:
                         XmlUtil.copyNodes(dimElt, cast(ModelObject, dimValue.typedMember))
                 elif dimMemberQname:
                     dimElt = XmlUtil.addChild(contextElt, XbrlConst.xbrldi, "xbrldi:explicitMember",
@@ -866,7 +866,7 @@ class ModelXbrl:
                         fbdq[NONDEFAULT].add(fact) # set of all facts that have non-default value for dimension
                         if dimValue.isExplicit:
                             fbdq[dimValue.memberQname].add(fact) # set of facts that have this dim and mem
-                        elif dimValue.isTyped:
+                        elif dimValue.isTyped and dimValue.typedMember:
                             fbdq[dimValue.typedMember.textValue].add(fact) # set of facts that have this dim and mem
                     else: # default typed dimension
                         fbdq[DEFAULT].add(fact)


### PR DESCRIPTION
#### Reason for change
Exceptions are raised if a context contains an invalid typed member

#### Description of change
Added additional condition to check that the typedMember is not None.

#### Steps to Test
The attached filing has an empty typedMember element. If we run it though Arelle with the following command it will result in an exception. This PR is meant to avoid the exception and only output the xbrldie:IllegalTypedDimensionContentError error.

`arelleCmdLine.py --xdgConfigHome $XDG_CONFIG_HOME --file "$PATH_TO_FILE/EXFILINGFEES.htm" -v --disclosureSystem efm-pragmatic --plugins EdgarRenderer`

[EXFILINGFEES.htm](https://github.com/user-attachments/files/27286847/EXFILINGFEES.htm)


**review**:
@Arelle/arelle



