### PR TITLE
Auto Retry Test S3 Downloads

### DIFF
--- a/tests/integration_tests/download_cache.py
+++ b/tests/integration_tests/download_cache.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
+
 import argparse
 import os
-import urllib.request
 import zipfile
-from pathlib import Path
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 
 TEMP_ZIP_NAME = '_tempcache.zip'
 
@@ -30,16 +29,8 @@ def download_and_apply_cache(name: str, cache_directory: str | None = None, vers
     :param cache_directory: Directory to unpack cache package into
     :param version_id: The S3 object version to retrieve. None for latest.
     """
-    # Download ZIP from public S3 bucket.
-    uri = get_s3_uri(
-        f'ci/caches/{name}',
-        version_id=version_id
-    )
-    try:
-        urllib.request.urlretrieve(uri, TEMP_ZIP_NAME)
-        apply_cache(TEMP_ZIP_NAME, cache_directory)
-    except Exception as exc:
-        raise Exception(f'Failed to download cache from {uri} and extract to {cache_directory}.') from exc
+    download_from_public_s3(TEMP_ZIP_NAME, f'ci/caches/{name}', version_id=version_id)
+    apply_cache(TEMP_ZIP_NAME, cache_directory)
 
 
 def download_taxonomy_package(name: str, download_path: str, version_id: str | None = None) -> None:
@@ -50,15 +41,7 @@ def download_taxonomy_package(name: str, download_path: str, version_id: str | N
     """
     if os.path.exists(download_path):
         return
-    os.makedirs(os.path.dirname(download_path), exist_ok=True)
-    uri = get_s3_uri(
-        f'ci/taxonomy_packages/{name}',
-        version_id=version_id
-    )
-    try:
-        urllib.request.urlretrieve(uri, download_path)
-    except Exception as exc:
-        raise Exception(f'Failed to download package from {uri} to {download_path}') from exc
+    download_from_public_s3(download_path, f'ci/taxonomy_packages/{name}', version_id=version_id)
 
 
 def download_program() -> None:

--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import json
 import locale
 import os
-import urllib.parse
 from collections import Counter, defaultdict
 from pathlib import PurePath
-from typing import TYPE_CHECKING, cast, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import boto3
 import pytest
@@ -15,10 +14,10 @@ from botocore import UNSIGNED
 from botocore.config import Config as BotocoreConfig
 
 from arelle import PackageManager, PluginManager
-from arelle.ModelDocumentType import ModelDocumentType
 from arelle.Cntlr import Cntlr
 from arelle.CntlrCmdLine import parseAndRun
 from arelle.FileSource import archiveFilenameParts
+from arelle.ModelDocumentType import ModelDocumentType
 
 if TYPE_CHECKING:
     from _pytest.mark import ParameterSet
@@ -70,14 +69,6 @@ def get_document_id(doc: ModelDocument) -> str:
 
 def get_document_id_from_basepath(doc: ModelDocument, basepath: str) -> str:
     return PurePath(doc.filepath).relative_to(basepath).as_posix()
-
-
-def get_s3_uri(path: str, version_id: str | None = None) -> str:
-    path = urllib.parse.quote(path)
-    uri = f'https://arelle-public.s3.amazonaws.com/{path}'
-    if version_id is not None:
-        uri += f'?versionId={version_id}'
-    return uri
 
 
 _S3_BASE_CONFIG = BotocoreConfig(

--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import json
 import locale
-import os.path
+import os
 import urllib.parse
 from collections import Counter, defaultdict
 from pathlib import PurePath
 from typing import TYPE_CHECKING, cast, Any
 
+import boto3
 import pytest
 import regex
+from botocore import UNSIGNED
+from botocore.config import Config as BotocoreConfig
 
 from arelle import PackageManager, PluginManager
 from arelle.ModelDocumentType import ModelDocumentType
@@ -19,6 +22,8 @@ from arelle.FileSource import archiveFilenameParts
 
 if TYPE_CHECKING:
     from _pytest.mark import ParameterSet
+    from types_boto3_s3 import S3Client
+
     from arelle.ModelDocument import ModelDocument
 
 
@@ -73,6 +78,61 @@ def get_s3_uri(path: str, version_id: str | None = None) -> str:
     if version_id is not None:
         uri += f'?versionId={version_id}'
     return uri
+
+
+_S3_BASE_CONFIG = BotocoreConfig(
+    retries={
+        "mode": "adaptive",
+        "total_max_attempts": 5,
+    }
+)
+
+
+_PRIVATE_S3_CLIENT: S3Client | None = None
+
+
+def _get_private_s3_client() -> S3Client:
+    global _PRIVATE_S3_CLIENT
+    if _PRIVATE_S3_CLIENT is None:
+        _PRIVATE_S3_CLIENT = boto3.client(
+            service_name="s3",
+            config=_S3_BASE_CONFIG,
+        )
+    return _PRIVATE_S3_CLIENT
+
+
+_PUBLIC_S3_CLIENT: S3Client | None = None
+
+
+def _get_public_s3_client() -> S3Client:
+    global _PUBLIC_S3_CLIENT
+    if _PUBLIC_S3_CLIENT is None:
+        _PUBLIC_S3_CLIENT = boto3.client(
+            service_name="s3",
+            config=_S3_BASE_CONFIG.merge(BotocoreConfig(signature_version=UNSIGNED)),
+        )
+    return _PUBLIC_S3_CLIENT
+
+
+def _download_from_s3(
+    client: S3Client,
+    bucket: str,
+    download_path: str | os.PathLike[str],
+    key: str,
+    version_id: str | None = None,
+) -> None:
+    if parent_dir := os.path.dirname(download_path):
+        os.makedirs(parent_dir, exist_ok=True)
+    extra_args = {"VersionId": version_id} if version_id else {}
+    client.download_file(bucket, Key=key, Filename=str(download_path), ExtraArgs=extra_args)
+
+
+def download_from_public_s3(download_path: str | os.PathLike[str], key: str, version_id: str | None = None) -> None:
+    _download_from_s3(_get_public_s3_client(), "arelle-public", download_path, key, version_id)
+
+
+def download_from_private_s3(download_path: str | os.PathLike[str], key: str, version_id: str | None = None) -> None:
+    _download_from_s3(_get_private_s3_client(), "arelle", download_path, key, version_id)
 
 
 def get_test_data(

--- a/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
+++ b/tests/integration_tests/scripts/tests/duplicate_facts_deduplication.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import os
-import urllib.request
 import zipfile
 from pathlib import Path
 from shutil import rmtree
 
 import regex
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
@@ -25,13 +24,12 @@ test_directory = Path(args.test_directory)
 report_zip_path = test_directory / 'report.zip'
 report_directory = test_directory / 'report'
 report_path = report_directory / "report.xbrl"
-report_zip_url = get_s3_uri(
-    'ci/packages/duplicate_facts_deduplication.zip',
-    version_id='1NplyThuJkNOmSNITHdVuqE4MYtvDGOq'
+print(f"Downloading report: {report_zip_path}")
+download_from_public_s3(
+    report_zip_path,
+    "ci/packages/duplicate_facts_deduplication.zip",
+    version_id="1NplyThuJkNOmSNITHdVuqE4MYtvDGOq",
 )
-
-print(f"Downloading report: {report_zip_url}")
-urllib.request.urlretrieve(report_zip_url, report_zip_path)
 
 print(f"Extracting report: {report_directory}")
 with zipfile.ZipFile(report_zip_path, "r") as zip_ref:

--- a/tests/integration_tests/scripts/tests/duplicate_facts_validate.py
+++ b/tests/integration_tests/scripts/tests/duplicate_facts_validate.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import os
-import urllib.request
 import zipfile
 from pathlib import Path
 from shutil import rmtree
 
 import regex
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
@@ -25,13 +24,12 @@ test_directory = Path(args.test_directory)
 report_zip_path = test_directory / 'report.zip'
 report_directory = test_directory / 'report'
 report_path = report_directory / "report.xbrl"
-report_zip_url = get_s3_uri(
-    'ci/packages/fact_deduplication.zip',
-    version_id='.KKcbsQZQx5jLzXilkFZlQ3OdwTuFaoe'
+print(f"Downloading report: {report_zip_path}")
+download_from_public_s3(
+    report_zip_path,
+    "ci/packages/fact_deduplication.zip",
+    version_id=".KKcbsQZQx5jLzXilkFZlQ3OdwTuFaoe",
 )
-
-print(f"Downloading report: {report_zip_url}")
-urllib.request.urlretrieve(report_zip_url, report_zip_path)
 
 print(f"Extracting report: {report_directory}")
 with zipfile.ZipFile(report_zip_path, "r") as zip_ref:

--- a/tests/integration_tests/scripts/tests/eba_tablesets.py
+++ b/tests/integration_tests/scripts/tests/eba_tablesets.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import html.parser
 import os
-import urllib.request
 import zipfile
 from pathlib import Path
 from shutil import rmtree
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import (
     assert_result,
     parse_args,
@@ -28,12 +27,12 @@ samples_zip_path = test_directory / "eba_samples.zip"
 samples_directory = test_directory / "eba_samples"
 target_path = samples_directory / "DUMMYLEI123456789012_GB_COREP030000_COREPLECON_2021-06-30_20201218154732000.xbrl"
 tablesets_report_path = test_directory / "index.html"
-sample_report_zip_url = get_s3_uri("ci/packages/eba-samples.zip", version_id="iDJU3nFy6_rQ289k.mosenHjUFrXCmCM")
-
-samples_url = get_s3_uri("ci/packages/eba_samples.zip", version_id="O7uYHbSYmxe_20nBhWWoXMfjGpquNMMj")
-
 print(f"Downloading EBA sample files: {samples_zip_path}")
-urllib.request.urlretrieve(samples_url, samples_zip_path)
+download_from_public_s3(
+    samples_zip_path,
+    "ci/packages/eba_samples.zip",
+    version_id="O7uYHbSYmxe_20nBhWWoXMfjGpquNMMj",
+)
 
 print(f"Extracting EBA sample files: {samples_directory}")
 with zipfile.ZipFile(samples_zip_path, "r") as zip_ref:

--- a/tests/integration_tests/scripts/tests/entry_point_from_taxonomy_package.py
+++ b/tests/integration_tests/scripts/tests/entry_point_from_taxonomy_package.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import os
-import urllib.request
 from pathlib import Path
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import (
     assert_result,
     parse_args,
@@ -25,12 +24,8 @@ test_directory = Path(args.test_directory)
 arelle_log_file = prepare_logfile(test_directory, this_file)
 taxonomy_package_name = "entry_point_from_taxonomy_package.zip"
 taxonomy_package_path = test_directory / taxonomy_package_name
-taxonomy_package_zip_url = get_s3_uri(
-    f"ci/packages/{taxonomy_package_name}", version_id="nbaiNmQvDfvRSZzmrFRsuhH5yS2RDVk."
-)
-
 print(f"Downloading taxonomy package: {taxonomy_package_name}")
-urllib.request.urlretrieve(taxonomy_package_zip_url, taxonomy_package_path)
+download_from_public_s3(taxonomy_package_path, f"ci/packages/{taxonomy_package_name}", version_id="nbaiNmQvDfvRSZzmrFRsuhH5yS2RDVk.")
 
 entry_point = "https://arelle.org/example/example.xsd"
 print(f"Validating entry point: {entry_point}")

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_cli.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import os
-import urllib.request
 import zipfile
 
 from pathlib import Path
 from shutil import rmtree
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
@@ -27,13 +26,12 @@ samples_zip_path = test_directory / 'samples.zip'
 samples_directory = test_directory / 'samples'
 target_path = samples_directory / "samples/src/ixds-test/document1.html"
 viewer_path = test_directory / "viewer.html"
-report_zip_url = get_s3_uri(
-    'ci/packages/IXBRLViewerSamples.zip',
-    version_id='6eS7qUUoWLeM9JSSTXOfANkHoLz1Zv5o'
-)
-
 print(f"Downloading samples: {samples_zip_path}")
-urllib.request.urlretrieve(report_zip_url, samples_zip_path)
+download_from_public_s3(
+    samples_zip_path,
+    "ci/packages/IXBRLViewerSamples.zip",
+    version_id="6eS7qUUoWLeM9JSSTXOfANkHoLz1Zv5o",
+)
 
 print(f"Extracting samples: {samples_directory}")
 with zipfile.ZipFile(samples_zip_path, "r") as zip_ref:

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_webserver.py
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_webserver.py
@@ -7,7 +7,7 @@ import zipfile
 from pathlib import Path
 from shutil import rmtree
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import parse_args, validate_log_file, assert_result, prepare_logfile, run_arelle_webserver
 
 errors = []
@@ -27,13 +27,12 @@ samples_zip_path = test_directory / 'samples.zip'
 samples_directory = test_directory / 'samples'
 target_path = samples_directory / "samples/src/ixds-test/document1.html"
 viewer_path = test_directory / "viewer.html"
-report_zip_url = get_s3_uri(
-    'ci/packages/IXBRLViewerSamples.zip',
-    version_id='6eS7qUUoWLeM9JSSTXOfANkHoLz1Zv5o'
-)
-
 print(f"Downloading samples: {samples_zip_path}")
-urllib.request.urlretrieve(report_zip_url, samples_zip_path)
+download_from_public_s3(
+    samples_zip_path,
+    "ci/packages/IXBRLViewerSamples.zip",
+    version_id="6eS7qUUoWLeM9JSSTXOfANkHoLz1Zv5o",
+)
 
 print(f"Extracting samples: {samples_directory}")
 with zipfile.ZipFile(samples_zip_path, "r") as zip_ref:

--- a/tests/integration_tests/scripts/tests/ixbrl-viewer_webserver.py
+++ b/tests/integration_tests/scripts/tests/ixbrl-viewer_webserver.py
@@ -40,13 +40,12 @@ with zipfile.ZipFile(samples_zip_path, "r") as zip_ref:
 
 contents = ''
 port = 8100
-with run_arelle_webserver(arelle_command, port) as proc:
+with run_arelle_webserver(arelle_command, port, offline=arelle_offline) as proc:
     target_url = urllib.parse.quote_plus(str(target_path))
     url = f"http://localhost:{port}/rest/xbrl/{target_url}/open?media=xml"
     url += "&plugins=ixbrl-viewer"
     url += "&viewer_feature_review=true"
     url += f"&saveViewerDest={urllib.parse.quote_plus(str(viewer_path))}"
-    url += f"&internetConnectivity={'false' if arelle_offline else 'true'}"
     url += f"&logFile={urllib.parse.quote_plus(str(arelle_log_file))}"
     print(f"Generating IXBRL viewer: {url}")
     contents = urllib.request.urlopen(url).read()

--- a/tests/integration_tests/scripts/tests/japan_ixds.py
+++ b/tests/integration_tests/scripts/tests/japan_ixds.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import os
-import urllib.request
 import zipfile
 from pathlib import Path
 from shutil import rmtree
 
 import regex
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
@@ -29,13 +28,12 @@ report_zip_path = test_directory / 'report.zip'
 report_directory = test_directory / 'report'
 manifest_path = report_directory / "manifest.xml"
 extracted_path = report_directory / "tse-qcedjpfr-21750-2024-06-30-01-2024-07-26_extracted.xbrl"
-report_zip_url = get_s3_uri(
-    'ci/packages/JapaneseXBRLReport.zip',
-    version_id='v.H1rasRpwFzqN.dPha4L2D_NCCXLkTv'
+print(f"Downloading report: {report_zip_path}")
+download_from_public_s3(
+    report_zip_path,
+    "ci/packages/JapaneseXBRLReport.zip",
+    version_id="v.H1rasRpwFzqN.dPha4L2D_NCCXLkTv",
 )
-
-print(f"Downloading report: {report_zip_url}")
-urllib.request.urlretrieve(report_zip_url, report_zip_path)
 
 print(f"Extracting report: {report_directory}")
 with zipfile.ZipFile(report_zip_path, "r") as zip_ref:

--- a/tests/integration_tests/scripts/tests/load_from_excel.py
+++ b/tests/integration_tests/scripts/tests/load_from_excel.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import os
-import urllib.request
 from pathlib import Path
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import (
     assert_result,
     parse_args,
@@ -28,13 +27,12 @@ test_directory = Path(args.test_directory)
 arelle_log_file = prepare_logfile(test_directory, this_file)
 
 excel_taxonomy_path = test_directory / 'XII_Taxonomy.xlsx'
-excel_taxonomy_url = get_s3_uri(
-    'ci/packages/XII_Taxonomy.xlsx',
-    version_id='c5mjDshdqpmu8CvVt37Ur9yhh06fO1BB'
+print(f"Downloading Excel file: {excel_taxonomy_path}")
+download_from_public_s3(
+    excel_taxonomy_path,
+    "ci/packages/XII_Taxonomy.xlsx",
+    version_id="c5mjDshdqpmu8CvVt37Ur9yhh06fO1BB",
 )
-
-print(f"Downloading Excel file: {excel_taxonomy_url}")
-urllib.request.urlretrieve(excel_taxonomy_url, excel_taxonomy_path)
 
 run_arelle(
     arelle_command,

--- a/tests/integration_tests/scripts/tests/malformed_utr.py
+++ b/tests/integration_tests/scripts/tests/malformed_utr.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import os
-import urllib.request
 import zipfile
 from pathlib import Path
 from shutil import rmtree
 
 import regex
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import run_arelle, parse_args, validate_log_file, assert_result, prepare_logfile
 
 errors = []
@@ -25,13 +24,12 @@ test_directory = Path(args.test_directory)
 suite_zip_path = test_directory / 'suite.zip'
 suite_directory = test_directory / 'suite'
 instance_path = suite_directory / 'conf/utr-structure/tests/01-simple/simpleValid.xml'
-suite_zip_url = get_s3_uri(
-    'ci/conformance_suites/utr-structure-conf-cr-2013-11-18.zip',
-    version_id='ECn8HExI_mObgNG02YICSrDMCFg2vnzX'
+print(f"Downloading suite: {suite_zip_path}")
+download_from_public_s3(
+    suite_zip_path,
+    "ci/conformance_suites/utr-structure-conf-cr-2013-11-18.zip",
+    version_id="ECn8HExI_mObgNG02YICSrDMCFg2vnzX",
 )
-
-print(f"Downloading suite: {suite_zip_url}")
-urllib.request.urlretrieve(suite_zip_url, suite_zip_path)
 
 print(f"Extracting suite: {suite_directory}")
 with zipfile.ZipFile(suite_zip_path, "r") as zip_ref:

--- a/tests/integration_tests/scripts/tests/python_api_instance_extraction.py
+++ b/tests/integration_tests/scripts/tests/python_api_instance_extraction.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 import os
-import urllib.request
 import zipfile
 from pathlib import Path
 
@@ -10,7 +9,7 @@ import regex
 
 from arelle.RuntimeOptions import RuntimeOptions
 from arelle.api.Session import Session
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import parse_args, assert_result, prepare_logfile, validate_log_xml
 
 errors = []
@@ -32,13 +31,12 @@ manifest_path = report_zip_path / "manifest.xml"
 extracted_zip_path = test_directory / "extracted.zip"
 extracted_instance_path = test_directory / "tse-acedjpfr-19990-2023-06-30-01-2023-08-18_extracted.xbrl"
 extracted_final_path = report_zip_path / "tse-acedjpfr-19990-2023-06-30-01-2023-08-18_extracted.xbrl"
-report_zip_url = get_s3_uri(
-    'ci/packages/JapaneseXBRLReport.zip',
-    version_id='M7vTPhHhir1rOm7nSMPiCGcbCA0ksObh'
+print(f"Downloading report: {report_zip_path}")
+download_from_public_s3(
+    report_zip_path,
+    "ci/packages/JapaneseXBRLReport.zip",
+    version_id="M7vTPhHhir1rOm7nSMPiCGcbCA0ksObh",
 )
-
-print(f"Downloading report: {report_zip_url}")
-urllib.request.urlretrieve(report_zip_url, report_zip_path)
 
 print(f"Extracting instance: {manifest_path}")
 with io.BytesIO() as extracted_stream:

--- a/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
+++ b/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import urllib.request
 from logging import LogRecord
 from pathlib import Path
 
@@ -10,7 +9,7 @@ from arelle.RuntimeOptions import RuntimeOptions
 # include import start
 from arelle.api.Session import Session
 # include import end
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import parse_args, validate_log_xml, assert_result
 
 errors = []
@@ -28,13 +27,12 @@ test_directory = Path(args.test_directory)
 samples_zip_path = test_directory / 'samples.zip'
 target_path = samples_zip_path / "samples/src/ixds-test/document1.html"
 viewer_path = test_directory / "viewer.html"
-report_zip_url = get_s3_uri(
-    'ci/packages/IXBRLViewerSamples.zip',
-    version_id='6eS7qUUoWLeM9JSSTXOfANkHoLz1Zv5o'
-)
-
 print(f"Downloading samples: {samples_zip_path}")
-urllib.request.urlretrieve(report_zip_url, samples_zip_path)
+download_from_public_s3(
+    samples_zip_path,
+    "ci/packages/IXBRLViewerSamples.zip",
+    version_id="6eS7qUUoWLeM9JSSTXOfANkHoLz1Zv5o",
+)
 
 
 class TestFilter(logging.Filter):

--- a/tests/integration_tests/scripts/tests/python_api_query_model.py
+++ b/tests/integration_tests/scripts/tests/python_api_query_model.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import os
-import urllib.request
 from pathlib import Path
 
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelValue import qname
 from arelle.RuntimeOptions import RuntimeOptions
 from arelle.api.Session import Session
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import parse_args, prepare_logfile
 from tests.integration_tests.validation.assets import ESEF_PACKAGES
 from tests.integration_tests.validation.download_assets import download_assets
@@ -26,13 +25,12 @@ test_directory = Path(args.test_directory)
 arelle_log_file = prepare_logfile(test_directory, this_file)
 report_zip_path = test_directory / 'TC2_invalid.zip'
 target_path = report_zip_path
-report_zip_url = get_s3_uri(
-    'ci/packages/python_api_validate_esef.zip',
-    version_id='U3sEz.B8kjUWw0l6momz87EndK05cxFZ'
-)
-
 print(f"Downloading report: {report_zip_path}")
-urllib.request.urlretrieve(report_zip_url, report_zip_path)
+download_from_public_s3(
+    report_zip_path,
+    "ci/packages/python_api_validate_esef.zip",
+    version_id="U3sEz.B8kjUWw0l6momz87EndK05cxFZ",
+)
 
 print("Downloading packages...")
 package_assets = {

--- a/tests/integration_tests/scripts/tests/python_api_taxonomy_service.py
+++ b/tests/integration_tests/scripts/tests/python_api_taxonomy_service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 import json
-import urllib.request
 import zipfile
 from pathlib import Path
 from shutil import rmtree
@@ -11,7 +10,7 @@ from arelle.RuntimeOptions import RuntimeOptions
 from arelle.api.Session import Session
 from arelle.logging.handlers.StructuredMessageLogHandler import StructuredMessageLogHandler
 from arelle.plugin.validate import FERC
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import parse_args, prepare_logfile
 
 
@@ -28,14 +27,14 @@ cache_directory = test_directory / 'cache'
 arelle_log_file = prepare_logfile(test_directory, this_file, ext='json')
 entry_point_url = 'https://eCollection.ferc.gov/taxonomy/form60/2024-04-01/form/form60/form-60_2024-04-01.xsd'
 remove_file = cache_directory / 'http' / 'www.xbrl.org' / '2005' / 'xbrldt-2005.xsd'
-cache_zip_url = get_s3_uri(
-    'ci/caches/scripts/python_api_taxonomy_service.zip',
-    version_id='rSYFEO6UrUHEHl4zaRnFiZZKgIcDFKkY'
-)
 cache_zip_path = test_directory / 'cache.zip'
 
 print(f"Downloading cache with missing labels file: {cache_zip_path}")
-urllib.request.urlretrieve(cache_zip_url, cache_zip_path)
+download_from_public_s3(
+    cache_zip_path,
+    "ci/caches/scripts/python_api_taxonomy_service.zip",
+    version_id="rSYFEO6UrUHEHl4zaRnFiZZKgIcDFKkY",
+)
 with zipfile.ZipFile(cache_zip_path, "r") as zip_ref:
     zip_ref.extractall(cache_directory)
 

--- a/tests/integration_tests/scripts/tests/python_api_validate_esef.py
+++ b/tests/integration_tests/scripts/tests/python_api_validate_esef.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import os
-import urllib.request
 from pathlib import Path
 
 import regex
 
 from arelle.RuntimeOptions import RuntimeOptions
 from arelle.api.Session import Session
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import parse_args, validate_log_xml, assert_result, prepare_logfile
 from tests.integration_tests.validation.assets import ESEF_PACKAGES
 from tests.integration_tests.validation.download_assets import download_assets
@@ -26,13 +25,12 @@ test_directory = Path(args.test_directory)
 arelle_log_file = prepare_logfile(test_directory, this_file)
 report_zip_path = test_directory / 'TC2_invalid.zip'
 target_path = report_zip_path
-report_zip_url = get_s3_uri(
-    'ci/packages/python_api_validate_esef.zip',
-    version_id='U3sEz.B8kjUWw0l6momz87EndK05cxFZ'
-)
-
 print(f"Downloading report: {report_zip_path}")
-urllib.request.urlretrieve(report_zip_url, report_zip_path)
+download_from_public_s3(
+    report_zip_path,
+    "ci/packages/python_api_validate_esef.zip",
+    version_id="U3sEz.B8kjUWw0l6momz87EndK05cxFZ",
+)
 
 print("Downloading packages...")
 package_assets = {

--- a/tests/integration_tests/scripts/tests/validation_exit_code.py
+++ b/tests/integration_tests/scripts/tests/validation_exit_code.py
@@ -1,10 +1,9 @@
 import os
-import urllib.request
 import zipfile
 from pathlib import Path
 from shutil import rmtree
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import (
     parse_args,
     assert_result,
@@ -28,13 +27,12 @@ samples_zip_path = test_directory / 'samples.zip'
 samples_directory = test_directory / 'samples'
 warning_target_path = samples_directory / "warning.xbrl"
 error_target_path = samples_directory / "error.xbri"
-report_zip_url = get_s3_uri(
-    'ci/packages/validation_exit_code.zip',
-    version_id='0CXwl2Zj3yC5eEXohH_boOl0JfWBzy89'
-    )
-
 print(f"Downloading samples: {samples_zip_path}")
-urllib.request.urlretrieve(report_zip_url, samples_zip_path)
+download_from_public_s3(
+    samples_zip_path,
+    "ci/packages/validation_exit_code.zip",
+    version_id="0CXwl2Zj3yC5eEXohH_boOl0JfWBzy89",
+)
 
 print(f"Extracting samples: {samples_directory}")
 with zipfile.ZipFile(samples_zip_path, "r") as zip_ref:

--- a/tests/integration_tests/scripts/tests/webserver_reject_remote_plugins.py
+++ b/tests/integration_tests/scripts/tests/webserver_reject_remote_plugins.py
@@ -19,6 +19,7 @@ args = parse_args(
     arelle=False,
 )
 arelle_command = args.arelle
+arelle_offline = args.offline
 
 REJECTION_MESSAGE = "Remote URL plug-in references are not permitted via the webserver"
 
@@ -32,7 +33,7 @@ REMOTE_REJECT_CASES = [
 ]
 
 port = 8101
-with run_arelle_webserver(arelle_command, port) as proc:
+with run_arelle_webserver(arelle_command, port, offline=arelle_offline) as proc:
     base = f"http://localhost:{port}"
 
     for label, query in REMOTE_REJECT_CASES:

--- a/tests/integration_tests/scripts/tests/webserver_validate_esef.py
+++ b/tests/integration_tests/scripts/tests/webserver_validate_esef.py
@@ -53,11 +53,10 @@ package_paths = [str(a.full_local_path) for a in package_assets]
 contents = b''
 port = 8100
 log_xml_bytes = None
-with run_arelle_webserver(arelle_command, port) as proc:
+with run_arelle_webserver(arelle_command, port, offline=arelle_offline) as proc:
     url = f"http://localhost:{port}/rest/xbrl/validation?media=xml"
     url += "&plugins=validate/ESEF"
     url += "&disclosureSystemName=esef-2024"
-    url += f"&internetConnectivity={'false' if arelle_offline else 'true'}"
     url += f"&logFile={urllib.parse.quote_plus(str(arelle_log_file))}"
     url += "&packages=" + '|'.join(urllib.parse.quote_plus(str(p)) for p in package_paths)
     url += "&parameters=authority=SE"

--- a/tests/integration_tests/scripts/tests/webserver_validate_esef.py
+++ b/tests/integration_tests/scripts/tests/webserver_validate_esef.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import os
 import urllib.parse
-import urllib.request
 from pathlib import Path
 
 import regex
 import requests
 
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_public_s3
 from tests.integration_tests.scripts.script_util import (
     assert_result,
     parse_args,
@@ -32,13 +31,12 @@ working_directory = Path(args.working_directory)
 test_directory = Path(args.test_directory)
 report_zip_path = test_directory / 'TC2_invalid.zip'
 arelle_log_file = prepare_logfile(test_directory, this_file)
-report_zip_url = get_s3_uri(
-    'ci/packages/python_api_validate_esef.zip',
-    version_id='U3sEz.B8kjUWw0l6momz87EndK05cxFZ'
-)
-
 print(f"Downloading report: {report_zip_path}")
-urllib.request.urlretrieve(report_zip_url, report_zip_path)
+download_from_public_s3(
+    report_zip_path,
+    "ci/packages/python_api_validate_esef.zip",
+    version_id="U3sEz.B8kjUWw0l6momz87EndK05cxFZ",
+)
 
 print("Downloading packages...")
 package_assets = {

--- a/tests/integration_tests/validation/download_assets.py
+++ b/tests/integration_tests/validation/download_assets.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import boto3
 import os
 import urllib.request
 import zipfile
 from pathlib import Path
 
 from tests.integration_tests.download_cache import apply_cache
-from tests.integration_tests.integration_test_util import get_s3_uri
+from tests.integration_tests.integration_test_util import download_from_private_s3, download_from_public_s3
 from tests.integration_tests.validation.conformance_suite_config import ConformanceSuiteAssetConfig, AssetType, AssetSource, CONFORMANCE_SUITE_PATH_PREFIX
 
 
@@ -50,14 +49,9 @@ def _download_private_s3_asset(asset: ConformanceSuiteAssetConfig) -> None:
     assert key is not None
     if asset.type == AssetType.CONFORMANCE_SUITE:
         key = f'conformance_suites/{key}'
-    asset.full_local_path.parent.mkdir(parents=True, exist_ok=True)
     assert 'AWS_ACCESS_KEY_ID' in os.environ.keys(), 'Must have AWS_ACCESS_KEY_ID environment variable set.'
     assert 'AWS_SECRET_ACCESS_KEY' in os.environ.keys(), 'Must have AWS_SECRET_ACCESS_KEY environment variable set.'
-    s3 = boto3.client('s3')
-    if asset.s3_version_id:
-        s3.download_file('arelle', Key=key, Filename=str(asset.full_local_path), ExtraArgs={'VersionId': asset.s3_version_id})
-    else:
-        s3.download_file('arelle', Key=key, Filename=str(asset.full_local_path))
+    download_from_private_s3(asset.full_local_path, key, version_id=asset.s3_version_id)
 
 
 def _download_public_s3_asset(asset: ConformanceSuiteAssetConfig) -> None:
@@ -72,8 +66,7 @@ def _download_public_s3_asset(asset: ConformanceSuiteAssetConfig) -> None:
         key = f'ci/caches/conformance_suites/{key}'
     elif asset.type == AssetType.TAXONOMY_PACKAGE:
         key = f'ci/taxonomy_packages/{key}'
-    uri = get_s3_uri(key, version_id=asset.s3_version_id)
-    _download_public_uri(uri, asset.full_local_path)
+    download_from_public_s3(asset.full_local_path, key, version_id=asset.s3_version_id)
 
 
 def _download_public_uri(uri: str, download_path: Path) -> None:


### PR DESCRIPTION
#### Reason for change

There's been a recent uptick in CI failures due to AWS S3 network issues that have required manually rerunning CI tests.

#### Description of change

* Use boto client configured with retries for all S3 test artifact downloads.
* Configure offline mode for webserver script tests.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
