### PR TITLE
Add retries to address shallow file conflict during merge

### DIFF
--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -29,7 +29,16 @@ runs:
         git fetch --deepen="$DEPTH" "https://github.com/$REPO.git" "$SHA"
 
         echo "Deepening base branch history to depth $DEPTH..."
-        git fetch --deepen="$DEPTH" origin
+        max_attempts=3
+        for ((i=1; i<=max_attempts; i++)); do
+          git fetch --deepen="$DEPTH" origin && break
+          if ((i == max_attempts)); then
+            echo "::error::Failed to deepen base branch history after $max_attempts attempts."
+            exit 1
+          fi
+          echo "Attempt $i failed, retrying..."
+          sleep 1
+        done
 
         git merge "$SHA" --no-edit || {
           echo "::error::Merge failed. Ancestor not found within $DEPTH commits or a conflict exists."


### PR DESCRIPTION
#### Reason for change
Intermittent failures during merge in CI ([example](https://github.com/Arelle/Arelle/actions/runs/25341592128/job/74300022929?pr=2356)).

#### Description of change
The merge action's two sequential git fetch --deepen calls can race over .git/shallow, causing a fatal: shallow file has changed since we read it error. This is a transient concurrency issue — the first fetch modifies the shallow file, and the second fetch occasionally reads it mid-write.

Wrap the second git fetch --deepen in a retry loop (up to 3 attempts with a 1-second delay) so the action recovers automatically when the race occurs.

#### Steps to Test
Watch for merge failures after this merges.

**review**:
@Arelle/arelle
