### PR TITLE
Create ModuleDeprecations helper

### DIFF
--- a/arelle/ModelRelationshipSet.py
+++ b/arelle/ModelRelationshipSet.py
@@ -4,7 +4,6 @@ See COPYRIGHT.md for copyright information.
 from __future__ import annotations
 
 import sys
-import warnings
 from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -18,6 +17,7 @@ from arelle.ModelDtsObject import ModelRelationship, ModelLink
 from arelle.ModelObject import ModelObject
 from arelle.PrototypeDtsObject import PrototypeObject, LinkPrototype
 from arelle.PythonUtil import OrderedSet
+from arelle.utils.deprecation import ModuleDeprecations
 from arelle.XbrlConst import consecutiveArcrole
 
 from arelle.typing import TypeGetText
@@ -30,23 +30,6 @@ _: TypeGetText
 USING_EQUIVALENCE_KEY = sys.intern(str("using_equivalence_key")) # indicates hash entry replaced with keyed entry
 NoneType = type(None)
 
-_DEPRECATED: Mapping[str, str] = MappingProxyType({
-    "baseSetArcroles":
-        "ModelRelationshipSet.baseSetArcroles is deprecated; non-GUI callers should "
-        "iterate modelXbrl.baseSets.keys() directly.",
-    "labelroles":
-        "ModelRelationshipSet.labelroles is deprecated; non-GUI callers should use "
-        "modelXbrl.labelroles directly, unioning with {XbrlConst.conceptNameLabelRole} "
-        "when the concept-name pseudo role is needed.",
-})
-
-
-def __getattr__(name: str) -> object:
-    if deprecated_name := _DEPRECATED.get(name):
-        warnings.warn(deprecated_name, DeprecationWarning, stacklevel=2)
-        from arelle import ViewUtil
-        return getattr(ViewUtil, name)
-    raise AttributeError(name)
 
 def create(
         modelXbrl: ModelXbrl,
@@ -481,3 +464,28 @@ class ModelRelationshipSet:
             if returnMultiple: return regionalVariant.labels
             else: return regionalVariant.labels[0]
         return None
+
+
+def _view_util_attr(name: str) -> Any:
+    # lazy import to avoid circular dependency
+    from arelle import ViewUtil
+
+    return getattr(ViewUtil, name)
+
+
+_DEPRECATIONS = ModuleDeprecations(__name__)
+_DEPRECATIONS.add_lazy(
+    "baseSetArcroles",
+    lambda: _view_util_attr("baseSetArcroles"),
+    "non-GUI callers should iterate modelXbrl.baseSets.keys() directly",
+)
+_DEPRECATIONS.add_lazy(
+    "labelroles",
+    lambda: _view_util_attr("labelroles"),
+    "non-GUI callers should use modelXbrl.labelroles directly, "
+    "unioning with {XbrlConst.conceptNameLabelRole} when the concept-name pseudo role is needed",
+)
+
+
+def __getattr__(name: str) -> Any:
+    return _DEPRECATIONS.resolve(name)

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -4,30 +4,19 @@ See COPYRIGHT.md for copyright information.
 from __future__ import annotations
 
 import os
-import warnings
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import regex as re
 
 from arelle.ModelValue import qname
 from arelle.typing import TypeGetText
+from arelle.utils.deprecation import ModuleDeprecations
 
 if TYPE_CHECKING:
     from arelle.ModelObject import ModelObject
     from arelle.ModelValue import QName
 
 _: TypeGetText
-
-# Defined early but see end of file for entries.
-_DEPRECATED: dict[str, tuple[object, str]] = {}
-
-
-def __getattr__(name: str) -> object:
-    if name in _DEPRECATED:
-        value, message = _DEPRECATED[name]
-        warnings.warn(message, DeprecationWarning, stacklevel=2)
-        return value
-    raise AttributeError(name)
 
 
 xsd = "http://www.w3.org/2001/XMLSchema"
@@ -1169,20 +1158,12 @@ lrrUnapprovedArcroles = {  # lrr entries which are not REC or ACK status
     "http://www.xbrl.org/2005/arcrole/nieRole": "NIE",
 }
 
-_DEPRECATED.update({
-    "tuple":
-        (
-            formulaTuple,
-            "XbrlConst.tuple is deprecated, use XbrlConst.formulaTuple instead."
-        ),
-    "dimStartsWith":
-        (
-            "http://xbrl.org/int/dim",
-            "XbrlConst.dimStartsWith is deprecated, use XbrlConst.isDimensionArcrole() instead."
-        ),
-    "dtrTypesStartsWith":
-        (
-            _dtrTypesStartsWith,
-            "XbrlConst.dtrTypesStartsWith is deprecated, use XbrlConst.isDtrTypeNamespace() instead."
-        )
-})
+
+_DEPRECATIONS = ModuleDeprecations(__name__)
+_DEPRECATIONS.add("tuple", formulaTuple, "use XbrlConst.formulaTuple instead.")
+_DEPRECATIONS.add("dimStartsWith", "http://xbrl.org/int/dim", "use XbrlConst.isDimensionArcrole() instead.")
+_DEPRECATIONS.add("dtrTypesStartsWith", _dtrTypesStartsWith, "use XbrlConst.isDtrTypeNamespace() instead.")
+
+
+def __getattr__(name: str) -> Any:
+    return _DEPRECATIONS.resolve(name)

--- a/arelle/utils/deprecation.py
+++ b/arelle/utils/deprecation.py
@@ -1,0 +1,94 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+_DEFAULT_REMOVAL_VERSION = "3.0"
+
+
+class ModuleDeprecations:
+    """Registry of deprecated module-level attributes.
+
+    Pairs with a module's `__getattr__` to emit a :class:`DeprecationWarning`
+    when a removed attribute is accessed, while still returning its value for
+    backward compatibility.
+
+    Example usage in a module:
+
+        _DEPRECATIONS = ModuleDeprecations(__name__)
+        _DEPRECATIONS.add("old_const", new_const, "use new_const instead")
+
+        def __getattr__(name: str) -> Any:
+            return _DEPRECATIONS.resolve(name)
+    """
+
+    def __init__(self, module_name: str) -> None:
+        """Create a deprecation registry for the given *module_name*."""
+        self._module_name = module_name
+        self._deprecated: dict[str, tuple[Any, str]] = {}
+        self._lazy_keys: set[str] = set()
+
+    def add(
+        self,
+        name: str,
+        value: Any,
+        guidance: str,
+        removal_version: str = _DEFAULT_REMOVAL_VERSION,
+    ) -> None:
+        """Register a deprecated attribute that returns *value* on access."""
+        if name in self._deprecated:
+            raise ValueError(f"Deprecated attr '{name}' already registered in {self._module_name}")
+        self._deprecated[name] = (value, self._message(name, guidance, removal_version))
+
+    def add_all(
+        self,
+        items: dict[str, Any],
+        guidance: str,
+        removal_version: str = _DEFAULT_REMOVAL_VERSION,
+    ) -> None:
+        """Register multiple deprecated attributes sharing the same *guidance*."""
+        for name, value in items.items():
+            self.add(name, value, guidance, removal_version)
+
+    def add_lazy(
+        self,
+        name: str,
+        factory: Callable[[], Any],
+        guidance: str,
+        removal_version: str = _DEFAULT_REMOVAL_VERSION,
+    ) -> None:
+        """Register a deprecated attribute whose value is produced by *factory* on access."""
+        if name in self._deprecated:
+            raise ValueError(f"Deprecated attr '{name}' already registered in {self._module_name}")
+        self._deprecated[name] = (factory, self._message(name, guidance, removal_version))
+        self._lazy_keys.add(name)
+
+    def add_lazy_all(
+        self,
+        items: dict[str, Callable[[], Any]],
+        guidance: str,
+        removal_version: str = _DEFAULT_REMOVAL_VERSION,
+    ) -> None:
+        """Register multiple lazy deprecated attributes sharing the same *guidance*."""
+        for name, factory in items.items():
+            self.add_lazy(name, factory, guidance, removal_version)
+
+    def _message(self, name: str, guidance: str, removal_version: str) -> str:
+        return f"{self._module_name}.{name} is deprecated. Will be removed in {removal_version}. {guidance}."
+
+    def resolve(self, name: str) -> Any:
+        """Look up *name*, emit a :class:`DeprecationWarning`, and return its value.
+
+        Raises :class:`AttributeError` if *name* is not registered.
+        Intended to be called from a module-level `__getattr__`.
+        """
+        if name not in self._deprecated:
+            raise AttributeError(name)
+        value, message = self._deprecated[name]
+        warnings.warn(message, DeprecationWarning, stacklevel=3)
+        return value() if name in self._lazy_keys else value

--- a/tests/unit_tests/arelle/utils/test_deprecation.py
+++ b/tests/unit_tests/arelle/utils/test_deprecation.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from arelle.utils.deprecation import ModuleDeprecations
+
+
+class TestModuleDeprecations:
+    def test_resolve_static(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add("old_name", 42, "use new_name instead")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert d.resolve("old_name") == 42
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert str(w[0].message) == "test.old_name is deprecated. Will be removed in 3.0. use new_name instead."
+
+    def test_custom_version(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add("old_name", 42, "use new_name instead", removal_version="4.0")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            d.resolve("old_name")
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert str(w[0].message) == "test.old_name is deprecated. Will be removed in 4.0. use new_name instead."
+
+    def test_multiple_attrs(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add("attr_a", "value_a", "use A instead")
+        d.add("attr_b", "value_b", "use B instead")
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assert d.resolve("attr_a") == "value_a"
+            assert d.resolve("attr_b") == "value_b"
+
+    def test_none_value(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add("old_name", None, "use new_name instead")
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assert d.resolve("old_name") is None
+
+    def test_unknown_attr_raises_attribute_error(self) -> None:
+        d = ModuleDeprecations("test")
+        with pytest.raises(AttributeError):
+            d.resolve("nonexistent")
+
+    def test_empty_raises_attribute_error(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add("anything", 42, "use new_name instead")
+        with pytest.raises(AttributeError):
+            d.resolve("other_attr")
+
+    def test_duplicate_add_raises(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add("old_name", 42, "use new_name instead")
+        with pytest.raises(ValueError, match="already registered"):
+            d.add("old_name", 99, "use other_name instead")
+
+    def test_duplicate_add_after_add_lazy_raises(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add_lazy("old_name", lambda: 42, "use new_name instead")
+        with pytest.raises(ValueError, match="already registered"):
+            d.add("old_name", 99, "use other_name instead")
+
+    def test_add_all(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add_all({"attr_a": "value_a", "attr_b": "value_b"}, "use new module instead")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert d.resolve("attr_a") == "value_a"
+            assert d.resolve("attr_b") == "value_b"
+            assert len(w) == 2
+            assert "attr_a" in str(w[0].message)
+            assert "attr_b" in str(w[1].message)
+
+    def test_add_all_duplicate_raises(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add("old_name", 42, "use new_name instead")
+        with pytest.raises(ValueError, match="already registered"):
+            d.add_all({"old_name": 99}, "use other_name instead")
+
+
+class TestModuleDeprecationsLazy:
+    def test_resolve_calls_factory(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add_lazy("old_name", lambda: 42, "use new_name instead")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert d.resolve("old_name") == 42
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert str(w[0].message) == "test.old_name is deprecated. Will be removed in 3.0. use new_name instead."
+
+    def test_duplicate_add_lazy_raises(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add_lazy("old_name", lambda: 42, "use new_name instead")
+        with pytest.raises(ValueError, match="already registered"):
+            d.add_lazy("old_name", lambda: 99, "use other_name instead")
+
+    def test_duplicate_add_lazy_after_add_raises(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add("old_name", 42, "use new_name instead")
+        with pytest.raises(ValueError, match="already registered"):
+            d.add_lazy("old_name", lambda: 99, "use other_name instead")
+
+    def test_add_lazy_all(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add_lazy_all(
+            {"attr_a": lambda: "lazy_a", "attr_b": lambda: "lazy_b"},
+            "use new module instead",
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert d.resolve("attr_a") == "lazy_a"
+            assert d.resolve("attr_b") == "lazy_b"
+            assert len(w) == 2
+            assert "attr_a" in str(w[0].message)
+            assert "attr_b" in str(w[1].message)
+
+    def test_add_lazy_all_duplicate_raises(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add_lazy("old_name", lambda: 42, "use new_name instead")
+        with pytest.raises(ValueError, match="already registered"):
+            d.add_lazy_all({"old_name": lambda: 99}, "use other_name instead")
+
+    def test_mixed_static_and_lazy(self) -> None:
+        d = ModuleDeprecations("test")
+        d.add("static_attr", "static_value", "use A instead")
+        d.add_lazy("lazy_attr", lambda: "lazy_value", "use B instead")
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assert d.resolve("static_attr") == "static_value"
+            assert d.resolve("lazy_attr") == "lazy_value"


### PR DESCRIPTION
#### Reason for change

We've started deprecating functions and variables for removal in future major Arelle releases. Currently this is handled ad hoc in each module. 

#### Description of change

Create a helper class for consistently tracking and documenting deprecations.

#### Steps to Test

* CI

**review**:
@Arelle/arelle
