### PR TITLE
Disable git GC in merge action

### DIFF
--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -22,6 +22,9 @@ runs:
         REPO: ${{ inputs.repository_full_name }}
         SHA: ${{ inputs.commit_sha }}
       run: |
+        # Background GC occassionally causes shallow file conflicts during fetch, so we disable it.
+        git config gc.auto 0
+
         git config user.name "github-actions"
         git config user.email "github-actions@github.com"
         


### PR DESCRIPTION
#### Reason for change
Background GC may be the cause for shallow file conflicts.

#### Description of change
Disable git GC, which isn't really necessary on a disposable runner anyway.

#### Steps to Test
Monitor CI failures after this merges.

**review**:
@Arelle/arelle
