### PR TITLE
Support XSD type validation without XML elements

### DIFF
--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -3,6 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 import datetime, isodate
+from collections.abc import Mapping
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, cast, overload, Optional, Union
 from fractions import Fraction
@@ -151,6 +152,14 @@ def qnameEltPfxName(
     prefixedName: str,
     prefixException: Exception | type[Exception] | None = None,
 ) -> QName | None:
+    return qnameFromNsmap(element.nsmap, prefixedName, prefixException)
+
+
+def qnameFromNsmap(
+    nsmap: Mapping[str | None, str],
+    prefixedName: str,
+    prefixException: Exception | type[Exception] | None = None,
+) -> QName | None:
     prefix: str | None
     namespaceURI: str | None
 
@@ -163,7 +172,7 @@ def qnameEltPfxName(
     prefix,_sep,localName = prefixedName.rpartition(':')
     if not prefix:
         prefix = None # don't want '' but instead None if no prefix
-    namespaceURI = element.nsmap.get(prefix)
+    namespaceURI = nsmap.get(prefix)
     if not namespaceURI:
         if prefix:
             if prefix == 'xml':

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -385,6 +385,222 @@ def validate(
             if isinstance(child, ModelObject):
                 validate(modelXbrl, child, recurse, attrQname, ixFacts, setTargetModelXbrl)
 
+def _validateValue(
+    elt: ModelObject,
+    baseXsdType: str,
+    value: str,
+    isNillable: bool = False,
+    isNil: bool = False,
+    facets: dict[str, Any] | None = None,
+) -> tuple[TypeSValue, TypeXValue, int]:
+    sValue: TypeSValue
+    xValue: TypeXValue
+    xValid = VALID
+    whitespaceReplace = (baseXsdType == "normalizedString")
+    whitespaceCollapse = (not whitespaceReplace and baseXsdType != "string")
+    isList = baseXsdType in {"IDREFS", "ENTITIES", "NMTOKENS"}
+    if isList:
+        baseXsdType = baseXsdType[:-1] # remove plural
+        if facets:
+            if "minLength" not in facets:
+                facets = facets.copy()
+                facets["minLength"] = 1
+        else:
+            facets = {"minLength": 1}
+    pattern = baseXsdTypePatterns.get(baseXsdType)
+    if facets:
+        if "pattern" in facets:
+            pattern = facets["pattern"]
+            # note multiple patterns are or'ed togetner, which isn't yet implemented!
+        if "whiteSpace" in facets:
+            whitespaceReplace, whitespaceCollapse = {"preserve":(False,False), "replace":(True,False), "collapse":(False,True)}[facets["whiteSpace"]]
+    if whitespaceReplace:
+        value = XmlUtil.replaceWhitespace(value)
+    elif whitespaceCollapse:
+        value = XmlUtil.collapseWhitespace(value)
+    if baseXsdType == "noContent":
+        if len(value) > 0 and not entirelyWhitespacePattern.match(value): # only xml schema pattern whitespaces removed
+            raise ValueError("value content not permitted")
+        # note that sValue and xValue are not innerText but only text elements on specific element (or attribute)
+        xValue = sValue = None
+        xValid = VALID_NO_CONTENT # notify others that element may contain subelements (for stringValue needs)
+    elif not value and isNil and isNillable: # rest of types get None if nil/empty value
+        xValue = sValue = None
+    else:
+        if pattern is not None:
+            if ((isList and any(pattern.match(v) is None for v in value.split())) or
+                (not isList and pattern.match(value) is None)):
+                raise ValueError("pattern facet " + facets["pattern"].pattern if facets and "pattern" in facets else "pattern mismatch")
+        if facets:
+            if "enumeration" in facets and value not in facets["enumeration"]:
+                raise ValueError("{0} is not in {1}".format(value, facets["enumeration"].keys()))
+            if "length" in facets and len(value) != facets["length"]:
+                raise ValueError("length {0}, expected {1}".format(len(value), facets["length"]))
+            if "minLength" in facets and len(value) < facets["minLength"]:
+                raise ValueError("length {0}, minLength {1}".format(len(value), facets["minLength"]))
+            if "maxLength" in facets and len(value) > facets["maxLength"]:
+                raise ValueError("length {0}, maxLength {1}".format(len(value), facets["maxLength"]))
+        if baseXsdType in {"string", "normalizedString", "language", "languageOrEmpty", "token", "NMTOKEN","Name","NCName","IDREF","ENTITY"}:
+            xValue = sValue = value
+        elif baseXsdType == "ID":
+            xValue = sValue = value
+            xValid = VALID_ID
+        elif baseXsdType == "anyURI":
+            if not UrlUtil.isValidUriReference(value):
+                raise ValueError("IETF RFC 2396 4.3 syntax")
+            # encode PSVI xValue similarly to Xerces and other implementations
+            xValue = anyURI(UrlUtil.anyUriQuoteForPSVI(value))
+            sValue = value
+        elif baseXsdType in ("decimal", "float", "double", "XBRLI_NONZERODECIMAL"):
+            if baseXsdType in ("decimal", "XBRLI_NONZERODECIMAL"):
+                if decimalPattern.match(value) is None:
+                    raise ValueError("lexical pattern mismatch")
+                xValue = Decimal(value)
+                sValue = float(value) # s-value uses Number (float) representation
+                if sValue == 0 and baseXsdType == "XBRLI_NONZERODECIMAL":
+                    raise ValueError("zero is not allowed")
+            else:
+                if floatPattern.match(value) is None:
+                    raise ValueError("lexical pattern mismatch")
+                xValue = sValue = float(value)
+            if facets:
+                if "totalDigits" in facets and len(value.replace(".","")) > facets["totalDigits"]:
+                    raise ValueError("totalDigits facet {0}".format(facets["totalDigits"]))
+                if "fractionDigits" in facets and ( '.' in value and
+                    len(value[value.index('.') + 1:]) > facets["fractionDigits"]):
+                    raise ValueError("fraction digits facet {0}".format(facets["fractionDigits"]))
+                if "maxInclusive" in facets and xValue > facets["maxInclusive"]:
+                    raise ValueError(" > maxInclusive {0}".format(facets["maxInclusive"]))
+                if "maxExclusive" in facets and xValue >= facets["maxExclusive"]:
+                    raise ValueError(" >= maxInclusive {0}".format(facets["maxExclusive"]))
+                if "minInclusive" in facets and xValue < facets["minInclusive"]:
+                    raise ValueError(" < minInclusive {0}".format(facets["minInclusive"]))
+                if "minExclusive" in facets and xValue <= facets["minExclusive"]:
+                    raise ValueError(" <= minExclusive {0}".format(facets["minExclusive"]))
+        elif baseXsdType in {"integer",
+                             "nonPositiveInteger","negativeInteger","nonNegativeInteger","positiveInteger",
+                             "long","unsignedLong",
+                             "int","unsignedInt",
+                             "short","unsignedShort",
+                             "byte","unsignedByte"}:
+            xValue = sValue = int(value)
+            if ((baseXsdType in {"nonNegativeInteger","unsignedLong","unsignedInt"}
+                 and xValue < 0) or
+                (baseXsdType == "nonPositiveInteger" and xValue > 0) or
+                (baseXsdType == "positiveInteger" and xValue <= 0) or
+                (baseXsdType == "byte" and not -128 <= xValue <= 127) or
+                (baseXsdType == "unsignedByte" and not 0 <= xValue <= 255) or
+                (baseXsdType == "short" and not -32768 <= xValue <= 32767) or
+                (baseXsdType == "unsignedShort" and not 0 <= xValue <= 65535) or
+                (baseXsdType == "positiveInteger" and xValue <= 0)):
+                raise ValueError("{0} is not {1}".format(value, baseXsdType))
+            if facets:
+                if "totalDigits" in facets and len(value.replace(".","")) > facets["totalDigits"]:
+                    raise ValueError("totalDigits facet {0}".format(facets["totalDigits"]))
+                if "fractionDigits" in facets and ( '.' in value and
+                    len(value[value.index('.') + 1:]) > facets["fractionDigits"]):
+                    raise ValueError("fraction digits facet {0}".format(facets["fractionDigits"]))
+                if "maxInclusive" in facets and xValue > facets["maxInclusive"]:
+                    raise ValueError(" > maxInclusive {0}".format(facets["maxInclusive"]))
+                if "maxExclusive" in facets and xValue >= facets["maxExclusive"]:
+                    raise ValueError(" >= maxInclusive {0}".format(facets["maxExclusive"]))
+                if "minInclusive" in facets and xValue < facets["minInclusive"]:
+                    raise ValueError(" < minInclusive {0}".format(facets["minInclusive"]))
+                if "minExclusive" in facets and xValue <= facets["minExclusive"]:
+                    raise ValueError(" <= minExclusive {0}".format(facets["minExclusive"]))
+        elif baseXsdType == "boolean":
+            if value in ("true", "1"):
+                xValue = sValue = True
+            elif value in ("false", "0"):
+                xValue = sValue = False
+            else: raise ValueError
+        elif baseXsdType == "QName":
+            xValue = qnameEltPfxName(elt, value, prefixException=ValueError)
+            #xValue = qname(elt, value, castException=ValueError, prefixException=ValueError)
+            sValue = value
+            ''' not sure here, how are explicitDimensions validated, but bad units not?
+            if xValue.namespaceURI in modelXbrl.namespaceDocs:
+                if (xValue not in modelXbrl.qnameConcepts and
+                    xValue not in modelXbrl.qnameTypes and
+                    xValue not in modelXbrl.qnameAttributes and
+                    xValue not in modelXbrl.qnameAttributeGroups):
+                    raise ValueError("qname not defined " + str(xValue))
+            '''
+        elif baseXsdType == "enumerationHrefs":
+            xValue = [qnameHref(href) for href in value.split()]
+            sValue = value
+        elif baseXsdType == "enumerationQNames":
+            xValue = [qnameEltPfxName(elt, qn, prefixException=ValueError) for qn in value.split()]
+            sValue = value
+        elif baseXsdType in ("XBRLI_DECIMALSUNION", "XBRLI_PRECISIONUNION"):
+            xValue = sValue = value if value == "INF" else int(value)
+        elif baseXsdType == "xsd-pattern":
+            # for facet compiling
+            try:
+                sValue = value
+                if value in xmlSchemaPatterns:
+                    xValue = xmlSchemaPatterns[value]
+                else:
+                    xValue = XsdPattern.compile(value)
+            except Exception as err:
+                raise ValueError(err)
+        elif baseXsdType == "fraction":
+            numeratorStr, denominatorStr = elt.fractionValue  # type: ignore[attr-defined]
+            if numeratorStr == INVALIDixVALUE or denominatorStr == INVALIDixVALUE:
+                sValue = xValue = INVALIDixVALUE
+                xValid = INVALID
+            else:
+                sValue = value
+                numeratorNum = float(numeratorStr)
+                denominatorNum = float(denominatorStr)
+                if numeratorNum.is_integer() and denominatorNum.is_integer():
+                    xValue = Fraction(int(numeratorNum), int(denominatorNum))
+                else:
+                    xValue = Fraction(numeratorNum / denominatorNum)
+        else:
+            if baseXsdType in lexicalPatterns:
+                match = lexicalPatterns[baseXsdType].match(value)
+                if match is None:
+                    raise ValueError("lexical pattern mismatch")
+                if baseXsdType == "XBRLI_DATEUNION":
+                    xValue = dateTime(value, type=DATEUNION, castException=ValueError)
+                    sValue = value
+                elif baseXsdType == "dateTime":
+                    xValue = dateTime(value, type=DATETIME, castException=ValueError)
+                    sValue = value
+                elif baseXsdType == "date":
+                    xValue = dateTime(value, type=DATE, castException=ValueError)
+                    sValue = value
+                elif baseXsdType == "time":
+                    xValue = time(value, castException=ValueError)
+                    sValue = value
+                elif baseXsdType == "gMonthDay":
+                    month, day, zSign, zHrMin, zHr, zMin = match.groups()
+                    if int(day) > {2:29, 4:30, 6:30, 9:30, 11:30, 1:31, 3:31, 5:31, 7:31, 8:31, 10:31, 12:31}[int(month)]:
+                        raise ValueError("invalid day {0} for month {1}".format(day, month))
+                    xValue = gMonthDay(month, day)
+                elif baseXsdType == "gYearMonth":
+                    year, month, zSign, zHrMin, zHr, zMin = match.groups()
+                    xValue = gYearMonth(year, month)
+                elif baseXsdType == "gYear":
+                    year, zSign, zHrMin, zHr, zMin = match.groups()
+                    xValue = gYear(year)
+                elif baseXsdType == "gMonth":
+                    month, zSign, zHrMin, zHr, zMin = match.groups()
+                    xValue = gMonth(month)
+                elif baseXsdType == "gDay":
+                    day, zSign, zHrMin, zHr, zMin = match.groups()
+                    xValue = gDay(day)
+                elif baseXsdType == "duration":
+                    xValue = isoDuration(value)
+                else:
+                    xValue = value
+            else: # no lexical pattern, forget compiling value
+                xValue = value
+            sValue = value
+    return sValue, xValue, xValid
+
+
 def validateValue(
     modelXbrl: ModelXbrl | None,
     elt: ModelObject,
@@ -397,217 +613,9 @@ def validateValue(
 ) -> None:
     sValue: TypeSValue
     xValue: TypeXValue
-
     if baseXsdType:
         try:
-            '''
-            if (len(value) == 0 and attrTag is None and not isNillable and
-                baseXsdType not in ("anyType", "string", "normalizedString", "token", "NMTOKEN", "anyURI", "noContent")):
-                raise ValueError("missing value for not nillable element")
-            '''
-            xValid = VALID
-            whitespaceReplace = (baseXsdType == "normalizedString")
-            whitespaceCollapse = (not whitespaceReplace and baseXsdType != "string")
-            isList = baseXsdType in {"IDREFS", "ENTITIES", "NMTOKENS"}
-            if isList:
-                baseXsdType = baseXsdType[:-1] # remove plural
-                if facets:
-                    if "minLength" not in facets:
-                        facets = facets.copy()
-                        facets["minLength"] = 1
-                else:
-                    facets = {"minLength": 1}
-            pattern = baseXsdTypePatterns.get(baseXsdType)
-            if facets:
-                if "pattern" in facets:
-                    pattern = facets["pattern"]
-                    # note multiple patterns are or'ed togetner, which isn't yet implemented!
-                if "whiteSpace" in facets:
-                    whitespaceReplace, whitespaceCollapse = {"preserve":(False,False), "replace":(True,False), "collapse":(False,True)}[facets["whiteSpace"]]
-            if whitespaceReplace:
-                value = XmlUtil.replaceWhitespace(value)
-            elif whitespaceCollapse:
-                value = XmlUtil.collapseWhitespace(value)
-            if baseXsdType == "noContent":
-                if len(value) > 0 and not entirelyWhitespacePattern.match(value): # only xml schema pattern whitespaces removed
-                    raise ValueError("value content not permitted")
-                # note that sValue and xValue are not innerText but only text elements on specific element (or attribute)
-                xValue = sValue = None
-                xValid = VALID_NO_CONTENT # notify others that element may contain subelements (for stringValue needs)
-            elif not value and isNil and isNillable: # rest of types get None if nil/empty value
-                xValue = sValue = None
-            else:
-                if pattern is not None:
-                    if ((isList and any(pattern.match(v) is None for v in value.split())) or
-                        (not isList and pattern.match(value) is None)):
-                        raise ValueError("pattern facet " + facets["pattern"].pattern if facets and "pattern" in facets else "pattern mismatch")
-                if facets:
-                    if "enumeration" in facets and value not in facets["enumeration"]:
-                        raise ValueError("{0} is not in {1}".format(value, facets["enumeration"].keys()))
-                    if "length" in facets and len(value) != facets["length"]:
-                        raise ValueError("length {0}, expected {1}".format(len(value), facets["length"]))
-                    if "minLength" in facets and len(value) < facets["minLength"]:
-                        raise ValueError("length {0}, minLength {1}".format(len(value), facets["minLength"]))
-                    if "maxLength" in facets and len(value) > facets["maxLength"]:
-                        raise ValueError("length {0}, maxLength {1}".format(len(value), facets["maxLength"]))
-                if baseXsdType in {"string", "normalizedString", "language", "languageOrEmpty", "token", "NMTOKEN","Name","NCName","IDREF","ENTITY"}:
-                    xValue = sValue = value
-                elif baseXsdType == "ID":
-                    xValue = sValue = value
-                    xValid = VALID_ID
-                elif baseXsdType == "anyURI":
-                    if not UrlUtil.isValidUriReference(value):
-                        raise ValueError("IETF RFC 2396 4.3 syntax")
-                    # encode PSVI xValue similarly to Xerces and other implementations
-                    xValue = anyURI(UrlUtil.anyUriQuoteForPSVI(value))
-                    sValue = value
-                elif baseXsdType in ("decimal", "float", "double", "XBRLI_NONZERODECIMAL"):
-                    if baseXsdType in ("decimal", "XBRLI_NONZERODECIMAL"):
-                        if decimalPattern.match(value) is None:
-                            raise ValueError("lexical pattern mismatch")
-                        xValue = Decimal(value)
-                        sValue = float(value) # s-value uses Number (float) representation
-                        if sValue == 0 and baseXsdType == "XBRLI_NONZERODECIMAL":
-                            raise ValueError("zero is not allowed")
-                    else:
-                        if floatPattern.match(value) is None:
-                            raise ValueError("lexical pattern mismatch")
-                        xValue = sValue = float(value)
-                    if facets:
-                        if "totalDigits" in facets and len(value.replace(".","")) > facets["totalDigits"]:
-                            raise ValueError("totalDigits facet {0}".format(facets["totalDigits"]))
-                        if "fractionDigits" in facets and ( '.' in value and
-                            len(value[value.index('.') + 1:]) > facets["fractionDigits"]):
-                            raise ValueError("fraction digits facet {0}".format(facets["fractionDigits"]))
-                        if "maxInclusive" in facets and xValue > facets["maxInclusive"]:
-                            raise ValueError(" > maxInclusive {0}".format(facets["maxInclusive"]))
-                        if "maxExclusive" in facets and xValue >= facets["maxExclusive"]:
-                            raise ValueError(" >= maxInclusive {0}".format(facets["maxExclusive"]))
-                        if "minInclusive" in facets and xValue < facets["minInclusive"]:
-                            raise ValueError(" < minInclusive {0}".format(facets["minInclusive"]))
-                        if "minExclusive" in facets and xValue <= facets["minExclusive"]:
-                            raise ValueError(" <= minExclusive {0}".format(facets["minExclusive"]))
-                elif baseXsdType in {"integer",
-                                     "nonPositiveInteger","negativeInteger","nonNegativeInteger","positiveInteger",
-                                     "long","unsignedLong",
-                                     "int","unsignedInt",
-                                     "short","unsignedShort",
-                                     "byte","unsignedByte"}:
-                    xValue = sValue = int(value)
-                    if ((baseXsdType in {"nonNegativeInteger","unsignedLong","unsignedInt"}
-                         and xValue < 0) or
-                        (baseXsdType == "nonPositiveInteger" and xValue > 0) or
-                        (baseXsdType == "positiveInteger" and xValue <= 0) or
-                        (baseXsdType == "byte" and not -128 <= xValue <= 127) or
-                        (baseXsdType == "unsignedByte" and not 0 <= xValue <= 255) or
-                        (baseXsdType == "short" and not -32768 <= xValue <= 32767) or
-                        (baseXsdType == "unsignedShort" and not 0 <= xValue <= 65535) or
-                        (baseXsdType == "positiveInteger" and xValue <= 0)):
-                        raise ValueError("{0} is not {1}".format(value, baseXsdType))
-                    if facets:
-                        if "totalDigits" in facets and len(value.replace(".","")) > facets["totalDigits"]:
-                            raise ValueError("totalDigits facet {0}".format(facets["totalDigits"]))
-                        if "fractionDigits" in facets and ( '.' in value and
-                            len(value[value.index('.') + 1:]) > facets["fractionDigits"]):
-                            raise ValueError("fraction digits facet {0}".format(facets["fractionDigits"]))
-                        if "maxInclusive" in facets and xValue > facets["maxInclusive"]:
-                            raise ValueError(" > maxInclusive {0}".format(facets["maxInclusive"]))
-                        if "maxExclusive" in facets and xValue >= facets["maxExclusive"]:
-                            raise ValueError(" >= maxInclusive {0}".format(facets["maxExclusive"]))
-                        if "minInclusive" in facets and xValue < facets["minInclusive"]:
-                            raise ValueError(" < minInclusive {0}".format(facets["minInclusive"]))
-                        if "minExclusive" in facets and xValue <= facets["minExclusive"]:
-                            raise ValueError(" <= minExclusive {0}".format(facets["minExclusive"]))
-                elif baseXsdType == "boolean":
-                    if value in ("true", "1"):
-                        xValue = sValue = True
-                    elif value in ("false", "0"):
-                        xValue = sValue = False
-                    else: raise ValueError
-                elif baseXsdType == "QName":
-                    xValue = qnameEltPfxName(elt, value, prefixException=ValueError)
-                    #xValue = qname(elt, value, castException=ValueError, prefixException=ValueError)
-                    sValue = value
-                    ''' not sure here, how are explicitDimensions validated, but bad units not?
-                    if xValue.namespaceURI in modelXbrl.namespaceDocs:
-                        if (xValue not in modelXbrl.qnameConcepts and
-                            xValue not in modelXbrl.qnameTypes and
-                            xValue not in modelXbrl.qnameAttributes and
-                            xValue not in modelXbrl.qnameAttributeGroups):
-                            raise ValueError("qname not defined " + str(xValue))
-                    '''
-                elif baseXsdType == "enumerationHrefs":
-                    xValue = [qnameHref(href) for href in value.split()]
-                    sValue = value
-                elif baseXsdType == "enumerationQNames":
-                    xValue = [qnameEltPfxName(elt, qn, prefixException=ValueError) for qn in value.split()]
-                    sValue = value
-                elif baseXsdType in ("XBRLI_DECIMALSUNION", "XBRLI_PRECISIONUNION"):
-                    xValue = sValue = value if value == "INF" else int(value)
-                elif baseXsdType == "xsd-pattern":
-                    # for facet compiling
-                    try:
-                        sValue = value
-                        if value in xmlSchemaPatterns:
-                            xValue = xmlSchemaPatterns[value]
-                        else:
-                            xValue = XsdPattern.compile(value)
-                    except Exception as err:
-                        raise ValueError(err)
-                elif baseXsdType == "fraction":
-                    numeratorStr, denominatorStr = elt.fractionValue  # type: ignore[attr-defined]
-                    if numeratorStr == INVALIDixVALUE or denominatorStr == INVALIDixVALUE:
-                        sValue = xValue = INVALIDixVALUE
-                        xValid = INVALID
-                    else:
-                        sValue = value
-                        numeratorNum = float(numeratorStr)
-                        denominatorNum = float(denominatorStr)
-                        if numeratorNum.is_integer() and denominatorNum.is_integer():
-                            xValue = Fraction(int(numeratorNum), int(denominatorNum))
-                        else:
-                            xValue = Fraction(numeratorNum / denominatorNum)
-                else:
-                    if baseXsdType in lexicalPatterns:
-                        match = lexicalPatterns[baseXsdType].match(value)
-                        if match is None:
-                            raise ValueError("lexical pattern mismatch")
-                        if baseXsdType == "XBRLI_DATEUNION":
-                            xValue = dateTime(value, type=DATEUNION, castException=ValueError)
-                            sValue = value
-                        elif baseXsdType == "dateTime":
-                            xValue = dateTime(value, type=DATETIME, castException=ValueError)
-                            sValue = value
-                        elif baseXsdType == "date":
-                            xValue = dateTime(value, type=DATE, castException=ValueError)
-                            sValue = value
-                        elif baseXsdType == "time":
-                            xValue = time(value, castException=ValueError)
-                            sValue = value
-                        elif baseXsdType == "gMonthDay":
-                            month, day, zSign, zHrMin, zHr, zMin = match.groups()
-                            if int(day) > {2:29, 4:30, 6:30, 9:30, 11:30, 1:31, 3:31, 5:31, 7:31, 8:31, 10:31, 12:31}[int(month)]:
-                                raise ValueError("invalid day {0} for month {1}".format(day, month))
-                            xValue = gMonthDay(month, day)
-                        elif baseXsdType == "gYearMonth":
-                            year, month, zSign, zHrMin, zHr, zMin = match.groups()
-                            xValue = gYearMonth(year, month)
-                        elif baseXsdType == "gYear":
-                            year, zSign, zHrMin, zHr, zMin = match.groups()
-                            xValue = gYear(year)
-                        elif baseXsdType == "gMonth":
-                            month, zSign, zHrMin, zHr, zMin = match.groups()
-                            xValue = gMonth(month)
-                        elif baseXsdType == "gDay":
-                            day, zSign, zHrMin, zHr, zMin = match.groups()
-                            xValue = gDay(day)
-                        elif baseXsdType == "duration":
-                            xValue = isoDuration(value)
-                        else:
-                            xValue = value
-                    else: # no lexical pattern, forget compiling value
-                        xValue = value
-                    sValue = value
+            sValue, xValue, xValid = _validateValue(elt, baseXsdType, value, isNillable, isNil, facets)
         except (ValueError, InvalidOperation) as err:
             elt.xValueError = err
             errElt: str | QName

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -4,7 +4,7 @@ See COPYRIGHT.md for copyright information.
 from __future__ import annotations
 from dataclasses import dataclass
 import logging, os
-from collections.abc import Callable
+from collections.abc import Callable, Set
 from typing import TYPE_CHECKING, Any, cast
 from lxml import etree
 from regex import Match, Pattern, compile as re_compile
@@ -680,29 +680,40 @@ def validateValue(
         elt.xValue = xValue
         elt.sValue = sValue
 
-def validateFacet(typeElt: ModelType, facetElt: ModelObject) -> TypeXValue | None:
-    facetName = facetElt.localName
-    value = facetElt.get("value")
+
+def _facetTypeAndFacets(facetName: str, baseXsdType: str) -> tuple[str, dict[str, set[str]] | None]:
     if facetName in ("length", "minLength", "maxLength", "totalDigits", "fractionDigits"):
         baseXsdType = "integer"
         facets = None
     elif facetName in ("minInclusive", "maxInclusive", "minExclusive", "maxExclusive"):
-        baseXsdType = typeElt.baseXsdType
+        baseXsdType = baseXsdType
         facets = None
     elif facetName == "whiteSpace":
         baseXsdType = "string"
-        facets = {"enumeration": {"replace","preserve","collapse"}}
+        facets = {"enumeration": {"replace", "preserve", "collapse"}}
     elif facetName == "pattern":
         baseXsdType = "xsd-pattern"
         facets = None
     else:
         baseXsdType = "string"
         facets = None
+    return baseXsdType, facets
+
+def validateFacet(typeElt: ModelType, facetElt: ModelObject) -> TypeXValue | None:
+    facetName = facetElt.localName
+    value = facetElt.get("value")
+    facetType, facets = _facetTypeAndFacets(facetName, typeElt.baseXsdType)
     assert value is not None
-    validateValue(typeElt.modelXbrl, facetElt, None, baseXsdType, value, facets=facets)
+    validateValue(typeElt.modelXbrl, facetElt, None, facetType, value, facets=facets)
     if facetElt.xValid == VALID:
         return facetElt.xValue
     return None
+
+
+def validateFacetValueString(facetName: str, facetValue: str, baseXsdType: str) -> XmlValidationResult:
+    facetType, facets = _facetTypeAndFacets(facetName, baseXsdType)
+    return validateValueString(facetType, facetValue, facets=facets)
+
 
 def validateAnyWildcard(qnElt: QName, qnAttr: QName, attributeWildcards: list[ModelAny]) -> bool:
     # note wildcard is a set of possibly multiple values from inherited attribute groups

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -406,7 +406,6 @@ def fractionValidateValue(value: str, fractionValue: tuple[str, str]) -> tuple[T
 
 
 def _validateValue(
-    elt: ModelObject,
     baseXsdType: str,
     value: str,
     isNillable: bool = False,
@@ -630,7 +629,7 @@ def validateValue(
                 # Fraction reads numerator/denominator from child elements, not from the value string
                 sValue, xValue, xValid = fractionValidateValue(value, elt.fractionValue)  # type: ignore[attr-defined]
             else:
-                sValue, xValue, xValid = _validateValue(elt, baseXsdType, value, isNillable, isNil, facets, elt.nsmap)
+                sValue, xValue, xValid = _validateValue(baseXsdType, value, isNillable, isNil, facets, elt.nsmap)
         except (ValueError, InvalidOperation) as err:
             elt.xValueError = err
             errElt: str | QName

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -442,7 +442,7 @@ def validateValueString(
             pattern = facets["pattern"]
             # note multiple patterns are or'ed togetner, which isn't yet implemented!
         if "whiteSpace" in facets:
-            whitespaceReplace, whitespaceCollapse = {"preserve":(False,False), "replace":(True,False), "collapse":(False,True)}[facets["whiteSpace"]]
+            whitespaceReplace, whitespaceCollapse = {"preserve": (False, False), "replace": (True, False), "collapse": (False, True)}[facets["whiteSpace"]]
     if whitespaceReplace:
         value = XmlUtil.replaceWhitespace(value)
     elif whitespaceCollapse:

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -11,7 +11,7 @@ from regex import Match, Pattern, compile as re_compile
 from decimal import Decimal, InvalidOperation
 from fractions import Fraction
 from arelle import UrlUtil, XbrlConst, XmlUtil, XmlValidateConst
-from arelle.ModelValue import (qname, qnameEltPfxName, qnameClarkName, qnameHref,
+from arelle.ModelValue import (qname, qnameFromNsmap, qnameClarkName, qnameHref,
                                dateTime, DATE, DATETIME, DATEUNION, time,
                                anyURI, INVALIDixVALUE, gYearMonth, gMonthDay, gYear, gMonth, gDay, isoDuration)
 from arelle.ModelObject import ModelObject, ModelAttribute
@@ -412,7 +412,10 @@ def _validateValue(
     isNillable: bool = False,
     isNil: bool = False,
     facets: dict[str, Any] | None = None,
+    nsmap: dict[str | None, str] | None = None,
 ) -> tuple[TypeSValue, TypeXValue, int]:
+    if nsmap is None:
+        nsmap = {}
     sValue: TypeSValue
     xValue: TypeXValue
     xValid = VALID
@@ -535,7 +538,7 @@ def _validateValue(
                 xValue = sValue = False
             else: raise ValueError
         elif baseXsdType == "QName":
-            xValue = qnameEltPfxName(elt, value, prefixException=ValueError)
+            xValue = qnameFromNsmap(nsmap, value, prefixException=ValueError)
             #xValue = qname(elt, value, castException=ValueError, prefixException=ValueError)
             sValue = value
             ''' not sure here, how are explicitDimensions validated, but bad units not?
@@ -550,7 +553,7 @@ def _validateValue(
             xValue = [qnameHref(href) for href in value.split()]
             sValue = value
         elif baseXsdType == "enumerationQNames":
-            xValue = [qnameEltPfxName(elt, qn, prefixException=ValueError) for qn in value.split()]
+            xValue = [qnameFromNsmap(nsmap, qn, prefixException=ValueError) for qn in value.split()]
             sValue = value
         elif baseXsdType in ("XBRLI_DECIMALSUNION", "XBRLI_PRECISIONUNION"):
             xValue = sValue = value if value == "INF" else int(value)
@@ -627,7 +630,7 @@ def validateValue(
                 # Fraction reads numerator/denominator from child elements, not from the value string
                 sValue, xValue, xValid = fractionValidateValue(value, elt.fractionValue)  # type: ignore[attr-defined]
             else:
-                sValue, xValue, xValid = _validateValue(elt, baseXsdType, value, isNillable, isNil, facets)
+                sValue, xValue, xValid = _validateValue(elt, baseXsdType, value, isNillable, isNil, facets, elt.nsmap)
         except (ValueError, InvalidOperation) as err:
             elt.xValueError = err
             errElt: str | QName

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -526,8 +526,8 @@ def validateValueString(
             if facets:
                 if "totalDigits" in facets and len(value.replace(".","")) > facets["totalDigits"]:
                     raise ValueError("totalDigits facet {0}".format(facets["totalDigits"]))
-                if "fractionDigits" in facets and ( '.' in value and
-                    len(value[value.index('.') + 1:]) > facets["fractionDigits"]):
+                if "fractionDigits" in facets and ("." in value and
+                    len(value[value.index(".") + 1:]) > facets["fractionDigits"]):
                     raise ValueError("fraction digits facet {0}".format(facets["fractionDigits"]))
                 if "maxInclusive" in facets and xValue > facets["maxInclusive"]:
                     raise ValueError(" > maxInclusive {0}".format(facets["maxInclusive"]))

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -507,11 +507,11 @@ def validateValueString(
                 if "minExclusive" in facets and xValue <= facets["minExclusive"]:
                     raise ValueError(" <= minExclusive {0}".format(facets["minExclusive"]))
         elif baseXsdType in {"integer",
-                             "nonPositiveInteger","negativeInteger","nonNegativeInteger","positiveInteger",
-                             "long","unsignedLong",
-                             "int","unsignedInt",
-                             "short","unsignedShort",
-                             "byte","unsignedByte"}:
+                             "nonPositiveInteger", "negativeInteger", "nonNegativeInteger", "positiveInteger",
+                             "long", "unsignedLong",
+                             "int", "unsignedInt",
+                             "short", "unsignedShort",
+                             "byte", "unsignedByte"}:
             xValue = sValue = int(value)
             if ((baseXsdType in {"nonNegativeInteger","unsignedLong","unsignedInt"}
                  and xValue < 0) or

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -385,6 +385,26 @@ def validate(
             if isinstance(child, ModelObject):
                 validate(modelXbrl, child, recurse, attrQname, ixFacts, setTargetModelXbrl)
 
+
+def fractionValidateValue(value: str, fractionValue: tuple[str, str]) -> tuple[TypeSValue, TypeXValue, int]:
+    sValue: TypeSValue
+    xValue: TypeXValue
+    numeratorStr, denominatorStr = fractionValue
+    if numeratorStr == INVALIDixVALUE or denominatorStr == INVALIDixVALUE:
+        sValue = xValue = INVALIDixVALUE
+        xValid = INVALID
+    else:
+        sValue = value
+        xValid = VALID
+        numeratorNum = float(numeratorStr)
+        denominatorNum = float(denominatorStr)
+        if numeratorNum.is_integer() and denominatorNum.is_integer():
+            xValue = Fraction(int(numeratorNum), int(denominatorNum))
+        else:
+            xValue = Fraction(numeratorNum / denominatorNum)
+    return (sValue, xValue, xValid)
+
+
 def _validateValue(
     elt: ModelObject,
     baseXsdType: str,
@@ -544,19 +564,6 @@ def _validateValue(
                     xValue = XsdPattern.compile(value)
             except Exception as err:
                 raise ValueError(err)
-        elif baseXsdType == "fraction":
-            numeratorStr, denominatorStr = elt.fractionValue  # type: ignore[attr-defined]
-            if numeratorStr == INVALIDixVALUE or denominatorStr == INVALIDixVALUE:
-                sValue = xValue = INVALIDixVALUE
-                xValid = INVALID
-            else:
-                sValue = value
-                numeratorNum = float(numeratorStr)
-                denominatorNum = float(denominatorStr)
-                if numeratorNum.is_integer() and denominatorNum.is_integer():
-                    xValue = Fraction(int(numeratorNum), int(denominatorNum))
-                else:
-                    xValue = Fraction(numeratorNum / denominatorNum)
         else:
             if baseXsdType in lexicalPatterns:
                 match = lexicalPatterns[baseXsdType].match(value)
@@ -615,7 +622,12 @@ def validateValue(
     xValue: TypeXValue
     if baseXsdType:
         try:
-            sValue, xValue, xValid = _validateValue(elt, baseXsdType, value, isNillable, isNil, facets)
+            isNilValue = not value and isNil and isNillable
+            if baseXsdType == "fraction" and not isNilValue:
+                # Fraction reads numerator/denominator from child elements, not from the value string
+                sValue, xValue, xValid = fractionValidateValue(value, elt.fractionValue)  # type: ignore[attr-defined]
+            else:
+                sValue, xValue, xValid = _validateValue(elt, baseXsdType, value, isNillable, isNil, facets)
         except (ValueError, InvalidOperation) as err:
             elt.xValueError = err
             errElt: str | QName

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -60,6 +60,13 @@ class XsdPattern:
         return self.xsdPattern
 
 
+@dataclass(frozen=True, slots=True)
+class XmlValidationResult:
+    sValue: TypeSValue
+    xValue: TypeXValue
+    xValid: int
+
+
 # support legacy direct imports from this module
 UNVALIDATED      = XmlValidateConst.UNVALIDATED
 UNKNOWN          = XmlValidateConst.UNKNOWN
@@ -386,7 +393,7 @@ def validate(
                 validate(modelXbrl, child, recurse, attrQname, ixFacts, setTargetModelXbrl)
 
 
-def fractionValidateValue(value: str, fractionValue: tuple[str, str]) -> tuple[TypeSValue, TypeXValue, int]:
+def fractionValidateValue(value: str, fractionValue: tuple[str, str]) -> XmlValidationResult:
     sValue: TypeSValue
     xValue: TypeXValue
     numeratorStr, denominatorStr = fractionValue
@@ -402,17 +409,17 @@ def fractionValidateValue(value: str, fractionValue: tuple[str, str]) -> tuple[T
             xValue = Fraction(int(numeratorNum), int(denominatorNum))
         else:
             xValue = Fraction(numeratorNum / denominatorNum)
-    return (sValue, xValue, xValid)
+    return XmlValidationResult(sValue=sValue, xValue=xValue, xValid=xValid)
 
 
-def _validateValue(
+def validateValueString(
     baseXsdType: str,
     value: str,
     isNillable: bool = False,
     isNil: bool = False,
     facets: dict[str, Any] | None = None,
     nsmap: dict[str | None, str] | None = None,
-) -> tuple[TypeSValue, TypeXValue, int]:
+) -> XmlValidationResult:
     if nsmap is None:
         nsmap = {}
     sValue: TypeSValue
@@ -607,7 +614,7 @@ def _validateValue(
             else: # no lexical pattern, forget compiling value
                 xValue = value
             sValue = value
-    return sValue, xValue, xValid
+    return XmlValidationResult(sValue=sValue, xValue=xValue, xValid=xValid)
 
 
 def validateValue(
@@ -627,9 +634,10 @@ def validateValue(
             isNilValue = not value and isNil and isNillable
             if baseXsdType == "fraction" and not isNilValue:
                 # Fraction reads numerator/denominator from child elements, not from the value string
-                sValue, xValue, xValid = fractionValidateValue(value, elt.fractionValue)  # type: ignore[attr-defined]
+                result = fractionValidateValue(value, elt.fractionValue)  # type: ignore[attr-defined]
             else:
-                sValue, xValue, xValid = _validateValue(baseXsdType, value, isNillable, isNil, facets, elt.nsmap)
+                result = validateValueString(baseXsdType, value, isNillable, isNil, facets, elt.nsmap)
+            sValue, xValue, xValid = result.sValue, result.xValue, result.xValid
         except (ValueError, InvalidOperation) as err:
             elt.xValueError = err
             errElt: str | QName

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -469,7 +469,7 @@ def validateValueString(
                 raise ValueError("length {0}, minLength {1}".format(len(value), facets["minLength"]))
             if "maxLength" in facets and len(value) > facets["maxLength"]:
                 raise ValueError("length {0}, maxLength {1}".format(len(value), facets["maxLength"]))
-        if baseXsdType in {"string", "normalizedString", "language", "languageOrEmpty", "token", "NMTOKEN","Name","NCName","IDREF","ENTITY"}:
+        if baseXsdType in {"string", "normalizedString", "language", "languageOrEmpty", "token", "NMTOKEN", "Name", "NCName", "IDREF", "ENTITY"}:
             xValue = sValue = value
         elif baseXsdType == "ID":
             xValue = sValue = value

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -495,8 +495,8 @@ def validateValueString(
             if facets:
                 if "totalDigits" in facets and len(value.replace(".","")) > facets["totalDigits"]:
                     raise ValueError("totalDigits facet {0}".format(facets["totalDigits"]))
-                if "fractionDigits" in facets and ( '.' in value and
-                    len(value[value.index('.') + 1:]) > facets["fractionDigits"]):
+                if "fractionDigits" in facets and ("." in value and
+                    len(value[value.index(".") + 1:]) > facets["fractionDigits"]):
                     raise ValueError("fraction digits facet {0}".format(facets["fractionDigits"]))
                 if "maxInclusive" in facets and xValue > facets["maxInclusive"]:
                     raise ValueError(" > maxInclusive {0}".format(facets["maxInclusive"]))

--- a/tests/unit_tests/arelle/test_modelvalue.py
+++ b/tests/unit_tests/arelle/test_modelvalue.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from arelle.ModelValue import QName, qnameFromNsmap
+
+NSMAP = {
+    None: "http://default.ns",
+    "pfx": "http://pfx.ns",
+    "other": "http://other.ns",
+}
+
+
+class TestQnameFromNsmap:
+    def test_unprefixed_name(self):
+        result = qnameFromNsmap(NSMAP, "localName")
+        assert result == QName(None, "http://default.ns", "localName")
+
+    def test_prefixed_name(self):
+        result = qnameFromNsmap(NSMAP, "pfx:localName")
+        assert result == QName("pfx", "http://pfx.ns", "localName")
+
+    def test_xml_prefix(self):
+        result = qnameFromNsmap(NSMAP, "xml:lang")
+        assert result == QName("xml", "http://www.w3.org/XML/1998/namespace", "lang")
+
+    def test_href_style(self):
+        result = qnameFromNsmap(NSMAP, "http://some.ns#localName")
+        assert result == QName(None, "http://some.ns", "localName")
+
+    def test_href_no_namespace(self):
+        result = qnameFromNsmap(NSMAP, "#localName")
+        assert result == QName(None, "", "localName")
+
+    def test_undefined_prefix_returns_none(self):
+        result = qnameFromNsmap(NSMAP, "bad:localName")
+        assert result is None
+
+    def test_undefined_prefix_raises_custom_exception(self):
+        with pytest.raises(ValueError):
+            qnameFromNsmap(NSMAP, "bad:localName", prefixException=ValueError)
+
+    def test_undefined_prefix_raises_custom_exception_instance(self):
+        with pytest.raises(ValueError, match="my message"):
+            qnameFromNsmap(NSMAP, "bad:localName", prefixException=ValueError("my message"))
+
+    def test_no_default_namespace(self):
+        nsmap = {"pfx": "http://pfx.ns"}
+        result = qnameFromNsmap(nsmap, "localName")
+        assert result == QName(None, None, "localName")
+
+    def test_empty_nsmap(self):
+        result = qnameFromNsmap({}, "localName")
+        assert result == QName(None, None, "localName")
+
+    def test_empty_nsmap_with_prefix_returns_none(self):
+        result = qnameFromNsmap({}, "pfx:localName")
+        assert result is None
+
+    def test_empty_nsmap_with_prefix_raises(self):
+        with pytest.raises(ValueError):
+            qnameFromNsmap({}, "pfx:localName", prefixException=ValueError)

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -11,7 +11,7 @@ import regex
 from unittest.mock import Mock
 
 from arelle.ModelValue import QName, DateTime, Time, isoDuration, gDay, gMonth, gMonthDay, gYear, gYearMonth
-from arelle.XmlValidate import validateValue, validateValueString, VALID, UNKNOWN, INVALID, VALID_ID, NMTOKENPattern, namePattern, NCNamePattern, VALID_NO_CONTENT, XsdPattern
+from arelle.XmlValidate import validateValue, validateValueString, validateFacetValueString, VALID, UNKNOWN, INVALID, VALID_ID, NMTOKENPattern, namePattern, NCNamePattern, VALID_NO_CONTENT, XsdPattern
 
 FLOAT_CASES = [
     {"value": "-1", "expected": (-1, -1, VALID)},
@@ -737,3 +737,82 @@ def test_validateValueString(
         _assertValidateValue(result.sValue, expectedSValue)
     _assertValidateValue(result.xValue, expectedXValue)
     assert result.xValid == expectedXValid
+
+
+class TestValidateFacetValueString:
+    def test_length(self):
+        assert validateFacetValueString("length", "3", "string").xValue == 3
+
+    def test_length_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("length", "abc", "string")
+
+    def test_minLength(self):
+        assert validateFacetValueString("minLength", "1", "string").xValue == 1
+
+    def test_minLength_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("minLength", "abc", "string")
+
+    def test_maxLength(self):
+        assert validateFacetValueString("maxLength", "10", "string").xValue == 10
+
+    def test_maxLength_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("maxLength", "abc", "string")
+
+    def test_totalDigits(self):
+        assert validateFacetValueString("totalDigits", "5", "decimal").xValue == 5
+
+    def test_totalDigits_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("totalDigits", "abc", "decimal")
+
+    def test_fractionDigits(self):
+        assert validateFacetValueString("fractionDigits", "2", "decimal").xValue == 2
+
+    def test_fractionDigits_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("fractionDigits", "abc", "decimal")
+
+    def test_minInclusive(self):
+        assert validateFacetValueString("minInclusive", "0", "integer").xValue == 0
+
+    def test_minInclusive_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("minInclusive", "abc", "integer")
+
+    def test_maxInclusive(self):
+        assert validateFacetValueString("maxInclusive", "100", "integer").xValue == 100
+
+    def test_maxInclusive_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("maxInclusive", "abc", "integer")
+
+    def test_minExclusive(self):
+        assert validateFacetValueString("minExclusive", "-1", "integer").xValue == -1
+
+    def test_minExclusive_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("minExclusive", "abc", "integer")
+
+    def test_maxExclusive(self):
+        assert validateFacetValueString("maxExclusive", "50", "integer").xValue == 50
+
+    def test_maxExclusive_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("maxExclusive", "abc", "integer")
+
+    def test_whiteSpace(self):
+        assert validateFacetValueString("whiteSpace", "collapse", "string").xValue == "collapse"
+
+    def test_pattern(self):
+        result = validateFacetValueString("pattern", "[A-Z]+", "string")
+        assert isinstance(result.xValue, XsdPattern)
+
+    def test_pattern_invalid(self):
+        with pytest.raises(ValueError):
+            validateFacetValueString("pattern", "invalid(", "string")
+
+    def test_unknown_facet(self):
+        assert validateFacetValueString("unknownFacet", "value", "string").xValue == "value"

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from _decimal import Decimal
+from _decimal import Decimal, InvalidOperation
 from fractions import Fraction
 from math import inf, nan, isnan
 from typing import Any
@@ -11,7 +11,7 @@ import regex
 from unittest.mock import Mock
 
 from arelle.ModelValue import QName, DateTime, Time, isoDuration, gDay, gMonth, gMonthDay, gYear, gYearMonth
-from arelle.XmlValidate import validateValue, VALID, UNKNOWN, INVALID, VALID_ID, NMTOKENPattern, namePattern, NCNamePattern, VALID_NO_CONTENT, XsdPattern
+from arelle.XmlValidate import validateValue, validateValueString, VALID, UNKNOWN, INVALID, VALID_ID, NMTOKENPattern, namePattern, NCNamePattern, VALID_NO_CONTENT, XsdPattern
 
 FLOAT_CASES = [
     {"value": "-1", "expected": (-1, -1, VALID)},
@@ -679,3 +679,61 @@ def test_validateValue_facets_whitespace(whitespace: str, value: str, expected: 
     }
     validateValue(modelXbrl=Mock(), elt=elt, attrTag=None, baseXsdType="string", value=value, facets=facets)
     _assertExpected(value, attrTag=None, elt=elt, expected=expected)
+
+
+NSMAP = {"prefix": "namespaceURI"}
+_SKIP_TYPES_FOR_VALUE_STRING = {None, "fraction"}
+
+
+def _generate_value_string_test_cases():
+    test_cases = []
+    for isNillable in [False, True]:
+        for isNil in [False, True]:
+            for baseXsdType, cases in BASE_XSD_TYPES.items():
+                if baseXsdType in _SKIP_TYPES_FOR_VALUE_STRING:
+                    continue
+                for case in cases:
+                    test_cases.append(
+                        (
+                            baseXsdType,
+                            case.get("value"),
+                            isNillable,
+                            isNil,
+                            case.get("facets"),
+                            case.get("expected"),
+                        )
+                    )
+    return test_cases
+
+
+@pytest.mark.parametrize(
+    "baseXsdType,value,isNillable,isNil,facets,expected",
+    [pytest.param(*testcase) for testcase in _generate_value_string_test_cases()],
+)
+def test_validateValueString(
+    baseXsdType: str, value: str, isNillable: bool, isNil: bool, facets: dict, expected: tuple
+):
+    expectedXValid = expected[2]
+    try:
+        result = validateValueString(
+            baseXsdType=baseXsdType,
+            value=value,
+            isNillable=isNillable,
+            isNil=isNil,
+            facets=facets,
+            nsmap=NSMAP,
+        )
+    except (ValueError, InvalidOperation):
+        assert expectedXValid == INVALID
+        return
+    expectedSValue = value if expected[0] == "=" else expected[0]
+    expectedXValue = value if expected[1] == "=" else expected[1]
+    if not value and isNil and isNillable:
+        expectedSValue = None
+        expectedXValue = None
+    if expectedSValue == nan:
+        assert isnan(result.sValue)
+    else:
+        _assertValidateValue(result.sValue, expectedSValue)
+    _assertValidateValue(result.xValue, expectedXValue)
+    assert result.xValid == expectedXValid


### PR DESCRIPTION
#### Reason for change

XBRL OIM formats (CSV, JSON) don't use XML, but they do use XML Schema types to validate values. The current `validateValue` function requires lxml XML element objects for namespace resolution, error reporting, and result storage. This coupling prevents reuse in non-XML contexts.

#### Description of change

Extracts the core XSD type validation logic from `validateValue` into standalone functions that can operate on plain strings:

- `validateValueString`: validates a string against an XSD type.
- `validateFacetValueString`: validates a facet value string against its expected type. 

The existing `validateValue` and `validateFacet` functions are preserved as thin wrappers that handle element storage and error reporting. Fraction validation is handled separately in the wrapper since it reads from child elements rather than parsing a string value.

Cleanup and refactoring was limited to the code being extracted. Formatting and refactoring of surrounding code was intentionally avoided to keep the diff focused. Best reviewed commit by commit with whitespace diffs disabled.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
