### PR TITLE
Close global Package/Plugin managers before Session runs

### DIFF
--- a/arelle/api/Session.py
+++ b/arelle/api/Session.py
@@ -129,7 +129,7 @@ class Session:
         with _session_lock:
             self._check_thread()
             PackageManager.getInstance().close()
-            PluginManager.getInstance().reset()
+            PluginManager.getInstance().close()
             if self._cntlr is None:
                 # Certain options must be passed into the controller constructor to have the intended effect
                 self._cntlr = createCntlrAndPreloadPlugins(

--- a/arelle/api/Session.py
+++ b/arelle/api/Session.py
@@ -128,7 +128,7 @@ class Session:
         """
         with _session_lock:
             self._check_thread()
-            PackageManager.reset()
+            PackageManager.getInstance().close()
             PluginManager.getInstance().reset()
             if self._cntlr is None:
                 # Certain options must be passed into the controller constructor to have the intended effect

--- a/arelle/packages/_package_manager.py
+++ b/arelle/packages/_package_manager.py
@@ -445,8 +445,7 @@ class PackageManager:
             self.packagesConfigChanged = False
 
     def close(self) -> None:
-        self._getPackagesConfig().clear()
-        self.packagesMappings.clear()
+        self.reset()
 
     ''' packagesConfig structure
     {

--- a/arelle/plugin_system/_plugin_manager.py
+++ b/arelle/plugin_system/_plugin_manager.py
@@ -145,10 +145,7 @@ class PluginManager:
     def close(self) -> None:  # close all loaded methods
         if self.pluginConfig is not None:
             self.pluginConfig.clear()
-        if self.modulePluginInfos is not None:
-            self.modulePluginInfos.clear()
-        if self.pluginMethodsForClasses is not None:
-            self.pluginMethodsForClasses.clear()
+        self.reset()
 
     ''' pluginInfo structure:
 


### PR DESCRIPTION
#### Reason for change
Using `PluginManager.reset` rather than `close` before Session runs meant that the global `PluginManager.pluginConfig` could have existing data that bleeds into the Session run (though the Session does call `PluginManager.close` _after_ execution so this generally isn't a concern for subsequent Session runs).

#### Description of change
Call `PluginManager.close` rather than `reset` before Session runs. Do the same for `PackageManager`, though there was little effective difference between `PackageManager.close` and `reset`.

#### Steps to Test
CI

**review**:
@Arelle/arelle
