### PR TITLE
Fix EDINET path-resolution issue

### DIFF
--- a/arelle/plugin/validate/EDINET/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/EDINET/PluginValidationDataExtension.py
@@ -177,12 +177,23 @@ class PluginValidationDataExtension(PluginData):
         return bool(statement.isConsolidated == contextIsConsolidated)
 
     def _initializeDocument(self, uri: str, modelDocument: ModelDocument, modelXbrl: ModelXbrl) -> None:
-        docPath = Path(uri)
         basePath = Path(str(modelXbrl.fileSource.basefile))
-        if not docPath.is_relative_to(basePath):
+
+        def relativeToBase(path: Path) -> Path | None:
+            if path.is_relative_to(basePath):
+                return path.relative_to(basePath)
+            resolvedPath = path.resolve()
+            resolvedBasePath = basePath.resolve()
+            if resolvedPath.is_relative_to(resolvedBasePath):
+                return resolvedPath.relative_to(resolvedBasePath)
+            return None
+
+        docRelativePath = relativeToBase(Path(uri))
+        if docRelativePath is None:
             return
         controllerPluginData = ControllerPluginData.get(modelXbrl.modelManager.cntlr, self.name)
-        controllerPluginData.addUsedFilepath(docPath.relative_to(basePath))
+        controllerPluginData.addUsedFilepath(docRelativePath)
+        documentFullPath = basePath / docRelativePath
         for elt, name, value in self.getUriAttributeValues(modelDocument):
             self._uriReferences.append(UriReference(
                 attributeName=name,
@@ -190,9 +201,9 @@ class PluginValidationDataExtension(PluginData):
                 document=modelDocument,
                 element=elt,
             ))
-            fullPath = (Path(modelDocument.uri).parent / value).resolve()
-            if fullPath.is_relative_to(basePath):
-                fileSourcePath = fullPath.relative_to(basePath)
+            fullPath = Path(os.path.normpath(documentFullPath.parent / value))
+            fileSourcePath = relativeToBase(fullPath)
+            if fileSourcePath is not None:
                 controllerPluginData.addUsedFilepath(fileSourcePath)
             referenceUri = str(fullPath)
             if (

--- a/arelle/plugin/validate/EDINET/rules/upload.py
+++ b/arelle/plugin/validate/EDINET/rules/upload.py
@@ -3,6 +3,7 @@ See COPYRIGHT.md for copyright information.
 """
 from __future__ import annotations
 
+import os
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
@@ -800,7 +801,7 @@ def rule_uri_references(
 
         uriPath = Path(uriReference.attributeValue)
         documentFullPath = Path(uriReference.document.uri)
-        referenceFullPath = (documentFullPath.parent / uriPath).resolve()
+        referenceFullPath = Path(os.path.normpath(documentFullPath.parent / uriPath))
         documentPathInfo = uploadContents.uploadPathsByFullPath.get(documentFullPath)
         assert documentPathInfo is not None # Should always be present, as it must exist to have a uriReference discovered.
         reportFullPath = Path(str(val.modelXbrl.fileSource.baseurl)) / (documentPathInfo.reportPath or "")


### PR DESCRIPTION
#### Reason for change

`Path.resolve()` is called on the *reference* path but not on the *base* / *report* / *document* paths it's later compared against. On macOS, `/tmp` is a symlink to `/private/tmp`, so `Path('/tmp/foo.zip/...').resolve()` returns `/private/tmp/foo.zip/...`, which then fails the `is_relative_to(basePath)` and `parents` containment checks even though the path is logically inside the report folder.


#### Steps to Test
CI 

and

- Manually reproduce the bug to confirm the fix: copy any valid filing zip (e.g. `tests/resources/conformance_suites/edinet/valid/valid05.zip`) to `/tmp/` and run `python -m arelle.CntlrCmdLine --plugins "validate/EDINET|inlineXbrlDocumentSet" --disclosureSystem EDINET --packages tests/resources/packages/edinet-2025.zip -f /tmp/valid05.zip --validate`. Before the fix, `EC1017E:1` and `EC1035E:18` appear; after the fix, they should be gone.

**review**:
@Arelle/arelle
