### PR TITLE
Add environment variable to suppress web server warning

### DIFF
--- a/arelle/CntlrWebMain.py
+++ b/arelle/CntlrWebMain.py
@@ -90,7 +90,7 @@ def startWebserver(cntlr: CntlrCmdLine, options: RuntimeOptions) -> Bottle | Non
     """
     setCntlr(cntlr)
     setRuntimeOptions(options)
-    if not os.getenv('ARELLE_WEBSERVER_NO_WARNING'):
+    if not os.getenv('ARELLE_WEBSERVER_NO_SECURITY_WARNING'):
         print(
             _("WARNING: Arelle's built-in webserver performs no authentication and must only be "
             "reachable by trusted users. It can read arbitrary files from this host and load "

--- a/arelle/CntlrWebMain.py
+++ b/arelle/CntlrWebMain.py
@@ -90,13 +90,14 @@ def startWebserver(cntlr: CntlrCmdLine, options: RuntimeOptions) -> Bottle | Non
     """
     setCntlr(cntlr)
     setRuntimeOptions(options)
-    print(
-        _("WARNING: Arelle's built-in webserver performs no authentication and must only be "
-          "reachable by trusted users. It can read arbitrary files from this host and load "
-          "plug-ins on request. Do not expose it to untrusted users or networks. "
-          "See docs/webserver_security.md."),
-        file=sys.stderr,
-    )
+    if not os.getenv('ARELLE_WEBSERVER_NO_WARNING'):
+        print(
+            _("WARNING: Arelle's built-in webserver performs no authentication and must only be "
+            "reachable by trusted users. It can read arbitrary files from this host and load "
+            "plug-ins on request. Do not expose it to untrusted users or networks. "
+            "See docs/webserver_security.md."),
+            file=sys.stderr,
+        )
     assert options.webserver is not None
     host, sep, portServer = options.webserver.partition(":")
     port, sep, server = portServer.partition(":")


### PR DESCRIPTION
#### Reason for change
Suppress web server warning

#### Description of change
Add an environment variable `ARELLE_WEBSERVER_NO_WARNING`

#### Steps to Test
1. Run web server `python arelleCmdLine.py --webserver 127.0.0.1`
2. Add new environment variable according to your OS `ARELLE_WEBSERVER_NO_WARNING=1`
3. Run web server again
4. Remove environment variable to revert your environment

**review**:
@Arelle/arelle
