### PR TITLE
Update documentation on prefixedNamespaces and include more prefixes

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -3,18 +3,16 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 
-from functools import cached_property
 import logging
 import os
 import sys
 import traceback
-from types import MappingProxyType
 import uuid
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, TypeVar, Union, cast, Optional
 
 import regex as re
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Iterator
 
 import arelle
 from arelle import FileSource, ModelRelationshipSet, XmlUtil, ModelValue, XbrlConst, XmlValidate

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -3,6 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 
+from functools import cached_property
 import logging
 import os
 import sys
@@ -560,18 +561,38 @@ class ModelXbrl:
         assert self.modelDocument is not None
         self.modelDocument.save(**kwargs)
 
-    @property
+    @cached_property
     def prefixedNamespaces(self) -> dict[str, str]:
-        """Dict of prefixes for namespaces defined in DTS
+        """
+        Dict of prefixes for namespaces defined in DTS.
+        
+        If a namespace has a prefix on its defining schema document, that prefix
+        is used.  Otherwise, if the namespace is declared on the root element of
+        the entry point, that prefix is used.
+
+        Note that:
+        1. There may well be prefixes or namespaces used in the report or taxonomy
+        that are not included in this dict.
+        2. This dict can include namespaces which no facts or concepts use.
         """
         prefixedNamespaces = {}
+        seen_ns = set()
+        # Prefer a given namespace's self-specified prefix
         for nsDocs in self.namespaceDocs.values():
             for nsDoc in nsDocs:
-                ns = nsDoc.targetNamespace
-                if ns:
-                    prefix = XmlUtil.xmlnsprefix(nsDoc.xmlRootElement, ns)
-                    if prefix and prefix not in prefixedNamespaces:
-                        prefixedNamespaces[prefix] = ns
+                if (
+                    (ns := nsDoc.targetNamespace) and
+                    ns not in seen_ns and
+                    (prefix := XmlUtil.xmlnsprefix(nsDoc.xmlRootElement, ns))
+                ):
+                    prefixedNamespaces.setdefault(prefix, ns)
+                    seen_ns.add(ns)
+        # Add in any others on the root element of the DTS entry point.
+        if self.modelDocument and (root := self.modelDocument.xmlRootElement) is not None:
+            for k, v in root.nsmap.items():
+                if k is not None and v not in seen_ns:
+                    prefixedNamespaces.setdefault(k, v)
+                    seen_ns.add(v)
         return prefixedNamespaces
 
     def matchContext(

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -8,12 +8,13 @@ import logging
 import os
 import sys
 import traceback
+from types import MappingProxyType
 import uuid
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, TypeVar, Union, cast, Optional
 
 import regex as re
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 
 import arelle
 from arelle import FileSource, ModelRelationshipSet, XmlUtil, ModelValue, XbrlConst, XmlValidate
@@ -561,7 +562,7 @@ class ModelXbrl:
         assert self.modelDocument is not None
         self.modelDocument.save(**kwargs)
 
-    @cached_property
+    @property
     def prefixedNamespaces(self) -> dict[str, str]:
         """
         Dict of prefixes for namespaces defined in DTS.

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -565,7 +565,7 @@ class ModelXbrl:
     def prefixedNamespaces(self) -> dict[str, str]:
         """
         Dict of prefixes for namespaces defined in DTS.
-        
+
         If a namespace has a prefix on its defining schema document, that prefix
         is used.  Otherwise, if the namespace is declared on the root element of
         the entry point, that prefix is used.
@@ -575,7 +575,7 @@ class ModelXbrl:
         that are not included in this dict.
         2. This dict can include namespaces which no facts or concepts use.
         """
-        prefixedNamespaces = {}
+        prefixedNamespaces: dict[str, str] = {}
         seen_ns = set()
         # Prefer a given namespace's self-specified prefix
         for nsDocs in self.namespaceDocs.values():


### PR DESCRIPTION
#### Reason for change
`ModelXbrl.prefixedNamespaces` is list of the prefixes and namespaces used in a report and taxonomy. It is built from the self-declared prefixes in every schema document in a DTS.

#### Description of change

- Add documentation to note the incomplete nature of prefixedNamespaces:
  - Two or more namespaces requesting the same prefix: first one wins;
  - Prefix used on a given QName can be different to the relevant namespace's self-declared prefix
- Add all the namespace prefix bindings found on the root document as long as they don't conflict with those found already as it's a relatively cheap way to fill in a few more gaps.
- Convert to `cached_property` 

#### Steps to Test

Should just get the same dict as before when used with a sample document or the same + additional entries

**review**:
@Arelle/arelle
