### PR TITLE
Fix ValueError found via INFO-SEMANTIC calls

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -327,7 +327,7 @@ class Cntlr:
     def validation(self, val: Validation, fileSource: FileSource | None = None) -> None:
         """Same as `error`, but parameters passed in from Validation object
         """
-        self.error(codes=val.codes, msg=val.msg, level=val.level.name, fileSource=fileSource, **val.args)
+        self.error(codes=val.codes, msg=val.msg, level=val.level.value, fileSource=fileSource, **val.args)
 
     def error(self, codes: Any, msg: str, level: str = "ERROR", fileSource: FileSource | None = None, **args: Any) -> None:
         if self.logger is None or self.errorManager is None:


### PR DESCRIPTION
#### Reason for change
ParsePort shared with us an error they were receiving via the EDINET validations.

#### Description of change
Fixed the call of level

#### Steps to Test
CI

**review**:
@Arelle/arelle
