### PR TITLE
Use `level.value` rather than `level.name`

### DIFF
--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -1067,7 +1067,7 @@ class ModelXbrl:
     def validation(self, val: Validation) -> None:
         """Same as log, but parameters passed in from Validation object
         """
-        self.log(level=val.level.name, codes=val.codes, msg=val.msg, **val.args)
+        self.log(level=val.level.value, codes=val.codes, msg=val.msg, **val.args)
 
     def log(self, level: str, codes: Any, msg: str, **args: Any) -> None:
         """Same as error(), but level passed in as argument

--- a/arelle/ValidateFileSource.py
+++ b/arelle/ValidateFileSource.py
@@ -27,7 +27,7 @@ class ValidateFileSource:
                 codes = [val.codes] if isinstance(val.codes, str) else val.codes
                 for code in codes:
                     self._cntrl.error(
-                        level=val.level.name,
+                        level=val.level.value,
                         codes=code,
                         msg=val.msg,
                         fileSource=self._filesource,

--- a/arelle/packages/_package_manager.py
+++ b/arelle/packages/_package_manager.py
@@ -488,7 +488,7 @@ class PackageManager:
         for validator in TAXONOMY_PACKAGE_ABORTING_VALIDATIONS:
             if validation := validator(TAXONOMY_PACKAGE_TYPE, filesource):
                 cntlr.error(
-                    level=validation.level.name,
+                    level=validation.level.value,
                     codes=validation.codes,
                     msg=validation.msg,
                     fileSource=filesource,
@@ -502,7 +502,7 @@ class PackageManager:
         for validator in TAXONOMY_PACKAGE_NON_ABORTING_VALIDATIONS:
             if validation := validator(TAXONOMY_PACKAGE_TYPE, filesource):
                 cntlr.error(
-                    level=validation.level.name,
+                    level=validation.level.value,
                     codes=validation.codes,
                     msg=validation.msg,
                     fileSource=filesource,

--- a/arelle/utils/validate/ESEFImage.py
+++ b/arelle/utils/validate/ESEFImage.py
@@ -80,7 +80,7 @@ def validateImageAndLog(
         args = validation.args.copy()
         if cssSelectors:
             args["cssSelectors"] = cssSelectors
-        modelXbrl.log(level=validation.level.name, codes=validation.codes, msg=validation.msg, **args)
+        modelXbrl.log(level=validation.level.value, codes=validation.codes, msg=validation.msg, **args)
 
 # check image contents against mime/file ext and for Steganography
 def validateImage(


### PR DESCRIPTION
#### Reason for change
Inconsistent usage of `value` vs. `name` for validation `Level`. This is specifically a problem for [INFO_SEMANTIC](https://github.com/Arelle/Arelle/blob/2956920e46fa3ae3602f75f5e6e708cbb33cc9d0/arelle/utils/validate/Validation.py#L15) due to the hyphen vs. underscore.

#### Description of change
Use `value` consistently.

#### Steps to Test
CI

**review**:
@Arelle/arelle
