### PR TITLE
Fix missing instance refs in assertionUnsatisfied log for sequence

### DIFF
--- a/arelle/formula/FormulaEvaluator.py
+++ b/arelle/formula/FormulaEvaluator.py
@@ -281,7 +281,7 @@ def evaluateVariableBindings(xpCtx, varSet, uncoveredAspectFacts):
                 for vb in xpCtx.varBindings.values():
                     if not vb.isFallback:
                         if vb.isBindAsSequence:
-                            if isinstance(vb.yieldedEvaluation, list):
+                            if isinstance(vb.yieldedEvaluation, (list, tuple)):
                                 _modelObjects.extend(vb.yieldedEvaluation)
                         elif vb.yieldedFact is not None:
                             _modelObjects.append(vb.yieldedFact)
@@ -327,7 +327,7 @@ def evaluateVariableBindings(xpCtx, varSet, uncoveredAspectFacts):
                         )
                     else:
                         if vb.isBindAsSequence:
-                            if isinstance(vb.yieldedEvaluation, list):
+                            if isinstance(vb.yieldedEvaluation, (list, tuple)):
                                 _modelObjects.extend(vb.yieldedEvaluation)
                         elif vb.yieldedFact is not None:
                             _modelObjects.append(vb.yieldedFact)


### PR DESCRIPTION
#### Reason for change

Commit 0b22a035e changed `matchesSubPartitions` to yield tuples (via `itertools.product`) instead of lists. Two `isinstance` checks that gate adding bound facts to the log modelObjects list were not updated, so they silently started omitting refs from logs.

#### Description of change

Include refs for bound facts when bound as sequence.

#### Steps to Test
CI

**review**:
@Arelle/arelle
