### PR TITLE
Update --version output to release version and/or tags when building from source or docker

### DIFF
--- a/arelle/Version.py
+++ b/arelle/Version.py
@@ -17,6 +17,9 @@ def getBuildVersion() -> str | None:
         return None
 
 
+def getGitTag() -> str | None:
+    return tryRunCommand('git', 'describe', '--tags')
+
 def getGitHash() -> str | None:
     return tryRunCommand('git', 'rev-parse', 'HEAD')
 
@@ -25,7 +28,7 @@ def getDefaultVersion() -> str:
 
 
 def getVersion() -> str:
-    for version_fetcher in [getBuildVersion, getGitHash, getDefaultVersion]:
+    for version_fetcher in [getBuildVersion, getGitTag, getGitHash, getDefaultVersion]:
         fetched_version = version_fetcher()
         if fetched_version is not None:
             return fetched_version


### PR DESCRIPTION
#### Reason for change
#2394 
1. Building from source displays the full git hash of the most recent commit (757f127b331f4fb8516f08ba0545c167b796acac). 
2. Published docker containers displays the default version (0.0.0). 

#### Description of change

1. I propose adding a getGitTag method prior to the getGitHash method in arelle.Version.py which will return `2.41.3-3-g757f127b`. If this method fails it will still fall back to the git hash and then the default. Checkout [this commit](https://github.com/ryangeiser1/Arelle/commit/e5d04dcdbbe3f2dfe22cdf2395aa410d0f58828e).

2. arelle.Version.py tries to locate the build version by importing arelle._version which appears to be created during the build process/workflow (ie buildLinuxDist.sh). What do we need to add/change to the docker image workflows to properly display the release/container version in the final docker containers? Is it as simple as adding `RUN /bin/sh ./scripts/buildLinuxDist.sh docker` to the end of the Dockerfile?

#### Steps to Test
1. clone repository locally & `python arelleCmdLine.py --version`
2. Spin up docker container & `docker exec arelle-webserver python arelleCmdLine.py --version`

**review**:
@Arelle/arelle
