### PR TITLE
EDINET.EC5003E: Include numeric char references in message

### DIFF
--- a/arelle/plugin/validate/EDINET/rules/upload.py
+++ b/arelle/plugin/validate/EDINET/rules/upload.py
@@ -1136,11 +1136,14 @@ def rule_EC5003E(
                 if illegalChars:
                     yield Validation.error(
                         codes='EDINET.EC5003E',
-                        msg=_("Prohibited characters (%(chars)s) are used. "
+                        msg=_("Prohibited characters are used: %(chars)s "
                               "File name: '%(file)s' (line %(line)s). "
                               "The file in question contains prohibited characters. "
                               "Please correct the prohibited characters. "),
-                        chars=', '.join(sorted(illegalChars)),
+                        chars=', '.join(
+                            f'{c} (&#{ord(c)};)'
+                            for c in sorted(illegalChars)
+                        ),
                         file=filepath,
                         line=lineNumber,
                     )


### PR DESCRIPTION
#### Reason for change
Whitespace characters rendered in the error message as `Prohibited characters () are used.`

#### Description of change
Add numeric character reference for invalid characters so they are both easier to identify and replace in the document.

Example:
```
[EDINET.EC5003E] Prohibited characters are used: ｫ (&#65387;) File name: '...' (line 55). The file in question contains prohibited characters. Please correct the prohibited characters.  - 
```

#### Steps to Test
CI

**review**:
@Arelle/arelle
