### PR TITLE
Add Release Versions to Docker Images

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,6 +6,11 @@ name: Publish Docker images
 on:
   workflow_call:
     inputs:
+      arelle_version:
+        default: ''
+        description: 'Version Arelle should declare itself to be in the image (blank to skip)'
+        required: false
+        type: string
       python_version:
         default: '3.14.4'
         description: 'Python version to use'
@@ -24,6 +29,11 @@ on:
 
   workflow_dispatch:
     inputs:
+      arelle_version:
+        default: ''
+        description: 'Version Arelle should declare itself to be in the image (blank to skip)'
+        required: false
+        type: string
       python_version:
         default: '3.14.4'
         description: 'Python version to use'
@@ -102,6 +112,7 @@ jobs:
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
+            ARELLE_VERSION=${{ inputs.arelle_version }}
             PYTHON_VERSION=${{ inputs.python_version }}
           push: true
           tags: ${{ steps.meta-slim.outputs.tags }}
@@ -158,6 +169,7 @@ jobs:
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
+            ARELLE_VERSION=${{ inputs.arelle_version }}
             PYTHON_VERSION=${{ inputs.python_version }}
             INCLUDE_EDGAR=true
             EXTRA_PIP=-r requirements-plugins.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
     secrets: inherit
 
   publish-docker:
-    needs: 
+    needs:
       - tests
     permissions:
       packages: write
@@ -129,4 +129,6 @@ jobs:
       attestations: write
       id-token: write
     uses: ./.github/workflows/publish-docker.yml
+    with:
+      arelle_version: ${{ github.ref_name }}
     secrets: inherit

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,16 @@ RUN pip install --upgrade pip \
 COPY arelleCmdLine.py .
 COPY arelle ./arelle
 
+## Generate version file if version is provided
+ARG ARELLE_VERSION=""
+COPY requirements-versioning.txt .
+COPY pyproject.toml .
+RUN if [ -n "$ARELLE_VERSION" ]; then \
+      pip install --no-cache-dir -r requirements-versioning.txt \
+      && SETUPTOOLS_SCM_PRETEND_VERSION="$ARELLE_VERSION" \
+         python -m setuptools_scm --force-write-version-files; \
+    fi
+
 ## Install plugin requirements when building with EDGAR or XULE plugins
 ARG INCLUDE_EDGAR=""
 ARG EDGAR_REF=""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ## Copy python dependencies and application code
-COPY --from=builder /usr/src/app /usr/src/app
+COPY --from=builder /usr/src/app/arelle /usr/src/app/arelle
+COPY --from=builder /usr/src/app/arelleCmdLine.py /usr/src/app/arelleCmdLine.py
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,6 @@
 cx-Freeze==8.6.4
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
-setuptools-scm==10.0.5
 
 -r requirements-plugins.txt
+-r requirements-versioning.txt
 -r requirements.txt

--- a/requirements-versioning.txt
+++ b/requirements-versioning.txt
@@ -1,0 +1,1 @@
+setuptools-scm==10.0.5


### PR DESCRIPTION
#### Reason for change
Handles the second item from #2394.

> Published docker containers displays the default version (0.0.0).

#### Description of change
Plumb the setuptools scm versioning into the docker build.

#### Steps to Test
* [x] Test [on a fork ](https://github.com/austinmatherne-wk/Arelle/actions/runs/26911785777/job/79391434802)

Current releases always show `0.0.0` version.
```shell
❯ docker run arelleproject/arelle:latest python arelleCmdLine.py --version
Arelle(r) 0.0.0 (64bit)
```

Branch workflow shows test release tag `3.0.0`.
```shell
❯ docker run austinmatherne/arelle:latest python arelleCmdLine.py --version
Arelle(r) 3.0.0 (64bit)
```

**review**:
@Arelle/arelle
@ryangeiser1 