### PR TITLE
Use system level shortcuts for Windows installer

### DIFF
--- a/installWin64.nsi
+++ b/installWin64.nsi
@@ -31,6 +31,7 @@ Unicode true
 
 !include "MUI2.nsh"
 !include "FileFunc.nsh"
+!include "LogicLib.nsh"
 
 SetCompressor /SOLID lzma
 
@@ -118,6 +119,16 @@ Section "Arelle" SecArelle
 
   RMDir /r "$INSTDIR\*"
   
+  ; Clean up user shortcuts left by older installers
+  SetShellVarContext current
+  ReadRegStr $0 HKLM "Software\Arelle" "Start Menu Folder"
+  ${If} ${FileExists} "$SMPROGRAMS\$0\*.*"
+    Delete "$SMPROGRAMS\$0\*.*"
+    RMDir "$SMPROGRAMS\$0"
+  ${EndIf}
+
+  SetShellVarContext all
+
   ; ADD YOUR OWN FILES HERE...
   File /r $%BUILD_PATH%\*.*
   
@@ -185,6 +196,8 @@ SectionEnd
 ; Uninstaller Section
 
 Section "Uninstall"
+
+  SetShellVarContext all
 
   ;ADD YOUR OWN FILES HERE...
 


### PR DESCRIPTION
#### Reason for change
Resolves #1376 

#### Description of change
The installer requires admin privileges and defaults to system level install locations, but the shortcuts go to the user level start menu. This updates the shortcuts to install system wide to match.

#### Steps to Test
* Use [test build](https://github.com/Arelle/Arelle/actions/runs/26974018682)
  * [x] confirm shortcuts are installed to system start menu (`C:\ProgramData\Microsoft\Windows\Start Menu\Programs`)
  * [x] confirm installer removes old user start menu scoped shortcuts on upgrade (shortcuts aren't duplicated between user and system start menus)

**review**:
@Arelle/arelle
