### PR TITLE
Harden NL validations against disclosure system Inline/Traditional mismatch

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -673,7 +673,7 @@ class ModelDocument(ModelDocumentBase):
         self.uri: str = uri
         self.filepath: str = filepath
         self.xmlDocument: etree._ElementTree[etree._Element] | None = xmlDocument
-        self.targetXbrlElementTree: etree._ElementTree[etree._Element] | None = xmlDocument
+        self.targetXbrlElementTree: etree._ElementTree[etree._Element] | PrototypeElementTree | None = xmlDocument
         self.targetNamespace: str | None = None
         modelXbrl.urlDocs[uri] = self
         self.objectIndex: int = len(modelXbrl.modelObjects)
@@ -2160,7 +2160,7 @@ def inlineIxdsDiscover(modelXbrl: ModelXbrl, modelIxdsDocument: ModelDocument, s
 
     if ixdsTarget in modelXbrl.ixTargetRootElements:  # type: ignore[attr-defined]
         modelIxdsDocument.targetXbrlRootElement = modelXbrl.ixTargetRootElements[ixdsTarget]  # type: ignore[attr-defined]
-        modelIxdsDocument.targetXbrlElementTree = PrototypeElementTree(modelIxdsDocument.targetXbrlRootElement)  # type: ignore[assignment]
+        modelIxdsDocument.targetXbrlElementTree = PrototypeElementTree(modelIxdsDocument.targetXbrlRootElement)
 
     for pluginMethod in modelXbrl.modelManager.cntlr.plugins.hooks("ModelDocument.IxdsTargetDiscovered"):
         pluginMethod(modelXbrl, modelIxdsDocument)

--- a/arelle/XmlUtil.py
+++ b/arelle/XmlUtil.py
@@ -531,7 +531,7 @@ def descendant(
     return None
 
 def descendants(
-    element: ModelObject | PrototypeObject | etree._ElementTree,
+    element: ModelObject | PrototypeObject | etree._ElementTree | PrototypeElementTree,
     descendantNamespaceURI: str | None,
     descendantLocalNames: str | tuple[str, ...],
     attrName: str | None = None,

--- a/arelle/formula/XPathContext.py
+++ b/arelle/formula/XPathContext.py
@@ -72,6 +72,7 @@ ContextItem = Union[
     bool,
     datetime.datetime,
     etree._ElementTree,
+    PrototypeElementTree,
     float,
     int,
     range,

--- a/arelle/plugin/validate/NL/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/NL/PluginValidationDataExtension.py
@@ -205,7 +205,7 @@ class PluginValidationDataExtension(PluginData):
         ixHiddenFacts = set()
         presentedHiddenEltIds = defaultdict(list)
         requiredToDisplayFacts = set()
-        for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
+        for ixdsHtmlRootElt in self.getIxdsHtmlElements(modelXbrl):
             ixNStag = str(getattr(ixdsHtmlRootElt.modelDocument, "ixNStag", ixbrl11))
             for ixHiddenElt in ixdsHtmlRootElt.iterdescendants(tag=ixNStag + "hidden"):
                 for tag in (ixNStag + "nonNumeric", ixNStag+"nonFraction"):
@@ -222,7 +222,7 @@ class PluginValidationDataExtension(PluginData):
                         for ixElt in cssHiddenElt.iterdescendants(tag=tag):
                             if ixElt not in ixHiddenFacts:
                                 cssHiddenFacts.add(ixElt)
-        for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
+        for ixdsHtmlRootElt in self.getIxdsHtmlElements(modelXbrl):
             for ixElt in ixdsHtmlRootElt.getroottree().iterfind(".//{http://www.w3.org/1999/xhtml}*[@style]"):
                 styleValue = ixElt.get("style","")
                 hiddenFactRefMatch = STYLE_IX_HIDDEN_PATTERN.match(styleValue)
@@ -244,6 +244,12 @@ class PluginValidationDataExtension(PluginData):
             requiredToDisplayFacts=requiredToDisplayFacts,
         )
 
+    def getIxdsHtmlElements(self, modelXbrl: ModelXbrl) -> list[Any]:
+        ixdsHtmlElements = []
+        if hasattr(modelXbrl, "ixdsHtmlElements"):
+            ixdsHtmlElements = modelXbrl.ixdsHtmlElements
+        return ixdsHtmlElements
+
     @lru_cache(1)
     def checkInlineHTMLElements(self, modelXbrl: ModelXbrl) -> InlineHTMLData:
         baseElements = set()
@@ -254,7 +260,7 @@ class PluginValidationDataExtension(PluginData):
         noMatchLangFootnotes = set()
         tupleElements = set()
         orphanedFootnotes = set()
-        for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
+        for ixdsHtmlRootElt in self.getIxdsHtmlElements(modelXbrl):
             ixNStag = str(getattr(ixdsHtmlRootElt.modelDocument, "ixNStag", ixbrl11))
             ixFootnoteTag = ixNStag + "footnote"
             ixFractionTag = ixNStag + "fraction"
@@ -626,8 +632,9 @@ class PluginValidationDataExtension(PluginData):
     def getReportXmlLang(self, modelXbrl: ModelXbrl) -> str | None:
         reportXmlLang = None
         firstRootmostXmlLangDepth = 9999999
-        if modelXbrl.ixdsHtmlElements:
-            ixdsHtmlRootElt = modelXbrl.ixdsHtmlElements[0]
+        ixdsHtmlElements = self.getIxdsHtmlElements(modelXbrl)
+        if ixdsHtmlElements:
+            ixdsHtmlRootElt = ixdsHtmlElements[0]
             for elt, depth in etreeIterWithDepth(ixdsHtmlRootElt):
                 if isinstance(elt, (_Comment, _ElementTree, _Entity, _ProcessingInstruction)):
                     continue
@@ -640,7 +647,7 @@ class PluginValidationDataExtension(PluginData):
     @lru_cache(1)
     def getElementsByTarget(self, modelXbrl: ModelXbrl) -> dict[str | None, list[ModelObject]]:
         elementsByTarget = defaultdict(list)
-        for ixdsHtmlRootElt in modelXbrl.ixdsHtmlElements:
+        for ixdsHtmlRootElt in self.getIxdsHtmlElements(modelXbrl):
             ixNStag = str(getattr(ixdsHtmlRootElt.modelDocument, "ixNStag", ixbrl11))
             ixTags = (ixNStag + ln for ln in ("nonNumeric", "nonFraction", "references", "relationship"))
             for elt in ixdsHtmlRootElt.iter(*ixTags):

--- a/arelle/plugin/validate/NL/rules/fg_nl.py
+++ b/arelle/plugin/validate/NL/rules/fg_nl.py
@@ -52,10 +52,11 @@ def rule_fg_nl_03(
     """
     standardNamespaceMap: dict[str, set[str]] = defaultdict(set)
     for modelDocument in val.modelXbrl.urlDocs.values():
+        if modelDocument.targetXbrlElementTree is None:
+            continue
         if modelDocument.type == ModelDocumentType.INSTANCE:
             continue
 
-        assert isinstance(modelDocument.targetXbrlElementTree, _ElementTree)
         for element in modelDocument.targetXbrlElementTree.iter():
             for prefix, namespace in element.nsmap.items():
                 if prefix:
@@ -63,10 +64,11 @@ def rule_fg_nl_03(
 
     warningsMap: defaultdict[tuple[str, str], list[_Element]] = defaultdict(list)
     for modelDocument in val.modelXbrl.urlDocs.values():
+        if modelDocument.targetXbrlElementTree is None:
+            continue
         if modelDocument.type != ModelDocumentType.INSTANCE:
             continue
 
-        assert isinstance(modelDocument.targetXbrlElementTree, _ElementTree)
         for element in modelDocument.targetXbrlElementTree.iter():
             for prefix, namespace in element.nsmap.items():
                 if namespace not in standardNamespaceMap or not prefix:

--- a/arelle/plugin/validate/NL/rules/fr_kvk.py
+++ b/arelle/plugin/validate/NL/rules/fr_kvk.py
@@ -37,7 +37,7 @@ def rule_fr_kvk_1_01(
     """
     modelXbrl = val.modelXbrl
     for doc in modelXbrl.urlDocs.values():
-        if doc.type == ModelDocumentType.INSTANCE:
+        if doc.type in (ModelDocumentType.INSTANCE, ModelDocumentType.INLINEXBRL, ModelDocumentType.INLINEXBRLDOCUMENTSET):
             if not doc.basename.endswith('.xbrl'):
                 yield Validation.error(
                     codes='NL.FR-KVK-1.01',

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -666,7 +666,7 @@ def rule_nl_kvk_3_5_1_1_non_img (
     """
 
     executableElements = []
-    for ixdsHtmlRootElt in val.modelXbrl.ixdsHtmlElements:
+    for ixdsHtmlRootElt in pluginData.getIxdsHtmlElements(val.modelXbrl):
         for elt in ixdsHtmlRootElt.iter(Element):
             if containsScriptMarkers(elt):
                 executableElements.append(elt)
@@ -702,7 +702,7 @@ def rule_nl_kvk_3_5_1_img (
         recommendBase64EncodingEmbeddedImages=False,
         supportedImgTypes=SUPPORTED_IMAGE_TYPES_BY_IS_FILE,
     )
-    for ixdsHtmlRootElt in val.modelXbrl.ixdsHtmlElements:
+    for ixdsHtmlRootElt in pluginData.getIxdsHtmlElements(val.modelXbrl):
         for elt in ixdsHtmlRootElt.iter((f'{{{XbrlConst.xhtml}}}img', '{http://www.w3.org/2000/svg}svg')):
             src = elt.get('src', '').strip()
             evaluatedMsg = _('On line {line}, "alt" attribute value: "{alt}"').format(line=elt.sourceline, alt=elt.get('alt'))
@@ -789,7 +789,7 @@ def rule_nl_kvk_3_5_2_3(
     NL-KVK.3.5.2.3: The value of the @xml:lang attribute SHOULD be 'nl' or 'en' or 'de' or 'fr'.
     """
     badLangsUsed = set()
-    for ixdsHtmlRootElt in val.modelXbrl.ixdsHtmlElements:
+    for ixdsHtmlRootElt in pluginData.getIxdsHtmlElements(val.modelXbrl):
         for uncast_elt in ixdsHtmlRootElt.iter():
             elt = cast(Any, uncast_elt)
             xmlLang = elt.get("{http://www.w3.org/XML/1998/namespace}lang")


### PR DESCRIPTION
#### Reason for change
Addresses some unfortunate user experience described in #2393

#### Description of change
- Replace an assertion with a more lenient `None` check
- `NL.FR-KVK-1.01` fires on inline documents
- `NL-INLINE-2025` handles traditional XBRL more gracefully

#### Steps to Test
- `NT20` with inline:
  - `python arelleCmdLine.py -f "https://github.com/user-attachments/files/28333312/kvk-rpt-jaarverantwoording-2025-nlgaap-fondsenwervende-organisaties-klein.htm" --disclosureSystem "NT20" --noCertificateCheck --validate --calc=c10 --plugin "validate/NL"`
- `NL-INLINE-2025` with traditional:
  - `python arelleCmdLine.py -f "https://github.com/user-attachments/files/28593302/kvk-rpt-jaarverantwoording-2025-nlgaap-fondsenwervende-organisaties-klein.xml" --disclosureSystem "NL-INLINE-2025" --noCertificateCheck --validate --calc=c10 --plugin "validate/NL"`

**review**:
@Arelle/arelle
