### PR TITLE
Add UKSEF validation plugin infrastructure

### DIFF
--- a/arelle/plugin/validate/UKSEF/DisclosureSystems.py
+++ b/arelle/plugin/validate/UKSEF/DisclosureSystems.py
@@ -1,0 +1,7 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+
+UKSEF_2025_PREVIEW = "uksef-2025-preview"
+
+ALL_DISCLOSURE_SYSTEMS = [UKSEF_2025_PREVIEW]

--- a/arelle/plugin/validate/UKSEF/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/UKSEF/PluginValidationDataExtension.py
@@ -1,0 +1,68 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from arelle.ModelValue import QName
+from arelle.utils.PluginData import PluginData
+
+
+NAMESPACE_BUS = "http://xbrl.frc.org.uk/cd/2025-01-01/business"
+NAMESPACE_CORE = "http://xbrl.frc.org.uk/fr/2025-01-01/core"
+NAMESPACE_AUREP = "http://xbrl.frc.org.uk/reports/2025-01-01/aurep"
+NAMESPACE_DIREP = "http://xbrl.frc.org.uk/reports/2025-01-01/direp"
+
+
+@dataclass
+class PluginValidationDataExtension(PluginData):
+    """Plugin data extension for UKSEF validation.
+
+    Caches pre-compiled regexes, QNames for mandatory concepts,
+    and dimension/member QNames used across rule functions.
+    """
+
+    isUksefFiling: bool
+    frcEntryPointPattern: re.Pattern[str]
+
+    # Dimension QNames
+    accountsStatusDimensionQn: QName
+    scopeAccountsDimensionQn: QName
+
+    # Member QNames
+    auditedMemberQn: QName
+    groupAccountsOnlyMemberQn: QName
+    consolidatedGroupCompanyAccountsMemberQn: QName
+
+    # Mandatory concept QNames - business namespace
+    entityCurrentLegalOrRegisteredNameQn: QName
+    balanceSheetDateQn: QName
+    startDateForPeriodCoveredByReportQn: QName
+    endDateForPeriodCoveredByReportQn: QName
+    entityDormantQn: QName
+    entityTradingStatusQn: QName
+    accountsTypeQn: QName
+    accountsStatusQn: QName
+    companyRegistrationNumberQn: QName
+    countryOfIncorporationQn: QName
+    addressLine1Qn: QName
+    principalLocationQn: QName
+
+    # Mandatory concept QNames - core namespace
+    directorSigningFinancialStatementsQn: QName
+    dateSigningFinancialStatementsQn: QName
+
+    # Mandatory concept QNames - aurep namespace
+    typeOfAuditorsReportQn: QName
+    dateAuditorsReportQn: QName
+    nameIndividualAuditorQn: QName
+    nameOfFirmAuditorQn: QName
+
+    # Mandatory concept QNames - direp namespace
+    dateSigningDirectorsReportQn: QName
+
+    # Identity hash for caching.
+    def __hash__(self) -> int:
+        return id(self)

--- a/arelle/plugin/validate/UKSEF/ValidationPluginExtension.py
+++ b/arelle/plugin/validate/UKSEF/ValidationPluginExtension.py
@@ -1,0 +1,68 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+import re
+
+from arelle.Cntlr import Cntlr
+from arelle.ModelValue import qname
+from arelle.ValidateXbrl import ValidateXbrl
+from arelle.utils.validate.ValidationPlugin import ValidationPlugin
+from .PluginValidationDataExtension import (
+    NAMESPACE_AUREP,
+    NAMESPACE_BUS,
+    NAMESPACE_CORE,
+    NAMESPACE_DIREP,
+    PluginValidationDataExtension,
+)
+
+# Regex pattern for FRC taxonomy entry point URLs
+FRC_ENTRY_POINT_PATTERN = re.compile(
+    r"https?://xbrl\.frc\.org\.uk/"
+)
+
+
+class ValidationPluginExtension(ValidationPlugin):
+    """UKSEF validation plugin extension.
+
+    Extends the base ValidationPlugin to provide UKSEF-specific
+    plugin data with cached QNames and regex patterns.
+    """
+
+    def newPluginData(self, cntlr: Cntlr, validateXbrl: ValidateXbrl | None) -> PluginValidationDataExtension:
+        return PluginValidationDataExtension(
+            self.name,
+            isUksefFiling=False,
+            frcEntryPointPattern=FRC_ENTRY_POINT_PATTERN,
+            # Dimension QNames
+            accountsStatusDimensionQn=qname(f"{{{NAMESPACE_BUS}}}AccountsStatusDimension"),
+            scopeAccountsDimensionQn=qname(f"{{{NAMESPACE_BUS}}}ScopeAccountsDimension"),
+            # Member QNames
+            auditedMemberQn=qname(f"{{{NAMESPACE_BUS}}}Audited"),
+            groupAccountsOnlyMemberQn=qname(f"{{{NAMESPACE_BUS}}}GroupAccountsOnly"),
+            consolidatedGroupCompanyAccountsMemberQn=qname(f"{{{NAMESPACE_BUS}}}ConsolidatedGroupCompanyAccounts"),
+            # Mandatory concept QNames - business namespace
+            entityCurrentLegalOrRegisteredNameQn=qname(f"{{{NAMESPACE_BUS}}}EntityCurrentLegalOrRegisteredName"),
+            balanceSheetDateQn=qname(f"{{{NAMESPACE_BUS}}}BalanceSheetDate"),
+            startDateForPeriodCoveredByReportQn=qname(f"{{{NAMESPACE_BUS}}}StartDateForPeriodCoveredByReport"),
+            endDateForPeriodCoveredByReportQn=qname(f"{{{NAMESPACE_BUS}}}EndDateForPeriodCoveredByReport"),
+            entityDormantQn=qname(f"{{{NAMESPACE_BUS}}}EntityDormant"),
+            entityTradingStatusQn=qname(f"{{{NAMESPACE_BUS}}}EntityTradingStatus"),
+            accountsTypeQn=qname(f"{{{NAMESPACE_BUS}}}AccountsType"),
+            accountsStatusQn=qname(f"{{{NAMESPACE_BUS}}}AccountsStatus"),
+            companyRegistrationNumberQn=qname(f"{{{NAMESPACE_BUS}}}CompanyRegistrationNumber"),
+            countryOfIncorporationQn=qname(f"{{{NAMESPACE_BUS}}}CountryOfIncorporation"),
+            addressLine1Qn=qname(f"{{{NAMESPACE_BUS}}}AddressLine1"),
+            principalLocationQn=qname(f"{{{NAMESPACE_BUS}}}PrincipalLocation"),
+            # Mandatory concept QNames - core namespace
+            directorSigningFinancialStatementsQn=qname(f"{{{NAMESPACE_CORE}}}DirectorSigningFinancialStatements"),
+            dateSigningFinancialStatementsQn=qname(f"{{{NAMESPACE_CORE}}}DateSigningFinancialStatements"),
+            # Mandatory concept QNames - aurep namespace
+            typeOfAuditorsReportQn=qname(f"{{{NAMESPACE_AUREP}}}TypeOfAuditorsReport"),
+            dateAuditorsReportQn=qname(f"{{{NAMESPACE_AUREP}}}DateAuditorsReport"),
+            nameIndividualAuditorQn=qname(f"{{{NAMESPACE_AUREP}}}NameIndividualAuditor"),
+            nameOfFirmAuditorQn=qname(f"{{{NAMESPACE_AUREP}}}NameOfFirmAuditor"),
+            # Mandatory concept QNames - direp namespace
+            dateSigningDirectorsReportQn=qname(f"{{{NAMESPACE_DIREP}}}DateSigningDirectorsReport"),
+        )

--- a/arelle/plugin/validate/UKSEF/__init__.py
+++ b/arelle/plugin/validate/UKSEF/__init__.py
@@ -1,0 +1,49 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UK Single Electronic Format (UKSEF) validation plugin.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from arelle.Version import authorLabel, copyrightLabel
+from .ValidationPluginExtension import ValidationPluginExtension
+from .rules import context, document, entity, mandatory, package, target, taxonomy
+
+PLUGIN_NAME = "Validate UKSEF"
+DISCLOSURE_SYSTEM_VALIDATION_TYPE = "UKSEF"
+
+
+validationPlugin = ValidationPluginExtension(
+    name=PLUGIN_NAME,
+    disclosureSystemConfigUrl=Path(__file__).parent / "resources" / "config.xml",
+    validationTypes=[DISCLOSURE_SYSTEM_VALIDATION_TYPE],
+    validationRuleModules=[taxonomy, target, entity, context, package, document, mandatory],
+)
+
+
+def disclosureSystemTypes(*args: Any, **kwargs: Any) -> tuple[tuple[str, str], ...]:
+    return validationPlugin.disclosureSystemTypes
+
+
+def disclosureSystemConfigURL(*args: Any, **kwargs: Any) -> str:
+    return validationPlugin.disclosureSystemConfigURL
+
+
+def validateXbrlFinally(*args: Any, **kwargs: Any) -> None:
+    return validationPlugin.validateXbrlFinally(*args, **kwargs)
+
+
+__pluginInfo__ = {
+    "name": PLUGIN_NAME,
+    "version": "0.0.1",
+    "description": "Validation plugin for UK Single Electronic Format (UKSEF) filings.",
+    "license": "Apache-2",
+    "author": authorLabel,
+    "copyright": copyrightLabel,
+    "DisclosureSystem.Types": disclosureSystemTypes,
+    "DisclosureSystem.ConfigURL": disclosureSystemConfigURL,
+    "Validate.XBRL.Finally": validateXbrlFinally,
+}

--- a/arelle/plugin/validate/UKSEF/resources/config.xml
+++ b/arelle/plugin/validate/UKSEF/resources/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DisclosureSystems
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../config/disclosuresystems.xsd">
+    <!-- see arelle/config/disclosuresystems.xml for full comments -->
+    <DisclosureSystem
+            names="uksef-2025-preview"
+            description="Validates rules for UK Single Electronic Format (UKSEF) filings"
+            validationType="UKSEF"
+    />
+</DisclosureSystems>

--- a/arelle/plugin/validate/UKSEF/rules/__init__.py
+++ b/arelle/plugin/validate/UKSEF/rules/__init__.py
@@ -1,0 +1,76 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+Shared helper functions for UKSEF validation rules.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.ModelXbrl import ModelXbrl
+from arelle.typing import TypeGetText
+
+_: TypeGetText
+
+
+def get_ukfrs_ix_references(modelXbrl: ModelXbrl) -> list[Any]:
+    """Returns ix:references elements where target="UKFRS".
+
+    :param modelXbrl: The model XBRL instance.
+    :return: List of ix:references elements with target="UKFRS".
+    """
+    results = []
+    for doc in modelXbrl.urlDocs.values():
+        if doc.xmlRootElement is None:
+            continue
+        for elem in doc.xmlRootElement.iter():
+            if elem.localName == "references" and elem.get("target") == "UKFRS":
+                results.append(elem)
+    return results
+
+
+def get_default_ix_references(modelXbrl: ModelXbrl) -> list[Any]:
+    """Returns ix:references elements with no target attribute.
+
+    :param modelXbrl: The model XBRL instance.
+    :return: List of ix:references elements with no target.
+    """
+    results = []
+    for doc in modelXbrl.urlDocs.values():
+        if doc.xmlRootElement is None:
+            continue
+        for elem in doc.xmlRootElement.iter():
+            if elem.localName == "references" and elem.get("target") is None:
+                results.append(elem)
+    return results
+
+
+def get_inline_elements_by_target(modelXbrl: ModelXbrl) -> dict[str | None, list[Any]]:
+    """Returns inline XBRL elements grouped by their target attribute value.
+
+    :param modelXbrl: The model XBRL instance.
+    :return: Dictionary keyed by target value (None for default target).
+    """
+    result: dict[str | None, list[Any]] = defaultdict(list)
+    for doc in modelXbrl.urlDocs.values():
+        if doc.xmlRootElement is None:
+            continue
+        for elem in doc.xmlRootElement.iter():
+            if elem.localName in ("references", "resources"):
+                target = elem.get("target")
+                result[target].append(elem)
+    return dict(result)
+
+
+def is_uksef_filing(modelXbrl: ModelXbrl) -> bool:
+    """Determine if this is a UKSEF filing.
+
+    A filing is considered a UKSEF filing if any ix:references element
+    has target="UKFRS".
+
+    :param modelXbrl: The model XBRL instance.
+    :return: True if any ix:references has target="UKFRS".
+    """
+    return len(get_ukfrs_ix_references(modelXbrl)) > 0

--- a/arelle/plugin/validate/UKSEF/rules/context.py
+++ b/arelle/plugin/validate/UKSEF/rules/context.py
@@ -1,0 +1,37 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF context validation rules (UKFRC8).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ..DisclosureSystems import ALL_DISCLOSURE_SYSTEMS
+from ..PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc8(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC8: Context period validation for UKSEF filings.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None

--- a/arelle/plugin/validate/UKSEF/rules/document.py
+++ b/arelle/plugin/validate/UKSEF/rules/document.py
@@ -1,0 +1,55 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF document validation rules (UKFRC20, UKFRC21).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ..DisclosureSystems import ALL_DISCLOSURE_SYSTEMS
+from ..PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc20(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC20: Document structure validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc21(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC21: Document content type validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None

--- a/arelle/plugin/validate/UKSEF/rules/entity.py
+++ b/arelle/plugin/validate/UKSEF/rules/entity.py
@@ -1,0 +1,55 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF entity validation rules (UKFRC6, UKFRC7).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ..DisclosureSystems import ALL_DISCLOSURE_SYSTEMS
+from ..PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc6(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC6: Entity identifier scheme must be valid.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc7(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC7: Entity identifier must be a valid Companies House registration number.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None

--- a/arelle/plugin/validate/UKSEF/rules/mandatory.py
+++ b/arelle/plugin/validate/UKSEF/rules/mandatory.py
@@ -1,0 +1,38 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF mandatory facts validation rules for Companies House.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ..DisclosureSystems import ALL_DISCLOSURE_SYSTEMS
+from ..PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_mandatory_facts(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    Companies House mandatory facts: Validates that all required facts
+    are present in the filing.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None

--- a/arelle/plugin/validate/UKSEF/rules/package.py
+++ b/arelle/plugin/validate/UKSEF/rules/package.py
@@ -1,0 +1,217 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF package validation rules (UKFRC9-UKFRC19).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ..DisclosureSystems import ALL_DISCLOSURE_SYSTEMS
+from ..PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc9(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC9: Package structure validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc10(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC10: Package content validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc11(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC11: Package naming convention validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc12(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC12: Package metadata validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc13(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC13: Package file type validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc14(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC14: Package encoding validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc15(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC15: Package size validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc16(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC16: Package document count validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc17(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC17: Package image format validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc18(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC18: Package CSS validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc19(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC19: Package JavaScript validation.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None

--- a/arelle/plugin/validate/UKSEF/rules/target.py
+++ b/arelle/plugin/validate/UKSEF/rules/target.py
@@ -1,0 +1,73 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF target validation rules (UKFRC3, UKFRC4, UKFRC5).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ..DisclosureSystems import ALL_DISCLOSURE_SYSTEMS
+from ..PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc3(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC3: Inline XBRL document must define the correct target.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc4(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC4: Inline XBRL target must contain required schema references.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc5(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC5: Default target must reference the ESEF taxonomy.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None

--- a/arelle/plugin/validate/UKSEF/rules/taxonomy.py
+++ b/arelle/plugin/validate/UKSEF/rules/taxonomy.py
@@ -1,0 +1,55 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF taxonomy validation rules (UKFRC1, UKFRC2).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ..DisclosureSystems import ALL_DISCLOSURE_SYSTEMS
+from ..PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc1(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC1: Entry point schema reference must be a valid FRC taxonomy URL.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+    disclosureSystems=ALL_DISCLOSURE_SYSTEMS,
+)
+def rule_ukfrc2(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC2: Filing must reference a recognised FRC taxonomy entry point.
+    """
+    if not pluginData.isUksefFiling:
+        return None
+    return None

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -99,6 +99,7 @@ config = ConformanceSuiteConfig(
     ]}),
     info_url='https://www.frc.org.uk/library/standards-codes-policy/accounting-and-reporting/frc-taxonomies/frc-taxonomies-documentation-and-guidance/',
     name=PurePath(__file__).stem,
-    plugins=frozenset({'inlineXbrlDocumentSet'}),
+    disclosure_system='uksef-2025-preview',
+    plugins=frozenset({'inlineXbrlDocumentSet', 'validate/UKSEF'}),
     shards=4,
 )

--- a/tests/unit_tests/arelle/plugin/validate/UKSEF/test_plugin.py
+++ b/tests/unit_tests/arelle/plugin/validate/UKSEF/test_plugin.py
@@ -1,0 +1,196 @@
+"""
+Unit tests for the UKSEF validation plugin.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class TestPluginInfo:
+    """Tests for plugin registration and metadata."""
+
+    def test_plugin_loads(self):
+        from arelle.plugin.validate.UKSEF import __pluginInfo__
+        assert __pluginInfo__["name"] == "Validate UKSEF"
+        assert __pluginInfo__["version"] == "0.0.1"
+
+    def test_plugin_has_required_hooks(self):
+        from arelle.plugin.validate.UKSEF import __pluginInfo__
+        assert "DisclosureSystem.Types" in __pluginInfo__
+        assert "DisclosureSystem.ConfigURL" in __pluginInfo__
+        assert "Validate.XBRL.Finally" in __pluginInfo__
+
+    def test_disclosure_system_types(self):
+        from arelle.plugin.validate.UKSEF import disclosureSystemTypes
+        types = disclosureSystemTypes()
+        assert isinstance(types, tuple)
+        assert len(types) >= 1
+        # Each entry should be (validationType, disclosureSystemName)
+        for entry in types:
+            assert isinstance(entry, tuple)
+            assert len(entry) == 2
+
+    def test_disclosure_system_config_url(self):
+        from arelle.plugin.validate.UKSEF import disclosureSystemConfigURL
+        url = disclosureSystemConfigURL()
+        assert isinstance(url, (str, Path))
+        assert "config.xml" in str(url)
+
+    def test_plugin_name_constant(self):
+        from arelle.plugin.validate.UKSEF import PLUGIN_NAME
+        assert PLUGIN_NAME == "Validate UKSEF"
+
+    def test_validation_type_constant(self):
+        from arelle.plugin.validate.UKSEF import DISCLOSURE_SYSTEM_VALIDATION_TYPE
+        assert DISCLOSURE_SYSTEM_VALIDATION_TYPE == "UKSEF"
+
+
+class TestDisclosureSystems:
+    """Tests for disclosure system constants."""
+
+    def test_uksef_2025_preview_value(self):
+        from arelle.plugin.validate.UKSEF.DisclosureSystems import UKSEF_2025_PREVIEW
+        assert UKSEF_2025_PREVIEW == "uksef-2025-preview"
+
+    def test_all_disclosure_systems_contains_preview(self):
+        from arelle.plugin.validate.UKSEF.DisclosureSystems import (
+            ALL_DISCLOSURE_SYSTEMS,
+            UKSEF_2025_PREVIEW,
+        )
+        assert UKSEF_2025_PREVIEW in ALL_DISCLOSURE_SYSTEMS
+
+    def test_all_disclosure_systems_is_list(self):
+        from arelle.plugin.validate.UKSEF.DisclosureSystems import ALL_DISCLOSURE_SYSTEMS
+        assert isinstance(ALL_DISCLOSURE_SYSTEMS, list)
+        assert len(ALL_DISCLOSURE_SYSTEMS) >= 1
+
+
+class TestPluginValidationDataExtension:
+    """Tests for the plugin data extension."""
+
+    def test_data_extension_has_required_fields(self):
+        from arelle.plugin.validate.UKSEF.PluginValidationDataExtension import (
+            PluginValidationDataExtension,
+        )
+        import dataclasses
+        field_names = [f.name for f in dataclasses.fields(PluginValidationDataExtension)]
+        assert "isUksefFiling" in field_names
+        assert "frcEntryPointPattern" in field_names
+        assert "entityCurrentLegalOrRegisteredNameQn" in field_names
+        assert "balanceSheetDateQn" in field_names
+        assert "companyRegistrationNumberQn" in field_names
+
+    def test_namespace_constants(self):
+        from arelle.plugin.validate.UKSEF.PluginValidationDataExtension import (
+            NAMESPACE_BUS,
+            NAMESPACE_CORE,
+            NAMESPACE_AUREP,
+            NAMESPACE_DIREP,
+        )
+        assert "frc.org.uk" in NAMESPACE_BUS
+        assert "frc.org.uk" in NAMESPACE_CORE
+        assert "frc.org.uk" in NAMESPACE_AUREP
+        assert "frc.org.uk" in NAMESPACE_DIREP
+
+
+class TestValidationPluginExtension:
+    """Tests for the validation plugin extension."""
+
+    def test_extension_inherits_validation_plugin(self):
+        from arelle.plugin.validate.UKSEF.ValidationPluginExtension import (
+            ValidationPluginExtension,
+        )
+        from arelle.utils.validate.ValidationPlugin import ValidationPlugin
+        assert issubclass(ValidationPluginExtension, ValidationPlugin)
+
+    def test_frc_entry_point_pattern(self):
+        from arelle.plugin.validate.UKSEF.ValidationPluginExtension import (
+            FRC_ENTRY_POINT_PATTERN,
+        )
+        assert FRC_ENTRY_POINT_PATTERN.match("https://xbrl.frc.org.uk/fr/2025-01-01/core")
+        assert FRC_ENTRY_POINT_PATTERN.match("http://xbrl.frc.org.uk/reports/2025-01-01/aurep")
+        assert not FRC_ENTRY_POINT_PATTERN.match("https://example.com/taxonomy")
+
+
+class TestRulesHelpers:
+    """Tests for shared rule helper functions."""
+
+    def test_is_uksef_filing_function_exists(self):
+        from arelle.plugin.validate.UKSEF.rules import is_uksef_filing
+        assert callable(is_uksef_filing)
+
+    def test_get_ukfrs_ix_references_function_exists(self):
+        from arelle.plugin.validate.UKSEF.rules import get_ukfrs_ix_references
+        assert callable(get_ukfrs_ix_references)
+
+    def test_get_default_ix_references_function_exists(self):
+        from arelle.plugin.validate.UKSEF.rules import get_default_ix_references
+        assert callable(get_default_ix_references)
+
+    def test_get_inline_elements_by_target_function_exists(self):
+        from arelle.plugin.validate.UKSEF.rules import get_inline_elements_by_target
+        assert callable(get_inline_elements_by_target)
+
+
+class TestRuleModules:
+    """Tests that all rule modules load and have decorated functions."""
+
+    def test_taxonomy_module_loads(self):
+        from arelle.plugin.validate.UKSEF.rules import taxonomy
+        assert hasattr(taxonomy, 'rule_ukfrc1')
+        assert hasattr(taxonomy, 'rule_ukfrc2')
+
+    def test_target_module_loads(self):
+        from arelle.plugin.validate.UKSEF.rules import target
+        assert hasattr(target, 'rule_ukfrc3')
+        assert hasattr(target, 'rule_ukfrc4')
+        assert hasattr(target, 'rule_ukfrc5')
+
+    def test_entity_module_loads(self):
+        from arelle.plugin.validate.UKSEF.rules import entity
+        assert hasattr(entity, 'rule_ukfrc6')
+        assert hasattr(entity, 'rule_ukfrc7')
+
+    def test_context_module_loads(self):
+        from arelle.plugin.validate.UKSEF.rules import context
+        assert hasattr(context, 'rule_ukfrc8')
+
+    def test_package_module_loads(self):
+        from arelle.plugin.validate.UKSEF.rules import package
+        assert hasattr(package, 'rule_ukfrc9')
+        assert hasattr(package, 'rule_ukfrc19')
+
+    def test_document_module_loads(self):
+        from arelle.plugin.validate.UKSEF.rules import document
+        assert hasattr(document, 'rule_ukfrc20')
+        assert hasattr(document, 'rule_ukfrc21')
+
+    def test_mandatory_module_loads(self):
+        from arelle.plugin.validate.UKSEF.rules import mandatory
+        assert hasattr(mandatory, 'rule_mandatory_facts')
+
+
+class TestConfigXml:
+    """Tests for the disclosure system config XML."""
+
+    def test_config_xml_exists(self):
+        config_path = Path(__file__).resolve().parents[6] / (
+            "arelle/plugin/validate/UKSEF/resources/config.xml"
+        )
+        assert config_path.exists()
+
+    def test_config_xml_parseable(self):
+        from lxml import etree
+        config_path = Path(__file__).resolve().parents[6] / (
+            "arelle/plugin/validate/UKSEF/resources/config.xml"
+        )
+        tree = etree.parse(str(config_path))
+        root = tree.getroot()
+        assert root.tag == "DisclosureSystems"
+        disclosure_systems = root.findall("DisclosureSystem")
+        assert len(disclosure_systems) >= 1
+        ds = disclosure_systems[0]
+        assert "uksef-2025-preview" in ds.get("names", "")
+        assert ds.get("validationType") == "UKSEF"


### PR DESCRIPTION
#### Reason for change

Arelle needs support for validating UK Single Electronic Format (UKSEF) filings. This PR adds the plugin infrastructure and conformance suite wiring as the foundation for implementing UKSEF validation rules.

#### Description of change

Creates the plugin skeleton for `arelle/plugin/validate/UKSEF/` mirroring the `validate/DBA` architecture:

- **Plugin entry point** (`__init__.py`): Registers the plugin with `__pluginInfo__`, wires `validateXbrlFinally` hook
- **Disclosure system** (`DisclosureSystems.py`, `resources/config.xml`): Registers `uksef-2025-preview` disclosure system with `validationType="UKSEF"`
- **Plugin extension** (`ValidationPluginExtension.py`): Extends `ValidationPlugin`, overrides `newPluginData()`
- **Data extension** (`PluginValidationDataExtension.py`): Caches compiled regex for FRC entry point URLs, QNames for 19 mandatory concepts, and dimension/member QNames for group-audited detection
- **Rule placeholders** (`rules/`): Empty modules for taxonomy, target, entity, context, package, document, and mandatory rules with proper `@validation` decorator structure
- **Shared helpers** (`rules/__init__.py`): Utility functions for IX reference extraction and UKSEF filing detection
- **Conformance suite config** (`tests/integration_tests/validation/conformance_suite_configurations/uksef.py`): Wires test infrastructure with 45 expected failure IDs and 3 expected additional testcase errors
- **Unit tests** (`tests/unit_tests/arelle/plugin/validate/UKSEF/test_plugin.py`): 26 tests covering plugin loading, disclosure system registration, validation data extension, and rule module structure

No rule logic is implemented; this is purely structural scaffolding.

#### Steps to Test

- CI

**review**:
@Arelle/arelle