### PR TITLE
ESEF: Initial migration to `ValidationPlugin`

### DIFF
--- a/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
@@ -1,0 +1,10 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+from arelle.utils.PluginData import PluginData
+
+
+class PluginValidationDataExtension(PluginData):
+    pass

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -41,6 +41,8 @@ AUTHORITY_CODES: frozenset[str] = frozenset({
 
 ESEF_STANDARD_TAXONOMY_URI_PREFIXES_ATTR = "_esefStandardTaxonomyUriPrefixes"
 
+ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY = "ESEFplugin"
+
 
 def standardTaxonomyUriPrefixes(val: ValidateXbrl) -> frozenset[str]:
     taxonomyPrefixes: frozenset[str] | None = getattr(val, ESEF_STANDARD_TAXONOMY_URI_PREFIXES_ATTR, None)
@@ -199,3 +201,13 @@ def _hasEventAttributes(elt: Any, attributes: Collection[str]) -> bool:
     if isinstance(elt, _Element):
         return any(a in attributes for a in elt.keys())
     return False
+
+
+def esefDisclosureSystemSelected(modelXbrl: ModelXbrl) -> bool:
+    return getattr(modelXbrl.modelManager.disclosureSystem, ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY, False)
+
+
+def shouldRunEsefValidationRules(val: ValidateXbrl) -> bool:
+    if not val.validateDisclosureSystem:
+        return False
+    return esefDisclosureSystemSelected(val.modelXbrl)

--- a/arelle/plugin/validate/ESEF/ValidationPluginExtension.py
+++ b/arelle/plugin/validate/ESEF/ValidationPluginExtension.py
@@ -1,0 +1,17 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+from arelle.Cntlr import Cntlr
+from arelle.ValidateXbrl import ValidateXbrl
+from arelle.typing import TypeGetText
+from arelle.utils.validate.ValidationPlugin import ValidationPlugin
+from .PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+class ValidationPluginExtension(ValidationPlugin):
+    def newPluginData(self, cntlr: Cntlr, validateXbrl: ValidateXbrl | None) -> PluginValidationDataExtension:
+        return PluginValidationDataExtension(self.name)

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -71,15 +71,14 @@ from arelle.utils.PluginData import PluginData
 from arelle.utils.PluginHooks import PluginHooks
 from .ESEF_2021.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinally2021
 from .ESEF_Current.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinallyCurrent
-from .Util import AUTHORITY_CODES, getDisclosureSystemYear, loadAuthorityValidations
+from .Util import AUTHORITY_CODES, getDisclosureSystemYear, loadAuthorityValidations, ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY, esefDisclosureSystemSelected, shouldRunEsefValidationRules
+from .ValidationPluginExtension import ValidationPluginExtension
+from .rules import base
 
 _: TypeGetText
 
 ESEF_PLUGIN_NAME = "Validate ESMA ESEF"
-ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY = "ESEFplugin"
-
-ixErrorPattern = re.compile(r"ix11[.]|xmlSchema[:]|(?!xbrl.5.2.5.2|xbrl.5.2.6.2)xbrl[.]|xbrld[ti]e[:]|utre[:]")
-dupIdErrorPattern = re.compile(r"xml.3.3.1:idMustBeUnique|ix11.14.1.2:uniqueIxId")
+DISCLOSURE_SYSTEM_VALIDATION_TYPE = "ESEF"
 
 
 def validateEntity(modelXbrl: ModelXbrl, filename:str, filesource: FileSource) -> None:
@@ -98,16 +97,6 @@ def validateEntity(modelXbrl: ModelXbrl, filename:str, filesource: FileSource) -
     except (UnicodeDecodeError, XMLSyntaxError):
         # probably a image or a directory
         pass
-
-
-def esefDisclosureSystemSelected(modelXbrl: ModelXbrl) -> bool:
-    return getattr(modelXbrl.modelManager.disclosureSystem, ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY, False)
-
-
-def shouldRunEsefValidationRules(val: ValidateXbrl) -> bool:
-    if not val.validateDisclosureSystem:
-        return False
-    return esefDisclosureSystemSelected(val.modelXbrl)
 
 
 def getEsefAuthority(
@@ -161,7 +150,10 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> tuple[tuple[str, str], ...]:
-        return (("ESEF", ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY),)
+        return (
+            ("ESEF", ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY),
+            *validationPlugin.disclosureSystemTypes,
+        )
 
     @staticmethod
     def disclosureSystemConfigURL(
@@ -169,7 +161,7 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> str:
-        return str(Path(__file__).parent / "resources" / "config.xml")
+        return validationPlugin.disclosureSystemConfigURL
 
     @staticmethod
     def cntlrCmdLineOptions(
@@ -391,12 +383,7 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if not shouldRunEsefValidationRules(val):
-            return None
-        disclosureSystemYear = getDisclosureSystemYear(val.modelXbrl)
-        if disclosureSystemYear == 2021:
-            return validateXbrlFinally2021(val, *args, **kwargs)
-        return validateXbrlFinallyCurrent(val, *args, **kwargs)
+        return validationPlugin.validateXbrlFinally(val, *args, **kwargs)
 
     @staticmethod
     def validateFinally(
@@ -404,31 +391,7 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if not shouldRunEsefValidationRules(val):
-            return None
-        if val.unconsolidated:
-            return None
-        modelXbrl = val.modelXbrl
-        modelDocument = getattr(modelXbrl, "modelDocument")
-        if (modelDocument is None or not modelXbrl.facts) and "ESEF.RTS.Art.6.a.noInlineXbrlTags" not in modelXbrl.errors:
-            modelXbrl.error("ESEF.RTS.Art.6.a.noInlineXbrlTags",
-                            _("RTS on ESEF requires inline XBRL, no facts were reported."),
-                            modelObject=modelXbrl)
-            return # never loaded properly
-
-        disclosureSystemYear = getDisclosureSystemYear(modelXbrl)
-        if disclosureSystemYear >= 2025:
-            numDupIdErrors = sum(dupIdErrorPattern.match(e) is not None for e in modelXbrl.errors if isinstance(e,str))
-            if numDupIdErrors:
-                modelXbrl.warning("ESEF.2.2.8.duplicatedIdAttribute",
-                                _("ID attributes should be unique, %(numDupIdErrors)s such errors were reported."),
-                                modelObject=modelXbrl, numDupIdErrors=numDupIdErrors)
-
-        numXbrlErrors = sum(ixErrorPattern.match(e) is not None for e in modelXbrl.errors if isinstance(e,str))
-        if numXbrlErrors:
-            modelXbrl.error("ESEF.RTS.Annex.III.Par.1.invalidInlineXBRL",
-                            _("RTS on ESEF requires valid XBRL instances, %(numXbrlErrors)s errors were reported."),
-                            modelObject=modelXbrl, numXbrlErrors=numXbrlErrors)
+        return validationPlugin.validateFinally(val, *args, **kwargs)
 
     @staticmethod
     def validateFormulaCompiled(
@@ -480,9 +443,19 @@ class ESEFPlugin(PluginHooks):
         rptPkgIxdsOptions["combineIntoSingleIxds"] = True
 
 
+validationPlugin = ValidationPluginExtension(
+    name=ESEF_PLUGIN_NAME,
+    disclosureSystemConfigUrl=Path(__file__).parent / "resources" / "config.xml",
+    validationTypes=[DISCLOSURE_SYSTEM_VALIDATION_TYPE],
+    validationRuleModules=[
+        base
+    ],
+)
+
+
 __pluginInfo__ = {
     # Do not use _( ) in pluginInfo itself (it is applied later, after loading
-    "name": "Validate ESMA ESEF",
+    "name": ESEF_PLUGIN_NAME,
     "aliases": [
         # Aliases for when ESEF validation was handled by multiple plugins.
         "Validate ESMA ESEF-2022",
@@ -493,19 +466,19 @@ __pluginInfo__ = {
     "license": "Apache-2",
     "author": authorLabel,
     "copyright": copyrightLabel,
+    "import": ("inlineXbrlDocumentSet",),  # import dependent modules
+    # classes of mount points (required)
     "CntlrCmdLine.Options": ESEFPlugin.cntlrCmdLineOptions,
     "CntlrCmdLine.Utility.Run": ESEFPlugin.cntlrCmdLineUtilityRun,
     "CntlrWinMain.Menu.Validation": ESEFPlugin.cntlrWinMainMenuValidation,
-    "ModelDocument.PullLoader": ESEFPlugin.modelDocumentPullLoader,
-    "import": ("inlineXbrlDocumentSet",),  # import dependent modules
-    # classes of mount points (required)
-    "DisclosureSystem.Types": ESEFPlugin.disclosureSystemTypes,
     "DisclosureSystem.ConfigURL": ESEFPlugin.disclosureSystemConfigURL,
+    "DisclosureSystem.Types": ESEFPlugin.disclosureSystemTypes,
+    "ModelDocument.PullLoader": ESEFPlugin.modelDocumentPullLoader,
+    "ModelTestcaseVariation.ReportPackageIxdsOptions": ESEFPlugin.modelTestcaseVariationReportPackageIxdsOptions,
     "ModelXbrl.LoadComplete": ESEFPlugin.modelXbrlLoadComplete,
-    "Validate.XBRL.Start": ESEFPlugin.validateXbrlStart,
+    "Validate.Finally": ESEFPlugin.validateFinally,  # run *after* formula processing
     "Validate.XBRL.Finally": ESEFPlugin.validateXbrlFinally,  # before formula processing
+    "Validate.XBRL.Start": ESEFPlugin.validateXbrlStart,
     "ValidateFormula.Compiled": ESEFPlugin.validateFormulaCompiled,
     "ValidateFormula.Finished": ESEFPlugin.validateFormulaFinished,  # after formula processing
-    "Validate.Finally": ESEFPlugin.validateFinally,  # run *after* formula processing
-    "ModelTestcaseVariation.ReportPackageIxdsOptions": ESEFPlugin.modelTestcaseVariationReportPackageIxdsOptions,
 }

--- a/arelle/plugin/validate/ESEF/rules/base.py
+++ b/arelle/plugin/validate/ESEF/rules/base.py
@@ -1,0 +1,86 @@
+import re
+from typing import Any
+
+from collections.abc import Iterable
+
+from arelle.ValidateXbrl import ValidateXbrl
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from ..ESEF_2021.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinally2021
+from ..ESEF_Current.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinallyCurrent
+from ..PluginValidationDataExtension import PluginValidationDataExtension
+from ..Util import getDisclosureSystemYear, shouldRunEsefValidationRules
+
+_: TypeGetText
+
+ixErrorPattern = re.compile(r"ix11[.]|xmlSchema[:]|(?!xbrl.5.2.5.2|xbrl.5.2.6.2)xbrl[.]|xbrld[ti]e[:]|utre[:]")
+dupIdErrorPattern = re.compile(r"xml.3.3.1:idMustBeUnique|ix11.14.1.2:uniqueIxId")
+
+
+@validation(
+    hook=ValidationHook.FINALLY,
+)
+def rule_finally(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation]:
+    """
+    """
+    if not shouldRunEsefValidationRules(val):
+        return
+    if val.unconsolidated:
+        return
+    modelXbrl = val.modelXbrl
+    modelDocument = getattr(modelXbrl, "modelDocument")
+    if (modelDocument is None or not modelXbrl.facts) and "ESEF.RTS.Art.6.a.noInlineXbrlTags" not in modelXbrl.errors:
+        yield Validation.error(
+            "ESEF.RTS.Art.6.a.noInlineXbrlTags",
+            _("RTS on ESEF requires inline XBRL, no facts were reported."),
+            modelObject=modelXbrl
+        )
+        return # never loaded properly
+
+    disclosureSystemYear = getDisclosureSystemYear(modelXbrl)
+    if disclosureSystemYear >= 2025:
+        numDupIdErrors = sum(dupIdErrorPattern.match(e) is not None for e in modelXbrl.errors if isinstance(e,str))
+        if numDupIdErrors:
+            yield Validation.warning(
+                "ESEF.2.2.8.duplicatedIdAttribute",
+                  _("ID attributes should be unique, %(numDupIdErrors)s such errors were reported."),
+                  modelObject=modelXbrl,
+                numDupIdErrors=numDupIdErrors
+            )
+
+    numXbrlErrors = sum(ixErrorPattern.match(e) is not None for e in modelXbrl.errors if isinstance(e,str))
+    if numXbrlErrors:
+        yield Validation.error(
+            "ESEF.RTS.Annex.III.Par.1.invalidInlineXBRL",
+            _("RTS on ESEF requires valid XBRL instances, %(numXbrlErrors)s errors were reported."),
+            modelObject=modelXbrl,
+            numXbrlErrors=numXbrlErrors
+        )
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_xbrl_finally(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation]:
+    """
+    """
+    if not shouldRunEsefValidationRules(val):
+        return
+    disclosureSystemYear = getDisclosureSystemYear(val.modelXbrl)
+    if disclosureSystemYear == 2021:
+        validateXbrlFinally2021(val, *args, **kwargs)
+    else:
+        validateXbrlFinallyCurrent(val, *args, **kwargs)
+    yield from iter([])

--- a/arelle/plugin/validate/ESEF/rules/base.py
+++ b/arelle/plugin/validate/ESEF/rules/base.py
@@ -1,3 +1,6 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
 import re
 from typing import Any
 
@@ -29,6 +32,9 @@ def rule_finally(
         **kwargs: Any,
 ) -> Iterable[Validation]:
     """
+    Performs final ESEF validation checks after all other validation has completed.
+
+    Skips validation for unconsolidated reports or when ESEF rules are not applicable.
     """
     if not shouldRunEsefValidationRules(val):
         return
@@ -75,6 +81,9 @@ def rule_xbrl_finally(
         **kwargs: Any,
 ) -> Iterable[Validation]:
     """
+    Dispatches validations to the appropriate year-specific implementation.
+
+    Skips validation when ESEF rules are not applicable.
     """
     if not shouldRunEsefValidationRules(val):
         return


### PR DESCRIPTION
#### Reason for change
The ESEF plugin predates the `ValidationPlugin` architecture and doesn't benefit from some of the design patterns introduced in it.

#### Description of change
This PR is intended to be a least-friction pathway towards using the `ValidationPlugin` architecture while having as little as possible effect on behavior.

#### Steps to Test
- [x] CI
- [x] GUI testing

**review**:
@Arelle/arelle