### PR TITLE
Specify region for public/private arelle S3 bucket clients

### DIFF
--- a/.github/workflows/conformance-suite.yml
+++ b/.github/workflows/conformance-suite.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
       - name: Test Conformance Suite
         uses: ./.github/actions/test_conformance_suite
         with:

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
       - name: Test Conformance Suite
         uses: ./.github/actions/test_conformance_suite
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,7 +79,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
       - name: Test Conformance Suite
         uses: ./.github/actions/test_conformance_suite
         with:
@@ -113,7 +112,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
       - name: Test Script
         uses: ./.github/actions/test_script
         with:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
       - name: Test Script
         uses: ./.github/actions/test_script
         with:

--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -80,6 +80,7 @@ _S3_BASE_CONFIG = BotocoreConfig(
 
 
 _PRIVATE_S3_CLIENT: S3Client | None = None
+_S3_BUCKET_REGION = "us-east-1"
 
 
 def _get_private_s3_client() -> S3Client:
@@ -87,6 +88,7 @@ def _get_private_s3_client() -> S3Client:
     if _PRIVATE_S3_CLIENT is None:
         _PRIVATE_S3_CLIENT = boto3.client(
             service_name="s3",
+            region_name=_S3_BUCKET_REGION,
             config=_S3_BASE_CONFIG,
         )
     return _PRIVATE_S3_CLIENT
@@ -100,6 +102,7 @@ def _get_public_s3_client() -> S3Client:
     if _PUBLIC_S3_CLIENT is None:
         _PUBLIC_S3_CLIENT = boto3.client(
             service_name="s3",
+            region_name=_S3_BUCKET_REGION,
             config=_S3_BASE_CONFIG.merge(BotocoreConfig(signature_version=UNSIGNED)),
         )
     return _PUBLIC_S3_CLIENT


### PR DESCRIPTION
#### Reason for change
Running test scripts locally may fail if downloading assets from S3 is required.

Example:
```bash
python "./tests/integration_tests/scripts/tests/webserver_validate_esef.py" --arelle python arelleCmdLine.py --download-cache --offline 
```
Result:
```
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "https://arelle-public.s3.None.amazonaws.com/ci/packages/python_api_validate_esef.zip?versionId=U3sEz.B8kjUWw0l6momz87EndK05cxFZ"
```
The workaround is to provide `AWS_DEFAULT_REGION=us-east-1`, but since the region is already coupled to the hardcoded bucket name, we should just hardcode the region as well.

#### Steps to Test
Example above should pass without needing an environment variable set.

**review**:
@Arelle/arelle
