### PR TITLE
GUI: Multi-select packages and save on close

### DIFF
--- a/arelle/DialogPackageManager.py
+++ b/arelle/DialogPackageManager.py
@@ -384,8 +384,9 @@ class DialogPackageManager(Toplevel):
         initialdir = self.cntlr.pluginDir # default plugin directory
         #if not self.cntlr.isMac: # can't navigate within app easily, always start in default directory
         initialdir = self.cntlr.config.setdefault("packageOpenDir", initialdir)
-        filename = self.cntlr.uiFileDialog("open",
+        filenames = self.cntlr.uiFileDialog("open",
                                            parent=self,
+                                           multiple=True,
                                            title=_("Choose taxonomy package file"),
                                            initialdir=initialdir,
                                            filetypes=[(_("Taxonomy package files (*.zip)"), "*.zip"),
@@ -393,7 +394,7 @@ class DialogPackageManager(Toplevel):
                                                       (_("pre-PWD Manifest (*.taxonomyPackage.xml)"), "*.taxonomyPackage.xml"),
                                                       (_("pre-PWD Oasis Catalog (*catalog.xml)"), "*catalog.xml")],
                                            defaultextension=".zip")
-        if filename:
+        for filename in filenames:
             # check if a package is selected (any file in a directory containing an __init__.py
             self.cntlr.config["packageOpenDir"] = os.path.dirname(filename)
             packageInfo = self._packageManager.packageInfo(self.cntlr, filename, packageManifestName=self.manifestNamePattern)

--- a/arelle/DialogPackageManager.py
+++ b/arelle/DialogPackageManager.py
@@ -266,6 +266,7 @@ class DialogPackageManager(Toplevel):
         if self.packagesConfigChanged:
             self._packageManager.packagesConfig = self.packagesConfig
             self._packageManager.packagesConfigChanged = True
+            self._packageManager.save(self.cntlr)
             self.cntlr.onPackageEnablementChanged()
         self.close()
 


### PR DESCRIPTION
#### Reason for change
Selecting packages through the "Locally" menu requires selecting one package at a time. 

Additionally, package selections/settings aren't saved to disk when closing the package manager, which can result in loss of package configuration changes depending on how the application ultimately exits. 

#### Description of change
- Configure local package selection dialog to be multi-select.
- Save package config changes when closing (not cancelling) the package manager dialog.

#### Steps to Test
- [x] Tested on Mac OS and Windows.

**review**:
@Arelle/arelle
