### PR TITLE
Restore CI AWS auth region

### DIFF
--- a/.github/workflows/conformance-suite.yml
+++ b/.github/workflows/conformance-suite.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-east-1
       - name: Test Conformance Suite
         uses: ./.github/actions/test_conformance_suite
         with:

--- a/.github/workflows/conformance-suites.yml
+++ b/.github/workflows/conformance-suites.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-east-1
       - name: Test Conformance Suite
         uses: ./.github/actions/test_conformance_suite
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-east-1
       - name: Test Conformance Suite
         uses: ./.github/actions/test_conformance_suite
         with:
@@ -112,6 +113,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-east-1
       - name: Test Script
         uses: ./.github/actions/test_script
         with:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-east-1
       - name: Test Script
         uses: ./.github/actions/test_script
         with:


### PR DESCRIPTION
#### Reason for change
[CI is failing](https://github.com/Arelle/Arelle/actions/runs/28109581143/job/83233133674?pr=2434) with:
```
Run aws-actions/configure-aws-credentials@v6.2.0
Error: Input required and not supplied: aws-region
```

#### Description of change
* Add AWS region setting back to `aws-actions/configure-aws-credentials`

#### Steps to Test
* CI (will fail until merged into master) 

**review**:
@Arelle/arelle
