### PR TITLE
Initialize table rendering for supplemental IXDS target models

### DIFF
--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -2033,6 +2033,9 @@ class CntlrCmdLine(Cntlr.Cntlr):
                                             messageCode="info", file=self.entrypointFile)  # type: ignore[arg-type]
                 if modelXbrl.hasTableRendering:
                     RenderingEvaluator.init(modelXbrl)  # type: ignore[no-untyped-call]
+                for supplementalModel in getattr(modelXbrl, "supplementalModelXbrls", []):
+                    if supplementalModel.hasTableRendering:
+                        RenderingEvaluator.init(supplementalModel)  # type: ignore[no-untyped-call]
                 if options.importFiles:
                     for importFile in options.importFiles.split("|"):
                         fileName = importFile.strip()

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -1007,7 +1007,13 @@ class CntlrWinMain(Cntlr.Cntlr):
             self.addToLog(format_string(self.modelManager.locale,
                                         _("%s in %.2f secs"),
                                         (action, statTime)))
-            modelsWithTableRendering = [model for model in loadedModels if model.hasTableRendering]
+            modelsWithTableRendering = []
+            for model in loadedModels:
+                if model.hasTableRendering:
+                    modelsWithTableRendering.append(model)
+                for supplementalModel in getattr(model, "supplementalModelXbrls", []):
+                    if supplementalModel.hasTableRendering:
+                        modelsWithTableRendering.append(supplementalModel)
             if modelsWithTableRendering:
                 self.showStatus(_("Initializing table rendering"))
                 for model in modelsWithTableRendering:

--- a/arelle/ViewFileRenderedStructure.py
+++ b/arelle/ViewFileRenderedStructure.py
@@ -64,6 +64,8 @@ class ViewRenderedStructuralModel(ViewFile.View):
             self.zOrdinateChoices = {}
 
             strctMdlTable = resolveTableStructure(self, tblELR)
+            if strctMdlTable is None:
+                continue
 
             # uncomment below for debugging Definition and Structural Models
             def jsonStrctMdlEncoder(obj, indent="\n"):

--- a/arelle/rendering/RenderingLayout.py
+++ b/arelle/rendering/RenderingLayout.py
@@ -52,6 +52,8 @@ def layoutTable(view, table = None):
 
     for tblELR in tblELRs:
         strctMdlTableSet = resolveTableStructure(view, tblELR)
+        if strctMdlTableSet is None:
+            continue
         # each table z production
         defnMdlTable = strctMdlTableSet.defnMdlNode
         view.hasTableFilters = bool(view.defnMdlTable.filterRelationships)

--- a/arelle/rendering/RenderingResolution.py
+++ b/arelle/rendering/RenderingResolution.py
@@ -69,6 +69,9 @@ def resolveTableStructure(view, viewTblELR):
     try:
         for defnMdlTable in tblBrkdnRelSet.rootConcepts:
             view.rendrCntx = defnMdlTable.renderingXPathContext
+            if view.rendrCntx is None:
+                view.modelXbrl.modelManager.addToLog(_("no rendering context for {0}").format(viewTblELR))
+                return None
             strctMdlTableSet = StrctMdlTableSet(defnMdlTable)
             referencedVariables = defnMdlTable.variableRefs()
             for tblParamRel in view.modelXbrl.relationshipSet((XbrlConst.tableParameter, XbrlConst.tableParameterMMDD)).fromModelObject(defnMdlTable):


### PR DESCRIPTION
#### Reason for change

Table linkbase wasn't handled for supplemental models (multi-target).

```python
Exception preparing view of concepts: 'NoneType' object has no attribute 'modelXbrl', at Traceback (most recent call last):
  File "/Users/runner/work/Arelle/Arelle/arelle/CntlrWinMain.py", line 1079, in showLoadedXbrl
  File "/Users/runner/work/Arelle/Arelle/arelle/ViewWinRenderedGrid.py", line 91, in viewRenderedGrid
  File "/Users/runner/work/Arelle/Arelle/arelle/ViewWinRenderedGrid.py", line 209, in view
  File "/Users/runner/work/Arelle/Arelle/arelle/rendering/RenderingLayout.py", line 54, in layoutTable
  File "/Users/runner/work/Arelle/Arelle/arelle/rendering/RenderingResolution.py", line 89, in resolveTableStructure
  File "/Users/runner/work/Arelle/Arelle/arelle/rendering/RenderingResolution.py", line 135, in resolveTableAxesStructure
  File "/Users/runner/work/Arelle/Arelle/arelle/ModelRenderingObject.py", line 790, in filteredFacts
  File "/Users/runner/work/Arelle/Arelle/arelle/formula/FormulaEvaluator.py", line 1535, in __init__
AttributeError: 'NoneType' object has no attribute 'modelXbrl'
```

#### Description of change
* Initialize table linkbase rendering for reports with supplemental models (multi-target).
* Handle edge cases where dts includes table linkbase, but no rels.

#### Steps to Test
* [x] verify internal testing doc no longer raises `AttributeError` exception 

**review**:
@Arelle/arelle
