### PR TITLE
Base XSD type validation: `Name` permits a leading colon

### DIFF
--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -114,7 +114,7 @@ QNamePattern = re_compile("^([_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0
                           "[_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF]"
                             r"[_\-\."
                                "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\u0300-\u036F\u203F-\u2040]*$")
-namePattern = re_compile("^[_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF]"
+namePattern = re_compile("^[:_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF]"
                             r"[_\-\.:"
                                "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\u0300-\u036F\u203F-\u2040]*$")
 

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -323,6 +323,7 @@ BASE_XSD_TYPES = {
     ],
     "NCName": [
         {"value": "*invalid", "expected": ("=", None, INVALID)},
+        {"value": ":invalid", "expected": ("=", None, INVALID)},
         {"value": "valid", "expected": ("=", "=", VALID)},
     ],
     "negativeInteger": [

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -319,6 +319,7 @@ BASE_XSD_TYPES = {
     "Name": [
         {"value": "*invalid", "expected": ("=", None, INVALID)},
         {"value": "valid", "expected": ("=", "=", VALID)},
+        {"value": ":valid", "expected": ("=", "=", VALID)},
     ],
     "NCName": [
         {"value": "*invalid", "expected": ("=", None, INVALID)},


### PR DESCRIPTION
Part of #2445 

## Fix 1 — `Name` permits a leading colon

**Where:** `namePattern` (module-level compiled regex used as the lexical pattern
for `baseXsdType == "Name"`).

**Symptom:** the value space of `xsd:Name` was under-accepted — a `Name` beginning
with `:` (e.g. `:foo`) was rejected, although it is lexically valid.

**Change:** add `:` to the *first* character class of `namePattern` (the
NameStartChar position). The trailing class (NameChar) already permitted `:`.

```text
before:  ^[_A-Za-z…][ _-.: … ]*$
after:   ^[:_A-Za-z…][ _-.: … ]*$
              ^ colon added to the start-character class
```

**Normative basis:**

- XML 1.0 §2.3 *Common Syntactic Constructs*, production [4]:

  ```
  NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | …
  NameChar      ::= NameStartChar | "-" | "." | [0-9] | #xB7 | …
  ```

  `":"` is the **first** alternative of `NameStartChar`, so a `Name` may begin with
  a colon. <https://www.w3.org/TR/xml/#NT-NameStartChar>

- XSD 2 §3.3.7 *Name*: "Name represents XML Names. The value space of Name is the
  set of all strings which match the Name production of [XML 1.0]."
  <https://www.w3.org/TR/xmlschema-2/#Name>

- Contrast XSD 2 §3.3.8 *NCName*: "the set of all strings which match the NCName
  production" — i.e. `Name` *minus the colon*. The existence of a separate, colon-
  excluding `NCName` is precisely because `Name` itself **includes** the colon.
  <https://www.w3.org/TR/xmlschema-2/#NCName>

**Independent check:** the first character of `:foo` is `:`, which appears verbatim
in production [4] `NameStartChar`; the remaining characters `f`, `o`, `o` are
`[a-z]` ⊂ `NameChar`. Therefore `:foo` matches `Name ::= NameStartChar NameChar*`
and must be accepted. (NCName, by contrast, must still reject `:foo` — see Fix 2.)



#### Steps to Test
CI

**review**:
@Arelle/arelle
