### PR TITLE
Make package loading more resilient to invalid metadata files

### DIFF
--- a/arelle/DialogPackageManager.py
+++ b/arelle/DialogPackageManager.py
@@ -424,7 +424,7 @@ class DialogPackageManager(Toplevel):
             self.loadTreeViews()
         else:
             messagebox.showwarning(_("Package is not a taxonomy package."),
-                                   _("The selected file is not a taxonomy package. It does not contain a manifest file: \n\n{0}\n\n")
+                                   _("The selected file is not a taxonomy package. It does not contain a valid manifest file. See messages panel for more details. \n\n{0}\n\n")
                                    .format(url),
                                    parent=self)
 

--- a/arelle/packages/_package_manager.py
+++ b/arelle/packages/_package_manager.py
@@ -626,7 +626,8 @@ class PackageManager:
                         self._getCntlr(), filesource, packageFileUrl, packageFilePrefix, errors
                     )
                     if parsedPackage:
-                        packageNames.append(str(parsedPackage['name']))
+                        if parsedPackage.get("name"):
+                            packageNames.append(str(parsedPackage['name']))
                         if parsedPackage.get('description'):
                             descriptions.append(str(parsedPackage['description']))
                         _remappings = parsedPackage["remappings"]


### PR DESCRIPTION
#### Reason for change
Part of #2441 

When Arelle decides to quit early while parsing a invalid taxonomy package metadata file, it should log the error but make a best effort to continue loading the package and operating.

#### Description of change
Handle scenarios where the `name` was not parsed from package metadata.

Similarly, update GUI messaging to be clear that a *valid* manifest file was not found.

#### Steps to Test
- Recreate error as described in linked issue
- Confirm these changes result in logged error and/or polite error message.

**review**:
@Arelle/arelle
