### PR TITLE
Base XSD type validation: XSD regex escape `\i` includes colon

### DIFF
--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -31,11 +31,11 @@ if TYPE_CHECKING:
 
 _: TypeGetText
 
-# patterns to replace \c and \i in names
-iNameCharColon = "[:_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]"
-iNameChar = "[_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]"
-cNameChar = r"[_\-\.:"   "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040]"
-cMinusCNameChar = r"[_\-\."   "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040]"
+# XSD Part 2 Appendix F name-character escapes (\i, \c) → Python character classes.
+iNameChar = "[:_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]"  # \i
+iNameCharMinusColon = iNameChar.replace("[:", "[", 1)  # [\i-[:]]
+cNameChar = r"[:_\-\."   "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040]"  # \c
+cNameCharMinusColon = cNameChar.replace("[:", "[", 1)  # [\c-[:]]
 
 def _raiseOnNonXsdRegexSyntax(p: str) -> None:
     """
@@ -60,10 +60,22 @@ class XsdPattern:
     # shim class for python wrapper of xsd pattern
     @classmethod
     def compile(cls, p: str) -> XsdPattern:
+        """Expand XSD \\i and \\c escapes to Python character classes.
+
+        Per XSD Part 2 Appendix F:
+          \\i           → NameStartChar (Letter | '_' | ':')
+          [\\i-[:]]     → NCName start (NameStartChar minus ':')
+          \\c           → NameChar (includes ':')
+          [\\c-[:]]     → NameChar minus ':'
+
+        Subtract forms are replaced first so bare \\i/\\c inside them are not touched.
+        """
         _raiseOnNonXsdRegexSyntax(p)
         if r"\i" in p or r"\c" in p:
-            p = p.replace(r"[\i-[:]]", iNameChar).replace(r"\i", iNameCharColon) \
-                 .replace(r"[\c-[:]]", cMinusCNameChar).replace(r"\c", cNameChar)
+            p = (p.replace(r"[\i-[:]]", iNameCharMinusColon)
+                 .replace(r"\i", iNameChar)
+                 .replace(r"[\c-[:]]", cNameCharMinusColon)
+                 .replace(r"\c", cNameChar))
         pyPattern = re_compile(p + "$") # must match whole string
         return cls(p, pyPattern)
 

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 _: TypeGetText
 
 # patterns to replace \c and \i in names
+iNameCharColon = "[:_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]"
 iNameChar = "[_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]"
 cNameChar = r"[_\-\.:"   "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040]"
 cMinusCNameChar = r"[_\-\."   "\xB7A-Za-z0-9\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\u0300-\u036F\u203F-\u2040]"
@@ -61,7 +62,7 @@ class XsdPattern:
     def compile(cls, p: str) -> XsdPattern:
         _raiseOnNonXsdRegexSyntax(p)
         if r"\i" in p or r"\c" in p:
-            p = p.replace(r"[\i-[:]]", iNameChar).replace(r"\i", iNameChar) \
+            p = p.replace(r"[\i-[:]]", iNameChar).replace(r"\i", iNameCharColon) \
                  .replace(r"[\c-[:]]", cMinusCNameChar).replace(r"\c", cNameChar)
         pyPattern = re_compile(p + "$") # must match whole string
         return cls(p, pyPattern)

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -778,6 +778,19 @@ def test_validateValueString(
     assert result.isXValid == (expectedXValid >= VALID)
 
 
+class TestXsdPatternNameEscapes:
+    @pytest.mark.parametrize(
+        "pattern,value,expected_match",
+        [
+            (r"\i\c*", ":foo", True),
+            (r"[\i-[:]][\c-[:]]*", ":foo", False),
+        ],
+    )
+    def test_leading_colon(self, pattern: str, value: str, expected_match: bool):
+        compiled = XsdPattern.compile(pattern)
+        assert (compiled.match(value) is not None) == expected_match
+
+
 class TestValidateFacetValueString:
     def test_length(self):
         result = validateFacetValueString("length", "3", "string")


### PR DESCRIPTION
Part of #2445 

> [!IMPORTANT]
> First commit is the minimal change necessary to address the issue.
> Second commit is a slight refactor for readability. 

## Fix 2 — XSD regex escape `\i` includes the colon

**Where:** `XsdPattern.compile` — translation of XSD pattern escapes `\i` / `\c`
into Python character classes. Supporting constant `iNameCharColon` added.

**Symptom:** a schema `pattern` facet using `\i` (e.g. `\i\c{52}`) was compiled with
a colon-less initial-character class, so an otherwise-conforming value whose first
character is `:` failed the pattern. (`\c` was already correct.)

**Change:** introduce a colon-inclusive initial-name-character class and use it for
the *bare* `\i`, while the colon-subtracted form `[\i-[:]]` keeps the colon-less
class:

```text
before:  …replace("[\i-[:]]", iNameChar).replace("\i", iNameChar)…
after:   …replace("[\i-[:]]", iNameChar).replace("\i", iNameCharColon)…
                                                       ^ colon-inclusive set
```

This mirrors the already-correct asymmetry for `\c`: bare `\c` → `cNameChar` (with
colon), `[\c-[:]]` → `cMinusCNameChar` (without).

**Normative basis:**

- XSD 2 Appendix F *Regular Expressions*, F.1 *Character Class Escapes* defines the
  multi-character escapes and gives the equivalences:

  - `Name` is matched by `\i\c*`
  - `NCName` is matched by `[\i-[:]][\c-[:]]*`

  <https://www.w3.org/TR/xmlschema-2/#regexs>

  Because `\i\c*` is the `Name` production (Fix 1: `Name` allows a leading colon),
  `\i` **must include** `:`. The need to write `[\i-[:]]` — *`\i` with the colon
  removed* — to obtain the `NCName` start character is direct, normative evidence
  that `:` ∈ `\i`. (Equivalently `\i` ≡ `Letter | '_' | ':'`.)

- XSD 1.1 D Appendix G states the same escapes and `Name`/`NCName` equivalences.
  <https://www.w3.org/TR/xmlschema11-2/#regexs>

**Independent check:** expand `\i\c{52}` per the spec equivalence: `\i` =
`Letter | '_' | ':'` and `\c` = `NameChar`. A 53-character string whose first
character is `:` (a member of `\i`) followed by 52 `NameChar`s matches `\i\c{52}`.
The colon-subtracted variant `[\i-[:]]` must continue to reject a leading `:`,
preserving correct `NCName` behavior.


#### Steps to Test
CI

**review**:
@Arelle/arelle
