### PR TITLE
Enforce ordering facets on date/time and other ordered types

### DIFF
--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -475,7 +475,9 @@ def _orderedComparison(value: Any, bound: Any) -> int | None:
     """Order ``value`` against an ordering-facet ``bound``.
 
     Returns ``-1``/``0``/``1`` when ``value`` is less than/equal to/greater than
-    ``bound``, or ``None`` when the order is indeterminate.
+    ``bound``, or ``None`` when the order is indeterminate. Callers should treat
+    ``None`` as failing whichever relation the facet requires (Datatypes 3.2.6.3:
+    "indeterminate comparisons should be considered as 'false'").
 
     Ordinarily the operands' own comparison operators are used. For an xs:date/time
     value where exactly one operand carries a timezone, Python raises ``TypeError``
@@ -712,15 +714,17 @@ def _validateValueStringOrRaise(
             sValue = value
             if facets: # ordering facets on date/time/gYear/... (xValue is a comparable type)
                 # _orderedComparison tolerates xs:date/time values that mix timezoned and
-                # untimezoned operands (which Python won't order); an indeterminate order is
-                # treated as satisfying the facet rather than crashing or wrongly rejecting.
-                if "maxInclusive" in facets and _orderedComparison(xValue, facets["maxInclusive"]) == 1:
+                # untimezoned operands (which Python won't order); per XSD Datatypes 3.2.6.3
+                # ("indeterminate comparisons should be considered as 'false'") an
+                # indeterminate order fails the facet test, so the value is rejected rather
+                # than accepted or crashing.
+                if "maxInclusive" in facets and _orderedComparison(xValue, facets["maxInclusive"]) not in (-1, 0):
                     raise ValueError(" > maxInclusive {0}".format(facets["maxInclusive"]))
-                if "maxExclusive" in facets and _orderedComparison(xValue, facets["maxExclusive"]) in (0, 1):
+                if "maxExclusive" in facets and _orderedComparison(xValue, facets["maxExclusive"]) != -1:
                     raise ValueError(" >= maxExclusive {0}".format(facets["maxExclusive"]))
-                if "minInclusive" in facets and _orderedComparison(xValue, facets["minInclusive"]) == -1:
+                if "minInclusive" in facets and _orderedComparison(xValue, facets["minInclusive"]) not in (0, 1):
                     raise ValueError(" < minInclusive {0}".format(facets["minInclusive"]))
-                if "minExclusive" in facets and _orderedComparison(xValue, facets["minExclusive"]) in (0, -1):
+                if "minExclusive" in facets and _orderedComparison(xValue, facets["minExclusive"]) != 1:
                     raise ValueError(" <= minExclusive {0}".format(facets["minExclusive"]))
     return XmlValidationResult(sValue=sValue, xValue=xValue, xValid=xValid)
 

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -653,6 +653,15 @@ def _validateValueStringOrRaise(
             else: # no lexical pattern, forget compiling value
                 xValue = value
             sValue = value
+            if facets: # ordering facets on date/time/gYear/... (xValue is a comparable type)
+                if "maxInclusive" in facets and xValue > facets["maxInclusive"]:
+                    raise ValueError(" > maxInclusive {0}".format(facets["maxInclusive"]))
+                if "maxExclusive" in facets and xValue >= facets["maxExclusive"]:
+                    raise ValueError(" >= maxExclusive {0}".format(facets["maxExclusive"]))
+                if "minInclusive" in facets and xValue < facets["minInclusive"]:
+                    raise ValueError(" < minInclusive {0}".format(facets["minInclusive"]))
+                if "minExclusive" in facets and xValue <= facets["minExclusive"]:
+                    raise ValueError(" <= minExclusive {0}".format(facets["minExclusive"]))
     return XmlValidationResult(sValue=sValue, xValue=xValue, xValid=xValid)
 
 

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -3,6 +3,7 @@ See COPYRIGHT.md for copyright information.
 '''
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass
 import logging
 from collections.abc import Callable, Mapping
@@ -451,6 +452,62 @@ def fractionValidateValue(value: str, fractionValue: tuple[str, str]) -> XmlVali
     return XmlValidationResult(sValue=sValue, xValue=xValue, xValid=xValid)
 
 
+# XSD Datatypes 3.2.7.4: a date/time value with no timezone may stand for any
+# timezone in the [-14:00, +14:00] range, so its instant is only known to within 14h.
+_XSD_MAX_TIMEZONE_OFFSET = datetime.timedelta(hours=14)
+
+
+def _comparableInstant(value: datetime.datetime | datetime.time) -> datetime.datetime:
+    # Express an xs:dateTime/date/time value as a single datetime so values can be
+    # ordered: timezone-aware values are normalized to (naive) UTC; an xs:time is
+    # anchored to an arbitrary fixed date (XSD Datatypes 3.2.8).
+    # Timezone-naive values are left as-is.
+    if isinstance(value, datetime.datetime):
+        dt = value
+    else:  # datetime.time (xs:time)
+        dt = datetime.datetime(2000, 1, 1, value.hour, value.minute, value.second, value.microsecond, value.tzinfo)
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _orderedComparison(value: Any, bound: Any) -> int | None:
+    """Order ``value`` against an ordering-facet ``bound``.
+
+    Returns ``-1``/``0``/``1`` when ``value`` is less than/equal to/greater than
+    ``bound``, or ``None`` when the order is indeterminate.
+
+    Ordinarily the operands' own comparison operators are used. For an xs:date/time
+    value where exactly one operand carries a timezone, Python raises ``TypeError``
+    rather than ordering offset-naive against offset-aware values; in that case apply
+    the XSD timezone-straddling rule (Datatypes 3.2.7.4) on the underlying instants,
+    yielding ``None`` when the timezone uncertainty leaves the order undetermined.
+    """
+    try:
+        if value < bound:
+            return -1
+        if value > bound:
+            return 1
+        return 0
+    except TypeError:
+        if not isinstance(value, (datetime.datetime, datetime.time)) or \
+                not isinstance(bound, (datetime.datetime, datetime.time)):
+            raise
+        valueInstant = _comparableInstant(value)
+        boundInstant = _comparableInstant(bound)
+        if value.tzinfo is not None:  # bound is the timezone-naive operand
+            if valueInstant < boundInstant - _XSD_MAX_TIMEZONE_OFFSET:
+                return -1
+            if valueInstant > boundInstant + _XSD_MAX_TIMEZONE_OFFSET:
+                return 1
+        else:  # value is the timezone-naive operand
+            if valueInstant + _XSD_MAX_TIMEZONE_OFFSET < boundInstant:
+                return -1
+            if valueInstant - _XSD_MAX_TIMEZONE_OFFSET > boundInstant:
+                return 1
+        return None
+
+
 def validateValueString(
     baseXsdType: str,
     value: str,
@@ -654,13 +711,16 @@ def _validateValueStringOrRaise(
                 xValue = value
             sValue = value
             if facets: # ordering facets on date/time/gYear/... (xValue is a comparable type)
-                if "maxInclusive" in facets and xValue > facets["maxInclusive"]:
+                # _orderedComparison tolerates xs:date/time values that mix timezoned and
+                # untimezoned operands (which Python won't order); an indeterminate order is
+                # treated as satisfying the facet rather than crashing or wrongly rejecting.
+                if "maxInclusive" in facets and _orderedComparison(xValue, facets["maxInclusive"]) == 1:
                     raise ValueError(" > maxInclusive {0}".format(facets["maxInclusive"]))
-                if "maxExclusive" in facets and xValue >= facets["maxExclusive"]:
+                if "maxExclusive" in facets and _orderedComparison(xValue, facets["maxExclusive"]) in (0, 1):
                     raise ValueError(" >= maxExclusive {0}".format(facets["maxExclusive"]))
-                if "minInclusive" in facets and xValue < facets["minInclusive"]:
+                if "minInclusive" in facets and _orderedComparison(xValue, facets["minInclusive"]) == -1:
                     raise ValueError(" < minInclusive {0}".format(facets["minInclusive"]))
-                if "minExclusive" in facets and xValue <= facets["minExclusive"]:
+                if "minExclusive" in facets and _orderedComparison(xValue, facets["minExclusive"]) in (0, -1):
                     raise ValueError(" <= minExclusive {0}".format(facets["minExclusive"]))
     return XmlValidationResult(sValue=sValue, xValue=xValue, xValid=xValid)
 

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -474,6 +474,12 @@ def _comparableInstant(value: datetime.datetime | datetime.time) -> datetime.dat
 def _orderedComparison(value: Any, bound: Any) -> int | None:
     """Order ``value`` against an ordering-facet ``bound``.
 
+    ``value`` and ``bound`` must be the same type: they are expected to be the
+    already-validated value and facet bound for the same ``baseXsdType``, e.g. both
+    ``DateTime`` or both ``Time``. Raises ``TypeError`` if they aren't, since a type
+    mismatch indicates a caller bug (a facet compiled against the wrong base type)
+    rather than an ordering that can be resolved here.
+
     Returns ``-1``/``0``/``1`` when ``value`` is less than/equal to/greater than
     ``bound``, or ``None`` when the order is indeterminate. Callers should treat
     ``None`` as failing whichever relation the facet requires (Datatypes 3.2.6.3:
@@ -485,6 +491,8 @@ def _orderedComparison(value: Any, bound: Any) -> int | None:
     the XSD timezone-straddling rule (Datatypes 3.2.7.4) on the underlying instants,
     yielding ``None`` when the timezone uncertainty leaves the order undetermined.
     """
+    if type(value) is not type(bound):
+        raise TypeError("Value type ({}) is not comparable with bound type ({}).".format(type(value), type (bound)))
     try:
         if value < bound:
             return -1

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -705,7 +705,7 @@ def test_validateValue_facets_minMaxExclusive(value: str, expected: tuple):
 @pytest.mark.parametrize(
     "base_xsd_type,value,facets,expected_x_valid",
     [
-        # date: the four bounding facets are enforced in the value space (Fix 3); on the
+        # date: the four bounding facets are enforced in the value space; on the
         # bound itself the inclusive variants accept and the exclusive variants reject.
         ("date", "2009-01-01", {"maxExclusive": DateTime(2011, 10, 16)}, VALID),
         ("date", "2011-10-16", {"maxExclusive": DateTime(2011, 10, 16)}, INVALID),
@@ -722,16 +722,72 @@ def test_validateValue_facets_minMaxExclusive(value: str, expected: tuple):
         # dateTime
         ("dateTime", "2025-01-02T03:04:05", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, VALID),
         ("dateTime", "2025-01-02T03:04:06", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),
+        # time (Time, a datetime.time subclass)
+        ("time", "03:04:04", {"maxInclusive": Time(3, 4, 5)}, VALID),
+        ("time", "03:04:05", {"maxInclusive": Time(3, 4, 5)}, VALID),
+        ("time", "03:04:06", {"maxInclusive": Time(3, 4, 5)}, INVALID),
+        ("time", "03:04:05", {"maxExclusive": Time(3, 4, 5)}, INVALID),
+        ("time", "03:04:05", {"minExclusive": Time(3, 4, 5)}, INVALID),
+        ("time", "03:04:06", {"minExclusive": Time(3, 4, 5)}, VALID),
         # gYear
         ("gYear", "0001", {"maxInclusive": gYear(5)}, VALID),
         ("gYear", "0009", {"maxInclusive": gYear(5)}, INVALID),
-        # duration whose bounds differ in the years/months/days part (independent of the
-        # seconds tie-break, which is Fix 6)
+        # gYearMonth
+        ("gYearMonth", "2010-12", {"maxInclusive": gYearMonth(2011, 1)}, VALID),
+        ("gYearMonth", "2011-01", {"maxExclusive": gYearMonth(2011, 1)}, INVALID),
+        ("gYearMonth", "2011-02", {"maxInclusive": gYearMonth(2011, 1)}, INVALID),
+        # gMonth (gMonth)
+        ("gMonth", "--05", {"maxInclusive": gMonth(6)}, VALID),
+        ("gMonth", "--06", {"maxExclusive": gMonth(6)}, INVALID),
+        ("gMonth", "--05", {"minInclusive": gMonth(6)}, INVALID),
+        ("gMonth", "--07", {"minExclusive": gMonth(6)}, VALID),
+        # gMonthDay (gMonthDay)
+        ("gMonthDay", "--06-14", {"maxInclusive": gMonthDay(6, 15)}, VALID),
+        ("gMonthDay", "--06-16", {"maxInclusive": gMonthDay(6, 15)}, INVALID),
+        ("gMonthDay", "--06-15", {"minExclusive": gMonthDay(6, 15)}, INVALID),
+        ("gMonthDay", "--06-16", {"minInclusive": gMonthDay(6, 15)}, VALID),
+        # gDay (gDay)
+        ("gDay", "---14", {"maxInclusive": gDay(15)}, VALID),
+        ("gDay", "---16", {"maxInclusive": gDay(15)}, INVALID),
+        ("gDay", "---15", {"minExclusive": gDay(15)}, INVALID),
+        ("gDay", "---16", {"minInclusive": gDay(15)}, VALID),
+        # duration whose bounds differ in the years/months/days part (not the seconds
+        # tie-break)
         ("duration", "P6M", {"maxExclusive": isoDuration("P1Y")}, VALID),
         ("duration", "P2Y", {"maxExclusive": isoDuration("P1Y")}, INVALID),
     ],
 )
 def test_validateValueString_facets_ordering(
+    base_xsd_type: str, value: str, facets: dict, expected_x_valid: int
+):
+    result = validateValueString(base_xsd_type, value, facets=facets)
+    assert result.xValid == expected_x_valid
+    assert result.isXValid == (expected_x_valid >= VALID)
+
+
+@pytest.mark.parametrize(
+    "base_xsd_type,value,facets,expected_x_valid",
+    [
+        # Ordering an xs:date/time value against a bound where exactly one side carries a
+        # timezone must not crash (Python refuses to order offset-naive vs offset-aware
+        # datetimes/times). Per XSD Datatypes 3.2.7.4 the absent timezone ranges over
+        # +/-14:00: when that uncertainty straddles the bound the order is indeterminate
+        # and the facet is treated as satisfied; only a value more than 14h beyond the
+        # bound is a determinate violation.
+        # timezone-aware value vs timezone-naive bound
+        ("dateTime", "2025-01-02T03:04:05Z", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, VALID),
+        ("dateTime", "2025-01-02T03:04:05Z", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, VALID),
+        ("dateTime", "2025-01-04T00:00:00Z", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),
+        ("dateTime", "2024-12-31T00:00:00Z", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),
+        # timezone-naive value vs timezone-aware bound
+        ("dateTime", "2025-01-02T03:04:05", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)}, VALID),
+        ("dateTime", "2024-12-31T00:00:00", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)}, INVALID),
+        # xs:time (no date component) with mixed timezone presence
+        ("time", "03:04:05", {"maxInclusive": Time(3, 4, 5, tzinfo=datetime.timezone.utc)}, VALID),
+        ("time", "03:04:05Z", {"minInclusive": Time(3, 4, 5)}, VALID),
+    ],
+)
+def test_validateValueString_facets_ordering_timezone(
     base_xsd_type: str, value: str, facets: dict, expected_x_valid: int
 ):
     result = validateValueString(base_xsd_type, value, facets=facets)

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -703,6 +703,43 @@ def test_validateValue_facets_minMaxExclusive(value: str, expected: tuple):
 
 
 @pytest.mark.parametrize(
+    "base_xsd_type,value,facets,expected_x_valid",
+    [
+        # date: the four bounding facets are enforced in the value space (Fix 3); on the
+        # bound itself the inclusive variants accept and the exclusive variants reject.
+        ("date", "2009-01-01", {"maxExclusive": DateTime(2011, 10, 16)}, VALID),
+        ("date", "2011-10-16", {"maxExclusive": DateTime(2011, 10, 16)}, INVALID),
+        ("date", "2027-07-04", {"maxExclusive": DateTime(2011, 10, 16)}, INVALID),
+        ("date", "2009-01-01", {"maxInclusive": DateTime(2011, 10, 16)}, VALID),
+        ("date", "2011-10-16", {"maxInclusive": DateTime(2011, 10, 16)}, VALID),
+        ("date", "2027-07-04", {"maxInclusive": DateTime(2011, 10, 16)}, INVALID),
+        ("date", "2027-07-04", {"minInclusive": DateTime(2011, 10, 16)}, VALID),
+        ("date", "2011-10-16", {"minInclusive": DateTime(2011, 10, 16)}, VALID),
+        ("date", "2009-01-01", {"minInclusive": DateTime(2011, 10, 16)}, INVALID),
+        ("date", "2027-07-04", {"minExclusive": DateTime(2011, 10, 16)}, VALID),
+        ("date", "2011-10-16", {"minExclusive": DateTime(2011, 10, 16)}, INVALID),
+        ("date", "2009-01-01", {"minExclusive": DateTime(2011, 10, 16)}, INVALID),
+        # dateTime
+        ("dateTime", "2025-01-02T03:04:05", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, VALID),
+        ("dateTime", "2025-01-02T03:04:06", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),
+        # gYear
+        ("gYear", "0001", {"maxInclusive": gYear(5)}, VALID),
+        ("gYear", "0009", {"maxInclusive": gYear(5)}, INVALID),
+        # duration whose bounds differ in the years/months/days part (independent of the
+        # seconds tie-break, which is Fix 6)
+        ("duration", "P6M", {"maxExclusive": isoDuration("P1Y")}, VALID),
+        ("duration", "P2Y", {"maxExclusive": isoDuration("P1Y")}, INVALID),
+    ],
+)
+def test_validateValueString_facets_ordering(
+    base_xsd_type: str, value: str, facets: dict, expected_x_valid: int
+):
+    result = validateValueString(base_xsd_type, value, facets=facets)
+    assert result.xValid == expected_x_valid
+    assert result.isXValid == (expected_x_valid >= VALID)
+
+
+@pytest.mark.parametrize(
     "whitespace,value,expected",
     [
         pytest.param("preserve", "\t\tA  B\n\nC ", ("=", "=", VALID)),

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -771,20 +771,27 @@ def test_validateValueString_facets_ordering(
         # Ordering an xs:date/time value against a bound where exactly one side carries a
         # timezone must not crash (Python refuses to order offset-naive vs offset-aware
         # datetimes/times). Per XSD Datatypes 3.2.7.4 the absent timezone ranges over
-        # +/-14:00: when that uncertainty straddles the bound the order is indeterminate
-        # and the facet is treated as satisfied; only a value more than 14h beyond the
-        # bound is a determinate violation.
+        # +/-14:00: when that uncertainty straddles the bound the order is indeterminate,
+        # and per Datatypes 3.2.6.3 ("indeterminate comparisons should be considered as
+        # 'false'") the facet is not satisfied, so the value is rejected. Only a value
+        # provably more than 14h beyond the bound, on the satisfying side, is a
+        # determinate acceptance; provably beyond it on the other side is a determinate
+        # violation.
         # timezone-aware value vs timezone-naive bound
-        ("dateTime", "2025-01-02T03:04:05Z", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, VALID),
-        ("dateTime", "2025-01-02T03:04:05Z", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, VALID),
-        ("dateTime", "2025-01-04T00:00:00Z", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),
-        ("dateTime", "2024-12-31T00:00:00Z", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),
+        ("dateTime", "2025-01-02T03:04:05Z", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),  # indeterminate
+        ("dateTime", "2025-01-02T03:04:05Z", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),  # indeterminate
+        ("dateTime", "2025-01-04T00:00:00Z", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),  # determinate violation
+        ("dateTime", "2024-12-31T00:00:00Z", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, INVALID),  # determinate violation
+        ("dateTime", "2025-01-05T00:00:00Z", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5)}, VALID),  # determinate acceptance
         # timezone-naive value vs timezone-aware bound
-        ("dateTime", "2025-01-02T03:04:05", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)}, VALID),
-        ("dateTime", "2024-12-31T00:00:00", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)}, INVALID),
+        ("dateTime", "2025-01-02T03:04:05", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)}, INVALID),  # indeterminate
+        ("dateTime", "2024-12-31T00:00:00", {"minInclusive": DateTime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)}, INVALID),  # determinate violation
+        ("dateTime", "2025-01-01T00:00:00", {"maxInclusive": DateTime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)}, VALID),  # determinate acceptance
         # xs:time (no date component) with mixed timezone presence
-        ("time", "03:04:05", {"maxInclusive": Time(3, 4, 5, tzinfo=datetime.timezone.utc)}, VALID),
-        ("time", "03:04:05Z", {"minInclusive": Time(3, 4, 5)}, VALID),
+        ("time", "03:04:05", {"maxInclusive": Time(3, 4, 5, tzinfo=datetime.timezone.utc)}, INVALID),  # indeterminate
+        ("time", "03:04:05Z", {"minInclusive": Time(3, 4, 5)}, INVALID),  # indeterminate
+        ("time", "23:00:00Z", {"minInclusive": Time(0, 0, 0)}, VALID),  # determinate acceptance
+        ("time", "00:00:00", {"maxInclusive": Time(23, 0, 0, tzinfo=datetime.timezone.utc)}, VALID),  # determinate acceptance
     ],
 )
 def test_validateValueString_facets_ordering_timezone(


### PR DESCRIPTION
Part of #2445

## Fix 3 — ordering facets enforced on date/time (and other ordered) types

**Where:** the `else` arm of `_validateValueStringOrRaise` that parses the
lexical-pattern datatypes (`date`, `dateTime`, `time`, `gYearMonth`, `gYear`,
`gMonthDay`, `gMonth`, `gDay`, `duration`, and the XBRL date union).

**Symptom:** the four bounding facets `maxInclusive`, `maxExclusive`,
`minInclusive`, `minExclusive` were only enforced in the numeric branches
(`decimal`/`float`/`double` and the integer family). For ordered non-numeric types
the value was parsed into a comparable object but the bounds were never checked, so
an out-of-range value (e.g. a `date` greater than a `maxExclusive` bound) was
accepted.

**Change:** after the value is parsed (so `xValue` is a comparable
date/time/duration object), apply the same four bounds already enforced by the
numeric branches, routed through a helper `_orderedComparison(value, bound)` that
returns `-1`/`0`/`1` for `<`/`=`/`>`, or `None` when the order between `value` and
`bound` is indeterminate:

```python
if facets:
    if "maxInclusive" in facets and _orderedComparison(xValue, facets["maxInclusive"]) not in (-1, 0):
        raise ValueError(…)
    if "maxExclusive" in facets and _orderedComparison(xValue, facets["maxExclusive"]) != -1:
        raise ValueError(…)
    if "minInclusive" in facets and _orderedComparison(xValue, facets["minInclusive"]) not in (0, 1):
        raise ValueError(…)
    if "minExclusive" in facets and _orderedComparison(xValue, facets["minExclusive"]) != 1:
        raise ValueError(…)
```

Each check requires a **determinate proof** that the value satisfies the facet;
anything else — a determinate violation, or an indeterminate order — is rejected
(see Fix 3a for why indeterminate orders arise and why they must be rejected, not
accepted). The facet bound is itself parsed through the same datatype path, so each
comparison is between like-typed, ordered values. Non-ordered lexical types
(`language`, `base64Binary`, `hexBinary`) never carry these facets, so gating on
facet presence needs no extra type guard.

**Normative basis:**

- XSD 2 §4.3 *Constraining Facets* defines the bounds and their facet-validity
  rules. For a value `v`:

  - §4.3.7 `maxInclusive`: valid iff `v ≤ maxInclusive`.
    <https://www.w3.org/TR/xmlschema-2/#rf-maxInclusive>
  - §4.3.8 `maxExclusive`: valid iff `v < maxExclusive`.
    <https://www.w3.org/TR/xmlschema-2/#rf-maxExclusive>
  - §4.3.9 `minExclusive`: valid iff `v > minExclusive`.
    <https://www.w3.org/TR/xmlschema-2/#rf-minExclusive>
  - §4.3.10 `minInclusive`: valid iff `v ≥ minInclusive`.
    <https://www.w3.org/TR/xmlschema-2/#rf-minInclusive>

  Each check above requires the corresponding relation to hold determinately
  (`_orderedComparison` result restricted to the value(s) that prove it); anything
  else raises.

- These facets apply to any datatype whose fundamental facet **ordered** is not
  `false`. The date/time and duration primitives are `ordered = partial`, and each
  lists `maxInclusive`/`maxExclusive`/`minInclusive`/`minExclusive` among its
  applicable Constraining facets — see, e.g.:

  - §3.2.7 `dateTime` <https://www.w3.org/TR/xmlschema-2/#dateTime>
  - §3.2.9 `date` <https://www.w3.org/TR/xmlschema-2/#date>
  - §3.2.8 `time`, §3.2.10 `gYearMonth`, §3.2.11 `gYear`, §3.2.12 `gMonthDay`,
    §3.2.13 `gDay`, §3.2.14 `gMonth`, §3.2.6 `duration`
  - Summary of applicable facets per datatype: Appendix B / §4.1.5.
    <https://www.w3.org/TR/xmlschema-2/#facets>

- The comparison itself is well-defined: XSD 2 §3.2.7 gives the **order relation**
  for `dateTime` (anchor `#dateTime-order`; the other date/time types order
  analogously), and §3.2.6 gives it for `duration` (anchor `#duration-order`).
  <https://www.w3.org/TR/xmlschema-2/#dateTime-order>

**Independent check:** take a `date`-derived type with `maxExclusive = 2011-10-16`
and the candidate value `2027-07-04`. By the §3.2.9 order relation,
`2027-07-04 > 2011-10-16`, hence `2027-07-04 < maxExclusive` is **false**, so by
§4.3.8 the value is **not** facet-valid and must be rejected. Symmetrically, a value
strictly before the bound (e.g. `2009-01-01`) is `< maxExclusive` and remains valid.

### Fix 3a — timezone-aware vs. timezone-naive ordering: no crash, and indeterminate orders are rejected

**Where:** the same ordering-facet block, plus the helpers `_orderedComparison` /
`_comparableInstant` in `arelle/XmlValidate.py`.

**Symptom:** two distinct problems in the naive four-comparison approach:

1. `DateTime` and `Time` subclass Python's `datetime.datetime` / `datetime.time`,
   and Python **raises `TypeError`** ("can't compare offset-naive and
   offset-aware datetimes/times") when ordering a value that carries a timezone
   against one that does not. So a `dateTime`/`date`/`time` value like
   `2025-01-02T03:04:05Z` compared against an un-timezoned facet bound (or vice
   versa) raised `TypeError`. `validateValue` only catches
   `ValueError`/`InvalidOperation`, so the `TypeError` escaped and crashed
   validation rather than producing a value error. (The gregorian types
   `gYear`/`gYearMonth`/`gMonth`/`gMonthDay`/`gDay` are unaffected — they discard
   the timezone at parse time and compare plain integers.)
2. Even once ordering is made not to crash, the order relation on `dateTime` (and
   analogously `date`/`time`) is only a **partial** order: when exactly one operand
   is timezoned, its untimezoned counterpart's instant is only known to within
   ±14 h, and the true order can be genuinely indeterminate. A naive
   `<`/`>`/`>=`/`<=` rewrite of the facet tests has no way to represent "neither
   provably true nor provably false", and must decide one way or the other for
   values that fall in that uncertain band.

**Change:** `_orderedComparison(value, bound)` returns `-1`/`0`/`1` for
`<`/`=`/`>`, or `None` when the order is indeterminate. It first uses the operands'
own comparison operators; on the `TypeError` from a naive-vs-aware `datetime`/`time`
it instead compares the underlying instants under the XSD timezone-straddling rule,
returning `-1`/`1` only when the ±14 h uncertainty band lies wholly to one side of
the other operand, and `None` when it straddles it. Every caller of
`_orderedComparison` (Fix 3) then requires a determinate proof of compliance, so
`None` is treated as **failing** the facet, on par with a determinate violation:
neither crashes, but neither is accepted.

**Normative basis:**

- XSD 2 §3.2.7.4 *Order relation on dateTime* (with §3.2.7.3): a `dateTime` (and,
  analogously, `date`/`time`) **without** a timezone is compared by considering the
  recoverable timezone offsets, i.e. as if it could lie anywhere in `[−14:00,
  +14:00]`. Concretely, normalize the timezoned operand to UTC; the un-timezoned
  operand's instant is then only known to within ±14 h. The order is **determinate**
  when that ±14 h band lies wholly to one side of the other operand, and
  **indeterminate** when it straddles it. <https://www.w3.org/TR/xmlschema-2/#dateTime-order>

- §3.2.6.3 *Facet Comparison for durations*: "In comparing duration values with
  minInclusive, minExclusive, maxInclusive and maxExclusive facet values
  indeterminate comparisons should be considered as 'false'."
  <https://www.w3.org/TR/xmlschema-2/#facet-comparison-for-durations> The same
  bounding facets, defined identically in §4.3.7–§4.3.10 for every ordered
  datatype, govern `dateTime`/`date`/`time`/the `g*` types; there is no basis for a
  different resolution of indeterminacy for these types than for `duration` — both
  share the fundamental facet `ordered = partial` and the same four Constraining
  facets.

- §3.2.4 `float` / §3.2.5 `double` state the equivalent rule for their own
  **incomparable** value (`NaN`): "Any value incomparable with the value used for
  the four bounding facets … will be excluded from the resulting restricted value
  space." <https://www.w3.org/TR/xmlschema-2/#float> Indeterminate/incomparable is
  consistently treated as exclusion (rejection), never inclusion, everywhere the
  specification is explicit about it.

**Independent check:** with `maxInclusive = 2025-01-02T03:04:05` (no timezone) and
the candidate `2025-01-04T00:00:00Z`, the bound's instant is at most
`2025-01-02T17:04:05Z` (offset −14:00), and the candidate exceeds that, so
`value > maxInclusive` is **determinate** and the value is rejected. The candidate
`2025-01-02T03:04:05Z` against the same bound falls inside the ±14 h band, so the
order is indeterminate; per §3.2.6.3 that is "false", so the value is rejected too
(without raising). By contrast, the candidate `2025-01-01T00:00:00` (no timezone)
against `maxInclusive = 2025-01-02T03:04:05Z` is provably more than 14 h before the
earliest instant the bound could represent, so the order is determinately `<` and
the value is **accepted**.


#### Steps to Test
- CI

**review**:
@Arelle/arelle
