### PR TITLE
Count octets for length facets on hexBinary/base64Binary

### DIFF
--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -531,12 +531,22 @@ def _validateValueStringOrRaise(
         if facets:
             if "enumeration" in facets and value not in facets["enumeration"]:
                 raise ValueError("{0} is not in {1}".format(value, facets["enumeration"].keys()))
-            if "length" in facets and len(value) != facets["length"]:
-                raise ValueError("length {0}, expected {1}".format(len(value), facets["length"]))
-            if "minLength" in facets and len(value) < facets["minLength"]:
-                raise ValueError("length {0}, minLength {1}".format(len(value), facets["minLength"]))
-            if "maxLength" in facets and len(value) > facets["maxLength"]:
-                raise ValueError("length {0}, maxLength {1}".format(len(value), facets["maxLength"]))
+            # length facets count octets of binary data for hexBinary/base64Binary,
+            # characters otherwise (XSD Datatypes 4.3.1); compute the units once.
+            if baseXsdType == "hexBinary":
+                valueLength = len(value) // 2
+            elif baseXsdType == "base64Binary":
+                # ignore lexical spaces before counting octets (whitespace already collapsed to spaces)
+                data = value.replace(" ", "")
+                valueLength = len(data) * 3 // 4 - data.count("=")
+            else:
+                valueLength = len(value)
+            if "length" in facets and valueLength != facets["length"]:
+                raise ValueError("length {0}, expected {1}".format(valueLength, facets["length"]))
+            if "minLength" in facets and valueLength < facets["minLength"]:
+                raise ValueError("length {0}, minLength {1}".format(valueLength, facets["minLength"]))
+            if "maxLength" in facets and valueLength > facets["maxLength"]:
+                raise ValueError("length {0}, maxLength {1}".format(valueLength, facets["maxLength"]))
         if baseXsdType in {"string", "normalizedString", "language", "languageOrEmpty", "token", "NMTOKEN", "Name", "NCName", "IDREF", "ENTITY"}:
             xValue = sValue = value
         elif baseXsdType == "ID":

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -1114,6 +1114,22 @@ class TestBase64BinaryValidation:
         assert result.xValid == INVALID
         assert not result.isXValid
 
+    @pytest.mark.parametrize("value,facet,length,expected_x_valid", [
+        # length facets count octets of decoded data, not lexical characters:
+        # "YQ==" is 4 characters but decodes to the single octet 0x61.
+        ("YQ==", "length", 1, VALID),
+        ("YQ==", "length", 4, INVALID),
+        ("YQ==", "maxLength", 1, VALID),
+        ("YQ==", "minLength", 2, INVALID),
+        ("YWI=", "length", 2, VALID),  # "ab"
+        ("YWJj", "length", 3, VALID),  # "abc"
+        ("A A A A", "length", 3, VALID),  # lexical whitespace ignored -> AAAA -> 3 octets
+    ])
+    def test_length_facets_count_octets(self, value: str, facet: str, length: int, expected_x_valid: int):
+        result = validateValueString("base64Binary", value, facets={facet: length})
+        assert result.xValid == expected_x_valid
+        assert result.isXValid == (expected_x_valid >= VALID)
+
 
 class TestHexBinaryValidation:
     @pytest.mark.parametrize("value", [
@@ -1142,6 +1158,20 @@ class TestHexBinaryValidation:
         result = validateValueString("hexBinary", value)
         assert result.xValid == INVALID
         assert not result.isXValid
+
+    @pytest.mark.parametrize("value,facet,length,expected_x_valid", [
+        # length facets count octets, not hex digits: two hex digits = one octet.
+        ("FF", "length", 1, VALID),
+        ("48656C6C6F", "length", 5, VALID),  # "Hello"
+        ("48656C6C6F", "length", 10, INVALID),
+        ("AABB", "maxLength", 2, VALID),
+        ("AABB", "maxLength", 1, INVALID),
+        ("FF", "minLength", 2, INVALID),
+    ])
+    def test_length_facets_count_octets(self, value: str, facet: str, length: int, expected_x_valid: int):
+        result = validateValueString("hexBinary", value, facets={facet: length})
+        assert result.xValid == expected_x_valid
+        assert result.isXValid == (expected_x_valid >= VALID)
 
 
 class TestTimezoneValidation:


### PR DESCRIPTION
Part of #2445

## Fix 4 — `length` facets count octets for `hexBinary` / `base64Binary`

**Where:** the `length` / `minLength` / `maxLength` facet checks in
`_validateValueStringOrRaise`.

**Symptom:** the length facets were measured with `len(value)` — the number of
*lexical characters* — for every type. For `hexBinary` and `base64Binary` this is
wrong: those facets count **octets of decoded binary data**, which is fewer than the
lexical character count (2 hex digits, or ~4 base64 characters, encode 1 octet). A
binary value within its octet bound could therefore be wrongly rejected (or, in the
other direction, a too-long value wrongly accepted).

**Change:** compute the facet unit count once, in octets for the two binary types
and in characters otherwise, then use it in all three comparisons:

```python
if baseXsdType == "hexBinary":
    valueLength = len(value) // 2
elif baseXsdType == "base64Binary":
    data = "".join(value.split())            # ignore lexical whitespace
    valueLength = len(data) * 3 // 4 - data.count("=")
else:
    valueLength = len(value)
```

The base64 count is arithmetic (no decoding), so it introduces no new exceptions or
ordering changes: a 4-character base64 quantum encodes 3 octets, less one octet per
`=` padding character. Lexical validity continues to be enforced separately by the
type's `pattern`.

**Normative basis:**

- XSD 2 §4.3.1 *length*: "length is the number of units of length, where units of
  length varies depending on the type… For `hexBinary` and `base64Binary` and
  datatypes derived from them, length is measured in octets (8-bit bytes) of binary
  data." §4.3.2 *minLength* and §4.3.3 *maxLength* are defined in the same units.
  <https://www.w3.org/TR/xmlschema-2/#rf-length>

- XSD 2 §3.2.16 *base64Binary* defines the lexical mapping (the Base64 encoding of
  [RFC 2045]); each 4-character group (less padding) corresponds to 3 octets.
  <https://www.w3.org/TR/xmlschema-2/#base64Binary>
  §3.2.15 *hexBinary* maps two hexadecimal digits to one octet.
  <https://www.w3.org/TR/xmlschema-2/#hexBinary>

  XSD 1.1 D §3.3.15–3.3.16 and §4.3.1 state the same octet-based length rule.
  <https://www.w3.org/TR/xmlschema11-2/#rf-length>

**Independent check:** the base64 literal `YQ==` decodes (RFC 2045 / §3.2.16) to the
single octet `0x61`, so its `length` is **1**, not its 4 lexical characters; thus it
satisfies e.g. `maxLength = 1`. More generally, for a base64 string of `n`
non-whitespace characters with `p` trailing `=` (`p ∈ {0,1,2}`), the octet count is
`n·3/4 − p`. For `hexBinary`, the literal `48656C6C6F` is 10 hex digits = **5**
octets. Either value must be judged against `length` facets using these octet counts,
not the character counts (10, or 4).



#### Steps to Test
- CI

**review**:
@Arelle/arelle
