### PR TITLE
Make length facets vacuous for QName and NOTATION

### DIFF
--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -531,22 +531,25 @@ def _validateValueStringOrRaise(
         if facets:
             if "enumeration" in facets and value not in facets["enumeration"]:
                 raise ValueError("{0} is not in {1}".format(value, facets["enumeration"].keys()))
-            # length facets count octets of binary data for hexBinary/base64Binary,
-            # characters otherwise (XSD Datatypes 4.3.1); compute the units once.
-            if baseXsdType == "hexBinary":
-                valueLength = len(value) // 2
-            elif baseXsdType == "base64Binary":
-                # ignore lexical spaces before counting octets (whitespace already collapsed to spaces)
-                data = value.replace(" ", "")
-                valueLength = len(data) * 3 // 4 - data.count("=")
-            else:
-                valueLength = len(value)
-            if "length" in facets and valueLength != facets["length"]:
-                raise ValueError("length {0}, expected {1}".format(valueLength, facets["length"]))
-            if "minLength" in facets and valueLength < facets["minLength"]:
-                raise ValueError("length {0}, minLength {1}".format(valueLength, facets["minLength"]))
-            if "maxLength" in facets and valueLength > facets["maxLength"]:
-                raise ValueError("length {0}, maxLength {1}".format(valueLength, facets["maxLength"]))
+            # length/minLength/maxLength are meaningless for QName and NOTATION; per
+            # XSD Datatypes 3.2.18/3.2.19 every value is facet-valid with respect to them.
+            if baseXsdType not in ("QName", "NOTATION"):
+                # length facets count octets of binary data for hexBinary/base64Binary,
+                # characters otherwise (XSD Datatypes 4.3.1); compute the units once.
+                if baseXsdType == "hexBinary":
+                    valueLength = len(value) // 2
+                elif baseXsdType == "base64Binary":
+                    # ignore lexical spaces before counting octets (whitespace already collapsed to spaces)
+                    data = value.replace(" ", "")
+                    valueLength = len(data) * 3 // 4 - data.count("=")
+                else:
+                    valueLength = len(value)
+                if "length" in facets and valueLength != facets["length"]:
+                    raise ValueError("length {0}, expected {1}".format(valueLength, facets["length"]))
+                if "minLength" in facets and valueLength < facets["minLength"]:
+                    raise ValueError("length {0}, minLength {1}".format(valueLength, facets["minLength"]))
+                if "maxLength" in facets and valueLength > facets["maxLength"]:
+                    raise ValueError("length {0}, maxLength {1}".format(valueLength, facets["maxLength"]))
         if baseXsdType in {"string", "normalizedString", "language", "languageOrEmpty", "token", "NMTOKEN", "Name", "NCName", "IDREF", "ENTITY"}:
             xValue = sValue = value
         elif baseXsdType == "ID":

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -606,6 +606,31 @@ def test_validateValue_facets_maxLength(value: str, expected: tuple):
 
 
 @pytest.mark.parametrize(
+    "base_xsd_type,value,facets,expected_x_valid",
+    [
+        # length/minLength/maxLength are vacuous for QName and NOTATION: every value is
+        # facet-valid with respect to them, regardless of the (prefix-dependent) lexical
+        # length (Fix 5).
+        ("QName", "prefix:localName", {"length": 5}, VALID),
+        ("QName", "prefix:localName", {"minLength": 100}, VALID),
+        ("QName", "prefix:localName", {"maxLength": 1}, VALID),
+        ("NOTATION", "prefix:localName", {"length": 5}, VALID),
+        ("NOTATION", "prefix:localName", {"minLength": 100}, VALID),
+        ("NOTATION", "prefix:localName", {"maxLength": 1}, VALID),
+        # control: length facets are still enforced for other types
+        ("string", "abc", {"maxLength": 1}, INVALID),
+        ("string", "abc", {"length": 3}, VALID),
+    ],
+)
+def test_validateValueString_length_vacuous_for_qname_notation(
+    base_xsd_type: str, value: str, facets: dict, expected_x_valid: int
+):
+    result = validateValueString(base_xsd_type, value, facets=facets, nsmap={"prefix": "namespaceURI"})
+    assert result.xValid == expected_x_valid
+    assert result.isXValid == (expected_x_valid >= VALID)
+
+
+@pytest.mark.parametrize(
     "value,expected",
     [
         pytest.param("ABC", ("=", "=", VALID)),


### PR DESCRIPTION
Part of #2445

## Fix 5 — `length` facets are vacuous for `QName` / `NOTATION`

**Where:** the `length` / `minLength` / `maxLength` facet checks in
`_validateValueStringOrRaise` (the same block as Fix 4).

**Symptom:** these facets were enforced for `QName` (and `NOTATION`) using
`len(value)` — the lexical character count of the *prefixed* name. That count
depends on the chosen prefix, which is **not part of a QName's value** (the value is
the (namespace name, local name) pair), so a perfectly conforming value could be
rejected (or accepted) purely because of its prefix length.

**Change:** skip the three length checks for `QName` and `NOTATION` — every value is
facet-valid with respect to them — by guarding the existing block:

```python
if baseXsdType not in ("QName", "NOTATION"):
    …existing length / minLength / maxLength checks…
```

(`enumeration`, `pattern`, `whiteSpace` for these types are unaffected.)

**Normative basis:**

- XSD 2 §3.2.18 *QName* (and §3.2.19 *NOTATION*): "The use of `length`, `minLength`
  and `maxLength` on … QName is **deprecated**. Future versions of this
  specification may remove these facets for this datatype."
  <https://www.w3.org/TR/xmlschema-2/#QName> ·
  <https://www.w3.org/TR/xmlschema-2/#NOTATION>

- The W3C XML Schema WG clarified the intended semantics (resolution of Bugzilla
  **Bug 3265**, amending §§4.3.1.3 / 4.3.2.3 / 4.3.3.3): "These facets are
  **meaningless** for such types, and so **all instances are facet-valid with
  respect to them**." i.e. `length`/`minLength`/`maxLength` impose no constraint on
  a QName- or NOTATION-derived type.
  <https://lists.w3.org/Archives/Public/www-xml-schema-comments/2007OctDec/0124.html>

  The rationale (Bug 3265 / RQ-6, 2005): the `length` facet is defined over the
  **value space**, and the value space of `QName` is the (namespace name, local
  name) pair — there is no well-defined character/octet length for it.
  <https://lists.w3.org/Archives/Public/www-xml-schema-comments/2005AprJun/0066.html>

**Independent check:** a `QName`-derived type with `length = 34` and a value bound to
namespace `http://www.nist.gov/xsdNS` with local name `sdevices` must be accepted
regardless of the `length` value, because the facet imposes no constraint on QName.
Note that the lexical form is prefix-dependent (`p:sdevices` = 10 chars,
`win_ava:sdevices` = 16 chars) for the *same* value — demonstrating why a lexical
length constraint on QName is ill-defined and, per the spec, vacuous.

#### Steps to Test
- CI

**review**:
@Arelle/arelle
