### PR TITLE
Fix IsoDuration.__gt__ seconds/microseconds tie-break

### DIFF
--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -1013,7 +1013,7 @@ class IsoDuration(isodate.Duration): # type: ignore[misc]
     def __gt__(self,other: Any) -> bool:
         if self.avgdays > other.avgdays:
             return True
-        elif self.avgdays > other.avgdays:
+        elif self.avgdays == other.avgdays:
             if self.tdelta.seconds > other.tdelta.seconds:
                 return True
             elif self.tdelta.seconds == other.tdelta.seconds:

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -1011,6 +1011,9 @@ class IsoDuration(isodate.Duration): # type: ignore[misc]
     def __le__(self, other: Any) -> bool:
         return self.__lt__(other) or self.__eq__(other)
     def __gt__(self,other: Any) -> bool:
+        if not isinstance(other, IsoDuration):
+            return NotImplemented
+
         if self.avgdays > other.avgdays:
             return True
         elif self.avgdays == other.avgdays:

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -1217,3 +1217,23 @@ class TestTimezoneValidation:
         result = validateValueString(base_xsd_type, value)
         assert result.xValid == INVALID
         assert not result.isXValid
+
+
+class TestIsoDurationComparison:
+    def test_gt_seconds_tiebreak_when_dates_equal(self):
+        # equal years/months/days; the value with greater seconds must compare greater
+        # via the seconds tie-break.
+        assert isoDuration("P1Y2M3DT10H36M30S") > isoDuration("P1Y2M3DT10H36M29S")
+
+    def test_not_gt_when_equal(self):
+        assert not (isoDuration("P1Y2M3DT10H36M29S") > isoDuration("P1Y2M3DT10H36M29S"))
+
+    def test_not_gt_when_seconds_less(self):
+        assert not (isoDuration("P1Y2M3DT10H36M28S") > isoDuration("P1Y2M3DT10H36M29S"))
+
+    def test_gt_when_avgdays_greater(self):
+        assert isoDuration("P2Y") > isoDuration("P1Y")
+
+    def test_ge_uses_gt(self):
+        assert isoDuration("P1Y2M3DT10H36M30S") >= isoDuration("P1Y2M3DT10H36M29S")
+        assert isoDuration("P1Y2M3DT10H36M29S") >= isoDuration("P1Y2M3DT10H36M29S")

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -5,6 +5,7 @@ from _decimal import Decimal
 from fractions import Fraction
 from math import inf, isnan, nan
 from typing import Any
+from unittest import TestCase
 from unittest.mock import Mock
 
 import pytest
@@ -1219,7 +1220,11 @@ class TestTimezoneValidation:
         assert not result.isXValid
 
 
-class TestIsoDurationComparison:
+class TestIsoDurationComparison(TestCase):
+    def test_gt_non_iso_duration(self):
+        with self.assertRaises(TypeError):
+            _ = isoDuration("P1Y2M3DT10H36M30S") > DateTime(2025, 1, 2)
+
     def test_gt_seconds_tiebreak_when_dates_equal(self):
         # equal years/months/days; the value with greater seconds must compare greater
         # via the seconds tie-break.
@@ -1237,3 +1242,25 @@ class TestIsoDurationComparison:
     def test_ge_uses_gt(self):
         assert isoDuration("P1Y2M3DT10H36M30S") >= isoDuration("P1Y2M3DT10H36M29S")
         assert isoDuration("P1Y2M3DT10H36M29S") >= isoDuration("P1Y2M3DT10H36M29S")
+
+    def test_lt_non_iso_duration(self):
+        with self.assertRaises(TypeError):
+            _ = isoDuration("P1Y2M3DT10H36M30S") < DateTime(2025, 1, 2)
+
+    def test_lt_seconds_tiebreak_when_dates_equal(self):
+        # equal years/months/days; the value with greater seconds must compare greater
+        # via the seconds tie-break.
+        assert isoDuration("P1Y2M3DT10H36M29S") < isoDuration("P1Y2M3DT10H36M30S")
+
+    def test_not_lt_when_equal(self):
+        assert not (isoDuration("P1Y2M3DT10H36M29S") < isoDuration("P1Y2M3DT10H36M29S"))
+
+    def test_not_lt_when_seconds_greater(self):
+        assert not (isoDuration("P1Y2M3DT10H36M29S") < isoDuration("P1Y2M3DT10H36M28S"))
+
+    def test_lt_when_avgdays_less(self):
+        assert isoDuration("P1Y") < isoDuration("P2Y")
+
+    def test_le_uses_lt(self):
+        assert isoDuration("P1Y2M3DT10H36M29S") <= isoDuration("P1Y2M3DT10H36M30S")
+        assert isoDuration("P1Y2M3DT10H36M29S") <= isoDuration("P1Y2M3DT10H36M29S")


### PR DESCRIPTION
Part of #2445

## Fix 6 — `xs:duration` greater-than comparison (`IsoDuration.__gt__`)

**Where:** `IsoDuration.__gt__` in `arelle/ModelValue.py` (the value object for
`xs:duration`). This underpins the ordering-facet checks added in Fix 3.

**Symptom:** for two durations with an equal "average days" component (i.e. equal
years/months/days) that differ only in the time-of-day part, `a > b` always returned
`False` — even when `a` was strictly greater. A copy/paste error tested the wrong
branch condition:

```python
if self.avgdays > other.avgdays:
    return True
elif self.avgdays > other.avgdays:        # bug: duplicates the '>' test
    … seconds / microseconds tie-break …  # therefore unreachable
return False
```

The second condition can never be true after the first, so the seconds /
microseconds tie-break was dead code and `__gt__` under-reported greater-than. (As a
consequence `maxInclusive`/`maxExclusive` bounds on `duration`, which use `>` / `>=`,
were not enforced when the bound and value shared the same year/month/day part.)

**Change:** mirror the already-correct `__lt__`: test equality in the `elif`, and add
the same `isinstance` guard `__lt__` uses.

```python
elif self.avgdays == other.avgdays:       # fixed: equal -> fall through to tie-break
```

**Normative basis:**

- XSD 2 §3.2.6.2 *Order relation on duration* defines that durations compare by their
  effect when added to specific reference `dateTime`s. Two durations differing only
  in seconds (e.g. `…T10H36M30S` vs `…T10H36M29S`, with identical
  years/months/days) order unambiguously: the `…30S` value is the greater under any
  reference instant. <https://www.w3.org/TR/xmlschema-2/#duration-order>

- §4.3.7 *maxInclusive*: a value is facet-valid iff `value ≤ maxInclusive`; a value
  strictly greater than the bound must be rejected.
  <https://www.w3.org/TR/xmlschema-2/#rf-maxInclusive>

  (Arelle approximates the partial duration order with an "average days" magnitude —
  see the `IsoDuration` docstring — but the seconds tie-break is still required for
  durations that agree on years/months/days, which is exactly the case this fix
  restores.)

**Independent check:** with `maxInclusive = P2004Y12M06DT10H36M29S` and the candidate
`P2004Y12M06DT10H36M30S`, the two agree on every field except seconds (30 vs 29);
by the §3.2.6.2 order relation the candidate is greater, so `value ≤ maxInclusive`
is false and the value must be rejected. Symmetrically, `…M29S` itself (equal to the
bound) and `…M28S` (less than the bound) remain valid.

#### Steps to Test
- CI

**review**:
@Arelle/arelle
