### PR TITLE
Exclude the sign when counting totalDigits

### DIFF
--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -569,13 +569,20 @@ def _validateValueStringOrRaise(
                 sValue = float(value) # s-value uses Number (float) representation
                 if sValue == 0 and baseXsdType == "XBRLI_NONZERODECIMAL":
                     raise ValueError("zero is not allowed")
+                # totalDigits isn't a valid constraining facet for float/double (XSD Datatypes 3.2.4/3.2.5),
+                # so it's only checked here. Digits are counted from the parsed (normalized) value, excluding
+                # the sign and any insignificant zeros, per XSD Datatypes 4.3.11.
+                if facets and "totalDigits" in facets:
+                    _sign, digits, exp = xValue.normalize().as_tuple()
+                    assert isinstance(exp, int) # decimalPattern rules out NaN/Infinity, whose exponents aren't ints
+                    digitCount = len(digits) + max(0, exp)
+                    if digitCount > facets["totalDigits"]:
+                        raise ValueError("totalDigits facet {0}".format(facets["totalDigits"]))
             else:
                 if floatPattern.match(value) is None:
                     raise ValueError("lexical pattern mismatch")
                 xValue = sValue = float(value)
             if facets:
-                if "totalDigits" in facets and len(value.replace(".","")) > facets["totalDigits"]:
-                    raise ValueError("totalDigits facet {0}".format(facets["totalDigits"]))
                 if "fractionDigits" in facets and ("." in value and
                     len(value[value.index(".") + 1:]) > facets["fractionDigits"]):
                     raise ValueError("fraction digits facet {0}".format(facets["fractionDigits"]))
@@ -594,7 +601,7 @@ def _validateValueStringOrRaise(
                 if (lowerLimit is not None and xValue < lowerLimit) or (upperLimit is not None and xValue > upperLimit):
                     raise ValueError(f"{value} is not {baseXsdType}")
             if facets:
-                if "totalDigits" in facets and len(value.replace(".","")) > facets["totalDigits"]:
+                if "totalDigits" in facets and len(str(abs(xValue))) > facets["totalDigits"]:
                     raise ValueError("totalDigits facet {0}".format(facets["totalDigits"]))
                 if "fractionDigits" in facets and ("." in value and
                     len(value[value.index(".") + 1:]) > facets["fractionDigits"]):

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -649,12 +649,17 @@ def test_validateValue_facets_pattern(value: str, expected: tuple):
 @pytest.mark.parametrize(
     "value,expected",
     [
-        pytest.param("1", (float(1), float(1), VALID)),
-        pytest.param("1.01", (float(1.01), float(1.01), VALID)),
-        pytest.param("100", (float(100), float(100), VALID)),
+        pytest.param("1", (float(1), Decimal("1"), VALID)),
+        pytest.param("1.01", (float(1.01), Decimal("1.01"), VALID)),
+        pytest.param("100", (float(100), Decimal("100"), VALID)),
         pytest.param("1.001", ("=", None, INVALID)),
-        pytest.param("1.000", ("=", None, INVALID)),
+        # insignificant trailing zeros are not counted as significant digits.
+        pytest.param("1.000", (float(1), Decimal("1.000"), VALID)),
         pytest.param("1000", ("=", None, INVALID)),
+        # a leading sign is not a digit and must not be counted.
+        pytest.param("-100", (float(-100), Decimal("-100"), VALID)),
+        pytest.param("-1.01", (float(-1.01), Decimal("-1.01"), VALID)),
+        pytest.param("-1000", ("=", None, INVALID)),
     ],
 )
 def test_validateValue_facets_totalDigits(value: str, expected: tuple):
@@ -662,8 +667,48 @@ def test_validateValue_facets_totalDigits(value: str, expected: tuple):
     facets = {
         "totalDigits": 3
     }
-    validateValue(modelXbrl=Mock(), elt=elt, attrTag=None, baseXsdType="float", value=value, facets=facets)
+    # totalDigits only applies to xs:decimal (and its derived types); it isn't a valid
+    # constraining facet for xs:float/xs:double.
+    validateValue(modelXbrl=Mock(), elt=elt, attrTag=None, baseXsdType="decimal", value=value, facets=facets)
     _assertExpected(value, attrTag=None, elt=elt, expected=expected)
+
+
+@pytest.mark.parametrize("base_xsd_type", ["float", "double"])
+def test_validateValue_facets_totalDigits_not_applicable_to_float(base_xsd_type: str):
+    # totalDigits isn't a valid constraining facet for xs:float/xs:double, so a value
+    # with more digits than totalDigits allows must still be valid.
+    elt = Mock()
+    facets = {
+        "totalDigits": 1
+    }
+    validateValue(modelXbrl=Mock(), elt=elt, attrTag=None, baseXsdType=base_xsd_type, value="123.456", facets=facets)
+    assert elt.xValid == VALID
+    assert elt.xValue == float("123.456")
+
+
+@pytest.mark.parametrize(
+    "base_xsd_type,value,total_digits,expected_x_valid",
+    [
+        # the integer branch and the decimal branch both exclude the sign.
+        ("integer", "-6", 1, VALID),
+        ("integer", "6", 1, VALID),
+        ("integer", "-66", 1, INVALID),
+        ("integer", "-66", 2, VALID),
+        ("decimal", "-1.5", 2, VALID),
+        ("decimal", "+1.5", 2, VALID),
+        ("decimal", "-1.55", 2, INVALID),
+        # insignificant zeros (leading or trailing) are not counted as significant digits.
+        ("decimal", "-1.50", 2, VALID),
+        ("decimal", "0001.5", 2, VALID),
+        ("decimal", "0.001", 1, VALID),
+    ],
+)
+def test_validateValueString_totalDigits_excludes_sign(
+    base_xsd_type: str, value: str, total_digits: int, expected_x_valid: int
+):
+    result = validateValueString(base_xsd_type, value, facets={"totalDigits": total_digits})
+    assert result.xValid == expected_x_valid
+    assert result.isXValid == (expected_x_valid >= VALID)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Part of #2445

## Fix 7 — `totalDigits` is decimal-only and must be counted from the parsed value

**Where:** the `totalDigits` check in `_validateValueStringOrRaise` — moved out of
the shared `decimal`/`float`/`double` facet block into the `decimal`/
`XBRLI_NONZERODECIMAL`-only branch, and reworked in the integer branch.

**Symptom:** the digit count was computed from the **lexical** string,
`len(value.replace(".", ""))`, rather than the already-parsed `xValue`. This was
wrong in three ways at once:

1. It counted the leading sign as a digit: a single-digit negative such as `"-6"`
   was counted as 2 digits, so a type with `totalDigits = 1` wrongly rejected it.
2. It counted **insignificant zeros** as significant digits: `"1.000"` was counted
   as 4 digits (and rejected under `totalDigits = 3`) even though it denotes the
   same value as `"1"`, which has only 1 significant digit.
3. It was applied to `float` and `double` values as well as `decimal`, but
   `totalDigits` is not a constraining facet of `float`/`double` at all — a
   schema-invalid facet was nonetheless being enforced, wrongly rejecting values on
   those types.

**Change:** drop the `totalDigits` check entirely from the `float`/`double` arm, and
in the two branches where it still applies, derive the digit count from `xValue`:

```python
# decimal / XBRLI_NONZERODECIMAL (xValue is already a Decimal)
if facets and "totalDigits" in facets:
    _sign, digits, exp = xValue.normalize().as_tuple()
    digitCount = len(digits) + max(0, exp)
    if digitCount > facets["totalDigits"]:
        raise ValueError(…)

# integer and derived types (xValue is already an int)
if "totalDigits" in facets and len(str(abs(xValue))) > facets["totalDigits"]:
    raise ValueError(…)
```

`Decimal.normalize()` removes trailing fractional zeros and switches to scientific
notation for trailing whole-number zeros (e.g. `Decimal("100").normalize()` →
`Decimal("1E+2")`, `digits=(1,)`, `exp=2`), so `len(digits) + max(0, exp)` counts
exactly the significant digits in both directions, with no sign in sight because
`Decimal`/`int` values carry no lexical sign character at all.

**Normative basis:**

- XSD 2 §4.3.11 *totalDigits*: "totalDigits is the maximum number of decimal
  **digits** … Note: this is the number of digits in the value, and the sign is not
  counted; leading and trailing zeroes are not significant." A value is facet-valid
  iff its number of significant digits is `≤ totalDigits`.
  <https://www.w3.org/TR/xmlschema-2/#rf-totalDigits>

- XSD 2 §4.1.5 (Appendix B) lists the facets applicable to each primitive datatype:
  `totalDigits` is applicable to `decimal` only; `float` and `double` do **not**
  have `totalDigits` among their applicable facets.
  <https://www.w3.org/TR/xmlschema-2/#facets> (Scope note: `fractionDigits` has the
  same restriction and is arguably subject to the same bug, but is left unchanged
  here — out of scope for this fix, which only addresses `totalDigits`.)

- The sign is part of the *lexical* representation but is not a digit — see the
  `integer` lexical mapping (XSD 2 §3.3.13, optional leading `+`/`-`) and `decimal`
  (§3.2.3). Deriving the count from the parsed `Decimal`/`int` value rather than the
  lexical string sidesteps the sign entirely, since neither type retains it.
  <https://www.w3.org/TR/xmlschema-2/#integer> ·
  <https://www.w3.org/TR/xmlschema-2/#decimal>

**Independent check:** `-6` parses to the `int` `-6`; `str(abs(-6))` is `"6"`, one
digit, so it satisfies `totalDigits = 1`. `"1.000"` parses to `Decimal("1.000")`,
whose `normalize()` is `Decimal("1")` (`digits=(1,)`, `exp=0`), i.e. **1** significant
digit — it satisfies `totalDigits = 3`, even though the un-normalized lexical form
has 4 numeral characters. `"1000"` parses to `Decimal("1000")`, whose `normalize()`
is `Decimal("1E+3")` (`digits=(1,)`, `exp=3`), giving `1 + 3 = 4` significant digits —
correctly still rejected under `totalDigits = 3`. A `float`/`double` value such as
`"123.456"` with `totalDigits = 1` must be accepted, since the facet does not apply
to those types at all.


#### Steps to Test
- CI

**review**:
@Arelle/arelle
