### PR TITLE
EDINET.EC5700W.GFM.1.5.5: Correct extension concept check

### DIFF
--- a/arelle/plugin/validate/EDINET/rules/gfm.py
+++ b/arelle/plugin/validate/EDINET/rules/gfm.py
@@ -1496,7 +1496,7 @@ def rule_gfm_1_5_5(
     if labelRelationshipSet is None:
         return
     for concept in val.modelXbrl.qnameConcepts.values():
-        if concept.namespaceURI is not None and not pluginData.isStandardTaxonomyUrl(concept.namespaceURI, val.modelXbrl):
+        if not pluginData.isStandardTaxonomyUrl(concept.modelDocument.uri, val.modelXbrl):
             continue
         labelRels = labelRelationshipSet.fromModelObject(concept)
         for rel in labelRels:

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.6/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.5.6/index.xml
@@ -18,7 +18,6 @@
         </data>
         <result>
             <warning>EDINET.EC5700W.GFM.1.5.3</warning>
-            <warning>EDINET.EC5700W.GFM.1.5.5</warning>
             <warning>EDINET.EC5700W.GFM.1.5.6</warning>
             <warning>EDINET.EC8043W</warning> <!-- from base sample filing -->
             <warning>EDINET.EC8045W</warning> <!-- from base sample filing -->


### PR DESCRIPTION
#### Reason for change
EDINET.EC5700W.GFM.1.5.5 was not correctly targeting standard concepts.

#### Description of change
Pass `concept.modelDocument.uri` to `isStandardTaxonomyUrl`

#### Steps to Test
CI

**review**:
@Arelle/arelle
