### PR TITLE
Match enumeration facets in the value space, not lexically

### DIFF
--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -1187,14 +1187,6 @@ class ModelAttributeGroup(ModelNamableTerm):
             return self.modelXbrl.qnameAttributeGroups.get(ModelValue.qname(self, ref))
         return self
 
-class _EnumerationFacet(dict[str, ModelObject]):
-    """dict of an enumeration facet's lexical value -> facetElt, with a lazily-populated,
-    out-of-band value-space cache (xValue -> lexical value) attached via the ``valueSpace``
-    attribute. Kept off the dict's own keys/items so existing consumers that treat this as a
-    plain ``dict[str, ModelObject]`` (equivalence checks, ViewX rendering, etc.) are unaffected."""
-    __slots__ = ("valueSpace",)
-    valueSpace: dict[Any, str]
-
 class ModelType(ModelNamableTerm):
     """
     .. class:: ModelType(modelDocument)
@@ -1568,7 +1560,7 @@ class ModelType(ModelNamableTerm):
         if "enumeration" not in facetValues:
             for facetElt in XmlUtil.schemaFacets(self, ["{http://www.w3.org/2001/XMLSchema}enumeration"]):
                 assert facetElt is not None, "facetElt is None"
-                facetValues.setdefault("enumeration", _EnumerationFacet())[facetElt.get("value")] = facetElt
+                facetValues.setdefault("enumeration", XmlValidate.EnumerationFacet())[facetElt.get("value")] = facetElt
         typeDerivedFrom = self.typeDerivedFrom
         if isinstance(typeDerivedFrom, ModelType):
             typeDerivedFrom.constrainingFacets(facetValues)

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -1187,6 +1187,14 @@ class ModelAttributeGroup(ModelNamableTerm):
             return self.modelXbrl.qnameAttributeGroups.get(ModelValue.qname(self, ref))
         return self
 
+class _EnumerationFacet(dict[str, ModelObject]):
+    """dict of an enumeration facet's lexical value -> facetElt, with a lazily-populated,
+    out-of-band value-space cache (xValue -> lexical value) attached via the ``valueSpace``
+    attribute. Kept off the dict's own keys/items so existing consumers that treat this as a
+    plain ``dict[str, ModelObject]`` (equivalence checks, ViewX rendering, etc.) are unaffected."""
+    __slots__ = ("valueSpace",)
+    valueSpace: dict[Any, str]
+
 class ModelType(ModelNamableTerm):
     """
     .. class:: ModelType(modelDocument)
@@ -1560,7 +1568,7 @@ class ModelType(ModelNamableTerm):
         if "enumeration" not in facetValues:
             for facetElt in XmlUtil.schemaFacets(self, ["{http://www.w3.org/2001/XMLSchema}enumeration"]):
                 assert facetElt is not None, "facetElt is None"
-                facetValues.setdefault("enumeration",{})[facetElt.get("value")] = facetElt
+                facetValues.setdefault("enumeration", _EnumerationFacet())[facetElt.get("value")] = facetElt
         typeDerivedFrom = self.typeDerivedFrom
         if isinstance(typeDerivedFrom, ModelType):
             typeDerivedFrom.constrainingFacets(facetValues)

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -192,9 +192,40 @@ _XSD_TYPE_INHERENT_INCLUSIVE_BOUNDS: dict[str, tuple[int | None, int | None]] = 
 }
 _INTEGER_BASE_XSD_TYPES = frozenset(_XSD_TYPE_INHERENT_INCLUSIVE_BOUNDS.keys() | {"integer"})
 
+
+class _EnumerationFacetMember:
+    """Stand-in for a schema enumeration facet element (a ``ModelObject``), used for
+    enumeration facets synthesized in this module (e.g. the predefined xml:space
+    attribute type, the whiteSpace facet's own permitted values) rather than derived
+    from a schema. Provides the ``nsmap`` a QName-lexical enumeration member would be
+    resolved against; empty by default since none of this module's synthetic
+    enumerations are QName-lexical types."""
+    __slots__ = ("nsmap",)
+
+    def __init__(self, nsmap: Mapping[str | None, str] | None = None) -> None:
+        self.nsmap = nsmap or {}
+
+
+class EnumerationFacet(dict[str, ModelObject | _EnumerationFacetMember]):
+    """dict of an enumeration facet's lexical value -> facet element (a schema
+    ``ModelObject`` for schema-derived enumerations, or an ``_EnumerationFacetMember``
+    for enumerations synthesized in this module), with a lazily-populated, out-of-band
+    value-space cache (xValue -> lexical value) attached via the ``valueSpace``
+    attribute. Kept off the dict's own keys/items so existing consumers that treat this
+    as a plain ``dict[str, ModelObject]`` (equivalence checks, ViewX rendering, etc.)
+    are unaffected."""
+    __slots__ = ("valueSpace",)
+    valueSpace: dict[Any, str] | None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.valueSpace = None
+
+
 predefinedAttributeTypes = {
     qname("{http://www.w3.org/XML/1998/namespace}xml:lang"):("languageOrEmpty",None),
-    qname("{http://www.w3.org/XML/1998/namespace}xml:space"):("NCName",{"enumeration":{"default","preserve"}})}
+    qname("{http://www.w3.org/XML/1998/namespace}xml:space"):("NCName", {"enumeration": EnumerationFacet(
+        {"default": _EnumerationFacetMember(), "preserve": _EnumerationFacetMember()})})}
 xAttributesSharedEmptyDict: dict[str, ModelAttribute] = {}
 
 def validate(
@@ -778,39 +809,26 @@ def _validateValueStringOrRaise(
             # XSD 1.0 Datatypes 4.3.5: the enumeration facet constrains the value space, so
             # a value is facet-valid when it equals a member in the value space even if its
             # lexical form differs (e.g. dateTime 12:01:01+00:00 vs -00:00, decimal 1.0 vs 1).
+            # Every enumeration facet (schema-derived, via ModelType.constrainingFacets, or
+            # synthesized in this module, e.g. for whiteSpace) is an EnumerationFacet: a
+            # dict of lexical value -> facet element, with a lazily-populated valueSpace cache.
             enumeration = facets["enumeration"]
-            # Only a schema-derived enumeration facet (a dict of lexical value -> facetElt,
-            # possibly an _EnumerationFacet) supports the lazily-populated valueSpace cache;
-            # synthetic enumerations built in this module (e.g. for whiteSpace) are plain
-            # sets/dicts without facetElts and always fall through to a fresh parse below.
-            valueSpace = getattr(enumeration, "valueSpace", None)
+            valueSpace = enumeration.valueSpace
             if valueSpace is None:
                 valueSpace = {}
-                members = (
-                    enumeration.items()
-                    if isinstance(enumeration, dict)
-                    else ((m, None) for m in enumeration)
-                )
-                for member, facetElt in members:
+                for member, facetElt in enumeration.items():
                     try:
                         # Use the enumeration facet's own schema-document nsmap (not the
                         # validated instance's) since a QName-lexical enumeration member's
                         # namespace bindings are fixed at the schema, per XSD Part 2 §3.2.18.
-                        memberNsmap = facetElt.nsmap if facetElt is not None else nsmap
-                        parsedMember = _validateValueStringOrRaise(baseXsdType, member, nsmap=memberNsmap)
+                        parsedMember = _validateValueStringOrRaise(baseXsdType, member, nsmap=facetElt.nsmap)
                         valueSpace[_hashableXValue(parsedMember.xValue)] = member
                     except (ValueError, InvalidOperation, TypeError):
                         pass
-                try: # only an _EnumerationFacet (schema-derived enumeration) supports this
-                    enumeration.valueSpace = valueSpace
-                except AttributeError:
-                    pass
+                enumeration.valueSpace = valueSpace
             found = _hashableXValue(xValue) in valueSpace
             if not found:
-                raise ValueError("{0} is not in {1}".format(value, (
-                    facets["enumeration"].keys()
-                    if isinstance(facets["enumeration"], dict)
-                    else facets["enumeration"])))
+                raise ValueError("{0} is not in {1}".format(value, enumeration.keys()))
     return XmlValidationResult(sValue=sValue, xValue=xValue, xValid=xValid)
 
 
@@ -878,8 +896,8 @@ def validateValue(
         elt.sValue = sValue
 
 
-def _facetTypeAndFacets(facetName: str, baseXsdType: str) -> tuple[str, dict[str, int | set[str]] | None]:
-    facets: dict[str, int | set[str]] | None
+def _facetTypeAndFacets(facetName: str, baseXsdType: str) -> tuple[str, dict[str, int | EnumerationFacet] | None]:
+    facets: dict[str, int | EnumerationFacet] | None
     if facetName in ("length", "minLength", "maxLength"):
         baseXsdType = "nonNegativeInteger"
         facets = None
@@ -907,7 +925,8 @@ def _facetTypeAndFacets(facetName: str, baseXsdType: str) -> tuple[str, dict[str
                 facets = {"minExclusive": lowerLimit}
     elif facetName == "whiteSpace":
         baseXsdType = "string"
-        facets = {"enumeration": {"replace", "preserve", "collapse"}}
+        facets = {"enumeration": EnumerationFacet(
+            {member: _EnumerationFacetMember() for member in ("replace", "preserve", "collapse")})}
     elif facetName == "pattern":
         baseXsdType = "xsd-pattern"
         facets = None

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -822,9 +822,9 @@ def _validateValueStringOrRaise(
                         # validated instance's) since a QName-lexical enumeration member's
                         # namespace bindings are fixed at the schema, per XSD Part 2 §3.2.18.
                         parsedMember = _validateValueStringOrRaise(baseXsdType, member, nsmap=facetElt.nsmap)
-                        valueSpace[_hashableXValue(parsedMember.xValue)] = member
-                    except (ValueError, InvalidOperation, TypeError):
-                        pass
+                    except (ValueError, InvalidOperation):
+                        continue
+                    valueSpace[_hashableXValue(parsedMember.xValue)] = member
                 enumeration.valueSpace = valueSpace
             found = _hashableXValue(xValue) in valueSpace
             if not found:

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -596,8 +596,6 @@ def _validateValueStringOrRaise(
                 (not isList and pattern.match(value) is None)):
                 raise ValueError("pattern facet " + facets["pattern"].pattern if facets and "pattern" in facets else "pattern mismatch")
         if facets:
-            if "enumeration" in facets and value not in facets["enumeration"]:
-                raise ValueError("{0} is not in {1}".format(value, facets["enumeration"].keys()))
             # length/minLength/maxLength are meaningless for QName and NOTATION; per
             # XSD Datatypes 3.2.18/3.2.19 every value is facet-valid with respect to them.
             if baseXsdType not in ("QName", "NOTATION"):
@@ -767,6 +765,46 @@ def _validateValueStringOrRaise(
                     raise ValueError(" < minInclusive {0}".format(facets["minInclusive"]))
                 if "minExclusive" in facets and _orderedComparison(xValue, facets["minExclusive"]) != 1:
                     raise ValueError(" <= minExclusive {0}".format(facets["minExclusive"]))
+        if facets and "enumeration" in facets and value not in facets["enumeration"]:
+            # XSD 1.0 Datatypes 4.3.5: the enumeration facet constrains the value space, so
+            # a value is facet-valid when it equals a member in the value space even if its
+            # lexical form differs (e.g. dateTime 12:01:01+00:00 vs -00:00, decimal 1.0 vs 1).
+            enumeration = facets["enumeration"]
+            # Only a schema-derived enumeration facet (a dict of lexical value -> facetElt,
+            # possibly an _EnumerationFacet) supports the lazily-populated valueSpace cache;
+            # synthetic enumerations built in this module (e.g. for whiteSpace) are plain
+            # sets/dicts without facetElts and always fall through to a fresh parse below.
+            valueSpace = getattr(enumeration, "valueSpace", None)
+            if valueSpace is None:
+                valueSpace = {}
+                members = (
+                    enumeration.items()
+                    if isinstance(enumeration, dict)
+                    else ((m, None) for m in enumeration)
+                )
+                for member, facetElt in members:
+                    try:
+                        # Use the enumeration facet's own schema-document nsmap (not the
+                        # validated instance's) since a QName-lexical enumeration member's
+                        # namespace bindings are fixed at the schema, per XSD Part 2 §3.17.2.
+                        memberNsmap = facetElt.nsmap if facetElt is not None else nsmap
+                        parsedMember = _validateValueStringOrRaise(baseXsdType, member, nsmap=memberNsmap)
+                        valueSpace[parsedMember.xValue] = member
+                    except (ValueError, InvalidOperation, TypeError):
+                        pass
+                try: # only an _EnumerationFacet (schema-derived enumeration) supports this
+                    enumeration.valueSpace = valueSpace
+                except AttributeError:
+                    pass
+            try:
+                found = xValue in valueSpace
+            except TypeError: # xValue is unhashable (e.g. a list); fall back to linear equality scan
+                found = any(xValue == v for v in valueSpace)
+            if not found:
+                raise ValueError("{0} is not in {1}".format(value, (
+                    facets["enumeration"].keys()
+                    if isinstance(facets["enumeration"], dict)
+                    else facets["enumeration"])))
     return XmlValidationResult(sValue=sValue, xValue=xValue, xValid=xValid)
 
 

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -897,26 +897,22 @@ def validateValue(
 
 
 def _facetTypeAndFacets(facetName: str, baseXsdType: str) -> tuple[str, dict[str, int | EnumerationFacet] | None]:
-    facets: dict[str, int | EnumerationFacet] | None
+    facets: dict[str, int | EnumerationFacet] | None = None
     if facetName in ("length", "minLength", "maxLength"):
         baseXsdType = "nonNegativeInteger"
-        facets = None
     elif facetName == "fractionDigits":
         # Integer and its derived types have fractionDigits fixed at 0 while xs:decimal allows any non-negative value.
         facets = {"maxInclusive": 0} if baseXsdType in _INTEGER_BASE_XSD_TYPES else None
         baseXsdType = "nonNegativeInteger"
     elif facetName == "totalDigits":
         baseXsdType = "positiveInteger"
-        facets = None
     elif facetName in ("minInclusive", "maxInclusive"):
         baseXsdType = baseXsdType
-        facets = None
     elif facetName in ("minExclusive", "maxExclusive"):
         # Reject values at or outside of the type's bounds, e.g. minExclusive="127" for byte.
         # The facet value itself is valid as a byte but it creates an empty range (nothing > 127)
         # for the value space of the type it restricts. Inclusive bounds don't need this because they
         # overshoot the range by one (minInclusive="128" for byte), which type parsing already rejects.
-        facets = None
         if inherentBounds := _XSD_TYPE_INHERENT_INCLUSIVE_BOUNDS.get(baseXsdType):
             lowerLimit, upperLimit = inherentBounds
             if facetName == "minExclusive" and upperLimit is not None:
@@ -929,10 +925,8 @@ def _facetTypeAndFacets(facetName: str, baseXsdType: str) -> tuple[str, dict[str
             {member: _EnumerationFacetMember() for member in ("replace", "preserve", "collapse")})}
     elif facetName == "pattern":
         baseXsdType = "xsd-pattern"
-        facets = None
     else:
         baseXsdType = "string"
-        facets = None
     return baseXsdType, facets
 
 def validateFacet(typeElt: ModelType, facetElt: ModelObject) -> TypeXValue | None:

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -484,6 +484,15 @@ def _comparableInstant(value: datetime.datetime | datetime.time) -> datetime.dat
     return dt
 
 
+def _hashableXValue(xValue: Any) -> Any:
+    # xValue is normally hashable, but list-valued types (e.g. enumerationHrefs/
+    # enumerationQNames, whose xValue is a list of QName) are not. Convert to a
+    # tuple so such values can still be used as (or looked up against) dict keys.
+    if isinstance(xValue, list):
+        return tuple(xValue)
+    return xValue
+
+
 def _orderedComparison(value: Any, bound: Any) -> int | None:
     """Order ``value`` against an ordering-facet ``bound``.
 
@@ -789,17 +798,14 @@ def _validateValueStringOrRaise(
                         # namespace bindings are fixed at the schema, per XSD Part 2 §3.2.18.
                         memberNsmap = facetElt.nsmap if facetElt is not None else nsmap
                         parsedMember = _validateValueStringOrRaise(baseXsdType, member, nsmap=memberNsmap)
-                        valueSpace[parsedMember.xValue] = member
+                        valueSpace[_hashableXValue(parsedMember.xValue)] = member
                     except (ValueError, InvalidOperation, TypeError):
                         pass
                 try: # only an _EnumerationFacet (schema-derived enumeration) supports this
                     enumeration.valueSpace = valueSpace
                 except AttributeError:
                     pass
-            try:
-                found = xValue in valueSpace
-            except TypeError: # xValue is unhashable (e.g. a list); fall back to linear equality scan
-                found = any(xValue == v for v in valueSpace)
+            found = _hashableXValue(xValue) in valueSpace
             if not found:
                 raise ValueError("{0} is not in {1}".format(value, (
                     facets["enumeration"].keys()

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -786,7 +786,7 @@ def _validateValueStringOrRaise(
                     try:
                         # Use the enumeration facet's own schema-document nsmap (not the
                         # validated instance's) since a QName-lexical enumeration member's
-                        # namespace bindings are fixed at the schema, per XSD Part 2 §3.17.2.
+                        # namespace bindings are fixed at the schema, per XSD Part 2 §3.2.18.
                         memberNsmap = facetElt.nsmap if facetElt is not None else nsmap
                         parsedMember = _validateValueStringOrRaise(baseXsdType, member, nsmap=memberNsmap)
                         valueSpace[parsedMember.xValue] = member

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -711,10 +711,29 @@ def test_validateValueString_enumeration_set_valued(value: str, expected_x_valid
     ],
 )
 def test_validateValueString_enumeration_unhashable_xvalue_does_not_crash(value: str, expected_x_valid: int):
-    # enumerationQNames produces a list xValue, which is unhashable; the value-space lookup
-    # must fall back to a linear scan instead of raising TypeError.
+    # enumerationQNames produces a list xValue, which is unhashable; the value-space cache
+    # must convert it to a (hashable) tuple rather than raise TypeError.
     facets = {"enumeration": {"p:a": None}}
     result = validateValueString("enumerationQNames", value, facets=facets, nsmap={"p": "urn:x"})
+    assert result.xValid == expected_x_valid
+
+
+@pytest.mark.parametrize(
+    "value,expected_x_valid",
+    [
+        ("p:a", VALID),  # exact lexical member (fast path)
+        ("q:a", VALID),  # lexical miss, but the same QName (via a different prefix) matches in the value space
+        ("q:b", INVALID),  # lexical miss, different QName -> no value-space match
+    ],
+)
+def test_validateValueString_enumeration_unhashable_xvalue_value_space_match(value: str, expected_x_valid: int):
+    # A list-valued xValue (e.g. enumerationQNames) is unhashable, so it is coerced to a tuple
+    # before being used as (or looked up against) a value-space dict key. Without that coercion,
+    # inserting a list key raises TypeError, which is silently swallowed, so every member is
+    # dropped from the cache and a value-space match (like q:a below) is wrongly rejected.
+    facets = {"enumeration": {"p:a": None}}
+    nsmap = {"p": "urn:x", "q": "urn:x"}
+    result = validateValueString("enumerationQNames", value, facets=facets, nsmap=nsmap)
     assert result.xValid == expected_x_valid
 
 

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock
 import pytest
 import regex
 
+from arelle.ModelDtsObject import _EnumerationFacet
 from arelle.ModelValue import DateTime, QName, Time, gDay, gMonth, gMonthDay, gYear, gYearMonth, isoDuration
 from arelle.XmlValidate import (
     NCNamePattern,
@@ -556,6 +557,170 @@ def test_validateValue_facets_enumeration(value: str, expected: tuple):
     }
     validateValue(modelXbrl=Mock(), elt=elt, attrTag=None, baseXsdType="string", value=value, facets=facets)
     _assertExpected(value, attrTag=None, elt=elt, expected=expected)
+
+
+@pytest.mark.parametrize(
+    "base_xsd_type,member,value,expected_x_valid",
+    [
+        # dateTime: Z, +00:00 and -00:00 all denote UTC, so they are equal in the value
+        # space even though their lexical forms differ.
+        ("dateTime", "2002-01-01T12:01:01-00:00", "2002-01-01T12:01:01-00:00", VALID),  # lexical fast path
+        ("dateTime", "2002-01-01T12:01:01-00:00", "2002-01-01T12:01:01Z", VALID),
+        ("dateTime", "2002-01-01T12:01:01-00:00", "2002-01-01T12:01:01+00:00", VALID),
+        ("dateTime", "2002-01-01T12:01:01-00:00", "2002-01-01T12:01:02+00:00", INVALID),  # different instant
+        # date: timezone spellings that denote the same day are equal
+        ("date", "2002-01-01-00:00", "2002-01-01Z", VALID),
+        ("date", "2002-01-01-00:00", "2002-01-01+00:00", VALID),
+        ("date", "2002-01-01-00:00", "2002-01-02Z", INVALID),
+        # time: Z and -00:00 denote the same instant of day
+        ("time", "12:00:00-00:00", "12:00:00Z", VALID),
+        ("time", "12:00:00-00:00", "13:00:00Z", INVALID),
+        # gYearMonth discards the timezone at parse time, so tz spellings collapse
+        ("gYearMonth", "2002-01Z", "2002-01", VALID),
+        ("gYearMonth", "2002-01Z", "2002-01+00:00", VALID),
+        ("gYearMonth", "2002-01Z", "2002-02", INVALID),
+        # duration: PT1H and PT60M are the same magnitude
+        ("duration", "PT1H", "PT60M", VALID),
+        ("duration", "PT1H", "PT61M", INVALID),
+        # decimal: 1, 1.0 and 1.00 denote the same value
+        ("decimal", "1", "1.0", VALID),
+        ("decimal", "1", "1.00", VALID),
+        ("decimal", "1", "2", INVALID),
+        # float / double: scientific and trailing-zero spellings are equal
+        ("float", "1", "1.0", VALID),
+        ("float", "100", "1E2", VALID),
+        ("float", "1", "2", INVALID),
+        ("double", "1.5", "1.50", VALID),
+        ("double", "1.5", "1.6", INVALID),
+        # integer: leading sign and leading zeros are not part of the value
+        ("integer", "1", "+1", VALID),
+        ("integer", "1", "01", VALID),
+        ("integer", "1", "2", INVALID),
+        # boolean: {true, 1} and {false, 0}
+        ("boolean", "1", "true", VALID),
+        ("boolean", "1", "1", VALID),
+        ("boolean", "1", "false", INVALID),
+        ("boolean", "0", "false", VALID),
+        ("boolean", "0", "true", INVALID),
+    ],
+)
+def test_validateValueString_enumeration_value_space(
+    base_xsd_type: str, member: str, value: str, expected_x_valid: int
+):
+    facets = {"enumeration": {member: None}}
+    result = validateValueString(base_xsd_type, value, facets=facets, nsmap={"prefix": "namespaceURI"})
+    assert result.xValid == expected_x_valid
+    assert result.isXValid == (expected_x_valid >= VALID)
+
+
+@pytest.mark.parametrize(
+    "value,expected_x_valid",
+    [
+        ("1", VALID),      # exact lexical member (fast path)
+        ("2", VALID),      # equals member "2.0" only in the value space
+        ("3.0", VALID),    # equals member "3" only in the value space
+        ("4", INVALID),    # not equal to any member
+    ],
+)
+def test_validateValueString_enumeration_value_space_multiple_members(value: str, expected_x_valid: int):
+    # a candidate may match any member, not just the first, by value-space equality
+    facets = {"enumeration": {"1": None, "2.0": None, "3": None}}
+    result = validateValueString("decimal", value, facets=facets)
+    assert result.xValid == expected_x_valid
+
+
+@pytest.mark.parametrize(
+    "value,expected_x_valid",
+    [
+        ("p:local", VALID),   # same value as member "q:local" (both bound to urn:x)
+        ("q:local", VALID),   # exact lexical member (fast path)
+        ("p:other", INVALID), # different local name
+    ],
+)
+def test_validateValueString_enumeration_qname_prefix_independent(value: str, expected_x_valid: int):
+    # A QName's value is the (namespace, local name) pair, not its lexical prefix. With both
+    # p: and q: bound to the same namespace in the instance, p:local and q:local are equal.
+    facets = {"enumeration": {"q:local": None}}
+    nsmap = {"p": "urn:x", "q": "urn:x"}
+    result = validateValueString("QName", value, facets=facets, nsmap=nsmap)
+    assert result.xValid == expected_x_valid
+
+
+def test_validateValueString_enumeration_qname_uses_schema_facet_nsmap():
+    # A QName-lexical member's namespace bindings are fixed at the schema (the facet element),
+    # not the validated instance. The member prefix "s" is only bound on the facet element;
+    # the instance binds the same namespace under a different prefix "i". Parsing the member
+    # with the facet's own nsmap is what lets the instance value match.
+    facetElt = Mock(nsmap={"s": "urn:x"})
+    facets = {"enumeration": {"s:local": facetElt}}
+    instanceNsmap = {"i": "urn:x"}
+    match = validateValueString("QName", "i:local", facets=facets, nsmap=instanceNsmap)
+    assert match.xValid == VALID
+    mismatch = validateValueString("QName", "i:other", facets=facets, nsmap=instanceNsmap)
+    assert mismatch.xValid == INVALID
+
+
+def test_validateValueString_enumeration_value_space_is_lazily_cached():
+    enumeration = _EnumerationFacet()
+    enumeration["1"] = None
+    facets = {"enumeration": enumeration}
+
+    # The lexical fast path must not build the value-space cache at all.
+    assert validateValueString("decimal", "1", facets=facets).xValid == VALID
+    assert getattr(enumeration, "valueSpace", "unset") == "unset"
+
+    # A lexical miss that matches in the value space builds and caches the map.
+    assert validateValueString("decimal", "1.0", facets=facets).xValid == VALID
+    cached = enumeration.valueSpace
+    assert Decimal("1") in cached
+
+    # A subsequent validation reuses the same cached object rather than rebuilding it.
+    assert validateValueString("decimal", "1.00", facets=facets).xValid == VALID
+    assert enumeration.valueSpace is cached
+
+
+@pytest.mark.parametrize(
+    "value,expected_x_valid",
+    [
+        ("1.0", VALID),    # matches the parseable member "1"
+        ("2", INVALID),    # matches nothing; must not crash on the bad member
+    ],
+)
+def test_validateValueString_enumeration_skips_unparseable_member(value: str, expected_x_valid: int):
+    # A member that cannot be parsed as the datatype is skipped, not fatal.
+    facets = {"enumeration": {"not-a-decimal": None, "1": None}}
+    result = validateValueString("decimal", value, facets=facets)
+    assert result.xValid == expected_x_valid
+
+
+@pytest.mark.parametrize(
+    "value,expected_x_valid",
+    [
+        ("1.0", VALID),
+        ("3", INVALID),
+    ],
+)
+def test_validateValueString_enumeration_set_valued(value: str, expected_x_valid: int):
+    # Some enumerations are plain sets (no facet elements, no cache attribute); value-space
+    # comparison must still work and the un-cacheable cache-write must be swallowed.
+    facets = {"enumeration": {"1", "2"}}
+    result = validateValueString("decimal", value, facets=facets)
+    assert result.xValid == expected_x_valid
+
+
+@pytest.mark.parametrize(
+    "value,expected_x_valid",
+    [
+        ("p:a", VALID),    # exact lexical member (fast path, list value never compared)
+        ("p:b", INVALID),  # lexical miss -> unhashable list xValue must not crash
+    ],
+)
+def test_validateValueString_enumeration_unhashable_xvalue_does_not_crash(value: str, expected_x_valid: int):
+    # enumerationQNames produces a list xValue, which is unhashable; the value-space lookup
+    # must fall back to a linear scan instead of raising TypeError.
+    facets = {"enumeration": {"p:a": None}}
+    result = validateValueString("enumerationQNames", value, facets=facets, nsmap={"p": "urn:x"})
+    assert result.xValid == expected_x_valid
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -11,13 +11,15 @@ from unittest.mock import Mock
 import pytest
 import regex
 
-from arelle.ModelDtsObject import _EnumerationFacet
-from arelle.ModelValue import DateTime, QName, Time, gDay, gMonth, gMonthDay, gYear, gYearMonth, isoDuration
+from arelle.ModelValue import DateTime, QName, Time, gDay, gMonth, gMonthDay, gYear, gYearMonth, isoDuration, qname
 from arelle.XmlValidate import (
     NCNamePattern,
     NMTOKENPattern,
     XsdPattern,
+    EnumerationFacet,
+    _EnumerationFacetMember,
     namePattern,
+    predefinedAttributeTypes,
     validateFacetValueString,
     validateValue,
     validateValueString,
@@ -549,11 +551,11 @@ def test_validateValue(attrTag: str, baseXsdType: str, value: str, isNillable: b
 def test_validateValue_facets_enumeration(value: str, expected: tuple):
     elt = Mock()
     facets = {
-        "enumeration": {
-            "valid1": None,
-            "valid2": None,
-            "valid3": None,
-        }
+        "enumeration": EnumerationFacet({
+            "valid1": _EnumerationFacetMember(),
+            "valid2": _EnumerationFacetMember(),
+            "valid3": _EnumerationFacetMember(),
+        })
     }
     validateValue(modelXbrl=Mock(), elt=elt, attrTag=None, baseXsdType="string", value=value, facets=facets)
     _assertExpected(value, attrTag=None, elt=elt, expected=expected)
@@ -602,7 +604,7 @@ def test_validateValue_facets_enumeration(value: str, expected: tuple):
 def test_validateValueString_enumeration_value_space(
     base_xsd_type: str, member: str, value: str, expected_x_valid: int
 ):
-    facets = {"enumeration": {member: None}}
+    facets = {"enumeration": EnumerationFacet({member: _EnumerationFacetMember()})}
     result = validateValueString(base_xsd_type, value, facets=facets, nsmap={"prefix": "namespaceURI"})
     assert result.xValid == expected_x_valid
     assert result.isXValid == (expected_x_valid >= VALID)
@@ -619,7 +621,7 @@ def test_validateValueString_enumeration_value_space(
 )
 def test_validateValueString_enumeration_value_space_multiple_members(value: str, expected_x_valid: int):
     # a candidate may match any member, not just the first, by value-space equality
-    facets = {"enumeration": {"1": None, "2.0": None, "3": None}}
+    facets = {"enumeration": EnumerationFacet({"1": _EnumerationFacetMember(), "2.0": _EnumerationFacetMember(), "3": _EnumerationFacetMember()})}
     result = validateValueString("decimal", value, facets=facets)
     assert result.xValid == expected_x_valid
 
@@ -634,9 +636,10 @@ def test_validateValueString_enumeration_value_space_multiple_members(value: str
 )
 def test_validateValueString_enumeration_qname_prefix_independent(value: str, expected_x_valid: int):
     # A QName's value is the (namespace, local name) pair, not its lexical prefix. With both
-    # p: and q: bound to the same namespace in the instance, p:local and q:local are equal.
-    facets = {"enumeration": {"q:local": None}}
+    # p: and q: bound to the same namespace (for both the member and the instance), p:local
+    # and q:local are equal.
     nsmap = {"p": "urn:x", "q": "urn:x"}
+    facets = {"enumeration": EnumerationFacet({"q:local": _EnumerationFacetMember(nsmap=nsmap)})}
     result = validateValueString("QName", value, facets=facets, nsmap=nsmap)
     assert result.xValid == expected_x_valid
 
@@ -647,7 +650,7 @@ def test_validateValueString_enumeration_qname_uses_schema_facet_nsmap():
     # the instance binds the same namespace under a different prefix "i". Parsing the member
     # with the facet's own nsmap is what lets the instance value match.
     facetElt = Mock(nsmap={"s": "urn:x"})
-    facets = {"enumeration": {"s:local": facetElt}}
+    facets = {"enumeration": EnumerationFacet({"s:local": facetElt})}
     instanceNsmap = {"i": "urn:x"}
     match = validateValueString("QName", "i:local", facets=facets, nsmap=instanceNsmap)
     assert match.xValid == VALID
@@ -656,17 +659,18 @@ def test_validateValueString_enumeration_qname_uses_schema_facet_nsmap():
 
 
 def test_validateValueString_enumeration_value_space_is_lazily_cached():
-    enumeration = _EnumerationFacet()
-    enumeration["1"] = None
+    enumeration = EnumerationFacet()
+    enumeration["1"] = _EnumerationFacetMember()
     facets = {"enumeration": enumeration}
 
     # The lexical fast path must not build the value-space cache at all.
     assert validateValueString("decimal", "1", facets=facets).xValid == VALID
-    assert getattr(enumeration, "valueSpace", "unset") == "unset"
+    assert enumeration.valueSpace is None
 
     # A lexical miss that matches in the value space builds and caches the map.
     assert validateValueString("decimal", "1.0", facets=facets).xValid == VALID
     cached = enumeration.valueSpace
+    assert cached is not None
     assert Decimal("1") in cached
 
     # A subsequent validation reuses the same cached object rather than rebuilding it.
@@ -683,7 +687,7 @@ def test_validateValueString_enumeration_value_space_is_lazily_cached():
 )
 def test_validateValueString_enumeration_skips_unparseable_member(value: str, expected_x_valid: int):
     # A member that cannot be parsed as the datatype is skipped, not fatal.
-    facets = {"enumeration": {"not-a-decimal": None, "1": None}}
+    facets = {"enumeration": EnumerationFacet({"not-a-decimal": _EnumerationFacetMember(), "1": _EnumerationFacetMember()})}
     result = validateValueString("decimal", value, facets=facets)
     assert result.xValid == expected_x_valid
 
@@ -691,15 +695,14 @@ def test_validateValueString_enumeration_skips_unparseable_member(value: str, ex
 @pytest.mark.parametrize(
     "value,expected_x_valid",
     [
-        ("1.0", VALID),
-        ("3", INVALID),
+        ("default", VALID),
+        ("preserve", VALID),
+        ("collapse", INVALID),
     ],
 )
-def test_validateValueString_enumeration_set_valued(value: str, expected_x_valid: int):
-    # Some enumerations are plain sets (no facet elements, no cache attribute); value-space
-    # comparison must still work and the un-cacheable cache-write must be swallowed.
-    facets = {"enumeration": {"1", "2"}}
-    result = validateValueString("decimal", value, facets=facets)
+def test_validateValueString_enumeration_predefined_xml_space(value: str, expected_x_valid: int):
+    baseXsdType, facets = predefinedAttributeTypes[qname("{http://www.w3.org/XML/1998/namespace}xml:space")]
+    result = validateValueString(baseXsdType, value, facets=facets)
     assert result.xValid == expected_x_valid
 
 
@@ -713,8 +716,9 @@ def test_validateValueString_enumeration_set_valued(value: str, expected_x_valid
 def test_validateValueString_enumeration_unhashable_xvalue_does_not_crash(value: str, expected_x_valid: int):
     # enumerationQNames produces a list xValue, which is unhashable; the value-space cache
     # must convert it to a (hashable) tuple rather than raise TypeError.
-    facets = {"enumeration": {"p:a": None}}
-    result = validateValueString("enumerationQNames", value, facets=facets, nsmap={"p": "urn:x"})
+    nsmap = {"p": "urn:x"}
+    facets = {"enumeration": EnumerationFacet({"p:a": _EnumerationFacetMember(nsmap=nsmap)})}
+    result = validateValueString("enumerationQNames", value, facets=facets, nsmap=nsmap)
     assert result.xValid == expected_x_valid
 
 
@@ -731,8 +735,8 @@ def test_validateValueString_enumeration_unhashable_xvalue_value_space_match(val
     # before being used as (or looked up against) a value-space dict key. Without that coercion,
     # inserting a list key raises TypeError, which is silently swallowed, so every member is
     # dropped from the cache and a value-space match (like q:a below) is wrongly rejected.
-    facets = {"enumeration": {"p:a": None}}
     nsmap = {"p": "urn:x", "q": "urn:x"}
+    facets = {"enumeration": EnumerationFacet({"p:a": _EnumerationFacetMember(nsmap=nsmap)})}
     result = validateValueString("enumerationQNames", value, facets=facets, nsmap=nsmap)
     assert result.xValid == expected_x_valid
 
@@ -1265,6 +1269,14 @@ class TestValidateFacetValueString:
         assert result.isXValid
         assert result.sValue == "collapse"
         assert result.xValue == "collapse"
+
+    def test_whiteSpace_invalid(self):
+        # whiteSpace's own enumeration facet is synthesized; an out-of-set
+        # value should still be rejected through the same enumeration logic.
+        result = validateFacetValueString("whiteSpace", "invalid", "string")
+        assert result.xValid == INVALID
+        assert not result.isXValid
+        assert result.xValue is None
 
     def test_pattern(self):
         result = validateFacetValueString("pattern", "[A-Z]+", "string")

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -575,10 +575,11 @@ def test_validateValue_facets_enumeration(value: str, expected: tuple):
         # time: Z and -00:00 denote the same instant of day
         ("time", "12:00:00-00:00", "12:00:00Z", VALID),
         ("time", "12:00:00-00:00", "13:00:00Z", INVALID),
-        # gYearMonth discards the timezone at parse time, so tz spellings collapse
-        ("gYearMonth", "2002-01Z", "2002-01", VALID),
+        # gregorian date tz alternate formats are equal
+        ("gYear", "2002Z", "2002-00:00", VALID),
         ("gYearMonth", "2002-01Z", "2002-01+00:00", VALID),
-        ("gYearMonth", "2002-01Z", "2002-02", INVALID),
+        ("gMonthDay", "--01-01-00:00", "--01-01+00:00", VALID),
+        ("gMonthDay", "--01-02", "--01-01", INVALID),
         # duration: PT1H and PT60M are the same magnitude
         ("duration", "PT1H", "PT60M", VALID),
         ("duration", "PT1H", "PT61M", INVALID),

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -596,12 +596,6 @@ def test_validateValue_facets_enumeration(value: str, expected: tuple):
         ("integer", "1", "+1", VALID),
         ("integer", "1", "01", VALID),
         ("integer", "1", "2", INVALID),
-        # boolean: {true, 1} and {false, 0}
-        ("boolean", "1", "true", VALID),
-        ("boolean", "1", "1", VALID),
-        ("boolean", "1", "false", INVALID),
-        ("boolean", "0", "false", VALID),
-        ("boolean", "0", "true", INVALID),
     ],
 )
 def test_validateValueString_enumeration_value_space(


### PR DESCRIPTION
Part of #2445

## Fix 8 — `enumeration` is matched in the value space, not lexically

**Where:** the `enumeration` facet check in `_validateValueStringOrRaise`, plus a
new `_EnumerationFacet` (a `dict` subclass) in `arelle/ModelDtsObject.py` that
`ModelType.facets` now uses to hold each enumeration and carry its cached value
space.

**Symptom:** enumeration membership was tested as `value not in facets["enumeration"]`
— a comparison of the *lexical* string against the lexical forms of the enumeration
members. That wrongly rejects a value that equals a member in the **value space** but
is spelled differently. For example, a `dateTime`-derived type whose only member is
`2002-01-01T12:01:01-00:00` rejected the values `2002-01-01T12:01:01+00:00` and
`2002-01-01T12:01:01Z`, even though all three denote the same instant. The same class
of false rejection applies to any type whose lexical space is many-to-one onto its
value space (`decimal` `1.0` vs `1`, `boolean` `1` vs `true`, etc.).

**Change:** keep the cheap lexical membership test as a fast path, but when it misses,
fall back to a value-space comparison. The check is moved to after `xValue` (the parsed
value-space object) is computed. On a miss the enumeration's members are parsed once into
a map from each member's parsed `xValue` to its lexical form; membership is then a lookup
of the candidate's `xValue` in that map. Each member is parsed through the same datatype
path (facets omitted, so the parse cannot recurse back into the enumeration facet) and
with its **own schema facet's** `nsmap` (a `QName`-lexical member's namespace bindings are
fixed at the schema, not the instance)

The parsed value space is built **lazily** (only on a lexical miss) and cached on the
enumeration facet object itself: `ModelType.facets` returns the enumeration as an
`_EnumerationFacet`, a `dict` subclass that stores the map in a `__slots__` attribute
(`valueSpace`) kept off the dict's own keys/items. Because `ModelType.facets` is memoized,
the map is computed at most once per type, while the facet still behaves as a plain
`dict[str, facetElt]` for existing consumers (type-equivalence checks, ViewX rendering, DB
export, sample-instance generation). Synthetic set/dict enumerations built elsewhere in
the module lack the attribute (the cache write is swallowed) and simply recompute.

Because the lexical fast path still accepts every previously-accepted value, the change
can only *accept* values that were formerly (wrongly) rejected; it never newly rejects a
value. Robustness: a member that fails to parse is skipped rather than aborting the check,
and an unhashable `xValue` (e.g. a list-valued type) falls back to a linear equality scan
instead of raising.

**Normative basis:**

- XSD 2 §4.3.5 *enumeration*: "enumeration constrains the **value space** to a specified
  set of values." Its facet-validity rule is value-space membership: a value is
  facet-valid with respect to enumeration iff the value is **equal** (in the value space)
  to one of the enumerated values — not iff its lexical form matches.
  <https://www.w3.org/TR/xmlschema-2/#rf-enumeration>

- Equality is the datatype's value-space identity, which is independent of lexical
  form. For `dateTime`, §3.2.7 *Order relation on dateTime* makes timezoned values that
  denote the same instant equal, and §3.2.7.1 notes that the timezones `Z`, `+00:00`
  and `-00:00` are equivalent. <https://www.w3.org/TR/xmlschema-2/#dateTime-order>
  Likewise `decimal` (§3.2.3) treats `1`, `1.0`, `1.00` as the same value, and `boolean`
  (§3.2.2) has the two values denoted by `{true, 1}` and `{false, 0}`.

- XSD 1.1 D §3.2.7 / §4.3.5 state the same value-space semantics for enumeration.
  <https://www.w3.org/TR/xmlschema11-2/#rf-enumeration>

**Independent check:** take a type derived from `dateTime` with the single enumerated
member `2002-01-01T12:01:01-00:00`. By the §3.2.7 order relation, `-00:00` denotes UTC,
so the value `2002-01-01T12:01:01+00:00` (also UTC) is **equal** to the member in the
value space; by §4.3.5 it is therefore facet-valid and must be accepted. A value at a
different instant (e.g. `2002-01-01T12:01:02+00:00`) is not equal to any member and must
still be rejected.

#### Steps to Test
CI

**review**:
@Arelle/arelle
