### PR TITLE
Filter ESEF validation by target in multi-target filings

### DIFF
--- a/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_2021/ValidateXbrlFinally.py
@@ -425,9 +425,12 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                         if elt.format is not None and elt.format.namespaceURI not in IXT_NAMESPACES:
                             transformRegistryErrors.add(elt)
                 ixHiddenFacts = set()
+                ixdsTarget = getattr(modelXbrl, "ixdsTarget", None)
                 for ixHiddenElt in ixdsHtmlRootElt.iterdescendants(tag=ixNStag + "hidden"):
                     for tag in (ixNStag + "nonNumeric", ixNStag+"nonFraction"):
                         for ixElt in ixHiddenElt.iterdescendants(tag=tag):
+                            if ixElt.get("target") != ixdsTarget:
+                                continue
                             if (getattr(ixElt, "xValid", 0) >= VALID  # may not be validated
                                 ): # add future "and" conditions on elements which can be in hidden
                                 if (ixElt.concept.baseXsdType not in untransformableTypes and  # type: ignore[union-attr]
@@ -443,6 +446,8 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     if styleCssHiddenPattern.match(cssHiddenElt.get("style","")):
                         for tag in (ixNStag + "nonNumeric", ixNStag+"nonFraction"):
                             for ixElt in cssHiddenElt.iterdescendants(tag=tag):
+                                if ixElt.get("target") != ixdsTarget:
+                                    continue
                                 if ixElt not in ixHiddenFacts:
                                     modelXbrl.error("ESEF.2.5.4.displayNoneUsedToHideTaggedFacts",
                                         _('CSS MUST not be used to hide tagged facts, e.g. by applying display:none style. Concept "%(concept)s", value: %(value)s - line %(sourceline)s'),

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -516,9 +516,12 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                         if elt.format is not None and elt.format.namespaceURI not in allowedTRnamespaces:
                             transformRegistryErrors.add(elt)
                 ixHiddenFacts = set()
+                ixdsTarget = getattr(modelXbrl, "ixdsTarget", None)
                 for ixHiddenElt in ixdsHtmlRootElt.iterdescendants(tag=ixNStag + "hidden"):
                     for tag in (ixNStag + "nonNumeric", ixNStag+"nonFraction"):
                         for ixElt in ixHiddenElt.iterdescendants(tag=tag):
+                            if ixElt.get("target") != ixdsTarget:
+                                continue
                             if (getattr(ixElt, "xValid", 0) >= VALID  # may not be validated
                                 ): # add future "and" conditions on elements which can be in hidden
                                 if (ixElt.concept.baseXsdType not in untransformableTypes and  # type: ignore[union-attr]
@@ -534,6 +537,8 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                     if styleCssHiddenPattern.match(cssHiddenElt.get("style","")):
                         for tag in (ixNStag + "nonNumeric", ixNStag+"nonFraction"):
                             for ixElt in cssHiddenElt.iterdescendants(tag=tag):
+                                if ixElt.get("target") != ixdsTarget:
+                                    continue
                                 if ixElt not in ixHiddenFacts:
                                     modelXbrl.error("ESEF.2.5.4.displayNoneUsedToHideTaggedFacts",
                                         _('CSS MUST not be used to hide tagged facts, e.g. by applying display:none style. Concept "%(concept)s", value: %(value)s - line %(sourceline)s'),

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -214,6 +214,12 @@ def hasEsefTaxonomy(modelXbrl: ModelXbrl) -> bool:
 def isEsefExcludedInstance(val: ValidateXbrl) -> bool:
     if hasEsefTaxonomy(val.modelXbrl):
         return False
+    if val.authParam["ixdsMultiUsage"] == "allowed":
+        reportPackage = val.modelXbrl.fileSource.reportPackage
+        if reportPackage and reportPackage.reports and len(reportPackage.reports) > 1:
+            # Multi iXDS reports are independent models so we can't cross check here.
+            # validateComplete hook logs an error after all validation if no report in the package was validated as ESEF.
+            return True
     if not hasattr(val.modelXbrl, "ixdsTarget"):
         return False
     if val.authParam["ixTargetUsage"] != "allowed":

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -207,7 +207,26 @@ def esefDisclosureSystemSelected(modelXbrl: ModelXbrl) -> bool:
     return getattr(modelXbrl.modelManager.disclosureSystem, ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY, False)
 
 
+def hasEsefTaxonomy(modelXbrl: ModelXbrl) -> bool:
+    return any(esefCorNsPattern.match(ns) for ns in modelXbrl.namespaceDocs)
+
+
+def isEsefExcludedInstance(val: ValidateXbrl) -> bool:
+    if hasEsefTaxonomy(val.modelXbrl):
+        return False
+    if not hasattr(val.modelXbrl, "ixdsTarget"):
+        return False
+    if val.authParam["ixTargetUsage"] != "allowed":
+        return False
+    primary = val.modelXbrl.modelManager.modelXbrl
+    allModels = [primary] + getattr(primary, "supplementalModelXbrls", [])
+    allOtherModels = [m for m in allModels if m is not val.modelXbrl]
+    return any(hasEsefTaxonomy(m) for m in allOtherModels)
+
+
 def shouldRunEsefValidationRules(val: ValidateXbrl) -> bool:
     if not val.validateDisclosureSystem:
         return False
-    return esefDisclosureSystemSelected(val.modelXbrl)
+    if not esefDisclosureSystemSelected(val.modelXbrl):
+        return False
+    return not isEsefExcludedInstance(val)

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -101,11 +101,11 @@ def validateEntity(modelXbrl: ModelXbrl, filename:str, filesource: FileSource) -
 
 def getEsefAuthority(
     modelXbrl: ModelXbrl,
+    pluginData: ESEFPluginData,
     parameters: dict[Any, Any] | None,
 ) -> str | None:
     cntlr = modelXbrl.modelManager.cntlr
-    pluginData = cntlr.getPluginData(ESEF_PLUGIN_NAME)
-    esefAuthority = pluginData.esefAuthority if isinstance(pluginData, ESEFPluginData) else None
+    esefAuthority = pluginData.esefAuthority
     if not esefAuthority and cntlr.hasGui and cntlr.config is not None:
         esefAuthority = cntlr.config.get("esefAuthority") or None
     formulaAuthority = None
@@ -141,6 +141,16 @@ def getEsefAuthority(
 @dataclass
 class ESEFPluginData(PluginData):
     esefAuthority: str | None = None
+
+    @staticmethod
+    def get(cntlr: Cntlr) -> ESEFPluginData:
+        pluginData = cntlr.getPluginData(ESEF_PLUGIN_NAME)
+        if pluginData is None:
+            pluginData = ESEFPluginData(name=ESEF_PLUGIN_NAME)
+            cntlr.setPluginData(pluginData)
+        elif not isinstance(pluginData, ESEFPluginData):
+            raise RuntimeError(f"PluginData already set for {pluginData.name} with unexpected type {type(pluginData)}.")
+        return pluginData
 
 
 class ESEFPlugin(PluginHooks):
@@ -186,7 +196,8 @@ class ESEFPlugin(PluginHooks):
     ) -> None:
         esefAuthority = getattr(options, "esefAuthority", None)
         if esefAuthority:
-            cntlr.setPluginData(ESEFPluginData(name=ESEF_PLUGIN_NAME, esefAuthority=esefAuthority))
+            pluginData = ESEFPluginData.get(cntlr)
+            pluginData.esefAuthority = esefAuthority
 
     @staticmethod
     def cntlrWinMainMenuValidation(
@@ -326,10 +337,11 @@ class ESEFPlugin(PluginHooks):
         if not shouldRunEsefValidationRules(val):
             return None
         modelXbrl = val.modelXbrl
+        pluginData = ESEFPluginData.get(modelXbrl.modelManager.cntlr)
         val.extensionImportedUrls = set()
         val.unconsolidated = any("unconsolidated" in n for n in val.disclosureSystem.names)
         val.consolidated = not val.unconsolidated
-        val.authority = getEsefAuthority(modelXbrl, parameters)
+        val.authority = getEsefAuthority(modelXbrl, pluginData, parameters)
 
         authorityValidations = loadAuthorityValidations(val.modelXbrl)
         # loadAuthorityValidations returns either a list or a dict but in this context, we expect a dict.

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -71,7 +71,15 @@ from arelle.utils.PluginData import PluginData
 from arelle.utils.PluginHooks import PluginHooks
 from .ESEF_2021.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinally2021
 from .ESEF_Current.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinallyCurrent
-from .Util import AUTHORITY_CODES, getDisclosureSystemYear, loadAuthorityValidations, ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY, esefDisclosureSystemSelected, shouldRunEsefValidationRules
+from .Util import (
+    AUTHORITY_CODES,
+    ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY,
+    esefDisclosureSystemSelected,
+    getDisclosureSystemYear,
+    isEsefExcludedInstance,
+    loadAuthorityValidations,
+    shouldRunEsefValidationRules,
+)
 from .ValidationPluginExtension import ValidationPluginExtension
 from .rules import base
 
@@ -334,7 +342,9 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        if not shouldRunEsefValidationRules(val):
+        if not val.validateDisclosureSystem:
+            return None
+        if not esefDisclosureSystemSelected(val.modelXbrl):
             return None
         modelXbrl = val.modelXbrl
         pluginData = ESEFPluginData.get(modelXbrl.modelManager.cntlr)
@@ -367,6 +377,9 @@ class ESEFPlugin(PluginHooks):
         for convertListIntoSet in ("outdatedTaxonomyURLs", "effectiveTaxonomyURLs", "standardTaxonomyURIs", "additionalMandatoryTags"):
             if convertListIntoSet in val.authParam:
                 val.authParam[convertListIntoSet] = set(val.authParam[convertListIntoSet])
+
+        if isEsefExcludedInstance(val):
+            return None
 
         # add in formula messages if not loaded
         formulaMsgsUrls = val.authParam.get("formulaMessagesAdditionalURLs", ())

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -149,6 +149,8 @@ def getEsefAuthority(
 @dataclass
 class ESEFPluginData(PluginData):
     esefAuthority: str | None = None
+    esefInstanceValidated: bool = False
+    nonEsefInstanceExcluded: bool = False
 
     @staticmethod
     def get(cntlr: Cntlr) -> ESEFPluginData:
@@ -159,6 +161,11 @@ class ESEFPluginData(PluginData):
         elif not isinstance(pluginData, ESEFPluginData):
             raise RuntimeError(f"PluginData already set for {pluginData.name} with unexpected type {type(pluginData)}.")
         return pluginData
+
+    def reset(self) -> None:
+        self.esefAuthority = None
+        self.esefInstanceValidated = False
+        self.nonEsefInstanceExcluded = False
 
 
 class ESEFPlugin(PluginHooks):
@@ -379,7 +386,9 @@ class ESEFPlugin(PluginHooks):
                 val.authParam[convertListIntoSet] = set(val.authParam[convertListIntoSet])
 
         if isEsefExcludedInstance(val):
+            pluginData.nonEsefInstanceExcluded = True
             return None
+        pluginData.esefInstanceValidated = True
 
         # add in formula messages if not loaded
         formulaMsgsUrls = val.authParam.get("formulaMessagesAdditionalURLs", ())
@@ -467,6 +476,21 @@ class ESEFPlugin(PluginHooks):
         rptPkgIxdsOptions["lookOutsideReportsDirectory"] = True
         rptPkgIxdsOptions["combineIntoSingleIxds"] = True
 
+    @staticmethod
+    def validateComplete(
+        cntlr: Cntlr,
+        fileSource: FileSource,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        pluginData = ESEFPluginData.get(cntlr)
+        if not pluginData.esefInstanceValidated and pluginData.nonEsefInstanceExcluded:
+            cntlr.error(
+                codes="ESEF.Arelle.noEsefReportFound",
+                msg=_("ESEF validation was requested but no reports import the ESEF taxonomy."),
+                fileSource=fileSource,
+            )
+        pluginData.reset()
 
 validationPlugin = ValidationPluginExtension(
     name=ESEF_PLUGIN_NAME,
@@ -501,6 +525,7 @@ __pluginInfo__ = {
     "ModelDocument.PullLoader": ESEFPlugin.modelDocumentPullLoader,
     "ModelTestcaseVariation.ReportPackageIxdsOptions": ESEFPlugin.modelTestcaseVariationReportPackageIxdsOptions,
     "ModelXbrl.LoadComplete": ESEFPlugin.modelXbrlLoadComplete,
+    "Validate.Complete": ESEFPlugin.validateComplete,
     "Validate.Finally": ESEFPlugin.validateFinally,  # run *after* formula processing
     "Validate.XBRL.Finally": ESEFPlugin.validateXbrlFinally,  # before formula processing
     "Validate.XBRL.Start": ESEFPlugin.validateXbrlStart,

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -262,7 +262,8 @@
         "name": "Spain"
     },
     "FI": {
-        "name": "Finland"
+        "name": "Finland",
+        "ixTargetUsage": "allowed"
     },
     "FR": {
         "name": "France",

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -17,6 +17,7 @@
         "minExternalResourceSizekB: minimal file size in kB for allowing external resources, 0 if no minimum requirement and -1 if external resources are forbidden",
         "reportPackageMeasurement: \"zipped\" or \"unzipped\"",
         "ixTargetUsage: allowed, warning or error",
+        "ixdsMultiUsage: allowed or error; controls whether non-ESEF reports in the same report package are permitted",
         "extensionAbstractContexts: allowed, warning or error",
         "lineItemsNotDimQualExclusionNsPattern: concepts namespace pattern excluded from check for extensionTaxonomyLineItemNotLinkedToAnyHypercube",
         "lineItemsMustBeInPreLbExclusionNsPattern: concepts namespace pattern excluded from check for required presence in presentation linkbase",
@@ -46,6 +47,7 @@
         "reportPackageExtensionTaxonomyDirectoryPrefix": null,
         "identifierScheme": "http://standards.iso.org/iso/17442",
         "ixTargetUsage": "warning",
+        "ixdsMultiUsage": "error",
         "extensionAbstractContexts": "warning",
         "LC3AllowCapitalsInWord": true,
         "reportFileNamePattern": null,
@@ -263,7 +265,8 @@
     },
     "FI": {
         "name": "Finland",
-        "ixTargetUsage": "allowed"
+        "ixTargetUsage": "allowed",
+        "ixdsMultiUsage": "allowed"
     },
     "FR": {
         "name": "France",

--- a/tests/unit_tests/arelle/plugin/validate/ESEF/test_esef_target_filtering.py
+++ b/tests/unit_tests/arelle/plugin/validate/ESEF/test_esef_target_filtering.py
@@ -6,12 +6,18 @@ ESEF_NAMESPACE = "http://www.esma.europa.eu/taxonomy/2024-03-27/esef_cor"
 NON_ESEF_NAMESPACE = "http://xbrl.frc.org.uk/fr/2022-01-01/core"
 
 
+def make_report_package(report_count: int) -> SimpleNamespace:
+    reports = [SimpleNamespace() for _ in range(report_count)]
+    return SimpleNamespace(reports=reports)
+
+
 def make_model_xbrl(
     namespace_docs: dict | None = None,
     ixds_target: object = object,
     supplemental_models: list | None = None,
     is_supplemental: bool = False,
     primary_namespace_docs: dict | None = None,
+    report_package: SimpleNamespace | None = None,
 ) -> SimpleNamespace:
     kwargs: dict = {"namespaceDocs": namespace_docs or {}}
     if ixds_target is not object:
@@ -29,7 +35,9 @@ def make_model_xbrl(
     else:
         primary = model_xbrl
     disclosure_system = SimpleNamespace(ESEFplugin=True)
-    model_xbrl.modelManager = SimpleNamespace(modelXbrl=primary, disclosureSystem=disclosure_system)
+    file_source = SimpleNamespace(reportPackage=report_package)
+    model_xbrl.modelManager = SimpleNamespace(modelXbrl=primary, disclosureSystem=disclosure_system)  # type: ignore[attr-defined]
+    model_xbrl.fileSource = file_source
     return model_xbrl
 
 
@@ -66,17 +74,17 @@ class TestHasEsefTaxonomy:
 class TestIsEsefExcludedInstance:
     def test_not_excluded_when_esef_taxonomy_present(self) -> None:
         model_xbrl = make_model_xbrl(namespace_docs={ESEF_NAMESPACE: []}, ixds_target=None)
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
         assert isEsefExcludedInstance(val) is False
 
     def test_not_excluded_when_not_ixds(self) -> None:
         model_xbrl = make_model_xbrl(namespace_docs={NON_ESEF_NAMESPACE: []})
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
         assert isEsefExcludedInstance(val) is False
 
     def test_not_excluded_when_ix_target_usage_not_allowed(self) -> None:
         model_xbrl = make_model_xbrl(namespace_docs={NON_ESEF_NAMESPACE: []}, ixds_target="DKGAAP")
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "warning"})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "warning", "ixdsMultiUsage": "error"})
         assert isEsefExcludedInstance(val) is False
 
     def test_excluded_when_multi_target_and_another_has_esef(self) -> None:
@@ -85,7 +93,7 @@ class TestIsEsefExcludedInstance:
             ixds_target="DKGAAP",
             is_supplemental=True,
         )
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
         assert isEsefExcludedInstance(val) is True
 
     def test_not_excluded_when_no_target_has_esef(self) -> None:
@@ -94,7 +102,7 @@ class TestIsEsefExcludedInstance:
             ixds_target=None,
             supplemental_models=[],
         )
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
         assert isEsefExcludedInstance(val) is False
 
     def test_excluded_for_supplemental_without_esef(self) -> None:
@@ -103,8 +111,52 @@ class TestIsEsefExcludedInstance:
             ixds_target="UKFRC",
             is_supplemental=True,
         )
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
         assert isEsefExcludedInstance(val) is True
+
+    def test_excluded_when_multi_doc_and_multi_report_package(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={NON_ESEF_NAMESPACE: []},
+            ixds_target=None,
+            report_package=make_report_package(2),
+        )
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "warning", "ixdsMultiUsage": "allowed"})
+        assert isEsefExcludedInstance(val) is True
+
+    def test_not_excluded_when_multi_doc_but_single_report(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={NON_ESEF_NAMESPACE: []},
+            ixds_target=None,
+            report_package=make_report_package(1),
+        )
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "warning", "ixdsMultiUsage": "allowed"})
+        assert isEsefExcludedInstance(val) is False
+
+    def test_not_excluded_when_multi_doc_has_esef(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={ESEF_NAMESPACE: []},
+            ixds_target=None,
+            report_package=make_report_package(2),
+        )
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "warning", "ixdsMultiUsage": "allowed"})
+        assert isEsefExcludedInstance(val) is False
+
+    def test_not_excluded_when_multi_doc_not_allowed(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={NON_ESEF_NAMESPACE: []},
+            ixds_target=None,
+            report_package=make_report_package(2),
+        )
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "warning", "ixdsMultiUsage": "error"})
+        assert isEsefExcludedInstance(val) is False
+
+    def test_not_excluded_when_no_report_package(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={NON_ESEF_NAMESPACE: []},
+            ixds_target=None,
+        )
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "warning", "ixdsMultiUsage": "allowed"})
+        assert isEsefExcludedInstance(val) is False
 
 
 class TestShouldRunEsefValidationRules:
@@ -114,21 +166,25 @@ class TestShouldRunEsefValidationRules:
             ixds_target="DKGAAP",
             is_supplemental=True,
         )
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
         assert shouldRunEsefValidationRules(val) is False
 
     def test_true_when_esef_instance(self) -> None:
         model_xbrl = make_model_xbrl(namespace_docs={ESEF_NAMESPACE: []}, ixds_target=None)
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
         assert shouldRunEsefValidationRules(val) is True
 
     def test_false_when_disclosure_system_not_validated(self) -> None:
         model_xbrl = make_model_xbrl(namespace_docs={ESEF_NAMESPACE: []}, ixds_target=None)
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"}, validate_disclosure_system=False)
+        val = make_val(
+            model_xbrl,
+            auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"},
+            validate_disclosure_system=False,
+        )
         assert shouldRunEsefValidationRules(val) is False
 
     def test_false_when_esef_not_selected(self) -> None:
         model_xbrl = make_model_xbrl(namespace_docs={ESEF_NAMESPACE: []}, ixds_target=None)
         model_xbrl.modelManager.disclosureSystem = SimpleNamespace(ESEFplugin=False)
-        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
         assert shouldRunEsefValidationRules(val) is False

--- a/tests/unit_tests/arelle/plugin/validate/ESEF/test_esef_target_filtering.py
+++ b/tests/unit_tests/arelle/plugin/validate/ESEF/test_esef_target_filtering.py
@@ -1,0 +1,134 @@
+from types import SimpleNamespace
+
+from arelle.plugin.validate.ESEF.Util import hasEsefTaxonomy, isEsefExcludedInstance, shouldRunEsefValidationRules
+
+ESEF_NAMESPACE = "http://www.esma.europa.eu/taxonomy/2024-03-27/esef_cor"
+NON_ESEF_NAMESPACE = "http://xbrl.frc.org.uk/fr/2022-01-01/core"
+
+
+def make_model_xbrl(
+    namespace_docs: dict | None = None,
+    ixds_target: object = object,
+    supplemental_models: list | None = None,
+    is_supplemental: bool = False,
+    primary_namespace_docs: dict | None = None,
+) -> SimpleNamespace:
+    kwargs: dict = {"namespaceDocs": namespace_docs or {}}
+    if ixds_target is not object:
+        kwargs["ixdsTarget"] = ixds_target
+    if supplemental_models is not None:
+        kwargs["supplementalModelXbrls"] = supplemental_models
+    if is_supplemental:
+        kwargs["isSupplementalIxdsTarget"] = True
+    model_xbrl = SimpleNamespace(**kwargs)
+    if is_supplemental:
+        primary = SimpleNamespace(
+            namespaceDocs=primary_namespace_docs or {ESEF_NAMESPACE: []},
+            supplementalModelXbrls=[model_xbrl],
+        )
+    else:
+        primary = model_xbrl
+    disclosure_system = SimpleNamespace(ESEFplugin=True)
+    model_xbrl.modelManager = SimpleNamespace(modelXbrl=primary, disclosureSystem=disclosure_system)
+    return model_xbrl
+
+
+def make_val(
+    model_xbrl: SimpleNamespace,
+    auth_param: dict | None = None,
+    validate_disclosure_system: bool = True,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        modelXbrl=model_xbrl,
+        validateDisclosureSystem=validate_disclosure_system,
+        authParam=auth_param or {},
+    )
+
+
+class TestHasEsefTaxonomy:
+    def test_returns_true_with_esef_namespace(self) -> None:
+        model = SimpleNamespace(namespaceDocs={ESEF_NAMESPACE: []})
+        assert hasEsefTaxonomy(model) is True
+
+    def test_returns_true_with_https_esef_namespace(self) -> None:
+        model = SimpleNamespace(namespaceDocs={"https://www.esma.europa.eu/taxonomy/2022-03-24/esef_cor": []})
+        assert hasEsefTaxonomy(model) is True
+
+    def test_returns_false_without_esef_namespace(self) -> None:
+        model = SimpleNamespace(namespaceDocs={NON_ESEF_NAMESPACE: []})
+        assert hasEsefTaxonomy(model) is False
+
+    def test_returns_false_with_empty_namespaces(self) -> None:
+        model = SimpleNamespace(namespaceDocs={})
+        assert hasEsefTaxonomy(model) is False
+
+
+class TestIsEsefExcludedInstance:
+    def test_not_excluded_when_esef_taxonomy_present(self) -> None:
+        model_xbrl = make_model_xbrl(namespace_docs={ESEF_NAMESPACE: []}, ixds_target=None)
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        assert isEsefExcludedInstance(val) is False
+
+    def test_not_excluded_when_not_ixds(self) -> None:
+        model_xbrl = make_model_xbrl(namespace_docs={NON_ESEF_NAMESPACE: []})
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        assert isEsefExcludedInstance(val) is False
+
+    def test_not_excluded_when_ix_target_usage_not_allowed(self) -> None:
+        model_xbrl = make_model_xbrl(namespace_docs={NON_ESEF_NAMESPACE: []}, ixds_target="DKGAAP")
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "warning"})
+        assert isEsefExcludedInstance(val) is False
+
+    def test_excluded_when_multi_target_and_another_has_esef(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={NON_ESEF_NAMESPACE: []},
+            ixds_target="DKGAAP",
+            is_supplemental=True,
+        )
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        assert isEsefExcludedInstance(val) is True
+
+    def test_not_excluded_when_no_target_has_esef(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={NON_ESEF_NAMESPACE: []},
+            ixds_target=None,
+            supplemental_models=[],
+        )
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        assert isEsefExcludedInstance(val) is False
+
+    def test_excluded_for_supplemental_without_esef(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={NON_ESEF_NAMESPACE: []},
+            ixds_target="UKFRC",
+            is_supplemental=True,
+        )
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        assert isEsefExcludedInstance(val) is True
+
+
+class TestShouldRunEsefValidationRules:
+    def test_false_when_excluded(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={NON_ESEF_NAMESPACE: []},
+            ixds_target="DKGAAP",
+            is_supplemental=True,
+        )
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        assert shouldRunEsefValidationRules(val) is False
+
+    def test_true_when_esef_instance(self) -> None:
+        model_xbrl = make_model_xbrl(namespace_docs={ESEF_NAMESPACE: []}, ixds_target=None)
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        assert shouldRunEsefValidationRules(val) is True
+
+    def test_false_when_disclosure_system_not_validated(self) -> None:
+        model_xbrl = make_model_xbrl(namespace_docs={ESEF_NAMESPACE: []}, ixds_target=None)
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"}, validate_disclosure_system=False)
+        assert shouldRunEsefValidationRules(val) is False
+
+    def test_false_when_esef_not_selected(self) -> None:
+        model_xbrl = make_model_xbrl(namespace_docs={ESEF_NAMESPACE: []}, ixds_target=None)
+        model_xbrl.modelManager.disclosureSystem = SimpleNamespace(ESEFplugin=False)
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed"})
+        assert shouldRunEsefValidationRules(val) is False


### PR DESCRIPTION
#### Description of change

* For jurisdictions that permit multi-target or multi-ixds filings, filter ESEF validation to only apply to targets/reports that import the ESEF taxonomy. Logs an error if no report in a package imports the ESEF taxonomy.
* Filter ESEF hidden section validation not to validate facts from other targets.
* Configure Finland authority to permit multi-target and multi-ixds report packages.

#### Steps to Test

Validate that the following Finland sample packages no longer emit ESEF errors on the non-ESEF targets and reports when validated with `--disclosureSystem esef-2024 --esefAuthority FI`:

[ESEF_and_SBR_both_extended1 (9).zip](https://github.com/user-attachments/files/29818477/ESEF_and_SBR_both_extended1.9.zip)
[ESEF_and_SBR_both_extended2_v2.zip](https://github.com/user-attachments/files/29818481/ESEF_and_SBR_both_extended2_v2.zip)
[SBR_tags_in_ESEF_blocktag.zip](https://github.com/user-attachments/files/29818482/SBR_tags_in_ESEF_blocktag.zip)

**review**:
@Arelle/arelle
