### PR TITLE
KVK: Duplicate label check, include base taxonomy concepts

### DIFF
--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -2005,40 +2005,25 @@ def rule_nl_kvk_4_4_5_2(
     ‘xlink:role’ other than already defined labels in the KVK taxonomy (e.g. verboseLabel).
     """
     labelsRelationshipSet = val.modelXbrl.relationshipSet(XbrlConst.conceptLabel)
-    extensionData = pluginData.getExtensionData(val.modelXbrl)
-    extensionConcepts = extensionData.extensionConcepts
     for concept in val.modelXbrl.qnameConcepts.values():
         conceptLangRoleLabels = defaultdict(list)
         labelRels = labelsRelationshipSet.fromModelObject(concept)
         for labelRel in labelRels:
-            label = cast(ModelResource, labelRel.toModelObject)
-            conceptLangRoleLabels[(label.xmlLang, label.role)].append(labelRel.toModelObject)
+            if isinstance(labelRel.toModelObject, ModelResource):
+                label = labelRel.toModelObject
+                conceptLangRoleLabels[(label.xmlLang, label.role)].append(label)
         for (lang, labelRole), labels in conceptLangRoleLabels.items():
-            if concept in extensionConcepts and len(labels) > 1:
-                yield Validation.warning(
-                    codes='NL.NL-KVK.4.4.5.2.taxonomyElementDuplicateLabels',
-                    msg=_('A concept was found with more than one label role for related language. '
-                          'Update to only one combination. Language: %(lang)s, Role: %(labelRole)s, Concept: %(concept)s.'),
-                    modelObject=[concept]+labels, concept=concept.qname, lang=lang, labelRole=labelRole,
-                )
-            elif labelRole == XbrlConst.standardLabel:
-                hasCoreLabel = False
-                hasExtensionLabel = False
-                for label in labels:  # type: ignore[assignment]
-                    if isExtensionUri(label.modelDocument.uri, val.modelXbrl, STANDARD_TAXONOMY_URL_PREFIXES):
-                        hasExtensionLabel = True
-                    else:
-                        hasCoreLabel = True
-                if hasCoreLabel and hasExtensionLabel:
-                    labels_files = ['"%s": %s' % (l.text, l.modelDocument.basename) for l in labels]  # type: ignore[union-attr]
-                    yield Validation.warning(
-                        codes='NL.NL-KVK.4.4.5.2.taxonomyElementDuplicateLabels',
-                        msg=_("An extension taxonomy defines a standard label for a concept "
-                              "already labeled by the base taxonomy. Language: %(lang)s, "
-                              "Role: %(labelRole)s, Concept: %(concept)s, Labels: %(labels)s"),
-                        modelObject=[concept]+labels, concept=concept.qname, lang=lang,
-                        labelRole=labelRole, labels=", ".join(labels_files),
-                    )
+            if len(labels) <= 1:
+                continue
+            labelFiles = [f'"{label.text}": {label.modelDocument.basename}' for label in labels]
+            yield Validation.warning(
+                codes='NL.NL-KVK.4.4.5.2.taxonomyElementDuplicateLabels',
+                msg=_("A concept was found with more than one label for the same role and language. "
+                      "Update to only one label per combination. Language: %(lang)s, "
+                      "Role: %(labelRole)s, Concept: %(concept)s, Labels: %(labels)s"),
+                modelObject=[concept]+labels, concept=concept.qname, lang=lang,
+                labelRole=labelRole, labels=", ".join(labelFiles),
+            )
 
 
 @validation(

--- a/arelle/plugin/validate/NL/rules/nl_kvk.py
+++ b/arelle/plugin/validate/NL/rules/nl_kvk.py
@@ -1998,8 +1998,11 @@ def rule_nl_kvk_4_4_5_2(
         **kwargs: Any,
 ) -> Iterable[Validation]:
     """
-    NL-KVK.4.4.5.2: Extension taxonomy elements SHOULD be assigned with at most one label for any combination of role and language.
-    Additionally, extension taxonomies shall not override or replace standard labels of elements referenced in the KVK taxonomy.
+    NL-KVK.4.4.5.2: Each element (both base and extension) in an extension taxonomy shall be defined with at most one
+    label for any combination of ‘xlink:role’ and ‘xml:lang’ attribute.
+    The above recommendation should not prevent legal entities from defining entity-specific labels for elements
+    referenced in the KVK taxonomy to better align with the human readable layer, providing that they are defined in
+    ‘xlink:role’ other than already defined labels in the KVK taxonomy (e.g. verboseLabel).
     """
     labelsRelationshipSet = val.modelXbrl.relationshipSet(XbrlConst.conceptLabel)
     extensionData = pluginData.getExtensionData(val.modelXbrl)


### PR DESCRIPTION
#### Reason for change

A user reported a filing error for a base taxonomy concept with duplicate labels. [Rereading of the rule](https://www.sbr-nl.nl/sites/default/files/2026-01/20251031_Reporting_Manual_2025_EN_SBR-domein_Handelsregister_ERRATA_20260120.pdf) suggests this check isn't limited to extension concepts:

<details>
<summary>#### Guidance 4.4.5– Use of labels on elements in extension taxonomies [last updated: February 2025]</summary>

> It is possible for an element in the extension taxonomy to be assigned with multiple label resources defined with different ‘xlink:role’ attributes, as listed by the XBRL 2.1 specification or Link Role Registry (LRR). Custom roles are not recommended to be used for labels, unless strictly necessary. Each element (both base and extension) in an extension taxonomy shall be defined with at most one label for any combination of ‘xlink:role’ and ‘xml:lang’ attribute.
> 
> ```txt
> G4-4-5_1 Custom labels roles SHOULD NOT be used.
> 
> In case of violation, the following message is recommended to be used:
> 
> Warning: “taxonomyElementLabelCustomRole”
> ```
> 
> At least one label defined in the standard label role, i.e. http://www.xbrl.org/2003/role/label, must be applied for each taxonomy element. Moreover, legal entities shall not override or replace standard labels (i.e. labels defined in the standard label role) of elements referenced in the KVK taxonomy. This means that in cases where the standard labels are used, no standard label for such taxonomy element should be presented in an extension taxonomy label linkbase.
> 
> ```txt
> G4-4-5_2 Extension taxonomy elements SHOULD be assigned with at most one label for any combination of role and language.
> 
> In case of violation, the following message is recommended to be used:
> 
> Warning: “taxonomyElementDuplicateLabels”
> ```
> 
> The above recommendation should not prevent legal entities from defining entity-specific labels for elements referenced in the KVK taxonomy to better align with the human readable layer, providing that they are defined in ‘xlink:role’ other than already defined labels in the KVK taxonomy (e.g. verboseLabel). Legal entities may apply such entity-specific labels through @preferredLabel attribute assigned in the presentation linkbase of their extension taxonomies.

</details>

#### Description of change

Include base concepts/labels in duplicate label check.

#### Steps to Test

* CI

**review**:
@Arelle/arelle
