### PR TITLE
Preserve timezone on gYearMonth/gYear/gMonthDay/gMonth/gDay

### DIFF
--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -671,6 +671,11 @@ class Time(datetime.time):
         return time
 
 
+GTYPE_ANCHOR_YEAR = 2000  # arbitrary leap year (XSD Datatypes 3.2.12: "in an arbitrary leap year")
+GTYPE_ANCHOR_MONTH = 1  # arbitrary month with 31 days (XSD Datatypes 3.2.13)
+GTYPE_ANCHOR_DAY = 1  # arbitrary day <= 28
+
+
 def _gTypeEqual(
     selfFields: tuple[int, ...], selfTz: datetime.timezone | None,
     otherFields: tuple[int, ...], otherTz: datetime.timezone | None,
@@ -691,17 +696,19 @@ def _gTypeOrder(
     selfFields: tuple[int, ...], selfTz: datetime.timezone | None,
     otherFields: tuple[int, ...], otherTz: datetime.timezone | None,
 ) -> int:
-    """Order two like-typed g* values (gYear/gYearMonth/gMonthDay/gMonth/gDay), whose only
-    lexical content is numeric fields plus an optional timezone.
+    """Order two like-typed g* values whose only lexical content is numeric fields plus
+    an optional timezone -- for ``gYear``/``gYearMonth``/``gMonth`` *only*. (``gMonthDay``/
+    ``gDay`` instead compare real anchored ``datetime`` instants via ``_gMonthDayInstant``/
+    ``_gDayInstant`` below: see the note there.)
 
     Returns -1/0/1 for less-than/equal/greater-than. Raises ``TypeError`` when exactly one
     operand carries a timezone and the numeric fields are equal: over the +-14h timezone
     range (XSD Datatypes 3.2.7.3) that difference can never bridge a whole field unit (a
-    year/month/day), so unequal ``selfFields``/``otherFields`` alone always determines the
+    year or month), so unequal ``selfFields``/``otherFields`` alone always determines the
     order; only a field tie leaves the order genuinely dependent on the missing timezone
-    (3.2.7.4, applied to g* types per 3.2.10.2/3.2.11.2/3.2.12.2/3.2.13.2/3.2.14.2), which
-    XmlValidate's ``_orderedComparison`` resolves with the +-14h straddling rule, mirroring
-    how it already handles offset-naive vs. offset-aware ``dateTime``/``date``/``time``.
+    (3.2.7.4, applied to g* types per 3.2.10.2/3.2.11.2/3.2.14.2), which XmlValidate's
+    ``_orderedComparison`` resolves with the +-14h straddling rule, mirroring how it
+    already handles offset-naive vs. offset-aware ``dateTime``/``date``/``time``.
     """
     if selfFields != otherFields:
         return -1 if selfFields < otherFields else 1
@@ -718,6 +725,14 @@ def _gTypeOrder(
     # occurs *earlier* in UTC: 00:00+05:00 is 19:00 UTC the previous day, earlier than
     # 00:00+04:00's 20:00 UTC.
     return -1 if selfOffset > otherOffset else 1
+
+
+def _gMonthDayInstant(month: int, day: int, tz: datetime.timezone | None) -> datetime.datetime:
+    return datetime.datetime(GTYPE_ANCHOR_YEAR, month, day, tzinfo=tz)
+
+
+def _gDayInstant(day: int, tz: datetime.timezone | None) -> datetime.datetime:
+    return datetime.datetime(GTYPE_ANCHOR_YEAR, GTYPE_ANCHOR_MONTH, day, tzinfo=tz)
 
 
 class gYearMonth:
@@ -775,7 +790,11 @@ class gMonthDay:
         self.month = int(month)
         self.day = int(day)
         self.tzinfo = tzinfo
-        self._hash = hash((self.month, self.day))
+        # Hashed via the anchor instant (not the raw fields): two different (month, day)
+        # pairs with different timezones can denote the *same* instant (see the note on
+        # _gTypeOrder), and Python's own aware-datetime hash already makes such equal
+        # instants hash equal regardless of offset, keeping __hash__/__eq__ consistent.
+        self._hash = hash(_gMonthDayInstant(self.month, self.day, self.tzinfo))
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -786,32 +805,32 @@ class gMonthDay:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return _gTypeEqual((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo)
+        return _gMonthDayInstant(self.month, self.day, self.tzinfo) == _gMonthDayInstant(other.month, other.day, other.tzinfo)
 
     def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return not _gTypeEqual((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo)
+        return _gMonthDayInstant(self.month, self.day, self.tzinfo) != _gMonthDayInstant(other.month, other.day, other.tzinfo)
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return _gTypeOrder((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo) < 0
+        return _gMonthDayInstant(self.month, self.day, self.tzinfo) < _gMonthDayInstant(other.month, other.day, other.tzinfo)
 
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return _gTypeOrder((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo) <= 0
+        return _gMonthDayInstant(self.month, self.day, self.tzinfo) <= _gMonthDayInstant(other.month, other.day, other.tzinfo)
 
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return _gTypeOrder((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo) > 0
+        return _gMonthDayInstant(self.month, self.day, self.tzinfo) > _gMonthDayInstant(other.month, other.day, other.tzinfo)
 
     def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return _gTypeOrder((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo) >= 0
+        return _gMonthDayInstant(self.month, self.day, self.tzinfo) >= _gMonthDayInstant(other.month, other.day, other.tzinfo)
 
     def __bool__(self) -> bool:
         return self.month != 0 or self.day != 0
@@ -920,6 +939,11 @@ class gDay:
     def __init__(self, day: int | str, tzinfo: datetime.timezone | None = None) -> None:
         self.day = int(day)
         self.tzinfo = tzinfo
+        # Hashed via the anchor instant, not the raw day, for the same reason as
+        # gMonthDay: two different days with different timezones can denote the same
+        # instant (see the note on _gTypeOrder above), and Python's own aware-datetime
+        # hash already makes such equal instants hash equal regardless of offset.
+        self._hash = hash(_gDayInstant(self.day, self.tzinfo))
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -930,38 +954,38 @@ class gDay:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return _gTypeEqual((self.day,), self.tzinfo, (other.day,), other.tzinfo)
+        return _gDayInstant(self.day, self.tzinfo) == _gDayInstant(other.day, other.tzinfo)
 
     def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return not _gTypeEqual((self.day,), self.tzinfo, (other.day,), other.tzinfo)
+        return _gDayInstant(self.day, self.tzinfo) != _gDayInstant(other.day, other.tzinfo)
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return _gTypeOrder((self.day,), self.tzinfo, (other.day,), other.tzinfo) < 0
+        return _gDayInstant(self.day, self.tzinfo) < _gDayInstant(other.day, other.tzinfo)
 
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return _gTypeOrder((self.day,), self.tzinfo, (other.day,), other.tzinfo) <= 0
+        return _gDayInstant(self.day, self.tzinfo) <= _gDayInstant(other.day, other.tzinfo)
 
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return _gTypeOrder((self.day,), self.tzinfo, (other.day,), other.tzinfo) > 0
+        return _gDayInstant(self.day, self.tzinfo) > _gDayInstant(other.day, other.tzinfo)
 
     def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return _gTypeOrder((self.day,), self.tzinfo, (other.day,), other.tzinfo) >= 0
+        return _gDayInstant(self.day, self.tzinfo) >= _gDayInstant(other.day, other.tzinfo)
 
     def __bool__(self) -> bool:
         return self.day != 0
 
     def __hash__(self) -> int:
-        return self.day
+        return self._hash
 
 
 isoDurationPattern = re.compile(

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -295,11 +295,15 @@ def tzinfo(tz: str | None) -> datetime.timezone | None:
     else:
         return datetime.timezone(datetime.timedelta(hours=int(tz[0:3]), minutes=int(tz[0]+tz[4:6])))
 
+def _tzSuffix(tz: datetime.tzinfo | None) -> str:
+    s = str(tz or "")
+    if s.startswith("UTC"):
+        return s[3:] or "Z"
+    return ""
+
 def tzinfoStr(dt: datetime.datetime | datetime.date) -> str:
     if isinstance(dt, datetime.datetime):
-        tz = str(dt.tzinfo or "")
-        if tz.startswith("UTC"):
-            return tz[3:] or "Z"
+        return _tzSuffix(dt.tzinfo)
     return ""
 
 
@@ -750,7 +754,7 @@ class gYearMonth:
         return self.__str__()
 
     def __str__(self) -> str:
-        return "{0:0{2}}-{1:02}".format(self.year, self.month, 5 if self.year < 0 else 4)  # may be negative
+        return "{0:0{2}}-{1:02}{3}".format(self.year, self.month, 5 if self.year < 0 else 4, _tzSuffix(self.tzinfo))  # may be negative
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
@@ -804,7 +808,7 @@ class gMonthDay:
         return self.__str__()
 
     def __str__(self) -> str:
-        return "--{0:02}-{1:02}".format(self.month, self.day)
+        return "--{0:02}-{1:02}{2}".format(self.month, self.day, _tzSuffix(self.tzinfo))
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
@@ -853,7 +857,7 @@ class gYear:
         return self.__str__()
 
     def __str__(self) -> str:
-        return "{0:0{1}}".format(self.year, 5 if self.year < 0 else 4)  # may be negative
+        return "{0:0{1}}{2}".format(self.year, 5 if self.year < 0 else 4, _tzSuffix(self.tzinfo))  # may be negative
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
@@ -902,7 +906,7 @@ class gMonth:
         return self.__str__()
 
     def __str__(self) -> str:
-        return "--{0:02}".format(self.month)
+        return "--{0:02}{1}".format(self.month, _tzSuffix(self.tzinfo))
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
@@ -955,7 +959,7 @@ class gDay:
         return self.__str__()
 
     def __str__(self) -> str:
-        return "---{0:02}".format(self.day)
+        return "---{0:02}{1}".format(self.day, _tzSuffix(self.tzinfo))
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gDay):

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -786,9 +786,6 @@ class gYearMonth:
             return NotImplemented
         return _gTypeOrder((self.year, self.month), self.tzinfo, (other.year, other.month), other.tzinfo) >= 0
 
-    def __bool__(self) -> bool:
-        return self.year != 0 or self.month != 0
-
     def __hash__(self) -> int:
         return self._hash
 
@@ -840,9 +837,6 @@ class gMonthDay:
             return NotImplemented
         return _gMonthDayInstant(self.month, self.day, self.tzinfo) >= _gMonthDayInstant(other.month, other.day, other.tzinfo)
 
-    def __bool__(self) -> bool:
-        return self.month != 0 or self.day != 0
-
     def __hash__(self) -> int:
         return self._hash
 
@@ -889,9 +883,6 @@ class gYear:
             return NotImplemented
         return _gTypeOrder((self.year,), self.tzinfo, (other.year,), other.tzinfo) >= 0
 
-    def __bool__(self) -> bool:
-        return self.year != 0
-
     def __hash__(self) -> int:
         return self._hash
 
@@ -937,9 +928,6 @@ class gMonth:
         if not isinstance(other, gMonth):
             return NotImplemented
         return _gTypeOrder((self.month,), self.tzinfo, (other.month,), other.tzinfo) >= 0
-
-    def __bool__(self) -> bool:
-        return self.month != 0
 
     def __hash__(self) -> int:
         return self._hash
@@ -990,9 +978,6 @@ class gDay:
         if not isinstance(other, gDay):
             return NotImplemented
         return _gDayInstant(self.day, self.tzinfo) >= _gDayInstant(other.day, other.tzinfo)
-
-    def __bool__(self) -> bool:
-        return self.day != 0
 
     def __hash__(self) -> int:
         return self._hash

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -671,10 +671,60 @@ class Time(datetime.time):
         return time
 
 
+def _gTypeEqual(
+    selfFields: tuple[int, ...], selfTz: datetime.timezone | None,
+    otherFields: tuple[int, ...], otherTz: datetime.timezone | None,
+) -> bool:
+    # XSD Datatypes 3.2.7 gives dateTime (and, analogously per 3.2.10.2/3.2.11.2/etc, the
+    # g* types) a boolean "timezoned" property that is part of the value: a timezoned value
+    # is never equal to an untimezoned one, regardless of field values.
+    if selfFields != otherFields:
+        return False
+    if selfTz is None and otherTz is None:
+        return True
+    if selfTz is None or otherTz is None:
+        return False
+    return selfTz.utcoffset(None) == otherTz.utcoffset(None)
+
+
+def _gTypeOrder(
+    selfFields: tuple[int, ...], selfTz: datetime.timezone | None,
+    otherFields: tuple[int, ...], otherTz: datetime.timezone | None,
+) -> int:
+    """Order two like-typed g* values (gYear/gYearMonth/gMonthDay/gMonth/gDay), whose only
+    lexical content is numeric fields plus an optional timezone.
+
+    Returns -1/0/1 for less-than/equal/greater-than. Raises ``TypeError`` when exactly one
+    operand carries a timezone and the numeric fields are equal: over the +-14h timezone
+    range (XSD Datatypes 3.2.7.3) that difference can never bridge a whole field unit (a
+    year/month/day), so unequal ``selfFields``/``otherFields`` alone always determines the
+    order; only a field tie leaves the order genuinely dependent on the missing timezone
+    (3.2.7.4, applied to g* types per 3.2.10.2/3.2.11.2/3.2.12.2/3.2.13.2/3.2.14.2), which
+    XmlValidate's ``_orderedComparison`` resolves with the +-14h straddling rule, mirroring
+    how it already handles offset-naive vs. offset-aware ``dateTime``/``date``/``time``.
+    """
+    if selfFields != otherFields:
+        return -1 if selfFields < otherFields else 1
+    if selfTz is None and otherTz is None:
+        return 0
+    if selfTz is None or otherTz is None:
+        raise TypeError("can't order timezone-aware and timezone-naive values of this type")
+    selfOffset = selfTz.utcoffset(None)
+    otherOffset = otherTz.utcoffset(None)
+    if selfOffset == otherOffset:
+        return 0
+    # A larger UTC offset means "further ahead of UTC", so the same local wall-clock instant
+    # (each of these types' fields denote the *start* of a period, i.e. wall-clock 00:00)
+    # occurs *earlier* in UTC: 00:00+05:00 is 19:00 UTC the previous day, earlier than
+    # 00:00+04:00's 20:00 UTC.
+    return -1 if selfOffset > otherOffset else 1
+
+
 class gYearMonth:
-    def __init__(self, year: int | str, month: int | str) -> None:
+    def __init__(self, year: int | str, month: int | str, tzinfo: datetime.timezone | None = None) -> None:
         self.year = int(year)  # may be negative
         self.month = int(month)
+        self.tzinfo = tzinfo
         self._hash = hash((self.year, self.month))
 
     def __repr__(self) -> str:
@@ -686,30 +736,32 @@ class gYearMonth:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
-        return self.year == other.year and self.month == other.month
+        return _gTypeEqual((self.year, self.month), self.tzinfo, (other.year, other.month), other.tzinfo)
 
     def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
+        if not isinstance(other, gYearMonth):
+            return NotImplemented
+        return not _gTypeEqual((self.year, self.month), self.tzinfo, (other.year, other.month), other.tzinfo)
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
-        return (self.year < other.year) or (self.year == other.year and self.month < other.month)
+        return _gTypeOrder((self.year, self.month), self.tzinfo, (other.year, other.month), other.tzinfo) < 0
 
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
-        return (self.year < other.year) or (self.year == other.year and self.month <= other.month)
+        return _gTypeOrder((self.year, self.month), self.tzinfo, (other.year, other.month), other.tzinfo) <= 0
 
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
-        return (self.year > other.year) or (self.year == other.year and self.month > other.month)
+        return _gTypeOrder((self.year, self.month), self.tzinfo, (other.year, other.month), other.tzinfo) > 0
 
     def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gYearMonth):
             return NotImplemented
-        return (self.year > other.year) or (self.year == other.year and self.month >= other.month)
+        return _gTypeOrder((self.year, self.month), self.tzinfo, (other.year, other.month), other.tzinfo) >= 0
 
     def __bool__(self) -> bool:
         return self.year != 0 or self.month != 0
@@ -719,9 +771,10 @@ class gYearMonth:
 
 
 class gMonthDay:
-    def __init__(self, month: int | str, day: int | str) -> None:
+    def __init__(self, month: int | str, day: int | str, tzinfo: datetime.timezone | None = None) -> None:
         self.month = int(month)
         self.day = int(day)
+        self.tzinfo = tzinfo
         self._hash = hash((self.month, self.day))
 
     def __repr__(self) -> str:
@@ -733,32 +786,32 @@ class gMonthDay:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return self.month == other.month and self.day == other.day
+        return _gTypeEqual((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo)
 
     def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return not self.__eq__(other)
+        return not _gTypeEqual((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo)
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return (self.month < other.month) or (self.month == other.month and self.day < other.day)
+        return _gTypeOrder((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo) < 0
 
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return (self.month < other.month) or (self.month == other.month and self.day <= other.day)
+        return _gTypeOrder((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo) <= 0
 
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return (self.month > other.month) or (self.month == other.month and self.day > other.day)
+        return _gTypeOrder((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo) > 0
 
     def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gMonthDay):
             return NotImplemented
-        return (self.month > other.month) or (self.month == other.month and self.day >= other.day)
+        return _gTypeOrder((self.month, self.day), self.tzinfo, (other.month, other.day), other.tzinfo) >= 0
 
     def __bool__(self) -> bool:
         return self.month != 0 or self.day != 0
@@ -768,8 +821,9 @@ class gMonthDay:
 
 
 class gYear:
-    def __init__(self, year: int | str) -> None:
+    def __init__(self, year: int | str, tzinfo: datetime.timezone | None = None) -> None:
         self.year = int(year)  # may be negative
+        self.tzinfo = tzinfo
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -780,32 +834,32 @@ class gYear:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
-        return self.year == other.year
+        return _gTypeEqual((self.year,), self.tzinfo, (other.year,), other.tzinfo)
 
     def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
-        return not self.__eq__(other)
+        return not _gTypeEqual((self.year,), self.tzinfo, (other.year,), other.tzinfo)
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
-        return self.year < other.year
+        return _gTypeOrder((self.year,), self.tzinfo, (other.year,), other.tzinfo) < 0
 
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
-        return self.year <= other.year
+        return _gTypeOrder((self.year,), self.tzinfo, (other.year,), other.tzinfo) <= 0
 
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
-        return self.year > other.year
+        return _gTypeOrder((self.year,), self.tzinfo, (other.year,), other.tzinfo) > 0
 
     def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gYear):
             return NotImplemented
-        return self.year >= other.year
+        return _gTypeOrder((self.year,), self.tzinfo, (other.year,), other.tzinfo) >= 0
 
     def __bool__(self) -> bool:
         return self.year != 0
@@ -815,8 +869,9 @@ class gYear:
 
 
 class gMonth:
-    def __init__(self, month: int | str) -> None:
+    def __init__(self, month: int | str, tzinfo: datetime.timezone | None = None) -> None:
         self.month = int(month)
+        self.tzinfo = tzinfo
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -827,32 +882,32 @@ class gMonth:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
-        return self.month == other.month
+        return _gTypeEqual((self.month,), self.tzinfo, (other.month,), other.tzinfo)
 
     def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
-        return not self.__eq__(other)
+        return not _gTypeEqual((self.month,), self.tzinfo, (other.month,), other.tzinfo)
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
-        return self.month < other.month
+        return _gTypeOrder((self.month,), self.tzinfo, (other.month,), other.tzinfo) < 0
 
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
-        return self.month <= other.month
+        return _gTypeOrder((self.month,), self.tzinfo, (other.month,), other.tzinfo) <= 0
 
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
-        return self.month > other.month
+        return _gTypeOrder((self.month,), self.tzinfo, (other.month,), other.tzinfo) > 0
 
     def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gMonth):
             return NotImplemented
-        return self.month >= other.month
+        return _gTypeOrder((self.month,), self.tzinfo, (other.month,), other.tzinfo) >= 0
 
     def __bool__(self) -> bool:
         return self.month != 0
@@ -862,8 +917,9 @@ class gMonth:
 
 
 class gDay:
-    def __init__(self, day: int | str) -> None:
+    def __init__(self, day: int | str, tzinfo: datetime.timezone | None = None) -> None:
         self.day = int(day)
+        self.tzinfo = tzinfo
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -874,32 +930,32 @@ class gDay:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return self.day == other.day
+        return _gTypeEqual((self.day,), self.tzinfo, (other.day,), other.tzinfo)
 
     def __ne__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return not self.__eq__(other)
+        return not _gTypeEqual((self.day,), self.tzinfo, (other.day,), other.tzinfo)
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return self.day < other.day
+        return _gTypeOrder((self.day,), self.tzinfo, (other.day,), other.tzinfo) < 0
 
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return self.day <= other.day
+        return _gTypeOrder((self.day,), self.tzinfo, (other.day,), other.tzinfo) <= 0
 
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return self.day > other.day
+        return _gTypeOrder((self.day,), self.tzinfo, (other.day,), other.tzinfo) > 0
 
     def __ge__(self, other: Any) -> bool:
         if not isinstance(other, gDay):
             return NotImplemented
-        return self.day >= other.day
+        return _gTypeOrder((self.day,), self.tzinfo, (other.day,), other.tzinfo) >= 0
 
     def __bool__(self) -> bool:
         return self.day != 0

--- a/arelle/ModelValue.py
+++ b/arelle/ModelValue.py
@@ -735,12 +735,16 @@ def _gDayInstant(day: int, tz: datetime.timezone | None) -> datetime.datetime:
     return datetime.datetime(GTYPE_ANCHOR_YEAR, GTYPE_ANCHOR_MONTH, day, tzinfo=tz)
 
 
+def _gTypeHash(fields: tuple[int, ...], tz: datetime.timezone | None) -> int:
+    return hash((fields, tz.utcoffset(None) if tz is not None else None))
+
+
 class gYearMonth:
     def __init__(self, year: int | str, month: int | str, tzinfo: datetime.timezone | None = None) -> None:
         self.year = int(year)  # may be negative
         self.month = int(month)
         self.tzinfo = tzinfo
-        self._hash = hash((self.year, self.month))
+        self._hash = _gTypeHash((self.year, self.month), tzinfo)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -843,6 +847,7 @@ class gYear:
     def __init__(self, year: int | str, tzinfo: datetime.timezone | None = None) -> None:
         self.year = int(year)  # may be negative
         self.tzinfo = tzinfo
+        self._hash = _gTypeHash((self.year,), tzinfo)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -884,13 +889,14 @@ class gYear:
         return self.year != 0
 
     def __hash__(self) -> int:
-        return self.year
+        return self._hash
 
 
 class gMonth:
     def __init__(self, month: int | str, tzinfo: datetime.timezone | None = None) -> None:
         self.month = int(month)
         self.tzinfo = tzinfo
+        self._hash = _gTypeHash((self.month,), tzinfo)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -932,7 +938,7 @@ class gMonth:
         return self.month != 0
 
     def __hash__(self) -> int:
-        return self.month
+        return self._hash
 
 
 class gDay:

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -15,7 +15,8 @@ from fractions import Fraction
 from arelle import UrlUtil, XbrlConst, XmlUtil, XmlValidateConst
 from arelle.ModelValue import (qname, qnameFromNsmap, qnameClarkName, qnameHref,
                                dateTime, DATE, DATETIME, DATEUNION, time,
-                               anyURI, INVALIDixVALUE, gYearMonth, gMonthDay, gYear, gMonth, gDay, isoDuration)
+                               anyURI, INVALIDixVALUE, gYearMonth, gMonthDay, gYear, gMonth, gDay, isoDuration,
+                               tzinfo as _parseTzinfo)
 from arelle.ModelObject import ModelObject, ModelAttribute
 from arelle.PythonUtil import strTruncate
 
@@ -501,15 +502,31 @@ def fractionValidateValue(value: str, fractionValue: tuple[str, str]) -> XmlVali
 _XSD_MAX_TIMEZONE_OFFSET = datetime.timedelta(hours=14)
 
 
-def _comparableInstant(value: datetime.datetime | datetime.time) -> datetime.datetime:
-    # Express an xs:dateTime/date/time value as a single datetime so values can be
-    # ordered: timezone-aware values are normalized to (naive) UTC; an xs:time is
-    # anchored to an arbitrary fixed date (XSD Datatypes 3.2.8).
-    # Timezone-naive values are left as-is.
+_GTYPE_ANCHOR_YEAR = 2000  # arbitrary leap year (XSD Datatypes 3.2.12: "in an arbitrary leap year")
+_GTYPE_ANCHOR_31DAY_MONTH = 12  # arbitrary month with 31 days (XSD Datatypes 3.2.13)
+
+
+def _comparableInstant(value: datetime.datetime | datetime.time | gYearMonth | gYear | gMonthDay | gMonth | gDay) -> datetime.datetime:
+    # Express an xs:dateTime/date/time/gYearMonth/gYear/gMonthDay/gMonth/gDay value as a
+    # single datetime so values can be ordered: timezone-aware values are normalized to
+    # (naive) UTC. xs:time and the g* types have no full calendar date of their own, so
+    # each is anchored to an arbitrary fixed point (XSD Datatypes 3.2.8 for time;
+    # 3.2.10.2/3.2.11.2/3.2.12.2/3.2.13.2/3.2.14.2 analogously for the g* types via their
+    # "starting instant", 3.2.7.4). Timezone-naive values are left as-is.
     if isinstance(value, datetime.datetime):
         dt = value
-    else:  # datetime.time (xs:time)
+    elif isinstance(value, datetime.time):  # xs:time
         dt = datetime.datetime(2000, 1, 1, value.hour, value.minute, value.second, value.microsecond, value.tzinfo)
+    elif isinstance(value, gYearMonth):
+        dt = datetime.datetime(value.year, value.month, 1, tzinfo=value.tzinfo)
+    elif isinstance(value, gYear):
+        dt = datetime.datetime(value.year, 1, 1, tzinfo=value.tzinfo)
+    elif isinstance(value, gMonthDay):
+        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, value.month, value.day, tzinfo=value.tzinfo)
+    elif isinstance(value, gMonth):
+        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, value.month, 1, tzinfo=value.tzinfo)
+    else:  # gDay
+        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, _GTYPE_ANCHOR_31DAY_MONTH, value.day, tzinfo=value.tzinfo)
     if dt.tzinfo is not None:
         dt = dt.astimezone(datetime.timezone.utc).replace(tzinfo=None)
     return dt
@@ -538,14 +555,16 @@ def _orderedComparison(value: Any, bound: Any) -> int | None:
     ``None`` as failing whichever relation the facet requires (Datatypes 3.2.6.3:
     "indeterminate comparisons should be considered as 'false'").
 
-    Ordinarily the operands' own comparison operators are used. For an xs:date/time
-    value where exactly one operand carries a timezone, Python raises ``TypeError``
-    rather than ordering offset-naive against offset-aware values; in that case apply
-    the XSD timezone-straddling rule (Datatypes 3.2.7.4) on the underlying instants,
-    yielding ``None`` when the timezone uncertainty leaves the order undetermined.
+    Ordinarily the operands' own comparison operators are used. For an xs:date/time or
+    g* (gYearMonth/gYear/gMonthDay/gMonth/gDay) value where exactly one operand carries a
+    timezone, that comparison raises ``TypeError`` rather than ordering offset-naive
+    against offset-aware values; in that case apply the XSD timezone-straddling rule
+    (Datatypes 3.2.7.4) on the underlying instants, yielding ``None`` when the timezone
+    uncertainty leaves the order undetermined.
     """
     if type(value) is not type(bound):
         raise TypeError("Value type ({}) is not comparable with bound type ({}).".format(type(value), type (bound)))
+    _orderableTypes = (datetime.datetime, datetime.time, gYearMonth, gYear, gMonthDay, gMonth, gDay)
     try:
         if value < bound:
             return -1
@@ -553,8 +572,7 @@ def _orderedComparison(value: Any, bound: Any) -> int | None:
             return 1
         return 0
     except TypeError:
-        if not isinstance(value, (datetime.datetime, datetime.time)) or \
-                not isinstance(bound, (datetime.datetime, datetime.time)):
+        if not isinstance(value, _orderableTypes) or not isinstance(bound, _orderableTypes):
             raise
         valueInstant = _comparableInstant(value)
         boundInstant = _comparableInstant(bound)
@@ -764,26 +782,28 @@ def _validateValueStringOrRaise(
                     xValue = time(value, castException=ValueError)
                     sValue = value
                 elif baseXsdType == "gMonthDay":
+                    # zSign is the whole timezone token ("Z"/"+hh:mm"/"-hh:mm"/None); the
+                    # remaining groups decompose it further but aren't needed here.
                     month, day, zSign, zHrMin, zHr, zMin = match.groups()
                     if int(day) > {2:29, 4:30, 6:30, 9:30, 11:30, 1:31, 3:31, 5:31, 7:31, 8:31, 10:31, 12:31}[int(month)]:
                         raise ValueError("invalid day {0} for month {1}".format(day, month))
-                    xValue = gMonthDay(month, day)
+                    xValue = gMonthDay(month, day, tzinfo=_parseTzinfo(zSign))
                 elif baseXsdType == "gYearMonth":
                     year, month, zSign, zHrMin, zHr, zMin = match.groups()
                     if int(year) == 0:
                         raise ValueError("year zero is not permitted per XSD 1.0")
-                    xValue = gYearMonth(year, month)
+                    xValue = gYearMonth(year, month, tzinfo=_parseTzinfo(zSign))
                 elif baseXsdType == "gYear":
                     year, zSign, zHrMin, zHr, zMin = match.groups()
                     if int(year) == 0:
                         raise ValueError("year zero is not permitted per XSD 1.0")
-                    xValue = gYear(year)
+                    xValue = gYear(year, tzinfo=_parseTzinfo(zSign))
                 elif baseXsdType == "gMonth":
                     month, zSign, zHrMin, zHr, zMin = match.groups()
-                    xValue = gMonth(month)
+                    xValue = gMonth(month, tzinfo=_parseTzinfo(zSign))
                 elif baseXsdType == "gDay":
                     day, zSign, zHrMin, zHr, zMin = match.groups()
-                    xValue = gDay(day)
+                    xValue = gDay(day, tzinfo=_parseTzinfo(zSign))
                 elif baseXsdType == "duration":
                     xValue = isoDuration(value)
                 else:

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -16,7 +16,7 @@ from arelle import UrlUtil, XbrlConst, XmlUtil, XmlValidateConst
 from arelle.ModelValue import (qname, qnameFromNsmap, qnameClarkName, qnameHref,
                                dateTime, DATE, DATETIME, DATEUNION, time,
                                anyURI, INVALIDixVALUE, gYearMonth, gMonthDay, gYear, gMonth, gDay, isoDuration,
-                               tzinfo as _parseTzinfo)
+                               tzinfo as _parseTzinfo, GTYPE_ANCHOR_YEAR, GTYPE_ANCHOR_MONTH, GTYPE_ANCHOR_DAY)
 from arelle.ModelObject import ModelObject, ModelAttribute
 from arelle.PythonUtil import strTruncate
 
@@ -502,11 +502,6 @@ def fractionValidateValue(value: str, fractionValue: tuple[str, str]) -> XmlVali
 _XSD_MAX_TIMEZONE_OFFSET = datetime.timedelta(hours=14)
 
 
-_GTYPE_ANCHOR_YEAR = 2000  # arbitrary leap year (XSD Datatypes 3.2.12: "in an arbitrary leap year")
-_GTYPE_ANCHOR_MONTH = 1  # arbitrary month with 31 days (XSD Datatypes 3.2.13)
-_GTYPE_ANCHOR_DAY = 1  # arbitrary day <= 28
-
-
 def _comparableInstant(value: datetime.datetime | datetime.time | gYearMonth | gYear | gMonthDay | gMonth | gDay) -> datetime.datetime:
     # Express an xs:dateTime/date/time/gYearMonth/gYear/gMonthDay/gMonth/gDay value as a
     # single datetime so values can be ordered: timezone-aware values are normalized to
@@ -518,19 +513,19 @@ def _comparableInstant(value: datetime.datetime | datetime.time | gYearMonth | g
         dt = value
     elif isinstance(value, datetime.time):  # xs:time
         dt = datetime.datetime(
-            _GTYPE_ANCHOR_YEAR, _GTYPE_ANCHOR_MONTH, _GTYPE_ANCHOR_DAY,
+            GTYPE_ANCHOR_YEAR, GTYPE_ANCHOR_MONTH, GTYPE_ANCHOR_DAY,
             value.hour, value.minute, value.second, value.microsecond, value.tzinfo
         )
     elif isinstance(value, gYearMonth):
-        dt = datetime.datetime(value.year, value.month, _GTYPE_ANCHOR_DAY, tzinfo=value.tzinfo)
+        dt = datetime.datetime(value.year, value.month, GTYPE_ANCHOR_DAY, tzinfo=value.tzinfo)
     elif isinstance(value, gYear):
-        dt = datetime.datetime(value.year, _GTYPE_ANCHOR_MONTH, _GTYPE_ANCHOR_DAY, tzinfo=value.tzinfo)
+        dt = datetime.datetime(value.year, GTYPE_ANCHOR_MONTH, GTYPE_ANCHOR_DAY, tzinfo=value.tzinfo)
     elif isinstance(value, gMonthDay):
-        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, value.month, value.day, tzinfo=value.tzinfo)
+        dt = datetime.datetime(GTYPE_ANCHOR_YEAR, value.month, value.day, tzinfo=value.tzinfo)
     elif isinstance(value, gMonth):
-        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, value.month, _GTYPE_ANCHOR_DAY, tzinfo=value.tzinfo)
+        dt = datetime.datetime(GTYPE_ANCHOR_YEAR, value.month, GTYPE_ANCHOR_DAY, tzinfo=value.tzinfo)
     else:  # gDay
-        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, _GTYPE_ANCHOR_MONTH, value.day, tzinfo=value.tzinfo)
+        dt = datetime.datetime(GTYPE_ANCHOR_YEAR, GTYPE_ANCHOR_MONTH, value.day, tzinfo=value.tzinfo)
     if dt.tzinfo is not None:
         dt = dt.astimezone(datetime.timezone.utc).replace(tzinfo=None)
     return dt

--- a/arelle/XmlValidate.py
+++ b/arelle/XmlValidate.py
@@ -503,7 +503,8 @@ _XSD_MAX_TIMEZONE_OFFSET = datetime.timedelta(hours=14)
 
 
 _GTYPE_ANCHOR_YEAR = 2000  # arbitrary leap year (XSD Datatypes 3.2.12: "in an arbitrary leap year")
-_GTYPE_ANCHOR_31DAY_MONTH = 12  # arbitrary month with 31 days (XSD Datatypes 3.2.13)
+_GTYPE_ANCHOR_MONTH = 1  # arbitrary month with 31 days (XSD Datatypes 3.2.13)
+_GTYPE_ANCHOR_DAY = 1  # arbitrary day <= 28
 
 
 def _comparableInstant(value: datetime.datetime | datetime.time | gYearMonth | gYear | gMonthDay | gMonth | gDay) -> datetime.datetime:
@@ -516,17 +517,20 @@ def _comparableInstant(value: datetime.datetime | datetime.time | gYearMonth | g
     if isinstance(value, datetime.datetime):
         dt = value
     elif isinstance(value, datetime.time):  # xs:time
-        dt = datetime.datetime(2000, 1, 1, value.hour, value.minute, value.second, value.microsecond, value.tzinfo)
+        dt = datetime.datetime(
+            _GTYPE_ANCHOR_YEAR, _GTYPE_ANCHOR_MONTH, _GTYPE_ANCHOR_DAY,
+            value.hour, value.minute, value.second, value.microsecond, value.tzinfo
+        )
     elif isinstance(value, gYearMonth):
-        dt = datetime.datetime(value.year, value.month, 1, tzinfo=value.tzinfo)
+        dt = datetime.datetime(value.year, value.month, _GTYPE_ANCHOR_DAY, tzinfo=value.tzinfo)
     elif isinstance(value, gYear):
-        dt = datetime.datetime(value.year, 1, 1, tzinfo=value.tzinfo)
+        dt = datetime.datetime(value.year, _GTYPE_ANCHOR_MONTH, _GTYPE_ANCHOR_DAY, tzinfo=value.tzinfo)
     elif isinstance(value, gMonthDay):
         dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, value.month, value.day, tzinfo=value.tzinfo)
     elif isinstance(value, gMonth):
-        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, value.month, 1, tzinfo=value.tzinfo)
+        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, value.month, _GTYPE_ANCHOR_DAY, tzinfo=value.tzinfo)
     else:  # gDay
-        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, _GTYPE_ANCHOR_31DAY_MONTH, value.day, tzinfo=value.tzinfo)
+        dt = datetime.datetime(_GTYPE_ANCHOR_YEAR, _GTYPE_ANCHOR_MONTH, value.day, tzinfo=value.tzinfo)
     if dt.tzinfo is not None:
         dt = dt.astimezone(datetime.timezone.utc).replace(tzinfo=None)
     return dt

--- a/tests/unit_tests/arelle/test_modelvalue.py
+++ b/tests/unit_tests/arelle/test_modelvalue.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import datetime
+
 import pytest
 
-from arelle.ModelValue import QName, qnameFromNsmap
+from arelle.ModelValue import QName, gDay, gMonthDay, qnameFromNsmap
 
 NSMAP = {
     None: "http://default.ns",
@@ -60,3 +62,45 @@ class TestQnameFromNsmap:
     def test_empty_nsmap_with_prefix_raises(self):
         with pytest.raises(ValueError):
             qnameFromNsmap({}, "pfx:localName", prefixException=ValueError)
+
+
+class TestGDateCombinedTimezoneOffset:
+    """gMonthDay/gDay are the only g* types whose field unit (a calendar day, 24h) is
+    shorter than the 28h two opposite +-14:00 offsets can combine to (XSD Datatypes
+    3.2.7.3), so unlike gYear/gYearMonth/gMonth, adjacent-day values with different,
+    explicit timezones can denote the *same* instant despite differing numeral fields.
+    """
+
+    def test_gMonthDay_adjacent_days_opposite_offsets_are_equal_instant(self):
+        # --06-14 at -10:00 is 2000-06-14T10:00:00Z; --06-15 at +14:00 is also
+        # 2000-06-14T10:00:00Z (2000-06-15T00:00:00 minus the +14:00 offset).
+        a = gMonthDay(6, 14, tzinfo=datetime.timezone(datetime.timedelta(hours=-10)))
+        b = gMonthDay(6, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=14)))
+        assert a == b
+        assert not (a < b)
+        assert not (a > b)
+        assert a <= b and a >= b
+        assert hash(a) == hash(b)
+
+    def test_gDay_adjacent_days_opposite_offsets_are_equal_instant(self):
+        a = gDay(14, tzinfo=datetime.timezone(datetime.timedelta(hours=-10)))
+        b = gDay(15, tzinfo=datetime.timezone(datetime.timedelta(hours=14)))
+        assert a == b
+        assert not (a < b)
+        assert not (a > b)
+        assert hash(a) == hash(b)
+
+    def test_gMonthDay_naive_vs_aware_never_equal_and_order_raises(self):
+        naive = gMonthDay(6, 14)
+        aware = gMonthDay(6, 14, tzinfo=datetime.timezone.utc)
+        assert naive != aware
+        assert not (naive == aware)
+        with pytest.raises(TypeError):
+            naive < aware
+
+    def test_gMonthDay_large_gap_still_determinate_despite_offsets(self):
+        # A gap of many days can never be closed by a <=28h combined swing.
+        early = gMonthDay(1, 1, tzinfo=datetime.timezone(datetime.timedelta(hours=-14)))
+        late = gMonthDay(6, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=14)))
+        assert early < late
+        assert not (early == late)

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -1065,12 +1065,26 @@ def test_validateValueString_facets_ordering(
         ("gMonthDay", "--06-15Z", {"maxInclusive": gMonthDay(6, 15)}, INVALID),  # indeterminate
         ("gMonthDay", "--06-20Z", {"maxInclusive": gMonthDay(6, 15)}, INVALID),  # determinate violation
         ("gMonthDay", "--06-10Z", {"maxInclusive": gMonthDay(6, 15)}, VALID),  # determinate acceptance
+        # gMonthDay with *both* sides explicitly timezoned, on adjacent days: --06-14 at
+        # -10:00 and --06-15 at +14:00 denote the *same* instant (00:00-10:00 on the 14th
+        # = 10:00 UTC = 00:00+14:00 on the 15th), since the combined +-14h swing of two
+        # opposite extreme offsets (28h) exceeds the 24h gap between adjacent days. A
+        # naive field-only comparison (14 < 15) would wrongly call this determinate
+        # "less than"; it must instead resolve as equal.
+        ("gMonthDay", "--06-14-10:00", {"maxExclusive": gMonthDay(6, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=14)))}, INVALID),  # equal, not strictly less
+        ("gMonthDay", "--06-14-10:00", {"maxInclusive": gMonthDay(6, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=14)))}, VALID),  # equal, satisfies <=
+        ("gMonthDay", "--06-15+14:00", {"minExclusive": gMonthDay(6, 14, tzinfo=datetime.timezone(datetime.timedelta(hours=-10)))}, INVALID),  # equal, not strictly greater
+        ("gMonthDay", "--06-15+14:00", {"minInclusive": gMonthDay(6, 14, tzinfo=datetime.timezone(datetime.timedelta(hours=-10)))}, VALID),  # equal, satisfies >=
         # gMonth
         ("gMonth", "--06Z", {"maxInclusive": gMonth(6)}, INVALID),  # indeterminate
         ("gMonth", "--05Z", {"maxInclusive": gMonth(6)}, VALID),  # determinate acceptance
         # gDay
         ("gDay", "---15Z", {"maxInclusive": gDay(15)}, INVALID),  # indeterminate
         ("gDay", "---10Z", {"maxInclusive": gDay(15)}, VALID),  # determinate acceptance
+        # gDay with both sides explicitly timezoned, on adjacent days: the same
+        # combined-offset equivalence as gMonthDay above.
+        ("gDay", "---14-10:00", {"maxExclusive": gDay(15, tzinfo=datetime.timezone(datetime.timedelta(hours=14)))}, INVALID),  # equal, not strictly less
+        ("gDay", "---14-10:00", {"maxInclusive": gDay(15, tzinfo=datetime.timezone(datetime.timedelta(hours=14)))}, VALID),  # equal, satisfies <=
     ],
 )
 def test_validateValueString_facets_ordering_timezone(

--- a/tests/unit_tests/arelle/test_xmlvalidate.py
+++ b/tests/unit_tests/arelle/test_xmlvalidate.py
@@ -177,10 +177,10 @@ BASE_XSD_TYPES = {
     "gDay": [
         {"value": "---01", "expected": ("=", gDay(1), VALID)},
         {"value": "---31", "expected": ("=", gDay(31), VALID)},
-        {"value": "---01Z", "expected": ("=", gDay(1), VALID)},
-        {"value": "---01+01:11", "expected": ("=", gDay(1), VALID)},
-        {"value": "---01-01:11", "expected": ("=", gDay(1), VALID)},
-        {"value": "---01-14:00", "expected": ("=", gDay(1), VALID)},
+        {"value": "---01Z", "expected": ("=", gDay(1, tzinfo=datetime.timezone.utc), VALID)},
+        {"value": "---01+01:11", "expected": ("=", gDay(1, tzinfo=datetime.timezone(datetime.timedelta(hours=1, minutes=11))), VALID)},
+        {"value": "---01-01:11", "expected": ("=", gDay(1, tzinfo=datetime.timezone(datetime.timedelta(hours=-1, minutes=-11))), VALID)},
+        {"value": "---01-14:00", "expected": ("=", gDay(1, tzinfo=datetime.timezone(datetime.timedelta(hours=-14))), VALID)},
         {"value": "01", "expected": ("=", None, INVALID)},
         {"value": "--01", "expected": ("=", None, INVALID)},
         {"value": "---1", "expected": ("=", None, INVALID)},
@@ -195,10 +195,10 @@ BASE_XSD_TYPES = {
     "gMonth": [
         {"value": "--01", "expected": ("=", gMonth(1), VALID)},
         {"value": "--12", "expected": ("=", gMonth(12), VALID)},
-        {"value": "--01Z", "expected": ("=", gMonth(1), VALID)},
-        {"value": "--01+01:11", "expected": ("=", gMonth(1), VALID)},
-        {"value": "--01-01:11", "expected": ("=", gMonth(1), VALID)},
-        {"value": "--01-14:00", "expected": ("=", gMonth(1), VALID)},
+        {"value": "--01Z", "expected": ("=", gMonth(1, tzinfo=datetime.timezone.utc), VALID)},
+        {"value": "--01+01:11", "expected": ("=", gMonth(1, tzinfo=datetime.timezone(datetime.timedelta(hours=1, minutes=11))), VALID)},
+        {"value": "--01-01:11", "expected": ("=", gMonth(1, tzinfo=datetime.timezone(datetime.timedelta(hours=-1, minutes=-11))), VALID)},
+        {"value": "--01-14:00", "expected": ("=", gMonth(1, tzinfo=datetime.timezone(datetime.timedelta(hours=-14))), VALID)},
         {"value": "01", "expected": ("=", None, INVALID)},
         {"value": "-01", "expected": ("=", None, INVALID)},
         {"value": "---01", "expected": ("=", None, INVALID)},
@@ -215,10 +215,10 @@ BASE_XSD_TYPES = {
         {"value": "--01-01", "expected": ("=", gMonthDay(1, 1), VALID)},
         {"value": "--01-31", "expected": ("=", gMonthDay(1, 31), VALID)},
         {"value": "--12-01", "expected": ("=", gMonthDay(12, 1), VALID)},
-        {"value": "--01-01Z", "expected": ("=", gMonthDay(1, 1), VALID)},
-        {"value": "--01-01+01:11", "expected": ("=", gMonthDay(1, 1), VALID)},
-        {"value": "--01-01-01:11", "expected": ("=", gMonthDay(1, 1), VALID)},
-        {"value": "--01-01-14:00", "expected": ("=", gMonthDay(1, 1), VALID)},
+        {"value": "--01-01Z", "expected": ("=", gMonthDay(1, 1, tzinfo=datetime.timezone.utc), VALID)},
+        {"value": "--01-01+01:11", "expected": ("=", gMonthDay(1, 1, tzinfo=datetime.timezone(datetime.timedelta(hours=1, minutes=11))), VALID)},
+        {"value": "--01-01-01:11", "expected": ("=", gMonthDay(1, 1, tzinfo=datetime.timezone(datetime.timedelta(hours=-1, minutes=-11))), VALID)},
+        {"value": "--01-01-14:00", "expected": ("=", gMonthDay(1, 1, tzinfo=datetime.timezone(datetime.timedelta(hours=-14))), VALID)},
         {"value": "01-01", "expected": ("=", None, INVALID)},
         {"value": "-01-01", "expected": ("=", None, INVALID)},
         {"value": "---01-01", "expected": ("=", None, INVALID)},
@@ -240,10 +240,10 @@ BASE_XSD_TYPES = {
         {"value": "-10000", "expected": ("=", gYear(10000), VALID)},
         {"value": "-0001", "expected": ("=", gYear(1), VALID)},
         {"value": "0001", "expected": ("=", gYear(1), VALID)},
-        {"value": "-0001Z", "expected": ("=", gYear(1), VALID)},
-        {"value": "-0001+01:11", "expected": ("=", gYear(1), VALID)},
-        {"value": "-0001-01:11", "expected": ("=", gYear(1), VALID)},
-        {"value": "-0001-14:00", "expected": ("=", gYear(1), VALID)},
+        {"value": "-0001Z", "expected": ("=", gYear(1, tzinfo=datetime.timezone.utc), VALID)},
+        {"value": "-0001+01:11", "expected": ("=", gYear(1, tzinfo=datetime.timezone(datetime.timedelta(hours=1, minutes=11))), VALID)},
+        {"value": "-0001-01:11", "expected": ("=", gYear(1, tzinfo=datetime.timezone(datetime.timedelta(hours=-1, minutes=-11))), VALID)},
+        {"value": "-0001-14:00", "expected": ("=", gYear(1, tzinfo=datetime.timezone(datetime.timedelta(hours=-14))), VALID)},
         {"value": "0000", "expected": ("=", None, INVALID)},
         {"value": "-0000", "expected": ("=", None, INVALID)},
         {"value": "0000Z", "expected": ("=", None, INVALID)},
@@ -260,10 +260,10 @@ BASE_XSD_TYPES = {
         {"value": "-10000-01", "expected": ("=", gYearMonth(10000, 1), VALID)},
         {"value": "-0001-01", "expected": ("=", gYearMonth(1, 1), VALID)},
         {"value": "0001-01", "expected": ("=", gYearMonth(1, 1), VALID)},
-        {"value": "-0001-01Z", "expected": ("=", gYearMonth(1, 1), VALID)},
-        {"value": "-0001-01+01:11", "expected": ("=", gYearMonth(1, 1), VALID)},
-        {"value": "-0001-01-01:11", "expected": ("=", gYearMonth(1, 1), VALID)},
-        {"value": "-0001-01-14:00", "expected": ("=", gYearMonth(1, 1), VALID)},
+        {"value": "-0001-01Z", "expected": ("=", gYearMonth(1, 1, tzinfo=datetime.timezone.utc), VALID)},
+        {"value": "-0001-01+01:11", "expected": ("=", gYearMonth(1, 1, tzinfo=datetime.timezone(datetime.timedelta(hours=1, minutes=11))), VALID)},
+        {"value": "-0001-01-01:11", "expected": ("=", gYearMonth(1, 1, tzinfo=datetime.timezone(datetime.timedelta(hours=-1, minutes=-11))), VALID)},
+        {"value": "-0001-01-14:00", "expected": ("=", gYearMonth(1, 1, tzinfo=datetime.timezone(datetime.timedelta(hours=-14))), VALID)},
         {"value": "0000-01", "expected": ("=", None, INVALID)},
         {"value": "-0000-01", "expected": ("=", None, INVALID)},
         {"value": "0000-06Z", "expected": ("=", None, INVALID)},
@@ -582,6 +582,7 @@ def test_validateValue_facets_enumeration(value: str, expected: tuple):
         ("gYearMonth", "2002-01Z", "2002-01+00:00", VALID),
         ("gMonthDay", "--01-01-00:00", "--01-01+00:00", VALID),
         ("gMonthDay", "--01-02", "--01-01", INVALID),
+        ("gMonthDay", "--01-01-01:00", "--01-01-00:00", INVALID),
         # duration: PT1H and PT60M are the same magnitude
         ("duration", "PT1H", "PT60M", VALID),
         ("duration", "PT1H", "PT61M", INVALID),
@@ -1046,6 +1047,30 @@ def test_validateValueString_facets_ordering(
         ("time", "03:04:05Z", {"minInclusive": Time(3, 4, 5)}, INVALID),  # indeterminate
         ("time", "23:00:00Z", {"minInclusive": Time(0, 0, 0)}, VALID),  # determinate acceptance
         ("time", "00:00:00", {"maxInclusive": Time(23, 0, 0, tzinfo=datetime.timezone.utc)}, VALID),  # determinate acceptance
+        # gYear: a difference of a whole year always swamps the +/-14h timezone
+        # uncertainty (Datatypes 3.2.7.4), so it is determinate even with
+        # mismatched timezones; only a tie on the year field is indeterminate.
+        ("gYear", "2025Z", {"maxInclusive": gYear(2025)}, INVALID),  # indeterminate: same year, tz mismatch
+        ("gYear", "2025", {"maxInclusive": gYear(2025, tzinfo=datetime.timezone.utc)}, INVALID),  # indeterminate, reversed
+        ("gYear", "2026Z", {"maxInclusive": gYear(2025)}, INVALID),  # determinate violation (later year)
+        ("gYear", "2024", {"minInclusive": gYear(2025, tzinfo=datetime.timezone.utc)}, INVALID),  # determinate violation
+        ("gYear", "2024Z", {"maxInclusive": gYear(2025)}, VALID),  # determinate acceptance (earlier year)
+        # gYearMonth: same reasoning one level finer (month, not year)
+        ("gYearMonth", "2025-06Z", {"maxInclusive": gYearMonth(2025, 6)}, INVALID),  # indeterminate
+        ("gYearMonth", "2025-07Z", {"maxInclusive": gYearMonth(2025, 6)}, INVALID),  # determinate violation
+        ("gYearMonth", "2025-05Z", {"maxInclusive": gYearMonth(2025, 6)}, VALID),  # determinate acceptance
+        # gMonthDay: the finest-grained g* type (a calendar day), where the +/-14h band
+        # is comparable to the unit size, yet an exact field tie is still indeterminate
+        # and a large-enough gap is still determinate.
+        ("gMonthDay", "--06-15Z", {"maxInclusive": gMonthDay(6, 15)}, INVALID),  # indeterminate
+        ("gMonthDay", "--06-20Z", {"maxInclusive": gMonthDay(6, 15)}, INVALID),  # determinate violation
+        ("gMonthDay", "--06-10Z", {"maxInclusive": gMonthDay(6, 15)}, VALID),  # determinate acceptance
+        # gMonth
+        ("gMonth", "--06Z", {"maxInclusive": gMonth(6)}, INVALID),  # indeterminate
+        ("gMonth", "--05Z", {"maxInclusive": gMonth(6)}, VALID),  # determinate acceptance
+        # gDay
+        ("gDay", "---15Z", {"maxInclusive": gDay(15)}, INVALID),  # indeterminate
+        ("gDay", "---10Z", {"maxInclusive": gDay(15)}, VALID),  # determinate acceptance
     ],
 )
 def test_validateValueString_facets_ordering_timezone(


### PR DESCRIPTION
Part of https://github.com/Arelle/Arelle/issues/2445

## Fix 9 — the `g*` date/time types (`gYearMonth`, `gYear`, `gMonthDay`, `gMonth`, `gDay`) silently discard their timezone

**Symptom:** the lexical patterns for all five types capture an optional trailing
timezone (`Z`, `+hh:mm`, or `-hh:mm`) — e.g. `"gYearMonth": re_compile(r"...(Z|(\+|-)
(...))?$")` — and `_validateValueStringOrRaise` even unpacks the timezone groups out of
the regex match (`month, day, zSign, zHrMin, zHr, zMin = match.groups()`), but the
captured groups were never used: every constructor call passed only the numeric
fields (`gMonthDay(month, day)`, `gYear(year)`, etc.), and none of the five classes had
anywhere to put a timezone even if one had been passed. Consequently:

- **Equality** (`__eq__`, and therefore the `EnumerationFacet` value-space lookup added
  in Fix 8) compared only the numeric fields, so an untimezoned value, a UTC value
  (`Z`/`+00:00`/`-00:00`), and a value in *any other timezone* with the same numeral
  fields were all treated as the identical value — e.g. `gYear` parsed from `"2002"`,
  `"2002Z"`, and `"2002+09:00"` compared equal to each other, even though the first has
  no defined instant at all and the third denotes a starting instant 9 hours away from
  the second's.
- **Ordering** (`__lt__` etc., and therefore the `maxInclusive`/`maxExclusive`/
  `minInclusive`/`minExclusive` facet checks added in Fix 3) had the same blind spot:
  `_orderedComparison` never saw a `TypeError` for a timezone mismatch on these types, 
  so a genuinely indeterminate order (per §3.2.7.4, applied to these five types by 
  §3.2.10.2/§3.2.11.2/§3.2.12.2/§3.2.13.2/§3.2.14.2) was silently treated as determined 
  by the numeral fields alone.

**Change:** give each of the five classes an optional `tzinfo: datetime.timezone | None`
field, populate it at parse time from the already-captured (previously discarded) regex
group, and route equality/ordering through helpers that treat a value's
timezone-presence as part of its identity, exactly as `dateTime`/`date`/`time` already
do.

**Normative basis:**

- XSD 2 §3.2.7 defines `dateTime` values as having "a boolean timezoned
  property" that is part of the value itself — not a display detail. §3.2.10 (`gYearMonth`),
  §3.2.11 (`gYear`), §3.2.12 (`gMonthDay`), §3.2.13 (`gDay`), and §3.2.14 (`gMonth`) each
  state: "Since the lexical representation allows an optional time zone indicator, \[this
  type's] values are partially ordered because it may not be possible to unequivocally
  determine the order of two values one of which has a time zone and the other does
  not." <https://www.w3.org/TR/xmlschema-2/#gYearMonth> ·
  <https://www.w3.org/TR/xmlschema-2/#gYear> ·
  <https://www.w3.org/TR/xmlschema-2/#gMonthDay> ·
  <https://www.w3.org/TR/xmlschema-2/#gDay> · <https://www.w3.org/TR/xmlschema-2/#gMonth>

- Each of those same sections continues: "the order relation on \[this type's] values is
  the order relation on their starting instants[, discussed in] Order relation on
  dateTime (§3.2.7.4)" — i.e. these five types do not get their own bespoke order
  relation; they explicitly reuse dateTime's, timezone handling included.
  <https://www.w3.org/TR/xmlschema-2/#dateTime-order>

- §3.2.7.3 *Timezones*: the lexical timezone ranges over `+14:00` to `-14:00` (a `hh:mm`
  duration with `hh <= 14`, and `hh == 14` only paired with `mm == 0`), which is the
  origin of the `+-14h` uncertainty band already established for `dateTime`/`date`/`time`
  in Fix 3a and reused here unchanged. <https://www.w3.org/TR/xmlschema-2/#dateTime>

- §3.2.12 *gMonthDay* and §3.2.13 *gDay* explicitly sanction picking an arbitrary
  reference year/month to reason about ordering — "in an arbitrary leap year" and "in an
  arbitrary month that has 31 days," respectively — which is exactly the anchoring
  `_comparableInstant` performs. <https://www.w3.org/TR/xmlschema-2/#gMonthDay> ·
  <https://www.w3.org/TR/xmlschema-2/#gDay>

- §3.2.7.1 *Lexical representation* / *Timezones*: `Z`, `+00:00`, and `-00:00` are three
  spellings of the same (UTC) timezone, so a value carrying any of the three must compare
  equal to a value carrying either of the others — the same equivalence already relied on
  for `dateTime` in Fix 8 now also holds for these five types.

#### Steps to Test
CI

**review**:
@Arelle/arelle
