### PR TITLE
Preserve internal order of unhashable facts.

### DIFF
--- a/arelle/ValidateDuplicateFacts.py
+++ b/arelle/ValidateDuplicateFacts.py
@@ -483,8 +483,7 @@ def getHashEquivalentFactGroups(facts: list[ModelFact]) -> list[list[ModelFact]]
     :param facts:
     :return: List of hash-equivalent fact lists
     """
-    hashDict = defaultdict(list)
-    unhashableGroups = []
+    hashDict: dict[int | object, list[ModelFact]] = defaultdict(list)
     for f in facts:
         if (
             (
@@ -498,8 +497,8 @@ def getHashEquivalentFactGroups(facts: list[ModelFact]) -> list[list[ModelFact]]
         ):
             hashDict[f.conceptContextUnitHash].append(f)
         else:
-            unhashableGroups.append([f])
-    return list(hashDict.values()) + unhashableGroups
+            hashDict[object()].append(f)
+    return list(hashDict.values())
 
 
 def logDeduplicatedFact(modelXbrl: ModelXbrl, fact: ModelFact) -> None:


### PR DESCRIPTION
https://github.com/Arelle/Arelle/pull/2097#discussion_r2672915596
"Internal" because as far as I can tell, non-validation consumers ignore the order.

Tested instance extraction.

**review**:
@Arelle/arelle
