### PR TITLE
Restore ttk Frame and Scrollbar imports in arelle.UiUtil

### DIFF
--- a/arelle/UiUtil.py
+++ b/arelle/UiUtil.py
@@ -14,9 +14,7 @@ from tkinter import (
     W,
     Canvas,
     Event,
-    Frame,
     Misc,
-    Scrollbar,
     StringVar,
 )
 
@@ -24,8 +22,10 @@ from tkinter.ttk import (
     Checkbutton,
     Combobox as _Combobox,
     Entry,
+    Frame,
     Label,
     Radiobutton,
+    Scrollbar,
     Separator,
 )
 from typing import Any

--- a/arelle/ViewWinGrid.py
+++ b/arelle/ViewWinGrid.py
@@ -26,7 +26,7 @@ class ViewGrid(ViewPane):
     ) -> None:
         contentView = scrolledHeaderedFrame(tabWin)
         super(ViewGrid, self).__init__(modelXbrl, tabWin, tabTitle,
-                                       contentView, hasToolTip=hasToolTip,  # type: ignore[arg-type]
+                                       contentView, hasToolTip=hasToolTip,
                                        lang=lang)
         self.gridTblHdr = self.viewFrame.tblHdrInterior  # type: ignore[attr-defined]
         self.gridColHdr = self.viewFrame.colHdrInterior  # type: ignore[attr-defined]


### PR DESCRIPTION
#### Reason for change

Addresses https://github.com/Arelle/Arelle/pull/2485#discussion_r3605459284

PR #2374 replaced `from tkinter.ttk import *` with explicit imports but incorrectly moved Frame and Scrollbar to the tkinter import block. These widgets were originally sourced from tkinter.ttk (themed variants) via the wildcard import. Importing the base tkinter versions degrades GUI appearance. Move them back to the tkinter.ttk import.

#### Description of change

Restore themed tkinter imports.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
