### PR TITLE
Load all targets from testcases by default

### DIFF
--- a/arelle/ModelTestcaseObject.py
+++ b/arelle/ModelTestcaseObject.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from arelle import XmlUtil, XbrlConst, ModelValue
 from arelle.PrototypeDtsObject import PrototypeObject
+from arelle.XbrlConst import DEFAULT_TARGET
 from arelle.conformance.Constants import CONFORMANCE_SUITE_ID_OVERRIDES
 from arelle.ModelObject import ModelObject
 
@@ -25,6 +26,9 @@ TXMY_PKG_SRC_ELTS = ("metadata", "catalog", "taxonomy")
 def testcaseVariationsByTarget(testcaseVariations: list[ModelTestcaseVariation]) -> Generator[ModelTestcaseVariation, None, None]:
     for modelTestcaseVariation in testcaseVariations:
         modelTestcaseVariation.errors = None # Errors accumulate over multiple ixdsTargets for same variation
+        # The Inline XBRL 1.1 conformance suite defines targets to validate using the `instance`
+        # element with a `target` attribute to specify a target name. An absent attribute indicates
+        # only the default target should be loaded.
         ixdsTargets = [instElt.get("target")
                       for resultElt in modelTestcaseVariation.iterdescendants("{*}result")
                       for instElt in resultElt.iterdescendants("{*}instance")]
@@ -33,7 +37,10 @@ def testcaseVariationsByTarget(testcaseVariations: list[ModelTestcaseVariation])
             allTargetsActual = []
             allTargetsStatus = ""
             for ixdsTarget in ixdsTargets:
-                modelTestcaseVariation.ixdsTarget = ixdsTarget
+                # A blank `target` value in the Inline XBRL 1.1 conformance suite
+                # indicates we should only load the default target. Setting `None` results
+                # in all targets being loaded, so we must pass DEFAULT_TARGET.
+                modelTestcaseVariation.ixdsTarget = DEFAULT_TARGET if ixdsTarget is None else ixdsTarget
                 yield modelTestcaseVariation
                 allTargetsActual.extend(modelTestcaseVariation.actual)
                 if allTargetsStatus not in ("fail", "fail (count)"):
@@ -41,6 +48,7 @@ def testcaseVariationsByTarget(testcaseVariations: list[ModelTestcaseVariation])
                     allTargetsStatus = modelTestcaseVariation.status
             modelTestcaseVariation.status = allTargetsStatus
         else: # probably an expected error situation
+            # To load all targets in the filing, we provide no value for `ixdsTarget`.
             modelTestcaseVariation.ixdsTarget = None
             yield modelTestcaseVariation
 
@@ -228,7 +236,7 @@ class ModelTestcaseVariation(ModelObject):
 
         for resultElt in self.iterdescendants("{*}result"):
             for instElt in resultElt.iterdescendants("{*}instance"):
-                if (instElt.get("target") or "") == (self.ixdsTarget or ""): # match null and emptyString
+                if (instElt.get("target") or DEFAULT_TARGET) == (self.ixdsTarget or DEFAULT_TARGET): # match null and DEFAULT_TARGET
                     return XmlUtil.text(instElt)
         return None
 

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -396,6 +396,9 @@ class Validate:
                     if archivePath:
                         with self.useFileSource.fs.open(archivePath[1]) as embeddedFile:  # type: ignore[union-attr]
                             readMeFirstUriIsArchive = readMeFirstUriIsEmbeddedZipFile = zipfile.is_zipfile(embeddedFile)  # type: ignore[arg-type]
+            modelXbrlLoadArgs: dict[str, Any] = {}
+            if modelTestcaseVariation.ixdsTarget:
+                modelXbrlLoadArgs["ixdsTarget"] = modelTestcaseVariation.ixdsTarget
             if not readMeFirstUriIsArchive:
                 modelXbrl = modelXbrlLoad(self.modelXbrl.modelManager,
                                             readMeFirstUri,
@@ -403,7 +406,7 @@ class Validate:
                                             base=baseForElement,
                                             useFileSource=self.useFileSource,
                                             errorCaptureLevel=errorCaptureLevel,
-                                            ixdsTarget=modelTestcaseVariation.ixdsTarget)
+                                            **modelXbrlLoadArgs)
                 loadedModels.append(modelXbrl)
             else: # need own file source, may need instance discovery
                 sourceFileSource = None
@@ -468,8 +471,8 @@ class Validate:
                                                                _("validating"),
                                                                base=filesource.basefile + "/",
                                                                errorCaptureLevel=errorCaptureLevel,
-                                                               ixdsTarget=modelTestcaseVariation.ixdsTarget,
-                                                               errors=preLoadingErrors)
+                                                               errors=preLoadingErrors,
+                                                               **modelXbrlLoadArgs)
                                     loadedModels.append(modelXbrl)
                     except Exception as err:
                         self.modelXbrl.error("exception:" + type(err).__name__,
@@ -495,8 +498,8 @@ class Validate:
                                                             _("validating"),
                                                             base=filesource.basefile + "/",
                                                             errorCaptureLevel=errorCaptureLevel,
-                                                            ixdsTarget=modelTestcaseVariation.ixdsTarget,
-                                                            errors=preLoadingErrors)
+                                                            errors=preLoadingErrors,
+                                                            **modelXbrlLoadArgs)
                                 loadedModels.append(modelXbrl)
                 else:
                     if _rptPkgIxdsOptions and filesource.isTaxonomyPackage:
@@ -509,9 +512,9 @@ class Validate:
                                                     _("validating"),
                                                     base=baseForElement,
                                                     errorCaptureLevel=errorCaptureLevel,
-                                                    ixdsTarget=modelTestcaseVariation.ixdsTarget,
                                                     isLoadable=modelTestcaseVariation.variationDiscoversDTS or filesource.url,
-                                                    errors=preLoadingErrors)
+                                                    errors=preLoadingErrors,
+                                                    **modelXbrlLoadArgs)
                         loadedModels.append(modelXbrl)
 
         for model in loadedModels:

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -330,6 +330,12 @@ class Validate:
         self.modelXbrl.modelManager.cntlr.testcaseVariationReset()
         modelTestcaseVariation.duration = time.perf_counter() - startTime
 
+    @staticmethod
+    def _collectLoadedModels(loadedModels: list[ModelXbrl], modelXbrl: ModelXbrl) -> None:
+        loadedModels.append(modelXbrl)
+        if supplementalModelXbrls := getattr(modelXbrl, "supplementalModelXbrls", None):
+            loadedModels.extend(supplementalModelXbrls)
+
     def _testcaseLoadReadMeFirstUri(
         self,
         testcase: ModelDocument,
@@ -369,7 +375,7 @@ class Validate:
                                 self.modelXbrl.modelManager.cntlr.webCache.normalizeUrl(readMeFirstUri[:-4] + ".dts", baseForElement),
                                 isEntry=True,
                                 errorCaptureLevel=errorCaptureLevel)
-                loadedModels.append(modelXbrl)
+                Validate._collectLoadedModels(loadedModels, modelXbrl)
             DTSdoc = modelXbrl.modelDocument
             assert DTSdoc is not None, "modelDocument must be set"
             DTSdoc.inDTS = True
@@ -407,7 +413,7 @@ class Validate:
                                             useFileSource=self.useFileSource,
                                             errorCaptureLevel=errorCaptureLevel,
                                             **modelXbrlLoadArgs)
-                loadedModels.append(modelXbrl)
+                Validate._collectLoadedModels(loadedModels, modelXbrl)
             else: # need own file source, may need instance discovery
                 sourceFileSource = None
                 newSourceFileSource = False
@@ -473,7 +479,7 @@ class Validate:
                                                                errorCaptureLevel=errorCaptureLevel,
                                                                errors=preLoadingErrors,
                                                                **modelXbrlLoadArgs)
-                                    loadedModels.append(modelXbrl)
+                                    Validate._collectLoadedModels(loadedModels, modelXbrl)
                     except Exception as err:
                         self.modelXbrl.error("exception:" + type(err).__name__,
                             _("Testcase variation validation exception: %(error)s, entry URL: %(instance)s"),
@@ -500,7 +506,7 @@ class Validate:
                                                             errorCaptureLevel=errorCaptureLevel,
                                                             errors=preLoadingErrors,
                                                             **modelXbrlLoadArgs)
-                                loadedModels.append(modelXbrl)
+                                Validate._collectLoadedModels(loadedModels, modelXbrl)
                 else:
                     if _rptPkgIxdsOptions and filesource.isTaxonomyPackage:
                         # Legacy ESEF conformance suite logic.
@@ -515,7 +521,7 @@ class Validate:
                                                     isLoadable=modelTestcaseVariation.variationDiscoversDTS or filesource.url,
                                                     errors=preLoadingErrors,
                                                     **modelXbrlLoadArgs)
-                        loadedModels.append(modelXbrl)
+                        Validate._collectLoadedModels(loadedModels, modelXbrl)
 
         for model in loadedModels:
             modelXbrl.isTestcaseVariation = True  # type: ignore[attr-defined]

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
 _: TypeGetText
 
 
+# Not a normative XBRL constant, but a value used internally in Arelle
+# to represent the default/unspecified target name in multi-target filings.
+DEFAULT_TARGET = "(default)"
+
+
 xsd = "http://www.w3.org/2001/XMLSchema"
 qnXsdComplexType = qname("{http://www.w3.org/2001/XMLSchema}xsd:complexType")
 qnXsdDocumentation = qname("{http://www.w3.org/2001/XMLSchema}xsd:documentation")

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -154,7 +154,8 @@ from arelle.XmlUtil import (
 from arelle.XmlValidate import NONE, VALID
 from arelle.XmlValidate import validate as xmlValidate
 
-DEFAULT_TARGET = "(default)"
+# Re-export for backwards compatability
+from arelle.XbrlConst import DEFAULT_TARGET
 
 MINIMUM_IXDS_DOC_COUNT = 2 # make this 2 to cause single-documents to be processed without a document set object
 

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2024.py
@@ -70,14 +70,6 @@ config = ConformanceSuiteConfig(
         'G3-5-2_3/index.xml:TC2_invalid': {
             'missingLabelForRoleInReportLanguage': 1,
         },
-        'G3-5-3_1/index.xml:TC2_invalid': {
-            'arelle:ixdsTargetNotDefined': 1,
-            'extensionTaxonomyWrongFilesStructure': 2,
-            'noInlineXbrlTags': 1,
-            # This test is looking at the usage of the target attribute and does not import the correct taxonomy urls
-            'requiredEntryPointNotImported': 1,
-            'incorrectKvkTaxonomyVersionUsed': 1,
-        },
         'G3-7-1_1/index.xml:TC2_invalid': {
             'message:valueKvKIdentifier': 13,
             'nonIdenticalIdentifier': 1,

--- a/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2025.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/nl_inline_2025.py
@@ -81,14 +81,6 @@ config = ConformanceSuiteConfig(
         'G3-5-2_3/index.xml:TC2_invalid': {
             'missingLabelForRoleInReportLanguage': 1,
         },
-        'G3-5-3_1/index.xml:TC2_invalid': {
-            'arelle:ixdsTargetNotDefined': 1,
-            'extensionTaxonomyWrongFilesStructure': 2,
-            'noInlineXbrlTags': 1,
-            # This test is looking at the usage of the target attribute and does not import the correct taxonomy urls
-            'requiredEntryPointNotImported': 1,
-            'incorrectKvkTaxonomyVersionUsed': 1,
-        },
         'G3-6-3_1/index.xml:TC2_invalid': {
             # deconformancebvdeponeringsgegevens-2024-12-31-nl.html
             'kvkFilingDocumentNameDoesNotFollowNamingConvention': 1,
@@ -191,6 +183,7 @@ config = ConformanceSuiteConfig(
         },
         'G6-1-3_4/index.xml:TC2_invalid': {
             'incorrectVersionEntryPointOtherReferenced': 1,
+            'kvkFilingDocumentNameDoesNotFollowNamingConvention': 1, # Fires for each of two instances
             'requiredEntryPointOtherNotReferenced': 1,
         },
         'G7-1-4_1/index.xml:TC1_valid': {

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -28,6 +28,18 @@ config = ConformanceSuiteConfig(
             source=AssetSource.S3_PUBLIC,
         ),
         ConformanceSuiteAssetConfig.public_taxonomy_package(
+            Path('FRC-2022-Taxonomy.zip'),
+            public_download_url='https://www.frc.org.uk/documents/969/FRC-2022-Taxonomy.zip',
+        ),
+        ConformanceSuiteAssetConfig.public_taxonomy_package(
+            Path('FRC-2024-Taxonomy-v1.0.0_GJp67Do.zip'),
+            public_download_url='https://www.frc.org.uk/documents/6566/FRC-2024-Taxonomy-v1.0.0_GJp67Do.zip',
+        ),
+        ConformanceSuiteAssetConfig.public_taxonomy_package(
+            Path('FRC-2025-Taxonomy-v1.0.0_LK4mek8.zip'),
+            public_download_url='https://www.frc.org.uk/documents/7759/FRC-2025-Taxonomy-v1.0.0_LK4mek8.zip',
+        ),
+        ConformanceSuiteAssetConfig.public_taxonomy_package(
             Path('The_2023_Taxonomy_suite_v1.0.1.zip'),
             public_download_url='https://www.frc.org.uk/documents/372/The_2023_Taxonomy_suite_v1.0.1.zip',
         ),

--- a/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.10.12/index.xml
+++ b/tests/resources/conformance_suites/edinet/EC5700W.GFM.1.10.12/index.xml
@@ -17,6 +17,7 @@
             <instance readMeFirst="true">invalid01.zip</instance>
         </data>
         <result>
+            <instance></instance> <!-- Workaround to force Arelle to only load the default target -->
             <warning>EDINET.EC5700W.GFM.1.10.12</warning>
             <error num="18">EDINET.EC1002E</error> <!--Targets assigned on cover page items-->
         </result>


### PR DESCRIPTION
#### Reason for change
The common/default case for instance loading in the the test suite runner is to [pass](https://github.com/Arelle/Arelle/blob/075c0599834753c76f526cf76680f0aa570593d7/arelle/ModelTestcaseObject.py#L44-L45) `None` for `ixdsTarget`. This [triggers](https://github.com/Arelle/Arelle/blob/075c0599834753c76f526cf76680f0aa570593d7/arelle/plugin/inlineXbrlDocumentSet.py#L205) the IXDS loader to load only the default target.

Some conformance suites (including the UKSEF suite we are currently working towards implementing support for) expect both targets to be loaded and validated without the suite indicating such through the only [supported method of `instance` elements with `target` attributes](https://github.com/Arelle/Arelle/blob/075c0599834753c76f526cf76680f0aa570593d7/arelle/ModelTestcaseObject.py#L28-L30).

#### Description of change
Load all targets from testcase instances by default, which aligns more closely with standard Arelle behavior.

#### Steps to Test
CI

**review**:
@Arelle/arelle
