### PR TITLE
Make `Cntlr.config` not optional

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -158,7 +158,7 @@ class Cntlr:
     hasClipboard: bool
     contextMenuClick: str
     hasWebServer: bool
-    config: dict[str, Any] | None
+    config: dict[str, Any]
     configJsonFile: str
     webCache: WebCache
     modelManager: ModelManager.ModelManager
@@ -278,7 +278,7 @@ class Cntlr:
             self.contextMenuClick = "<Button-3>"
         self.hasWebServer = hasWebServer()
         # assert that app dir must exist
-        self.config = None
+        config = None
         if self.hasFileSystem and not self.disablePersistentConfig:
             os.makedirs(self.userAppDir, exist_ok=True)
             # load config if it exists
@@ -286,14 +286,13 @@ class Cntlr:
             if os.path.exists(self.configJsonFile):
                 try:
                     with io.open(self.configJsonFile, 'rt', encoding='utf-8') as f:
-                        self.config = json.load(f)
+                        config = json.load(f)
                 except Exception as ex:
-                    self.config = None # restart with a new config
-        if not self.config:
-            self.config = {
-                'fileHistory': [],
-                'windowGeometry': "{0}x{1}+{2}+{3}".format(800, 500, 200, 100),
-            }
+                    config = None # restart with a new config
+        self.config = config or {
+            'fileHistory': [],
+            'windowGeometry': "{0}x{1}+{2}+{3}".format(800, 500, 200, 100),
+        }
 
         # start language translation for domain
         self.setUiLanguage(uiLang or self.config.get("userInterfaceLangOverride",None), fallbackToDefault=True)

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -1679,10 +1679,10 @@ class CntlrCmdLine(Cntlr.Cntlr):
             if options.proxy != "show":
                 proxySettings = proxyTuple(options.proxy)
                 self.webCache.resetProxies(proxySettings)
-                self.config["proxySettings"] = proxySettings  # type: ignore[index]
+                self.config["proxySettings"] = proxySettings
                 self.saveConfig()
                 self.addToLog(_("Proxy configuration has been set."), messageCode="info")
-            useOsProxy, urlAddr, urlPort, user, password = ProxyTuple.coerce(self.config.get("proxySettings")) or proxyTuple("none")  # type: ignore[union-attr]
+            useOsProxy, urlAddr, urlPort, user, password = ProxyTuple.coerce(self.config.get("proxySettings")) or proxyTuple("none")
             if useOsProxy:
                 self.addToLog(_("Proxy configured to use {0}.").format(
                     _("Microsoft Windows Internet Settings") if sys.platform.startswith("win")


### PR DESCRIPTION
#### Reason for change
`Cntlr.config` is type hinted as optional since it is temporarily `None` during `__init__`, but it always exits `__init__` with a value. This unnecessarily forces users of `Cntlr.config` to handle the `None` case.

#### Description of change
Update `Cntlr.config` to never be `None`.

#### Steps to Test
CI

**review**:
@Arelle/arelle
