### PR TITLE
Implement UKSEF validation framework within ESEF plugin

### DIFF
--- a/arelle/DisclosureSystem.py
+++ b/arelle/DisclosureSystem.py
@@ -75,6 +75,7 @@ class DisclosureSystem:
     EFMorGFM: bool
     HMRC: bool
     SBRNL: bool
+    authority: str | None
     pluginTypes: set[str]
     validateFileText: bool
     validateEntryText: bool
@@ -143,6 +144,7 @@ class DisclosureSystem:
         self.EFMorGFM = False
         self.HMRC = False
         self.SBRNL = False
+        self.authority = None
         self.pluginTypes = set()
         for pluginXbrlMethod in self.modelManager.cntlr.plugins.hooks("DisclosureSystem.Types"):
             for typeName, typeTestVariable in pluginXbrlMethod(self):
@@ -271,6 +273,7 @@ class DisclosureSystem:
                                 for pluginXbrlMethod in self.modelManager.cntlr.plugins.hooks("DisclosureSystem.Types"):
                                     for typeName, typeTestVariable in pluginXbrlMethod(self):
                                         setattr(self, typeTestVariable, self.validationType == typeName)
+                                self.authority = dsElt.get("authority")
                                 self.validateFileText = dsElt.get("validateFileText") == "true"
                                 self.validateEntryText = dsElt.get("validateEntryText") == "true"
                                 if allowedExternalHrefPattern := dsElt.get("allowedExternalHrefPattern"):

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -795,8 +795,9 @@ class Validate:
             if not isinstance(expected, list):
                 expected = [expected]  # type: ignore[list-item]
             for testErr in _errors:
+                testErrPrefix = None
                 if isinstance(testErr, str) and testErr.startswith(("ESEF.", "NL.NL-KVK")): # compared as list of strings to QName localname
-                    testErrSuffix = testErr.rpartition(".")[2]
+                    testErrPrefix, __, testErrSuffix = testErr.rpartition(".")
                     if not testErrSuffix.isdigit():
                         testErr = testErrSuffix
                 for _exp in _expectedList:
@@ -814,8 +815,11 @@ class Validate:
                                 # UKSEF conformance suite expects XML schema validation errors in format xbrl.core.xml.SchemaValidationError.*
                                 # Example: tests/FRC/FRC_08/index.xml:TC2_invalid
                                 (_exp.localName.startswith("xbrl.core.xml.SchemaValidationError.cvc") and errPrefix == "xmlSchema") or
-                                # Actual (str): *:match, Expected (QName): {*}*.match
-                                (errLocalName and errLocalName == _exp.localName.rpartition('.')[2])
+                                # ESEF.UK*: Actual (str): *:match, Expected (QName): {*}*.match
+                                (
+                                        testErrPrefix and testErrPrefix.startswith("ESEF.UK") and
+                                        errLocalName and errLocalName == _exp.localName.rpartition('.')[2]
+                                )
                         ):
                             _expMatched = True
                     elif type(testErr) is type(_exp):

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -803,12 +803,15 @@ class Validate:
                     _expMatched = False
                     if isinstance(_exp,QName) and isinstance(testErr,str):
                         errPrefix, sep, errLocalName = testErr.rpartition(":")
-                        if ((not sep and errLocalName in commaSpaceSplitPattern.split(_exp.localName.strip())) or # ESEF has comma separated list of localnames of errors
-                            (_exp == qname(XbrlConst.errMsgPrefixNS.get(errPrefix) or
+                        if (
+                                # ESEF has comma separated list of localnames of errors
+                                (not sep and errLocalName in commaSpaceSplitPattern.split(_exp.localName.strip())) or
+                                (_exp == qname(XbrlConst.errMsgPrefixNS.get(errPrefix) or
                                            (errPrefix == _exp.prefix and _exp.namespaceURI),
                                            errLocalName)) or
-                            # XDT xml schema tests expected results
-                            (_exp.namespaceURI == XbrlConst.xdtSchemaErrorNS and errPrefix == "xmlSchema")):
+                                # XDT xml schema tests expected results
+                                (_exp.namespaceURI == XbrlConst.xdtSchemaErrorNS and errPrefix == "xmlSchema")
+                        ):
                             _expMatched = True
                     elif type(testErr) is type(_exp):
                         if isinstance(testErr,dict):

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -810,7 +810,12 @@ class Validate:
                                            (errPrefix == _exp.prefix and _exp.namespaceURI),
                                            errLocalName)) or
                                 # XDT xml schema tests expected results
-                                (_exp.namespaceURI == XbrlConst.xdtSchemaErrorNS and errPrefix == "xmlSchema")
+                                (_exp.namespaceURI == XbrlConst.xdtSchemaErrorNS and errPrefix == "xmlSchema") or
+                                # UKSEF conformance suite expects XML schema validation errors in format xbrl.core.xml.SchemaValidationError.*
+                                # Example: tests/FRC/FRC_08/index.xml:TC2_invalid
+                                (_exp.localName.startswith("xbrl.core.xml.SchemaValidationError.cvc") and errPrefix == "xmlSchema") or
+                                # Actual (str): *:match, Expected (QName): {*}*.match
+                                (errLocalName and errLocalName == _exp.localName.rpartition('.')[2])
                         ):
                             _expMatched = True
                     elif type(testErr) is type(_exp):

--- a/arelle/config/disclosuresystems.xsd
+++ b/arelle/config/disclosuresystems.xsd
@@ -33,6 +33,7 @@
   </xs:simpleType>
   <xs:element name="DisclosureSystem">
     <xs:complexType>
+      <xs:attribute name="authority" type="xs:string"/>
       <xs:attribute name="validationType" use="required" type="validationType"/>
       <xs:attribute name="exclusiveTypesPattern" use="optional"/>
       <xs:attribute name="contextElement" use="optional" type="xs:NCName"/>

--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -14,6 +14,12 @@ styleCssHiddenPattern = re.compile(r"(.*[^\w]|^)display\s*:\s*none([^\w].*|$)")
 datetimePattern = lexicalPatterns["XBRLI_DATEUNION"]
 docTypeXhtmlPattern = re.compile(r"^<!(?:DOCTYPE\s+)\s*html(?:PUBLIC\s+)?(?:.*-//W3C//DTD\s+(X?HTML)\s)?.*>$", re.IGNORECASE)
 
+
+AUTHORITY_UKFRC = "UKFRC"
+
+TARGET_UKFRS = "UKFRS"
+
+
 FOOTNOTE_LINK_CHILDREN = frozenset((
     XbrlConst.qnLinkLoc,
     XbrlConst.qnLinkFootnoteArc,

--- a/arelle/plugin/validate/ESEF/ESEFPluginData.py
+++ b/arelle/plugin/validate/ESEF/ESEFPluginData.py
@@ -4,28 +4,75 @@ See COPYRIGHT.md for copyright information.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from arelle.Cntlr import Cntlr
+from arelle.ModelValue import qname
+from arelle.ModelXbrl import ModelXbrl
+from arelle.typing import TypeGetText
 from arelle.utils.PluginData import PluginData
+from .Util import AUTHORITY_CODES
+
+_: TypeGetText
 
 
 @dataclass
 class ESEFPluginData(PluginData):
-    esefAuthority: str | None = None
+    _esefAuthority: str | None = None
     esefInstanceValidated: bool = False
     nonEsefInstanceExcluded: bool = False
 
     @staticmethod
-    def get(cntlr: Cntlr, name: str) -> ESEFPluginData:
+    def get(cntlr: Cntlr, name: str, esefAuthority: str | None = None) -> ESEFPluginData:
         pluginData = cntlr.getPluginData(name)
         if pluginData is None:
             pluginData = ESEFPluginData(name)
+            pluginData._esefAuthority = esefAuthority
             cntlr.setPluginData(pluginData)
         elif not isinstance(pluginData, ESEFPluginData):
             raise RuntimeError(f"PluginData already set for {pluginData.name} with unexpected type {type(pluginData)}.")
         return pluginData
 
     def reset(self) -> None:
-        self.esefAuthority = None
+        self._esefAuthority = None
         self.esefInstanceValidated = False
         self.nonEsefInstanceExcluded = False
+
+
+    def getEsefAuthority(
+            self,
+            modelXbrl: ModelXbrl,
+            parameters: dict[Any, Any] | None,
+    ) -> str | None:
+        cntlr = modelXbrl.modelManager.cntlr
+        esefAuthority = self._esefAuthority
+        if not esefAuthority and cntlr.hasGui and cntlr.config is not None:
+            esefAuthority = cntlr.config.get("esefAuthority") or None
+        formulaAuthority = None
+        if parameters:
+            # formula parameter backwards compatibility for legacy users.
+            p = parameters.get(qname("authority", noPrefixIsNoNamespace=True))
+            if p and len(p) == 2 and p[1] not in ("null", "None", None):
+                formulaAuthority = p[1]
+        if esefAuthority and formulaAuthority and esefAuthority != formulaAuthority:
+            modelXbrl.error(
+                "Arelle.conflictingESEFAuthorityParameters",
+                _(
+                    "ESEF Authority '%(esefAuthority)s' conflicts with formula parameter authority '%(formulaAuthority)s'."
+                    " Continuing with '%(esefAuthority)s'."
+                ),
+                modelObject=modelXbrl,
+                esefAuthority=esefAuthority,
+                formulaAuthority=formulaAuthority,
+            )
+        authority = esefAuthority or formulaAuthority
+        if authority and authority not in AUTHORITY_CODES:
+            modelXbrl.error(
+                "Arelle.invalidESEFAuthority",
+                _("Invalid authority '%(authority)s'. Valid values: %(validValues)s."),
+                modelObject=modelXbrl,
+                authority=authority,
+                validValues=", ".join(sorted(AUTHORITY_CODES)),
+            )
+            return None
+        return authority

--- a/arelle/plugin/validate/ESEF/ESEFPluginData.py
+++ b/arelle/plugin/validate/ESEF/ESEFPluginData.py
@@ -23,11 +23,10 @@ class ESEFPluginData(PluginData):
     nonEsefInstanceExcluded: bool = False
 
     @staticmethod
-    def get(cntlr: Cntlr, name: str, esefAuthority: str | None = None) -> ESEFPluginData:
+    def get(cntlr: Cntlr, name: str) -> ESEFPluginData:
         pluginData = cntlr.getPluginData(name)
         if pluginData is None:
             pluginData = ESEFPluginData(name)
-            pluginData._esefAuthority = esefAuthority
             cntlr.setPluginData(pluginData)
         elif not isinstance(pluginData, ESEFPluginData):
             raise RuntimeError(f"PluginData already set for {pluginData.name} with unexpected type {type(pluginData)}.")
@@ -79,3 +78,6 @@ class ESEFPluginData(PluginData):
             )
             return None
         return authority
+
+    def setEsefAuthority(self, authority: str) -> None:
+        self._esefAuthority = authority

--- a/arelle/plugin/validate/ESEF/ESEFPluginData.py
+++ b/arelle/plugin/validate/ESEF/ESEFPluginData.py
@@ -46,6 +46,9 @@ class ESEFPluginData(PluginData):
     ) -> str | None:
         cntlr = modelXbrl.modelManager.cntlr
         esefAuthority = self._esefAuthority
+        disclosureSystem = modelXbrl.modelManager.disclosureSystem
+        if disclosureSystem is not None and disclosureSystem.authority is not None:
+            esefAuthority = disclosureSystem.authority
         if not esefAuthority and cntlr.hasGui and cntlr.config is not None:
             esefAuthority = cntlr.config.get("esefAuthority") or None
         formulaAuthority = None

--- a/arelle/plugin/validate/ESEF/ESEFPluginData.py
+++ b/arelle/plugin/validate/ESEF/ESEFPluginData.py
@@ -1,0 +1,31 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from arelle.Cntlr import Cntlr
+from arelle.utils.PluginData import PluginData
+
+
+@dataclass
+class ESEFPluginData(PluginData):
+    esefAuthority: str | None = None
+    esefInstanceValidated: bool = False
+    nonEsefInstanceExcluded: bool = False
+
+    @staticmethod
+    def get(cntlr: Cntlr, name: str) -> ESEFPluginData:
+        pluginData = cntlr.getPluginData(name)
+        if pluginData is None:
+            pluginData = ESEFPluginData(name)
+            cntlr.setPluginData(pluginData)
+        elif not isinstance(pluginData, ESEFPluginData):
+            raise RuntimeError(f"PluginData already set for {pluginData.name} with unexpected type {type(pluginData)}.")
+        return pluginData
+
+    def reset(self) -> None:
+        self.esefAuthority = None
+        self.esefInstanceValidated = False
+        self.nonEsefInstanceExcluded = False

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -26,7 +26,7 @@ from arelle.ModelValue import QName
 from arelle.ModelValue import qname
 from arelle.ModelXbrl import ModelXbrl
 
-from arelle.utils.validate.ContextIssues import getContextIssues
+from arelle.utils.validate.ContextIssues import getContextIssues, getContextsByEntityIdentifier
 from arelle.utils.validate.ESEFImage import ImageValidationParameters, checkSVGContentElt, validateImageAndLog
 from arelle.utils.validate.ValidationUtil import etreeIterWithDepth
 from arelle.PythonUtil import isLegacyAbs, normalizeSpace
@@ -612,10 +612,6 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
 
         # Shared context validation (period format, segment/scenario structure)
         contextIssues = getContextIssues(modelXbrl, esefYear=esefDisclosureSystemYear)
-        contextIdentifiers = defaultdict(list)
-        for context in modelXbrl.contexts.values():
-            contextIdentifiers[context.entityIdentifier].append(context)
-
         if contextIssues.contextsWithSegments:
             modelXbrl.error("ESEF.2.1.3.segmentUsed",
                 _("xbrli:segment container MUST NOT be used in contexts: %(contextIds)s"),
@@ -624,12 +620,15 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
             modelXbrl.error("ESEF.2.1.3.scenarioContainsNonDimensionalContent",
                 _("xbrli:scenario in contexts MUST NOT contain any other content than defined in XBRL Dimensions specification: %(contextIds)s"),
                 modelObject=contextIssues.contextsWithImproperContent, contextIds=", ".join(c.id for c in contextIssues.contextsWithImproperContent if c.id is not None))
-        if len(contextIdentifiers) > 1:
+
+        contextsByEntityIdentifier = getContextsByEntityIdentifier(modelXbrl)
+        if len(contextsByEntityIdentifier) > 1:
             modelXbrl.error("ESEF.2.1.4.multipleIdentifiers",
                 _("All entity identifiers in contexts MUST have identical content: %(contextIds)s"),
-                modelObject=modelXbrl, contextIds=", ".join(i[1] for i in contextIdentifiers))
+                modelObject=modelXbrl, contextIds=", ".join(i[1] for i in contextsByEntityIdentifier))
+
         requiredScheme = val.authParam["identifierScheme"]
-        for (contextScheme, contextIdentifier), contextElts in contextIdentifiers.items():
+        for (contextScheme, contextIdentifier), contextElts in contextsByEntityIdentifier.items():
             if contextScheme != requiredScheme:
                 modelXbrl.warning("ESEF.2.1.1.nonLEIContextScheme" if requiredScheme == iso17442 else "UK.ESEF.2.1.1.contextScheme",
                     _("The scheme attribute of the xbrli:identifier element should have \"%(requiredScheme)s\" as its content: %(contextScheme)s"),

--- a/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
@@ -17,6 +17,9 @@ from .Const import AUTHORITY_UKFRC, TARGET_UKFRS
 @dataclass
 class PluginValidationDataExtension(PluginData):
 
+    def getContextIssues(self, modelXbrl: ModelXbrl) -> ContextIssues:
+        return getContextIssues(modelXbrl)
+
     def isUkfrsTarget(self, modelXbrl: ModelXbrl) -> bool:
         if not hasattr(modelXbrl, "ixdsTarget"):
             return False

--- a/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
@@ -8,11 +8,9 @@ from typing import cast
 
 from arelle.ModelInstanceObject import ModelContext
 from arelle.ModelXbrl import ModelXbrl
-from arelle.ValidateXbrl import ValidateXbrl
 from arelle.utils.PluginData import PluginData
 from arelle.utils.validate.ContextIssues import ContextIssues, getContextIssues, getContextsByEntityIdentifier
-from .ESEFPluginData import ESEFPluginData
-from .Const import AUTHORITY_UKFRC, TARGET_UKFRS
+from .Const import TARGET_UKFRS
 
 
 @dataclass

--- a/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
@@ -28,8 +28,3 @@ class PluginValidationDataExtension(PluginData):
         if not hasattr(modelXbrl, "ixdsTarget"):
             return False
         return cast(str | None, modelXbrl.ixdsTarget) == TARGET_UKFRS
-
-    def isUkfrcAuthority(self, val: ValidateXbrl) -> bool:
-        esefPluginData = ESEFPluginData.get(val.modelXbrl.modelManager.cntlr, self.name)
-        authority = esefPluginData.getEsefAuthority(val.modelXbrl, val.parameters)
-        return authority == AUTHORITY_UKFRC

--- a/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
+from arelle.ModelInstanceObject import ModelContext
 from arelle.ModelXbrl import ModelXbrl
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.utils.PluginData import PluginData
-from arelle.utils.validate.ContextIssues import ContextIssues, getContextIssues
+from arelle.utils.validate.ContextIssues import ContextIssues, getContextIssues, getContextsByEntityIdentifier
 from .ESEFPluginData import ESEFPluginData
 from .Const import AUTHORITY_UKFRC, TARGET_UKFRS
 
@@ -19,6 +20,9 @@ class PluginValidationDataExtension(PluginData):
 
     def getContextIssues(self, modelXbrl: ModelXbrl) -> ContextIssues:
         return getContextIssues(modelXbrl)
+
+    def getContextsByEntityIdentifier(self, modelXbrl: ModelXbrl) -> dict[tuple[str, str], list[ModelContext]]:
+        return getContextsByEntityIdentifier(modelXbrl)
 
     def isUkfrsTarget(self, modelXbrl: ModelXbrl) -> bool:
         if not hasattr(modelXbrl, "ixdsTarget"):

--- a/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
+++ b/arelle/plugin/validate/ESEF/PluginValidationDataExtension.py
@@ -3,8 +3,26 @@ See COPYRIGHT.md for copyright information.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import cast
+
+from arelle.ModelXbrl import ModelXbrl
+from arelle.ValidateXbrl import ValidateXbrl
 from arelle.utils.PluginData import PluginData
+from arelle.utils.validate.ContextIssues import ContextIssues, getContextIssues
+from .ESEFPluginData import ESEFPluginData
+from .Const import AUTHORITY_UKFRC, TARGET_UKFRS
 
 
+@dataclass
 class PluginValidationDataExtension(PluginData):
-    pass
+
+    def isUkfrsTarget(self, modelXbrl: ModelXbrl) -> bool:
+        if not hasattr(modelXbrl, "ixdsTarget"):
+            return False
+        return cast(str | None, modelXbrl.ixdsTarget) == TARGET_UKFRS
+
+    def isUkfrcAuthority(self, val: ValidateXbrl) -> bool:
+        esefPluginData = ESEFPluginData.get(val.modelXbrl.modelManager.cntlr, self.name)
+        authority = esefPluginData.getEsefAuthority(val.modelXbrl, val.parameters)
+        return authority == AUTHORITY_UKFRC

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -25,7 +25,7 @@ from arelle.ValidateXbrl import ValidateXbrl
 from arelle.XmlValidateConst import VALID
 from arelle.typing import TypeGetText
 from arelle.utils.validate.Common import isExtensionUri
-from .Const import esefCorNsPattern, esefNotesStatementConcepts, esefTaxonomyNamespaceURIs, svgEventAttributes
+from .Const import AUTHORITY_UKFRC, esefCorNsPattern, esefNotesStatementConcepts, esefTaxonomyNamespaceURIs, svgEventAttributes
 
 _: TypeGetText
 
@@ -36,7 +36,7 @@ AUTHORITY_CODES: frozenset[str] = frozenset({
     "AT", "BE", "BG", "CY", "CZ", "DBA", "DE", "DK", "EE", "EL", "ES",
     "FI", "FR", "GB", "HR", "HU", "IE", "IS", "IT", "LI", "LT", "LU",
     "LV", "MT", "NL", "NO", "PL", "PT", "RO", "SE", "SI", "SK",
-    "UKFRC", "UKFRC-2022", "UKFRC-2023",
+    AUTHORITY_UKFRC, "UKFRC-2022", "UKFRC-2023",
 })
 
 ESEF_STANDARD_TAXONOMY_URI_PREFIXES_ATTR = "_esefStandardTaxonomyUriPrefixes"

--- a/arelle/plugin/validate/ESEF/Util.py
+++ b/arelle/plugin/validate/ESEF/Util.py
@@ -204,7 +204,13 @@ def _hasEventAttributes(elt: Any, attributes: Collection[str]) -> bool:
 
 
 def esefDisclosureSystemSelected(modelXbrl: ModelXbrl) -> bool:
-    return getattr(modelXbrl.modelManager.disclosureSystem, ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY, False)
+    disclosureSystem = modelXbrl.modelManager.disclosureSystem
+    if not getattr(disclosureSystem, ESEF_DISCLOSURE_SYSTEM_TEST_PROPERTY, False):
+        return False
+    if disclosureSystem.authority is not None:
+        # This is an authority-specific disclosure system
+        return False
+    return True
 
 
 def hasEsefTaxonomy(modelXbrl: ModelXbrl) -> bool:

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -82,6 +82,16 @@ from .Util import (
 )
 from .ValidationPluginExtension import ValidationPluginExtension
 from .rules import base
+from .rules.UKSEF import (
+    context as uksef_context,
+    document as uksef_document,
+    entity as uksef_entity,
+    mandatory as uksef_mandatory,
+    package as uksef_package,
+    target as uksef_target,
+    taxonomy as uksef_taxonomy
+)
+
 
 _: TypeGetText
 
@@ -437,7 +447,14 @@ validationPlugin = ValidationPluginExtension(
     disclosureSystemConfigUrl=Path(__file__).parent / "resources" / "config.xml",
     validationTypes=[DISCLOSURE_SYSTEM_VALIDATION_TYPE],
     validationRuleModules=[
-        base
+        base,
+        uksef_context,
+        uksef_document,
+        uksef_entity,
+        uksef_mandatory,
+        uksef_package,
+        uksef_target,
+        uksef_taxonomy,
     ],
 )
 

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -107,45 +107,6 @@ def validateEntity(modelXbrl: ModelXbrl, filename:str, filesource: FileSource) -
         pass
 
 
-def getEsefAuthority(
-    modelXbrl: ModelXbrl,
-    pluginData: ESEFPluginData,
-    parameters: dict[Any, Any] | None,
-) -> str | None:
-    cntlr = modelXbrl.modelManager.cntlr
-    esefAuthority = pluginData.esefAuthority
-    if not esefAuthority and cntlr.hasGui and cntlr.config is not None:
-        esefAuthority = cntlr.config.get("esefAuthority") or None
-    formulaAuthority = None
-    if parameters:
-        # formula parameter backwards compatibility for legacy users.
-        p = parameters.get(qname("authority", noPrefixIsNoNamespace=True))
-        if p and len(p) == 2 and p[1] not in ("null", "None", None):
-            formulaAuthority = p[1]
-    if esefAuthority and formulaAuthority and esefAuthority != formulaAuthority:
-        modelXbrl.error(
-            "Arelle.conflictingESEFAuthorityParameters",
-            _(
-                "ESEF Authority '%(esefAuthority)s' conflicts with formula parameter authority '%(formulaAuthority)s'."
-                " Continuing with '%(esefAuthority)s'."
-            ),
-            modelObject=modelXbrl,
-            esefAuthority=esefAuthority,
-            formulaAuthority=formulaAuthority,
-        )
-    authority = esefAuthority or formulaAuthority
-    if authority and authority not in AUTHORITY_CODES:
-        modelXbrl.error(
-            "Arelle.invalidESEFAuthority",
-            _("Invalid authority '%(authority)s'. Valid values: %(validValues)s."),
-            modelObject=modelXbrl,
-            authority=authority,
-            validValues=", ".join(sorted(AUTHORITY_CODES)),
-        )
-        return None
-    return authority
-
-
 class ESEFPlugin(PluginHooks):
     @staticmethod
     def disclosureSystemTypes(
@@ -187,10 +148,11 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        # For CLI runs, capture `options.esefAuthority` as soon as possible,
+        # before validation begins.
         esefAuthority = getattr(options, "esefAuthority", None)
         if esefAuthority:
-            pluginData = ESEFPluginData.get(cntlr, ESEF_PLUGIN_NAME)
-            pluginData.esefAuthority = esefAuthority
+            __ = ESEFPluginData.get(cntlr, ESEF_PLUGIN_NAME, esefAuthority)
 
     @staticmethod
     def cntlrWinMainMenuValidation(
@@ -336,7 +298,7 @@ class ESEFPlugin(PluginHooks):
         val.extensionImportedUrls = set()
         val.unconsolidated = any("unconsolidated" in n for n in val.disclosureSystem.names)
         val.consolidated = not val.unconsolidated
-        val.authority = getEsefAuthority(modelXbrl, pluginData, parameters)
+        val.authority = pluginData.getEsefAuthority(modelXbrl, parameters)
 
         authorityValidations = loadAuthorityValidations(val.modelXbrl)
         # loadAuthorityValidations returns either a list or a dict but in this context, we expect a dict.

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -67,8 +67,8 @@ from arelle.Version import authorLabel, copyrightLabel
 from arelle.XbrlConst import xhtml
 from arelle.formula.XPathContext import XPathContext
 from arelle.typing import TypeGetText
-from arelle.utils.PluginData import PluginData
 from arelle.utils.PluginHooks import PluginHooks
+from .ESEFPluginData import ESEFPluginData
 from .ESEF_2021.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinally2021
 from .ESEF_Current.ValidateXbrlFinally import validateXbrlFinally as validateXbrlFinallyCurrent
 from .Util import (
@@ -146,28 +146,6 @@ def getEsefAuthority(
     return authority
 
 
-@dataclass
-class ESEFPluginData(PluginData):
-    esefAuthority: str | None = None
-    esefInstanceValidated: bool = False
-    nonEsefInstanceExcluded: bool = False
-
-    @staticmethod
-    def get(cntlr: Cntlr) -> ESEFPluginData:
-        pluginData = cntlr.getPluginData(ESEF_PLUGIN_NAME)
-        if pluginData is None:
-            pluginData = ESEFPluginData(name=ESEF_PLUGIN_NAME)
-            cntlr.setPluginData(pluginData)
-        elif not isinstance(pluginData, ESEFPluginData):
-            raise RuntimeError(f"PluginData already set for {pluginData.name} with unexpected type {type(pluginData)}.")
-        return pluginData
-
-    def reset(self) -> None:
-        self.esefAuthority = None
-        self.esefInstanceValidated = False
-        self.nonEsefInstanceExcluded = False
-
-
 class ESEFPlugin(PluginHooks):
     @staticmethod
     def disclosureSystemTypes(
@@ -211,7 +189,7 @@ class ESEFPlugin(PluginHooks):
     ) -> None:
         esefAuthority = getattr(options, "esefAuthority", None)
         if esefAuthority:
-            pluginData = ESEFPluginData.get(cntlr)
+            pluginData = ESEFPluginData.get(cntlr, ESEF_PLUGIN_NAME)
             pluginData.esefAuthority = esefAuthority
 
     @staticmethod
@@ -354,7 +332,7 @@ class ESEFPlugin(PluginHooks):
         if not esefDisclosureSystemSelected(val.modelXbrl):
             return None
         modelXbrl = val.modelXbrl
-        pluginData = ESEFPluginData.get(modelXbrl.modelManager.cntlr)
+        pluginData = ESEFPluginData.get(modelXbrl.modelManager.cntlr, ESEF_PLUGIN_NAME)
         val.extensionImportedUrls = set()
         val.unconsolidated = any("unconsolidated" in n for n in val.disclosureSystem.names)
         val.consolidated = not val.unconsolidated
@@ -483,7 +461,7 @@ class ESEFPlugin(PluginHooks):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        pluginData = ESEFPluginData.get(cntlr)
+        pluginData = ESEFPluginData.get(cntlr, ESEF_PLUGIN_NAME)
         if not pluginData.esefInstanceValidated and pluginData.nonEsefInstanceExcluded:
             cntlr.error(
                 codes="ESEF.Arelle.noEsefReportFound",

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -301,10 +301,10 @@ class ESEFPlugin(PluginHooks):
     ) -> None:
         if not val.validateDisclosureSystem:
             return None
-        if not esefDisclosureSystemSelected(val.modelXbrl):
-            return None
         modelXbrl = val.modelXbrl
         pluginData = ESEFPluginData.get(modelXbrl.modelManager.cntlr, ESEF_PLUGIN_NAME)
+        if not esefDisclosureSystemSelected(val.modelXbrl):
+            return None
         val.extensionImportedUrls = set()
         val.unconsolidated = any("unconsolidated" in n for n in val.disclosureSystem.names)
         val.consolidated = not val.unconsolidated

--- a/arelle/plugin/validate/ESEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/__init__.py
@@ -162,7 +162,8 @@ class ESEFPlugin(PluginHooks):
         # before validation begins.
         esefAuthority = getattr(options, "esefAuthority", None)
         if esefAuthority:
-            __ = ESEFPluginData.get(cntlr, ESEF_PLUGIN_NAME, esefAuthority)
+            pluginData = ESEFPluginData.get(cntlr, ESEF_PLUGIN_NAME)
+            pluginData.setEsefAuthority(esefAuthority)
 
     @staticmethod
     def cntlrWinMainMenuValidation(
@@ -303,12 +304,12 @@ class ESEFPlugin(PluginHooks):
             return None
         modelXbrl = val.modelXbrl
         pluginData = ESEFPluginData.get(modelXbrl.modelManager.cntlr, ESEF_PLUGIN_NAME)
+        val.authority = pluginData.getEsefAuthority(modelXbrl, parameters)
         if not esefDisclosureSystemSelected(val.modelXbrl):
             return None
         val.extensionImportedUrls = set()
         val.unconsolidated = any("unconsolidated" in n for n in val.disclosureSystem.names)
         val.consolidated = not val.unconsolidated
-        val.authority = pluginData.getEsefAuthority(modelXbrl, parameters)
 
         authorityValidations = loadAuthorityValidations(val.modelXbrl)
         # loadAuthorityValidations returns either a list or a dict but in this context, we expect a dict.

--- a/arelle/plugin/validate/ESEF/resources/config.xml
+++ b/arelle/plugin/validate/ESEF/resources/config.xml
@@ -105,4 +105,14 @@
             contextElement="scenario"
     />
 
+    <DisclosureSystem
+            names="UKSEF-2025|uksef-2025|UKSEF|uksef"
+            description="UKSEF"
+            validationType="ESEF"
+            exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
+            blockDisallowedReferences="false"
+            validateFileText="false"
+            authority="UKFRC"
+    />
+
 </DisclosureSystems>

--- a/arelle/plugin/validate/ESEF/resources/config.xml
+++ b/arelle/plugin/validate/ESEF/resources/config.xml
@@ -106,8 +106,8 @@
     />
 
     <DisclosureSystem
-            names="UKSEF-2025|uksef-2025|UKSEF|uksef"
-            description="UKSEF"
+            names="UKSEF-ONLY-2025|uksef-only-2025|UKSEF-ONLY|uksef-only"
+            description="Only UKSEF Tagging Guide Validation Checks"
             validationType="ESEF"
             exclusiveTypesPattern="EFM|GFM|FERC|HMRC|SBR.NL|EBA|EIOPA|ESEF"
             blockDisallowedReferences="false"

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/__init__.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/__init__.py
@@ -1,0 +1,4 @@
+"""
+See COPYRIGHT.md for copyright information.
+"""
+ENTITY_IDENTIFIER_SCHEME_CRN = "http://www.companieshouse.gov.uk/"

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/context.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/context.py
@@ -13,6 +13,7 @@ from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
 from arelle.ValidateXbrl import ValidateXbrl
+from ...Const import AUTHORITY_UKFRC
 from ...PluginValidationDataExtension import PluginValidationDataExtension
 
 _: TypeGetText
@@ -31,7 +32,7 @@ def rule_ukfrc8(
     UKFRC8: xbrli:segment elements MUST be used in the contexts of UKFRS target FRC-tagged data.
     xbrli:scenario elements MUST be used in the contexts of default target ESEF-tagged data.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return
     modelXbrl = val.modelXbrl
     contextIssues = pluginData.getContextIssues(modelXbrl)

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/context.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/context.py
@@ -1,0 +1,35 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF context validation rules (UKFRC8).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ...PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc8(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC8: Context period validation for UKSEF filings.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/context.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/context.py
@@ -26,10 +26,28 @@ def rule_ukfrc8(
         val: ValidateXbrl,
         *args: Any,
         **kwargs: Any,
-) -> Iterable[Validation] | None:
+) -> Iterable[Validation]:
     """
-    UKFRC8: Context period validation for UKSEF filings.
+    UKFRC8: xbrli:segment elements MUST be used in the contexts of UKFRS target FRC-tagged data.
+    xbrli:scenario elements MUST be used in the contexts of default target ESEF-tagged data.
     """
     if not pluginData.isUkfrcAuthority(val):
-        return None
-    return None
+        return
+    modelXbrl = val.modelXbrl
+    contextIssues = pluginData.getContextIssues(modelXbrl)
+    if pluginData.isUkfrsTarget(modelXbrl):
+        if contextIssues.contextsWithScenarios:
+            yield Validation.error(
+                "ESEF.UKFRC8.scenarioUsed",
+                _("xbrli:segment elements MUST be used in the contexts of UKFRS target FRC-tagged data. : %(contextIds)s"),
+                modelObject=contextIssues.contextsWithScenarios,
+                contextIds=", ".join(c.id for c in contextIssues.contextsWithScenarios if c.id is not None)
+            )
+    else:
+        if contextIssues.contextsWithSegments:
+            yield Validation.error(
+                "ESEF.UKFRC8.segmentUsed",
+                _("xbrli:scenario elements MUST be used in the contexts of default target ESEF-tagged data: %(contextIds)s"),
+                modelObject=contextIssues.contextsWithSegments,
+                contextIds=", ".join(c.id for c in contextIssues.contextsWithSegments if c.id is not None)
+            )

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/document.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/document.py
@@ -13,6 +13,7 @@ from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
 from arelle.ValidateXbrl import ValidateXbrl
+from ...Const import AUTHORITY_UKFRC
 from ...PluginValidationDataExtension import PluginValidationDataExtension
 
 _: TypeGetText
@@ -30,7 +31,7 @@ def rule_ukfrc20(
     """
     UKFRC20: Document structure validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -47,6 +48,6 @@ def rule_ukfrc21(
     """
     UKFRC21: Document content type validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/document.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/document.py
@@ -29,7 +29,7 @@ def rule_ukfrc20(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC20: Document structure validation.
+    UKFRC20: UKSEF instance documents MUST use the UTF-8 character encoding.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -46,7 +46,7 @@ def rule_ukfrc21(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC21: Document content type validation.
+    UKFRC21: UKSEF report package "publisherCountry" metadata element MUST be "GB".
     """
     if val.authority != AUTHORITY_UKFRC:
         return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/document.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/document.py
@@ -1,0 +1,52 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF document validation rules (UKFRC20, UKFRC21).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ...PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc20(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC20: Document structure validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc21(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC21: Document content type validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/entity.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/entity.py
@@ -1,0 +1,51 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF entity validation rules (UKFRC6, UKFRC7).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ...PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc6(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC6: Entity identifier scheme must be valid.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc7(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC7: Entity identifier must be a valid Companies House registration number.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/entity.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/entity.py
@@ -15,6 +15,7 @@ from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
 from arelle.ValidateXbrl import ValidateXbrl
 from . import ENTITY_IDENTIFIER_SCHEME_CRN
+from ...Const import AUTHORITY_UKFRC
 from ...PluginValidationDataExtension import PluginValidationDataExtension
 
 _: TypeGetText
@@ -33,7 +34,7 @@ def rule_ukfrc6(
     UKFRC6: The "default" target document must use the LEI entity scheme (https://www.iso.org/standard/78829.html).
     The same LEI MUST be used throughout the document.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return
     modelXbrl = val.modelXbrl
     if pluginData.isUkfrsTarget(modelXbrl):
@@ -73,7 +74,7 @@ def rule_ukfrc7(
     UKFRC7: The "UKFRS" target document must use the CRN entity scheme (http://www.companieshouse.gov.uk/).
     The same CRN MUST be used throughout the document.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return
     modelXbrl = val.modelXbrl
     if not pluginData.isUkfrsTarget(modelXbrl):

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/entity.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/entity.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
+from arelle import XbrlConst
 from arelle.typing import TypeGetText
 from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
 from arelle.ValidateXbrl import ValidateXbrl
+from . import ENTITY_IDENTIFIER_SCHEME_CRN
 from ...PluginValidationDataExtension import PluginValidationDataExtension
 
 _: TypeGetText
@@ -26,13 +28,37 @@ def rule_ukfrc6(
         val: ValidateXbrl,
         *args: Any,
         **kwargs: Any,
-) -> Iterable[Validation] | None:
+) -> Iterable[Validation]:
     """
-    UKFRC6: Entity identifier scheme must be valid.
+    UKFRC6: The "default" target document must use the LEI entity scheme (https://www.iso.org/standard/78829.html).
+    The same LEI MUST be used throughout the document.
     """
     if not pluginData.isUkfrcAuthority(val):
-        return None
-    return None
+        return
+    modelXbrl = val.modelXbrl
+    if pluginData.isUkfrsTarget(modelXbrl):
+        return
+    invalidSchemeRefs = []
+    contextsByEntityIdentifier = pluginData.getContextsByEntityIdentifier(modelXbrl)
+    for (scheme, __), contexts in contextsByEntityIdentifier.items():
+        if scheme != XbrlConst.iso17442:
+            invalidSchemeRefs.extend(contexts)
+    if invalidSchemeRefs:
+        yield Validation.error(
+            "ESEF.UKFRC6.invalidIdentifier",
+            _("The default target document must use the LEI entity scheme (%(requiredScheme)s)."),
+            requiredScheme=XbrlConst.iso17442,
+            modelObject=invalidSchemeRefs,
+        )
+    if len(contextsByEntityIdentifier) > 1:
+        yield Validation.error(
+            "ESEF.UKFRC6.multipleIdentifiers",
+            _("The same LEI MUST be used throughout the default target (%(identifiers)s)."),
+            identifiers=", ".join(
+                f"{scheme} - {identifier}"
+                for scheme, identifier in contextsByEntityIdentifier
+            ),
+        )
 
 @validation(
     hook=ValidationHook.XBRL_FINALLY,
@@ -42,10 +68,34 @@ def rule_ukfrc7(
         val: ValidateXbrl,
         *args: Any,
         **kwargs: Any,
-) -> Iterable[Validation] | None:
+) -> Iterable[Validation]:
     """
-    UKFRC7: Entity identifier must be a valid Companies House registration number.
+    UKFRC7: The "UKFRS" target document must use the CRN entity scheme (http://www.companieshouse.gov.uk/).
+    The same CRN MUST be used throughout the document.
     """
     if not pluginData.isUkfrcAuthority(val):
-        return None
-    return None
+        return
+    modelXbrl = val.modelXbrl
+    if not pluginData.isUkfrsTarget(modelXbrl):
+        return
+    invalidSchemeRefs = []
+    contextsByEntityIdentifier = pluginData.getContextsByEntityIdentifier(modelXbrl)
+    for (scheme, __), contexts in contextsByEntityIdentifier.items():
+        if scheme != ENTITY_IDENTIFIER_SCHEME_CRN:
+            invalidSchemeRefs.extend(contexts)
+    if invalidSchemeRefs:
+        yield Validation.error(
+            "ESEF.UKFRC7.invalidIdentifier",
+            _("The UKFRS target document must use the CRN entity scheme (%(requiredScheme)s)."),
+            requiredScheme=ENTITY_IDENTIFIER_SCHEME_CRN,
+            modelObject=invalidSchemeRefs,
+        )
+    if len(contextsByEntityIdentifier) > 1:
+        yield Validation.error(
+            "ESEF.UKFRC7.multipleIdentifiers",
+            _("The same CRN MUST be used throughout the UKFRS target (%(identifiers)s)."),
+            identifiers=",".join(
+                f"{scheme} - {identifier}"
+                for scheme, identifier in contextsByEntityIdentifier
+            ),
+        )

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/mandatory.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/mandatory.py
@@ -1,0 +1,36 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF mandatory facts validation rules for Companies House.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ...PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_mandatory_facts(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    Companies House mandatory facts: Validates that all required facts
+    are present in the filing.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/mandatory.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/mandatory.py
@@ -13,6 +13,7 @@ from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
 from arelle.ValidateXbrl import ValidateXbrl
+from ...Const import AUTHORITY_UKFRC
 from ...PluginValidationDataExtension import PluginValidationDataExtension
 
 _: TypeGetText
@@ -31,6 +32,6 @@ def rule_mandatory_facts(
     Companies House mandatory facts: Validates that all required facts
     are present in the filing.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/package.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/package.py
@@ -1,0 +1,205 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF package validation rules (UKFRC9-UKFRC19).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ...PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc9(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC9: Package structure validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc10(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC10: Package content validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc11(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC11: Package naming convention validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc12(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC12: Package metadata validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc13(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC13: Package file type validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc14(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC14: Package encoding validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc15(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC15: Package size validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc16(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC16: Package document count validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc17(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC17: Package image format validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc18(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC18: Package CSS validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc19(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC19: Package JavaScript validation.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/package.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/package.py
@@ -13,6 +13,7 @@ from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
 from arelle.ValidateXbrl import ValidateXbrl
+from ...Const import AUTHORITY_UKFRC
 from ...PluginValidationDataExtension import PluginValidationDataExtension
 
 _: TypeGetText
@@ -30,7 +31,7 @@ def rule_ukfrc9(
     """
     UKFRC9: Package structure validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -47,7 +48,7 @@ def rule_ukfrc10(
     """
     UKFRC10: Package content validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -64,7 +65,7 @@ def rule_ukfrc11(
     """
     UKFRC11: Package naming convention validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -81,7 +82,7 @@ def rule_ukfrc12(
     """
     UKFRC12: Package metadata validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -98,7 +99,7 @@ def rule_ukfrc13(
     """
     UKFRC13: Package file type validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -115,7 +116,7 @@ def rule_ukfrc14(
     """
     UKFRC14: Package encoding validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -132,7 +133,7 @@ def rule_ukfrc15(
     """
     UKFRC15: Package size validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -149,7 +150,7 @@ def rule_ukfrc16(
     """
     UKFRC16: Package document count validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -166,7 +167,7 @@ def rule_ukfrc17(
     """
     UKFRC17: Package image format validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -183,7 +184,7 @@ def rule_ukfrc18(
     """
     UKFRC18: Package CSS validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -200,6 +201,6 @@ def rule_ukfrc19(
     """
     UKFRC19: Package JavaScript validation.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/package.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/package.py
@@ -29,7 +29,7 @@ def rule_ukfrc9(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC9: Package structure validation.
+    UKFRC9: UKSEF report package MUST be submitted in a zipped report package (*.zip or *.xbri extensions only)
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -46,7 +46,7 @@ def rule_ukfrc10(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC10: Package content validation.
+    UKFRC10: The report package MUST include only one report in the “reports” directory.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -63,7 +63,8 @@ def rule_ukfrc11(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC11: Package naming convention validation.
+    UKFRC11: Subdirectories MUST NOT be used in the “reports” directory and
+    MUST NOT contain more than one iXBRL document.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -80,7 +81,8 @@ def rule_ukfrc12(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC12: Package metadata validation.
+    UKFRC12: The report MUST be XHTML tagged using the iXBRL format with a .html
+    or .xhtml file extension only.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -97,7 +99,8 @@ def rule_ukfrc13(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC13: Package file type validation.
+    UKFRC13: Script-based iXBRL viewers MUST NOT be included either as part of
+    iXBRL documents or as a separate resource.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -114,7 +117,9 @@ def rule_ukfrc14(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC14: Package encoding validation.
+    UKFRC14: For tagged files, images can be provided either in the XHTML document
+    as a base64 encoded string or be referenced as separate files in the package.
+    The use of these two methods MUST NOT be combined.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -131,7 +136,9 @@ def rule_ukfrc15(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC15: Package size validation.
+    UKFRC15: If images are contained in separate files in the package, they MUST be in
+    PNG, GIF, SVG or JPG/JPEG format. All the external referenced images MUST be placed
+    in the same location within the zip package.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -148,7 +155,7 @@ def rule_ukfrc16(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC16: Package document count validation.
+    UKFRC16: CSS MUST be embedded in the XHTML document.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -165,7 +172,12 @@ def rule_ukfrc17(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC17: Package image format validation.
+    UKFRC17: For a report package, issuers are required to adopt a naming convention
+    which matches {base}-{date}.zip or {base}-{date}.xbri, whereby:
+    *	The {base} component of the filename shall indicate the LEI of the issuer
+    *	The {date} component of the filename should indicate the accounting reference date.
+        The {date} component should follow the YYYY-MM-DD format.
+    E.g. 213800YWQOYL4VQODV50-2022-12-31.zip.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -182,7 +194,15 @@ def rule_ukfrc18(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC18: Package CSS validation.
+    UKFRC18: For a tagged xHTML file within a report package, issuers are required to
+    adopt a naming convention which matches {base}-{date}.html or .xhtml whereby:
+    *	The {base} component of the filename shall indicate the LEI of the issuer
+    *	The {date} component of the filename should indicate the accounting reference date.
+        The {date} component should follow the YYYY-MM-DD format.
+    E.g. 213800YWQOYL4VQODV50-2022-12-31.html
+    The filename MAY also end with "-T01"
+    Note: This differs from the ESEF requirement which specifies a language component as well
+    (hence the ESEF package name errors in all cases)
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -199,7 +219,7 @@ def rule_ukfrc19(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC19: Package JavaScript validation.
+    UKFRC19: Any other file present in a report package MUST NOT include spaces in the filename.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/target.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/target.py
@@ -1,0 +1,69 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF target validation rules (UKFRC3, UKFRC4, UKFRC5).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ...PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc3(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC3: Inline XBRL document must define the correct target.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc4(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC4: Inline XBRL target must contain required schema references.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc5(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC5: Default target must reference the ESEF taxonomy.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/target.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/target.py
@@ -13,6 +13,7 @@ from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
 from arelle.ValidateXbrl import ValidateXbrl
+from ...Const import AUTHORITY_UKFRC
 from ...PluginValidationDataExtension import PluginValidationDataExtension
 
 _: TypeGetText
@@ -30,7 +31,7 @@ def rule_ukfrc3(
     """
     UKFRC3: Inline XBRL document must define the correct target.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -47,7 +48,7 @@ def rule_ukfrc4(
     """
     UKFRC4: Inline XBRL target must contain required schema references.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -64,6 +65,6 @@ def rule_ukfrc5(
     """
     UKFRC5: Default target must reference the ESEF taxonomy.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/target.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/target.py
@@ -29,7 +29,9 @@ def rule_ukfrc3(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC3: Inline XBRL document must define the correct target.
+    UKFRC3: If the target attribute exists on certain key Inline XBRL elements their content
+    is diverted to a target XBRL document with a name derived from the attribute value, which
+    for the UK MUST be "UKFRS" (all caps).
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -46,7 +48,8 @@ def rule_ukfrc4(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC4: Inline XBRL target must contain required schema references.
+    UKFRC4: In accordance with the ESEF Reporting Manual, Rule 2.5.3, 'All [ESEF] tagged data MUST
+    be in the "default" target XBRL document'. ESEF tagged data MUST NOT carry a target attribute.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -63,7 +66,9 @@ def rule_ukfrc5(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC5: Default target must reference the ESEF taxonomy.
+    UKFRC5: In a UKSEF report, there should be two ix:references containers – one should contain the
+    schemaRef for the issuer’s private extension as per ESEF requirements and MUST omit the target.
+    The other must contain a UKSEF schemaRef with the "UKFRS" target attribute.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/taxonomy.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/taxonomy.py
@@ -1,0 +1,52 @@
+"""
+See COPYRIGHT.md for copyright information.
+
+UKSEF taxonomy validation rules (UKFRC1, UKFRC2).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from arelle.typing import TypeGetText
+from arelle.utils.PluginHooks import ValidationHook
+from arelle.utils.validate.Decorator import validation
+from arelle.utils.validate.Validation import Validation
+from arelle.ValidateXbrl import ValidateXbrl
+from ...PluginValidationDataExtension import PluginValidationDataExtension
+
+_: TypeGetText
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc1(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC1: Entry point schema reference must be a valid FRC taxonomy URL.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None
+
+
+@validation(
+    hook=ValidationHook.XBRL_FINALLY,
+)
+def rule_ukfrc2(
+        pluginData: PluginValidationDataExtension,
+        val: ValidateXbrl,
+        *args: Any,
+        **kwargs: Any,
+) -> Iterable[Validation] | None:
+    """
+    UKFRC2: Filing must reference a recognised FRC taxonomy entry point.
+    """
+    if not pluginData.isUkfrcAuthority(val):
+        return None
+    return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/taxonomy.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/taxonomy.py
@@ -29,7 +29,20 @@ def rule_ukfrc1(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC1: Entry point schema reference must be a valid FRC taxonomy URL.
+    UKFRC1: UKSEF 2025 reports MUST have a reference (a schemaRef in a “UKFRS” targeted ix:references element)
+    to one of the three possible FRC taxonomy entry-points for either FRS102 or IFRS. Companies House allow use
+    of the current and last two annual versions of the FRC’s Taxonomy Suite. The 2025, 2024 or 2023 Taxonomy
+    Suites all contain the relevant UKSEF entry-points:
+    2025 Taxonomy Suite
+    *	https://xbrl.frc.org.uk/FRS-102/2025-01-01/UKSEF/FRS-102-2025-01-01.xsd; or
+    *	https://xbrl.frc.org.uk/IFRS/2025-01-01/UKSEF/IFRS-2025-01-01.xsd
+    2024 Taxonomy Suite
+    *	https://xbrl.frc.org.uk/FRS-102/2024-01-01/UKSEF/FRS-102-2024-01-01.xsd; or
+    *	https://xbrl.frc.org.uk/IFRS/2024-01-01/UKSEF/IFRS-2024-01-01.xsd
+    2023 Taxonomy Suite
+    *	https://xbrl.frc.org.uk/FRS-102/2023-01-01/UKSEF/FRS-102-2023-01-01.xsd; or
+    *	https://xbrl.frc.org.uk/IFRS/2023-01-01/UKSEF/IFRS-2023-01-01.xsd
+    The reference must be in the report, NOT in the extension taxonomy.
     """
     if val.authority != AUTHORITY_UKFRC:
         return None
@@ -46,7 +59,7 @@ def rule_ukfrc2(
         **kwargs: Any,
 ) -> Iterable[Validation] | None:
     """
-    UKFRC2: Filing must reference a recognised FRC taxonomy entry point.
+    UKFRC2: UKSEF 2025 reports MUST only be used in conjunction with ESEF 2022 or later
     """
     if val.authority != AUTHORITY_UKFRC:
         return None

--- a/arelle/plugin/validate/ESEF/rules/UKSEF/taxonomy.py
+++ b/arelle/plugin/validate/ESEF/rules/UKSEF/taxonomy.py
@@ -13,6 +13,7 @@ from arelle.utils.PluginHooks import ValidationHook
 from arelle.utils.validate.Decorator import validation
 from arelle.utils.validate.Validation import Validation
 from arelle.ValidateXbrl import ValidateXbrl
+from ...Const import AUTHORITY_UKFRC
 from ...PluginValidationDataExtension import PluginValidationDataExtension
 
 _: TypeGetText
@@ -30,7 +31,7 @@ def rule_ukfrc1(
     """
     UKFRC1: Entry point schema reference must be a valid FRC taxonomy URL.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None
 
@@ -47,6 +48,6 @@ def rule_ukfrc2(
     """
     UKFRC2: Filing must reference a recognised FRC taxonomy entry point.
     """
-    if not pluginData.isUkfrcAuthority(val):
+    if val.authority != AUTHORITY_UKFRC:
         return None
     return None

--- a/arelle/utils/validate/ContextIssues.py
+++ b/arelle/utils/validate/ContextIssues.py
@@ -21,6 +21,7 @@ class ContextIssues:
     contextsWithImproperContent: set[ModelContext]
     contextsWithPeriodTime: set[ModelContext]
     contextsWithPeriodTimeZone: set[ModelContext]
+    contextsWithScenarios: set[ModelContext]
     contextsWithSegments: set[ModelContext]
     contextsWithWrongInstantDate: set[ModelContext]
 
@@ -36,6 +37,7 @@ def getContextIssues(modelXbrl: ModelXbrl, esefYear: int | None = None, ) -> Con
     contextsWithImproperContent: set[ModelContext] = set()
     contextsWithPeriodTime: set[ModelContext] = set()
     contextsWithPeriodTimeZone: set[ModelContext] = set()
+    contextsWithScenarios: set[ModelContext] = set()
     contextsWithSegments: set[ModelContext] = set()
     contextsWithWrongInstantDate: set[ModelContext] = set()
 
@@ -49,6 +51,8 @@ def getContextIssues(modelXbrl: ModelXbrl, esefYear: int | None = None, ) -> Con
                     contextsWithPeriodTime.add(context)
                 if m.group(3):
                     contextsWithPeriodTimeZone.add(context)
+        if context.hasScenario:
+            contextsWithScenarios.add(context)
         if context.hasSegment:
             contextsWithSegments.add(context)
         if context.nonDimValues("scenario"):
@@ -61,6 +65,7 @@ def getContextIssues(modelXbrl: ModelXbrl, esefYear: int | None = None, ) -> Con
         contextsWithImproperContent=contextsWithImproperContent,
         contextsWithPeriodTime=contextsWithPeriodTime,
         contextsWithPeriodTimeZone=contextsWithPeriodTimeZone,
+        contextsWithScenarios=contextsWithScenarios,
         contextsWithSegments=contextsWithSegments,
         contextsWithWrongInstantDate=contextsWithWrongInstantDate,
     )

--- a/arelle/utils/validate/ContextIssues.py
+++ b/arelle/utils/validate/ContextIssues.py
@@ -3,6 +3,7 @@ See COPYRIGHT.md for copyright information.
 """
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -69,3 +70,9 @@ def getContextIssues(modelXbrl: ModelXbrl, esefYear: int | None = None, ) -> Con
         contextsWithSegments=contextsWithSegments,
         contextsWithWrongInstantDate=contextsWithWrongInstantDate,
     )
+
+def getContextsByEntityIdentifier(modelXbrl: ModelXbrl) -> dict[tuple[str, str], list[ModelContext]]:
+    contextIdentifiers = defaultdict(list)
+    for context in modelXbrl.contexts.values():
+        contextIdentifiers[context.entityIdentifier].append(context)
+    return dict(contextIdentifiers)

--- a/arelle/utils/validate/ValidationPlugin.py
+++ b/arelle/utils/validate/ValidationPlugin.py
@@ -230,6 +230,8 @@ class ValidationPlugin:
             *args: Any,
             **kwargs: Any,
     ) -> None:
+        if not cntlr.modelManager.validateDisclosureSystem:
+            return
         if self.disclosureSystemFromPluginSelected(cntlr.modelManager):
             pluginData = self.newPluginData(
                 cntlr=cntlr,
@@ -248,6 +250,8 @@ class ValidationPlugin:
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        if not validateXbrl.modelXbrl.modelManager.validateDisclosureSystem:
+            return
         if self.disclosureSystemFromPluginSelected(validateXbrl):
             pluginData = validateXbrl.getPluginData(self.name)
             if pluginData is None:

--- a/tests/integration_tests/scripts/tests/python_api_validate_uksef.py
+++ b/tests/integration_tests/scripts/tests/python_api_validate_uksef.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import regex
+
+from arelle.RuntimeOptions import RuntimeOptions
+from arelle.api.Session import Session
+from tests.integration_tests.integration_test_util import download_from_public_s3
+from tests.integration_tests.scripts.script_util import parse_args, validate_log_xml, assert_result, prepare_logfile
+from tests.integration_tests.validation.assets import ESEF_PACKAGES, UKFRC_PACKAGES
+from tests.integration_tests.validation.download_assets import download_assets
+
+errors = []
+this_file = Path(__file__)
+args = parse_args(
+    this_file.stem,
+    "Confirm ESEF+UKSEF validation runs successfully using Arelle's Python API.",
+    arelle=False,
+)
+arelle_offline = args.offline
+working_directory = Path(args.working_directory)
+test_directory = Path(args.test_directory)
+arelle_log_file = prepare_logfile(test_directory, this_file)
+report_zip_path = test_directory / 'report.zip'
+target_path = report_zip_path
+print(f"Downloading report: {report_zip_path}")
+# Based on FRC_06:TC2 testcase from UKSEF conformance suite
+download_from_public_s3(
+    report_zip_path,
+    "ci/packages/python_api_validate_uksef.zip",
+    version_id="eZImYqnzxvgXJtmhE8qfjaTwc2S9Oqs0",
+)
+
+print("Downloading packages...")
+package_assets = {
+    package for year in [2022] for package in ESEF_PACKAGES[year]
+} | set(UKFRC_PACKAGES.values())
+
+download_assets(
+    assets=package_assets,
+    overwrite=False,
+    download_and_apply_cache=False,
+    download_private=False,
+)
+package_paths = [str(a.full_local_path) for a in package_assets]
+
+print(f"Validating report: {target_path}")
+options = RuntimeOptions(
+    entrypointFile=str(report_zip_path),
+    formulaAction='none',
+    disclosureSystemName='esef-2022',
+    internetConnectivity='offline',
+    logFile=str(arelle_log_file),
+    logFormat="[%(messageCode)s] %(message)s - %(file)s",
+    packages=package_paths,
+    plugins='validate/ESEF',
+    validate=True,
+    pluginOptions={
+        "esefAuthority": "UKFRC",
+    },
+)
+with Session() as session:
+    session.run(options)
+    log_xml = session.get_logs('xml')
+
+print("Checking log XML for errors...")
+errors += validate_log_xml(log_xml, expected_results={
+    'error': {
+        regex.compile(r'^\[ESEF.2.6.1.reportIncorrectlyPlacedInPackage] .*'): 1,
+        regex.compile(r'^\[ESEF.2.1.4.multipleIdentifiers] .*'): 1,
+        regex.compile(r'^\[ESEF.UKFRC6.invalidIdentifier] .*'): 1,
+        regex.compile(r'^\[ESEF.UKFRC6.multipleIdentifiers] .*'): 1,
+    },
+})
+
+assert_result(errors)
+
+print("Cleaning up")
+try:
+    os.unlink(working_directory / 'python_api_validate_uksef' / 'report.zip')
+except PermissionError as exc:
+    print(f"Failed to cleanup test files: {exc}")

--- a/tests/integration_tests/scripts/tests/python_api_validate_uksef.py
+++ b/tests/integration_tests/scripts/tests/python_api_validate_uksef.py
@@ -23,7 +23,7 @@ arelle_offline = args.offline
 working_directory = Path(args.working_directory)
 test_directory = Path(args.test_directory)
 arelle_log_file = prepare_logfile(test_directory, this_file)
-report_zip_path = test_directory / 'report.zip'
+report_zip_path = test_directory / "report.zip"
 target_path = report_zip_path
 print(f"Downloading report: {report_zip_path}")
 # Based on FRC_06:TC2 testcase from UKSEF conformance suite
@@ -49,13 +49,13 @@ package_paths = [str(a.full_local_path) for a in package_assets]
 print(f"Validating report: {target_path}")
 options = RuntimeOptions(
     entrypointFile=str(report_zip_path),
-    formulaAction='none',
-    disclosureSystemName='esef-2022',
-    internetConnectivity='offline',
+    formulaAction="none",
+    disclosureSystemName="esef-2022",
+    internetConnectivity="offline",
     logFile=str(arelle_log_file),
     logFormat="[%(messageCode)s] %(message)s - %(file)s",
     packages=package_paths,
-    plugins='validate/ESEF',
+    plugins="validate/ESEF",
     validate=True,
     pluginOptions={
         "esefAuthority": "UKFRC",
@@ -63,15 +63,15 @@ options = RuntimeOptions(
 )
 with Session() as session:
     session.run(options)
-    log_xml = session.get_logs('xml')
+    log_xml = session.get_logs("xml")
 
 print("Checking log XML for errors...")
 errors += validate_log_xml(log_xml, expected_results={
-    'error': {
-        regex.compile(r'^\[ESEF.2.6.1.reportIncorrectlyPlacedInPackage] .*'): 1,
-        regex.compile(r'^\[ESEF.2.1.4.multipleIdentifiers] .*'): 1,
-        regex.compile(r'^\[ESEF.UKFRC6.invalidIdentifier] .*'): 1,
-        regex.compile(r'^\[ESEF.UKFRC6.multipleIdentifiers] .*'): 1,
+    "error": {
+        regex.compile(r"^\[ESEF.2.6.1.reportIncorrectlyPlacedInPackage] .*"): 1,
+        regex.compile(r"^\[ESEF.2.1.4.multipleIdentifiers] .*"): 1,
+        regex.compile(r"^\[ESEF.UKFRC6.invalidIdentifier] .*"): 1,
+        regex.compile(r"^\[ESEF.UKFRC6.multipleIdentifiers] .*"): 1,
     },
 })
 
@@ -79,6 +79,6 @@ assert_result(errors)
 
 print("Cleaning up")
 try:
-    os.unlink(working_directory / 'python_api_validate_uksef' / 'report.zip')
+    os.unlink(working_directory / "python_api_validate_uksef" / "report.zip")
 except PermissionError as exc:
     print(f"Failed to cleanup test files: {exc}")

--- a/tests/integration_tests/scripts/tests/python_api_validate_uksef_only.py
+++ b/tests/integration_tests/scripts/tests/python_api_validate_uksef_only.py
@@ -50,7 +50,7 @@ print(f"Validating report: {target_path}")
 options = RuntimeOptions(
     entrypointFile=str(report_zip_path),
     formulaAction='none',
-    disclosureSystemName='uksef',
+    disclosureSystemName='uksef-only',
     internetConnectivity='offline',
     logFile=str(arelle_log_file),
     logFormat="[%(messageCode)s] %(message)s - %(file)s",

--- a/tests/integration_tests/scripts/tests/python_api_validate_uksef_only.py
+++ b/tests/integration_tests/scripts/tests/python_api_validate_uksef_only.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import regex
+
+from arelle.RuntimeOptions import RuntimeOptions
+from arelle.api.Session import Session
+from tests.integration_tests.integration_test_util import download_from_public_s3
+from tests.integration_tests.scripts.script_util import parse_args, validate_log_xml, assert_result, prepare_logfile
+from tests.integration_tests.validation.assets import ESEF_PACKAGES, UKFRC_PACKAGES
+from tests.integration_tests.validation.download_assets import download_assets
+
+errors = []
+this_file = Path(__file__)
+args = parse_args(
+    this_file.stem,
+    "Confirm ESEF+UKSEF validation runs successfully using Arelle's Python API.",
+    arelle=False,
+)
+arelle_offline = args.offline
+working_directory = Path(args.working_directory)
+test_directory = Path(args.test_directory)
+arelle_log_file = prepare_logfile(test_directory, this_file)
+report_zip_path = test_directory / 'report.zip'
+target_path = report_zip_path
+print(f"Downloading report: {report_zip_path}")
+# Based on FRC_06:TC2 testcase from UKSEF conformance suite
+download_from_public_s3(
+    report_zip_path,
+    "ci/packages/python_api_validate_uksef.zip",
+    version_id="eZImYqnzxvgXJtmhE8qfjaTwc2S9Oqs0",
+)
+
+print("Downloading packages...")
+package_assets = {
+    package for year in [2022] for package in ESEF_PACKAGES[year]
+} | set(UKFRC_PACKAGES.values())
+
+download_assets(
+    assets=package_assets,
+    overwrite=False,
+    download_and_apply_cache=False,
+    download_private=False,
+)
+package_paths = [str(a.full_local_path) for a in package_assets]
+
+print(f"Validating report: {target_path}")
+options = RuntimeOptions(
+    entrypointFile=str(report_zip_path),
+    formulaAction='none',
+    disclosureSystemName='uksef',
+    internetConnectivity='offline',
+    logFile=str(arelle_log_file),
+    logFormat="[%(messageCode)s] %(message)s - %(file)s",
+    packages=package_paths,
+    plugins='validate/ESEF',
+    validate=True,
+)
+with Session() as session:
+    session.run(options)
+    log_xml = session.get_logs('xml')
+
+print("Checking log XML for errors...")
+errors += validate_log_xml(log_xml, expected_results={
+    'error': {
+        regex.compile(r'^\[ESEF.UKFRC6.invalidIdentifier] .*'): 1,
+        regex.compile(r'^\[ESEF.UKFRC6.multipleIdentifiers] .*'): 1,
+    },
+})
+
+assert_result(errors)
+
+print("Cleaning up")
+try:
+    os.unlink(working_directory / 'python_api_validate_uksef_only' / 'report.zip')
+except PermissionError as exc:
+    print(f"Failed to cleanup test files: {exc}")

--- a/tests/integration_tests/scripts/tests/python_api_validate_uksef_only.py
+++ b/tests/integration_tests/scripts/tests/python_api_validate_uksef_only.py
@@ -23,7 +23,7 @@ arelle_offline = args.offline
 working_directory = Path(args.working_directory)
 test_directory = Path(args.test_directory)
 arelle_log_file = prepare_logfile(test_directory, this_file)
-report_zip_path = test_directory / 'report.zip'
+report_zip_path = test_directory / "report.zip"
 target_path = report_zip_path
 print(f"Downloading report: {report_zip_path}")
 # Based on FRC_06:TC2 testcase from UKSEF conformance suite
@@ -49,24 +49,24 @@ package_paths = [str(a.full_local_path) for a in package_assets]
 print(f"Validating report: {target_path}")
 options = RuntimeOptions(
     entrypointFile=str(report_zip_path),
-    formulaAction='none',
-    disclosureSystemName='uksef-only',
-    internetConnectivity='offline',
+    formulaAction="none",
+    disclosureSystemName="uksef-only",
+    internetConnectivity="offline",
     logFile=str(arelle_log_file),
     logFormat="[%(messageCode)s] %(message)s - %(file)s",
     packages=package_paths,
-    plugins='validate/ESEF',
+    plugins="validate/ESEF",
     validate=True,
 )
 with Session() as session:
     session.run(options)
-    log_xml = session.get_logs('xml')
+    log_xml = session.get_logs("xml")
 
 print("Checking log XML for errors...")
 errors += validate_log_xml(log_xml, expected_results={
-    'error': {
-        regex.compile(r'^\[ESEF.UKFRC6.invalidIdentifier] .*'): 1,
-        regex.compile(r'^\[ESEF.UKFRC6.multipleIdentifiers] .*'): 1,
+    "error": {
+        regex.compile(r"^\[ESEF.UKFRC6.invalidIdentifier] .*"): 1,
+        regex.compile(r"^\[ESEF.UKFRC6.multipleIdentifiers] .*"): 1,
     },
 })
 
@@ -74,6 +74,6 @@ assert_result(errors)
 
 print("Cleaning up")
 try:
-    os.unlink(working_directory / 'python_api_validate_uksef_only' / 'report.zip')
+    os.unlink(working_directory / "python_api_validate_uksef_only" / "report.zip")
 except PermissionError as exc:
     print(f"Failed to cleanup test files: {exc}")

--- a/tests/integration_tests/validation/assets.py
+++ b/tests/integration_tests/validation/assets.py
@@ -229,3 +229,22 @@ NL_PACKAGES: dict[str, list[ConformanceSuiteAssetConfig]] = {
         LEI_2020_07_02,
     ],
 }
+
+UKFRC_PACKAGES: dict[int, ConformanceSuiteAssetConfig] = {
+    2022: ConformanceSuiteAssetConfig.public_taxonomy_package(
+        Path('FRC-2022-Taxonomy.zip'),
+        public_download_url='https://www.frc.org.uk/documents/969/FRC-2022-Taxonomy.zip',
+    ),
+    2023: ConformanceSuiteAssetConfig.public_taxonomy_package(
+        Path('The_2023_Taxonomy_suite_v1.0.1.zip'),
+        public_download_url='https://www.frc.org.uk/documents/372/The_2023_Taxonomy_suite_v1.0.1.zip',
+    ),
+    2024: ConformanceSuiteAssetConfig.public_taxonomy_package(
+        Path('FRC-2024-Taxonomy-v1.0.0_GJp67Do.zip'),
+        public_download_url='https://www.frc.org.uk/documents/6566/FRC-2024-Taxonomy-v1.0.0_GJp67Do.zip',
+    ),
+    2025: ConformanceSuiteAssetConfig.public_taxonomy_package(
+        Path('FRC-2025-Taxonomy-v1.0.0_LK4mek8.zip'),
+        public_download_url='https://www.frc.org.uk/documents/7759/FRC-2025-Taxonomy-v1.0.0_LK4mek8.zip',
+    ),
+}

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -48,6 +48,12 @@ config = ConformanceSuiteConfig(
     ],
     base_taxonomy_validation='none',
     expected_additional_testcase_errors={f'*tests/FRC/{s}': val for s, val in {
+        'FRC_08/index.xml:TC2_invalid': {
+            # Unexpected segment also triggers lxml error
+            'lxml.SCHEMAV_ELEMENT_CONTENT': 20,
+            # Testcase does not specify count (1 is default), so 19 additional occurrences
+            'xmlSchema:elementUnexpected': 19,
+        },
         # Test case references TC2_valid.zip, but actual file in suite has .xbri extension.
         'FRC_09/index.xml:TC2_valid': {
             'FileSourceError': 1,
@@ -80,8 +86,6 @@ config = ConformanceSuiteConfig(
         'FRC_07/index.xml:TC2_invalid',
         'FRC_07/index.xml:TC3_invalid',
         'FRC_07/index.xml:TC4_invalid',
-        'FRC_08/index.xml:TC2_invalid',
-        'FRC_08/index.xml:TC3_invalid',
         'FRC_09/index.xml:TC6_invalid',
         'FRC_10/index.xml:TC3_invalid',
         'FRC_10/index.xml:TC4_invalid',

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -1,6 +1,6 @@
 from pathlib import Path, PurePath
 
-from tests.integration_tests.validation.assets import ESEF_PACKAGES
+from tests.integration_tests.validation.assets import ESEF_PACKAGES, UKFRC_PACKAGES
 from tests.integration_tests.validation.conformance_suite_config import (
     AssetSource, ConformanceSuiteConfig, ConformanceSuiteAssetConfig
 )
@@ -26,24 +26,10 @@ config = ConformanceSuiteConfig(
             entry_point=Path('index.xml'),
             public_download_url='https://www.frc.org.uk/documents/8116/uksef-conformance-suite-v2.0.zip',
             source=AssetSource.S3_PUBLIC,
-        ),
-        ConformanceSuiteAssetConfig.public_taxonomy_package(
-            Path('FRC-2022-Taxonomy.zip'),
-            public_download_url='https://www.frc.org.uk/documents/969/FRC-2022-Taxonomy.zip',
-        ),
-        ConformanceSuiteAssetConfig.public_taxonomy_package(
-            Path('FRC-2024-Taxonomy-v1.0.0_GJp67Do.zip'),
-            public_download_url='https://www.frc.org.uk/documents/6566/FRC-2024-Taxonomy-v1.0.0_GJp67Do.zip',
-        ),
-        ConformanceSuiteAssetConfig.public_taxonomy_package(
-            Path('FRC-2025-Taxonomy-v1.0.0_LK4mek8.zip'),
-            public_download_url='https://www.frc.org.uk/documents/7759/FRC-2025-Taxonomy-v1.0.0_LK4mek8.zip',
-        ),
-        ConformanceSuiteAssetConfig.public_taxonomy_package(
-            Path('The_2023_Taxonomy_suite_v1.0.1.zip'),
-            public_download_url='https://www.frc.org.uk/documents/372/The_2023_Taxonomy_suite_v1.0.1.zip',
-        ),
-    ] + [
+        )
+    ] +
+    list(UKFRC_PACKAGES.values()) +
+    [
         package for year in [2022, 2024] for package in ESEF_PACKAGES[year]
     ],
     base_taxonomy_validation='none',

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -111,6 +111,7 @@ config = ConformanceSuiteConfig(
     ]}),
     info_url='https://www.frc.org.uk/library/standards-codes-policy/accounting-and-reporting/frc-taxonomies/frc-taxonomies-documentation-and-guidance/',
     name=PurePath(__file__).stem,
-    plugins=frozenset({'inlineXbrlDocumentSet'}),
+    disclosure_system='uksef-2025',
+    plugins=frozenset({'inlineXbrlDocumentSet', 'validate/ESEF'}),
     shards=4,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -100,7 +100,7 @@ config = ConformanceSuiteConfig(
     ]}),
     info_url='https://www.frc.org.uk/library/standards-codes-policy/accounting-and-reporting/frc-taxonomies/frc-taxonomies-documentation-and-guidance/',
     name=PurePath(__file__).stem,
-    disclosure_system='uksef-2025',
+    disclosure_system='uksef-only-2025',
     plugins=frozenset({'inlineXbrlDocumentSet', 'validate/ESEF'}),
     shards=4,
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -48,6 +48,10 @@ config = ConformanceSuiteConfig(
     ],
     base_taxonomy_validation='none',
     expected_additional_testcase_errors={f'*tests/FRC/{s}': val for s, val in {
+        'FRC_07/index.xml:TC2_invalid': {
+            # By the same logic that FRC_06:TC2 fires multipleIdentifiers, so should FRC_07:TC2
+            'multipleIdentifiers': 1,
+        },
         'FRC_08/index.xml:TC2_invalid': {
             # Unexpected segment also triggers lxml error
             'lxml.SCHEMAV_ELEMENT_CONTENT': 20,
@@ -81,11 +85,6 @@ config = ConformanceSuiteConfig(
         'FRC_05/index.xml:TC4_invalid',
         'FRC_05/index.xml:TC5_invalid',
         'FRC_05/index.xml:TC6_invalid',
-        'FRC_06/index.xml:TC2_invalid',
-        'FRC_06/index.xml:TC3_invalid',
-        'FRC_07/index.xml:TC2_invalid',
-        'FRC_07/index.xml:TC3_invalid',
-        'FRC_07/index.xml:TC4_invalid',
         'FRC_09/index.xml:TC6_invalid',
         'FRC_10/index.xml:TC3_invalid',
         'FRC_10/index.xml:TC4_invalid',

--- a/tests/unit_tests/arelle/plugin/validate/ESEF/test_esef_target_filtering.py
+++ b/tests/unit_tests/arelle/plugin/validate/ESEF/test_esef_target_filtering.py
@@ -18,6 +18,7 @@ def make_model_xbrl(
     is_supplemental: bool = False,
     primary_namespace_docs: dict | None = None,
     report_package: SimpleNamespace | None = None,
+    disclosureSystemAuthority: str | None = None,
 ) -> SimpleNamespace:
     kwargs: dict = {"namespaceDocs": namespace_docs or {}}
     if ixds_target is not object:
@@ -34,7 +35,10 @@ def make_model_xbrl(
         )
     else:
         primary = model_xbrl
-    disclosure_system = SimpleNamespace(ESEFplugin=True)
+    disclosure_system = SimpleNamespace(
+        authority=disclosureSystemAuthority,
+        ESEFplugin=True,
+    )
     file_source = SimpleNamespace(reportPackage=report_package)
     model_xbrl.modelManager = SimpleNamespace(modelXbrl=primary, disclosureSystem=disclosure_system)  # type: ignore[attr-defined]
     model_xbrl.fileSource = file_source
@@ -186,5 +190,14 @@ class TestShouldRunEsefValidationRules:
     def test_false_when_esef_not_selected(self) -> None:
         model_xbrl = make_model_xbrl(namespace_docs={ESEF_NAMESPACE: []}, ixds_target=None)
         model_xbrl.modelManager.disclosureSystem = SimpleNamespace(ESEFplugin=False)
+        val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
+        assert shouldRunEsefValidationRules(val) is False
+
+    def test_false_when_disclosure_system_authority_set(self) -> None:
+        model_xbrl = make_model_xbrl(
+            namespace_docs={ESEF_NAMESPACE: []},
+            ixds_target=None,
+            disclosureSystemAuthority="UKFRC",
+        )
         val = make_val(model_xbrl, auth_param={"ixTargetUsage": "allowed", "ixdsMultiUsage": "error"})
         assert shouldRunEsefValidationRules(val) is False


### PR DESCRIPTION
#### Description of change
##### Authority-specific validation framework
- Establish framework for authority-specific validations in the ESEF plugin. 
- This framework supports running ESEF _with_ authority-specific validations by selecting an ESEF disclosure system and specifying an `esefAuthority` through various means. (`--disclosureSystem esef-2022 --esefAuthority UKFRC`)
- Additionally, users can run only the authority-specific validations by selecting the authority-specific disclosure system. (`--disclosureSystem uksef`)

##### UKSEF validation initial progress + placeholders
- Configure UKSEF as first authority-specific validation set in ESEF
- Implement UKFRC6, UKFRC7 and UKFRC8 to demonstrate pattern
- Add integration test scripts that demonstrate ESEF + authority and authority-only uses

#### Steps to Test
CI

**review**:
@Arelle/arelle
