### PR TITLE
ESEF plug-in: make the report file names configurable per national regulator

### DIFF
--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -117,8 +117,8 @@ filenameRegexes = {
     "ref": r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}_ref[.]xml$",
 }
 
-reportBasenamePattern = "{base}-{date}-{version}-{lang}"
-reportBasenameRegex = re.compile(r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}-[1-9]-[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$")
+reportBasenamePattern = "{base}-{date}-{version}-{lang}.[x]htm[l]"
+reportBasenameRegex = re.compile(r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}-[1-9]-[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*[.][xX]?[hH][tT][mM][lL]?$")
 
 mandatory: set[QName] = set()  # mandatory element qnames
 

--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -117,8 +117,8 @@ filenameRegexes = {
     "ref": r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}_ref[.]xml$",
 }
 
-reportDefaultFileNamePattern = "{base}-{date}-{version}-{lang}.[x]htm[l]"
-reportDefaultFileNameRegex = re.compile(r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}-[1-9]-[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*[.]x?html?$")
+reportDefaultFileNamePattern = "{base}-{date}-{version}-{lang}.[x]html"
+reportDefaultFileNameRegex = re.compile(r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}-[1-9]-[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*[.]x?html$")
 
 mandatory: set[QName] = set()  # mandatory element qnames
 

--- a/arelle/plugin/validate/ESEF/Const.py
+++ b/arelle/plugin/validate/ESEF/Const.py
@@ -117,8 +117,8 @@ filenameRegexes = {
     "ref": r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}_ref[.]xml$",
 }
 
-reportBasenamePattern = "{base}-{date}-{version}-{lang}.[x]htm[l]"
-reportBasenameRegex = re.compile(r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}-[1-9]-[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*[.][xX]?[hH][tT][mM][lL]?$")
+reportDefaultFileNamePattern = "{base}-{date}-{version}-{lang}.[x]htm[l]"
+reportDefaultFileNameRegex = re.compile(r"(.{1,})-[0-9]{4}-[0-9]{2}-[0-9]{2}-[1-9]-[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*[.]x?html?$")
 
 mandatory: set[QName] = set()  # mandatory element qnames
 

--- a/arelle/plugin/validate/ESEF/ESEF_2021/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_2021/DTS.py
@@ -55,11 +55,6 @@ def checkFilingDTS(
         pass
 
     # the following doc type sections only pertain to extensionDocuments
-    elif modelDocument.type == ModelDocumentFile.Type.INLINEXBRL:
-        if val.authParam["reportFileNamePattern"]:
-            filenamePattern = val.authParam["reportFileNamePattern"]
-            filenameRegex = val.authParam["reportFileNameRegex"]
-
     elif modelDocument.type == ModelDocumentFile.Type.SCHEMA:
 
         val.hasExtensionSchema = True

--- a/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/DTS.py
@@ -56,11 +56,6 @@ def checkFilingDTS(val: ValidateXbrl, modelDocument: ModelDocument, esefNotesCon
         pass
 
     # the following doc type sections only pertain to extensionDocuments
-    elif modelDocument.type == ModelDocumentFile.Type.INLINEXBRL:
-        if val.authParam["reportFileNamePattern"]:
-            filenamePattern = val.authParam["reportFileNamePattern"]
-            filenameRegex = val.authParam["reportFileNameRegex"]
-
     elif modelDocument.type == ModelDocumentFile.Type.SCHEMA:
 
         val.hasExtensionSchema = True

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -98,6 +98,13 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
     prefixedNamespaces = modelXbrl.prefixedNamespaces
 
     reportPackageMaxMB = val.authParam["reportPackageMaxMB"]
+    reportFileNamePattern = val.authParam["reportFileNamePattern"]
+    reportFileNameRegex = val.authParam["reportFileNameRegex"]
+    if reportFileNameRegex:
+        reportFileNameRegex = re.compile(reportFileNameRegex)
+    if not reportFileNamePattern:
+        reportFileNamePattern = reportBasenamePattern
+        reportFileNameRegex = reportBasenameRegex
     if reportPackageMaxMB is not None and modelXbrl.fileSource.fs: # must be a zip to be a report package
         assert isinstance(modelXbrl.fileSource.fs, zipfile.ZipFile)
 
@@ -248,16 +255,22 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
         for doc in modelXbrl.urlDocs.values():
             if doc.type in (ModelDocument.Type.INLINEXBRL, ModelDocument.Type.UnknownXML):
                 _baseName, _baseExt = os.path.splitext(doc.basename)
-                if _baseExt not in (".xhtml",".html"):
-                    if val.consolidated:
-                        errorCode = "ESEF.2.6.1.incorrectFileExtension"
-                        reportType = _("Inline XBRL document included within a ESEF report package")
-                    else:
-                        errorCode = "ESEF.4.1.1.incorrectFileExtension"
-                        reportType = _("Stand-alone XHTML document")
+                possibleExtensions: [str]
+                if val.consolidated:
+                    errorCode = "ESEF.2.6.1.incorrectFileExtension"
+                    reportType = _("Inline XBRL document included within a ESEF report package")
+                    possibleExtensions = [".xhtml",".html",".htm"]
+                else:
+                    errorCode = "ESEF.4.1.1.incorrectFileExtension"
+                    reportType = _("Stand-alone XHTML document")
+                    possibleExtensions = [".xhtml",".html"]
+                if _baseExt not in possibleExtensions:
+                    extensionsExplanation: str = ", ".join(possibleExtensions[0:-1])
+                    extensionsExplanation += _(" or ") + possibleExtensions[-1]
                     modelXbrl.error(errorCode,
-                                    _("%(reportType)s MUST have a .html or .xhtml extension: %(fileName)s"),
-                                    modelObject=doc, fileName=doc.basename, reportType=reportType)
+                                    _("%(reportType)s MUST have a %(extensions)s extension: %(fileName)s"),
+                                    modelObject=doc, fileName=doc.basename, reportType=reportType,
+                                    extensions=extensionsExplanation)
                 docinfo = doc.xmlRootElement.getroottree().docinfo
                 docTypeMatch = docTypeXhtmlPattern.match(docinfo.doctype)
                 if val.consolidated:
@@ -303,11 +316,11 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                                 ".html: %(fileName)s (Document file not in correct place in package)"),
                                 modelObject=doc, fileName=doc.basename)
                     elif esefDisclosureSystemYear >= 2025:
-                        m = reportBasenameRegex.match(_baseName)
+                        m = reportFileNameRegex.match(doc.basename)
                         if not m:
                             modelXbrl.warning("ESEF.2.6.3.incorrectNamingConventionReportPackageReportFile",
                                 _("Inline XBRL document filename SHOULD match %(pattern)s"),
-                                modelObject=doc, fileName=doc.basename, pattern=reportBasenamePattern)
+                                modelObject=doc, fileName=doc.basename, pattern=reportFileNamePattern)
                 else: # non-consolidated
                     if docTypeMatch:
                         if not docTypeMatch.group(1) or docTypeMatch.group(1).lower() == "html":

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -259,7 +259,10 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
                 if val.consolidated:
                     errorCode = "ESEF.2.6.1.incorrectFileExtension"
                     reportType = _("Inline XBRL document included within a ESEF report package")
-                    possibleExtensions = [".xhtml",".html",".htm"]
+                    if val.authority and val.authority in {"DK", "DBA"}:
+                        possibleExtensions = [".xhtml",".html"]
+                    else:
+                        possibleExtensions = [".xhtml",".html",".htm"]
                 else:
                     errorCode = "ESEF.4.1.1.incorrectFileExtension"
                     reportType = _("Stand-alone XHTML document")

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -65,8 +65,8 @@ from ..Const import (
     styleCssHiddenPattern,
     supportedImgTypes,
     untransformableTypes,
-    reportBasenamePattern,
-    reportBasenameRegex
+    reportDefaultFileNamePattern,
+    reportDefaultFileNameRegex
 )
 from ..Dimensions import checkFilingDimensions
 from ..Util import (
@@ -103,8 +103,8 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
     if reportFileNameRegex:
         reportFileNameRegex = re.compile(reportFileNameRegex)
     if not reportFileNamePattern:
-        reportFileNamePattern = reportBasenamePattern
-        reportFileNameRegex = reportBasenameRegex
+        reportFileNamePattern = reportDefaultFileNamePattern
+        reportFileNameRegex = reportDefaultFileNameRegex
     if reportPackageMaxMB is not None and modelXbrl.fileSource.fs: # must be a zip to be a report package
         assert isinstance(modelXbrl.fileSource.fs, zipfile.ZipFile)
 

--- a/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
+++ b/arelle/plugin/validate/ESEF/ESEF_Current/ValidateXbrlFinally.py
@@ -255,25 +255,16 @@ def validateXbrlFinally(val: ValidateXbrl, *args: Any, **kwargs: Any) -> None:
         for doc in modelXbrl.urlDocs.values():
             if doc.type in (ModelDocument.Type.INLINEXBRL, ModelDocument.Type.UnknownXML):
                 _baseName, _baseExt = os.path.splitext(doc.basename)
-                possibleExtensions: [str]
-                if val.consolidated:
-                    errorCode = "ESEF.2.6.1.incorrectFileExtension"
-                    reportType = _("Inline XBRL document included within a ESEF report package")
-                    if val.authority and val.authority in {"DK", "DBA"}:
-                        possibleExtensions = [".xhtml",".html"]
+                if _baseExt not in (".xhtml",".html"):
+                    if val.consolidated:
+                        errorCode = "ESEF.2.6.1.incorrectFileExtension"
+                        reportType = _("Inline XBRL document included within a ESEF report package")
                     else:
-                        possibleExtensions = [".xhtml",".html",".htm"]
-                else:
-                    errorCode = "ESEF.4.1.1.incorrectFileExtension"
-                    reportType = _("Stand-alone XHTML document")
-                    possibleExtensions = [".xhtml",".html"]
-                if _baseExt not in possibleExtensions:
-                    extensionsExplanation: str = ", ".join(possibleExtensions[0:-1])
-                    extensionsExplanation += _(" or ") + possibleExtensions[-1]
+                        errorCode = "ESEF.4.1.1.incorrectFileExtension"
+                        reportType = _("Stand-alone XHTML document")
                     modelXbrl.error(errorCode,
-                                    _("%(reportType)s MUST have a %(extensions)s extension: %(fileName)s"),
-                                    modelObject=doc, fileName=doc.basename, reportType=reportType,
-                                    extensions=extensionsExplanation)
+                                    _("%(reportType)s MUST have a .html or .xhtml extension: %(fileName)s"),
+                                    modelObject=doc, fileName=doc.basename, reportType=reportType)
                 docinfo = doc.xmlRootElement.getroottree().docinfo
                 docTypeMatch = docTypeXhtmlPattern.match(docinfo.doctype)
                 if val.consolidated:

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -237,7 +237,7 @@
         "reportPackageMaxMB": "2000",
         "reportPackageMeasurement": "unzipped",
         "reportFileNamePattern": "{base}-*.[x]html",
-        "reportFileNameRegex": "([^-]{1,}).*[.]x?html?$",
+        "reportFileNameRegex": "([^-]{1,}).*[.]x?html$",
         "ixTargetUsage": "allowed",
         "formulaRunIDs": "(?!con_IdentifierSchemeMustBeLEI|lei-identifier-scheme)",
         "dtrNamespaces": {
@@ -253,7 +253,7 @@
         "reportPackageMaxMB": "2000",
         "reportPackageMeasurement": "unzipped",
         "reportFileNamePattern": "{base}-*.[x]html",
-        "reportFileNameRegex": "([^-]{1,}).*[.]x?html?$",
+        "reportFileNameRegex": "([^-]{1,}).*[.]x?html$",
         "ixTargetUsage": "allowed"
     },
     "EE": {

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -236,8 +236,8 @@
         "reportPackageExtensionTaxonomyDirectoryPrefix": "xbrl.",
         "reportPackageMaxMB": "2000",
         "reportPackageMeasurement": "unzipped",
-        "reportFileNamePattern": "{base}-{date}-{lang}.[x]html",
-        "reportFileNameRegex": "([^-]{1,}).*(-.*)?[.][xX]?[hH][tT][mM][lL]?$",
+        "reportFileNamePattern": "{base}-*.[x]html",
+        "reportFileNameRegex": "([^-]{1,}).*[.]x?html?$",
         "ixTargetUsage": "allowed",
         "formulaRunIDs": "(?!con_IdentifierSchemeMustBeLEI|lei-identifier-scheme)",
         "dtrNamespaces": {
@@ -252,8 +252,8 @@
         "name": "Denmark",
         "reportPackageMaxMB": "2000",
         "reportPackageMeasurement": "unzipped",
-        "reportFileNamePattern": "{base}-{date}-{lang}.[x]html",
-        "reportFileNameRegex": "([^-]{1,}).*[.][xX]?[hH][tT][mM][lL]?$",
+        "reportFileNamePattern": "{base}-*.[x]html",
+        "reportFileNameRegex": "([^-]{1,}).*[.]x?html?$",
         "ixTargetUsage": "allowed"
     },
     "EE": {

--- a/arelle/plugin/validate/ESEF/resources/authority-validations.json
+++ b/arelle/plugin/validate/ESEF/resources/authority-validations.json
@@ -236,6 +236,8 @@
         "reportPackageExtensionTaxonomyDirectoryPrefix": "xbrl.",
         "reportPackageMaxMB": "2000",
         "reportPackageMeasurement": "unzipped",
+        "reportFileNamePattern": "{base}-{date}-{lang}.[x]html",
+        "reportFileNameRegex": "([^-]{1,}).*(-.*)?[.][xX]?[hH][tT][mM][lL]?$",
         "ixTargetUsage": "allowed",
         "formulaRunIDs": "(?!con_IdentifierSchemeMustBeLEI|lei-identifier-scheme)",
         "dtrNamespaces": {
@@ -250,6 +252,8 @@
         "name": "Denmark",
         "reportPackageMaxMB": "2000",
         "reportPackageMeasurement": "unzipped",
+        "reportFileNamePattern": "{base}-{date}-{lang}.[x]html",
+        "reportFileNameRegex": "([^-]{1,}).*[.][xX]?[hH][tT][mM][lL]?$",
         "ixTargetUsage": "allowed"
     },
     "EE": {


### PR DESCRIPTION
#### Reason for change

Current ESEF guidance 2.6.3 is too restrictive for the Danish case. The Danish national regulator only prescribes the list of valid file extensions and not the file name itself.

#### Description of change

Take the regular expression to validate the file names from the authority configuration file (`authority-validations.json`).

The parameters  `reportFileNamePattern` and `reportFileNameRegex` were already defined, but not used. This pull request modifies the code to actually use those parameters to perform the `ESEF.2.6.3.incorrectNamingConventionReportPackageReportFile` validation. 

#### Steps to Test

1. Find an ESEF annual report from Denmark that does not comply with the general ESEF file naming convention given in the ESEF Filing Rules, guidance 2.6.3.
2. Validate that report, for instance by using the Arelle GUI. Expected result: the warning `ESEF.2.6.3.incorrectNamingConventionReportPackageReportFile` shows up.
3. Set the authority to "DK" or "DBA" in the Arelle GUI ('Tools' > 'Formula' > 'Parameters').
4. Validate again the report in the GUI. Expected result: to warning `ESEF.2.6.3.incorrectNamingConventionReportPackageReportFile` no longer shows up!

##### Bonus

1. Manually modify the report package so that the file extension becomes `.htm` instead of `.xhtml` or `.html`.
2. Validate the modified report again (always in the Arelle GUI) while the authority is either 'DK' or 'DBA'. Expected result: an error `ESEF.2.6.1.incorrectFileExtension` show up in this case!

**review**:
@Arelle/arelle
