### PR TITLE
remove assertion for propertyView and instead return (none)

### DIFF
--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -1824,7 +1824,7 @@ class ModelLocator(ModelResource):
         elif isinstance(hrefObj, ModelResource):
             return (("href", hrefObj.viewText()),)
         else:
-            return getattr(hrefObj, "propertyView", "(none)")
+            return getattr(hrefObj, "propertyView", (("href", "(none)"),))
 
 
 class RelationStatus:

--- a/arelle/ModelDtsObject.py
+++ b/arelle/ModelDtsObject.py
@@ -1824,8 +1824,7 @@ class ModelLocator(ModelResource):
         elif isinstance(hrefObj, ModelResource):
             return (("href", hrefObj.viewText()),)
         else:
-            assert hrefObj is not None
-            return hrefObj.propertyView
+            return getattr(hrefObj, "propertyView", "(none)")
 
 
 class RelationStatus:


### PR DESCRIPTION
#### Reason for change
An assertion would break the production workflow for EDGAR and other users.

#### Description of change
Removed the assertion and instead default to returning "(none)" string when the hrefObj is None

#### Steps to Test
In the EFM test suite the following test case was failing since the assertion causes the process to crash.
605-instance-syntax/605-32-footnote-loc-fragment-portable/605-32-footnote-loc-fragment-portable-testcase.xml

**review**:
@Arelle/arelle
