### PR TITLE
Add Ubuntu to dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: ubuntu
   - package-ecosystem: github-actions
     directories:
       - /**


### PR DESCRIPTION
#### Reason for change

Ubuntu is pinned to oldest supported version for glibc compatibility.

#### Steps to Test

* CI

**review**:
@Arelle/arelle
