### PR TITLE
Edgar ignore node modules

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -56,6 +56,9 @@ Pillow: Copyright © 2010-2022 by Alex Clark and contributors
 PyParsing: Copyright © 2003-2022 Paul McGuire.
 [License](https://github.com/pyparsing/pyparsing/blob/master/LICENSE)
 
+PythonMonkey: Copyright (c) 2023-2024 Distributive Corp.
+[License](https://github.com/Distributive-Network/PythonMonkey/blob/main/LICENSE)
+
 rdflib: Copyright (c) 2002-2021, RDFLib Team. All rights reserved.
 [License](https://opensource.org/licenses/BSD-3-Clause)
 

--- a/arelle/plugin_system/entry_point_ref.py
+++ b/arelle/plugin_system/entry_point_ref.py
@@ -117,7 +117,7 @@ class EntryPointRef:
         :return: List of discovered entry points.
         """
         for fileName in sorted(os.listdir(directory)):
-            if fileName in (".", "..", "__pycache__", "__init__.py", ".DS_Store", "site-packages"):
+            if fileName in (".", "..", "__pycache__", "__init__.py", ".DS_Store", "site-packages", "node_modules"):
                 continue  # Ignore these entries
             filePath = os.path.join(directory, fileName)
             if os.path.isdir(filePath):

--- a/distro.py
+++ b/distro.py
@@ -6,6 +6,7 @@ import platform
 import site
 import sys
 from importlib.metadata import entry_points
+from importlib.util import find_spec
 
 import regex as re
 from cx_Freeze import Executable, setup
@@ -55,6 +56,7 @@ includeLibs = [
     "dateutil.relativedelta",
     "email",
     "email.header",
+    "email._header_value_parser",
     "graphviz",
     "gzip",
     "isodate",
@@ -92,12 +94,24 @@ if os.path.exists("arelle/plugin/EDGAR") or os.path.exists("arelle/plugin/xule")
     includeLibs.append("aniso8601")
 
 if os.path.exists("arelle/plugin/EDGAR"):
+    includeLibs.append("aiohttp")
     includeLibs.append("holidays")
     includeLibs.append("holidays.countries")
     includeLibs.append("holidays.financial")
     includeLibs.append("matplotlib")
     includeLibs.append("matplotlib.pyplot")
+    includeLibs.append("pminit")
+    includeLibs.append("pythonmonkey")
     includeLibs.append("pytz")
+
+    pythonMonkeySpec = find_spec("pythonmonkey")
+    if pythonMonkeySpec is None or not pythonMonkeySpec.submodule_search_locations:
+        raise ValueError("PythonMonkey dependency not found")
+    pythonMonkeyDirectory = pythonMonkeySpec.submodule_search_locations[0]
+    includeFiles.append((
+        os.path.join(pythonMonkeyDirectory, "builtin_modules"),
+        os.path.join("lib", "pythonmonkey", "builtin_modules"),
+    ))
 
 if sys.platform == LINUX_PLATFORM:
     guiExecutable = Executable(

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,13 @@ WORKDIR /usr/src/app
 
 ## Requirements are installed here to ensure they will be cached.
 ARG EXTRA_PIP=""
+## Plugin requirements includes PythonMonkey which requires npm to install node modules.
+RUN case "$EXTRA_PIP" in \
+      *requirements-plugins.txt*) \
+        apt-get update \
+        && apt-get install -y --no-install-recommends npm \
+        && rm -rf /var/lib/apt/lists/* ;; \
+    esac
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 COPY requirements.txt .

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y && \
         libxmlsec1-dev \
         llvm \
         make \
+        npm \
         tk-dev \
         unixodbc-dev \
         uuid-dev \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ EFM = [
     'holidays>=0,<1',
     'matplotlib>=3,<4',
     'pytz',
+    'pythonmonkey>=1,<2',
 ]
 ESEF = [
     'tinycss2>=1,<2',

--- a/requirements-plugins.txt
+++ b/requirements-plugins.txt
@@ -5,6 +5,7 @@ ixbrl-viewer==1.5.0
 holidays==0.101
 matplotlib==3.10.9
 pytz==2026.3.post1
+pythonmonkey==1.3.2
 
 # EDGAR and XULE plugins
 aniso8601==10.0.1


### PR DESCRIPTION
#### Reason for change
Add python monkey dependency for EDGAR plugin. Ignore node_modules directory when discovering entrypoints.

#### Description of change
Upcoming EDGAR release will have a dependency on pythonmonkey. Ignoring node_modules directory when finding entrypoints.

#### Steps to Test

**review**:
@Arelle/arelle
