### PR TITLE
Pin freeze-core to keep macOS builds on Tcl/Tk 8.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,3 +56,4 @@ updates:
           - patch
     ignore:
       - dependency-name: cx_Freeze
+      - dependency-name: freeze-core

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,5 @@
 cx-Freeze==8.6.4
+freeze-core==0.6.1
 requests-negotiate-sspi==0.5.2 ; sys_platform == 'win32'
 
 -r requirements-plugins.txt


### PR DESCRIPTION
#### Reason for change

Discovered while attempting to test #2540. After enabling the EDGAR plugin the frozen macOS app crashes beginning with release 2.44.1.

cx-Freeze==8.6.4 was pinned, but it declares `freeze-core>=0.6.1` with no upper bound, and freeze-core ships the bundled Tcl/Tk that cx_Freeze copies into Arelle.app. That made the macOS build non-reproducible: no change landed in .github/ or requirements-build.txt between 2.44.0 and 2.44.1, and both builds resolved the same CPython tarball (3.14.4-25113653268), but the builds picked up different freeze-core versions:

  2.44.0 (Aug 3)   freeze_core-0.6.1          -> share/tcl8.6, share/tk8.6
  2.44.1 (Aug 10)  freeze_core-0.7.0.post1    -> share/tcl9.0, share/tk9.0

freeze-core 0.7.0 was published Aug 5, between the two release builds.

Tcl 9.0 removed the `trace variable` subcommand, so the EDGAR plugin's `Variable.trace("w", ...)` calls raise TclError during CntlrWinMain.__init__. macOS only: the Windows build takes Tcl/Tk from the Python install and still bundles 8.6.

#### Description of change

Pinning freeze-core==0.6.1 restores Tcl/Tk 8.6 and makes the build reproducible. Added to the dependabot ignore list alongside cx_Freeze so it is not silently bumped again.

#### Steps to Test

* [x] smoke test EDGAR plugin [in frozen macOS app](https://github.com/Arelle/Arelle/actions/runs/31526262147)

**review**:
@Arelle/arelle
