### PR TITLE
Use native macOS Tk font defaults

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -47,7 +47,6 @@ from tkinter import (
     Tk,
     W,
     Event,
-    font as tkFont,
     )
 
 try:
@@ -140,16 +139,6 @@ class CntlrWinMain(Cntlr.Cntlr):
         localeSetupMessage = self.modelManager.setLocale() # set locale before GUI for menu strings, pass any msg to logger after log pane starts up
         self.labelLang: str = overrideLang if overrideLang else self.modelManager.defaultLang
         self.data: dict[str, Any] = {}
-
-        if self.isMac: # mac Python fonts bigger than other apps (terminal, text edit, Word), and to windows Arelle
-            _defaultFont = tkFont.nametofont("TkDefaultFont") # label, status bar, treegrid
-            _defaultFont.configure(size=11)
-            _textFont = tkFont.nametofont("TkTextFont") # entry widget and combobox entry field
-            _textFont.configure(size=11)
-            #parent.option_add("*Font", _defaultFont) # would be needed if not using defaulted font
-            toolbarButtonPadding = 1
-        else:
-            toolbarButtonPadding = 4
 
         tkinter.CallWrapper = TkinterCallWrapper  # type: ignore[misc,assignment]
 
@@ -411,6 +400,7 @@ class CntlrWinMain(Cntlr.Cntlr):
                 try:
                     image = PhotoImage(file=image)  # type: ignore[assignment]
                     self.toolbar_images.append(image)  # type: ignore[arg-type]
+                    toolbarButtonPadding = 1 if self.isMac else 4
                     tbControl = Button(toolbar, image=image, command=command, style="Toolbutton", padding=toolbarButtonPadding)  # type: ignore[assignment]
                     tbControl.grid(row=0, column=menubarColumn)
                 except TclError as err:


### PR DESCRIPTION
#### Reason for change

Arelle explicitly configures font sizes for macOS. Besides overwriting the users system settings, these don't work the same across tk 8.6 and 9.0. On tk 9 the font size setting causes text to render at ~1.25x as compared to 8.6.

| branch | tk 8.6 | tk 9.0 |
| ------- | ------ | ------ | 
| master | <img width="1039" height="787" alt="master-tk-8 6" src="https://github.com/user-attachments/assets/77156167-36e6-4000-b1e6-73b6efa040e2" /> | <img width="1039" height="787" alt="master-tk-9" src="https://github.com/user-attachments/assets/eb3139c3-3305-4379-9a70-53a080589165" /> |
| PR | <img width="1039" height="787" alt="fix-tk-8 6" src="https://github.com/user-attachments/assets/68f02fa0-435d-4a9d-ae96-d9bea34638e9" /> | <img width="1039" height="787" alt="fix-tk-9" src="https://github.com/user-attachments/assets/a29668a5-e132-4ef6-8c15-622305008bab" /> |

#### Description of change

Remove macOS font size overrides.

#### Steps to Test

* [x] verify fonts render as expected on macOS for both tk 8.6 and 9.0

**review**:
@Arelle/arelle
