### PR TITLE
Allow SpiderMonkey to initialize in signed macOS builds

### DIFF
--- a/arelle/config/macosEntitlements.plist
+++ b/arelle/config/macosEntitlements.plist
@@ -5,8 +5,5 @@
     <!-- SpiderMonkey (pythonmonkey) needs MAP_JIT to initialize under Hardened Runtime. -->
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <!-- Required for x86_64 Python 3.14+ builds running on Apple Silicon via Rosetta. -->
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
 </dict>
 </plist>

--- a/distro.py
+++ b/distro.py
@@ -1,6 +1,7 @@
 """
 See COPYRIGHT.md for copyright information.
 """
+
 import os
 import platform
 import site
@@ -135,16 +136,15 @@ elif sys.platform == MACOS_PLATFORM:
         "bundle_name": "Arelle",
     }
     if codesignIdentity := os.environ.get("CODESIGN_IDENTITY"):
+        entitlementsFile = "rosettaEntitlements.plist" if platform.machine() == "x86_64" else "macosEntitlements.plist"
         options["bdist_mac"].update({
             "codesign_identity": codesignIdentity,
             "codesign_deep": True,
             "codesign_timestamp": True,
             "codesign_verify": True,
             "codesign_options": "runtime",
+            "codesign_entitlements": f"arelle/config/{entitlementsFile}",
         })
-        if platform.machine() == "x86_64" and sys.version_info >= (3, 14):
-            # Required for running x86_64 Python 3.14 builds on Apple Silicon via Rosetta.
-            options["bdist_mac"]["codesign_entitlements"] = "arelle/config/rosettaEntitlements.plist"
     if scmTagVersion := os.environ.get("SETUPTOOLS_SCM_PRETEND_VERSION"):
         semverRegex = r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
         if re.fullmatch(semverRegex, scmTagVersion):


### PR DESCRIPTION
#### Reason for change

New entitlement required for EDGAR 26.3 usage of pythonmonkey in macOS frozen builds.

#### Description of change

Add `com.apple.security.cs.allow-jit` entitlement`.

#### Steps to Test

* [x] smoke test EDGAR ixbrl viewer [in EDGAR 26.3 macOS build](https://github.com/Arelle/Arelle/actions/runs/31973667466).

**review**:
@Arelle/arelle
