### PR TITLE
Pin Windows Build to Python 3.14.6

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,8 +7,10 @@ on:
         description: 'Arelle/EDGAR branch, tag or SHA to checkout (blank for default)'
         required: false
         type: string
+      # CPython 3.14.7 Windows bundles Tcl/Tk 9.0.4. Xule still calls
+      # tkinter.Variable.trace(), which Tcl 9 removed.
       python_version:
-        default: '3.14.7'
+        default: '3.14.6'
         description: 'Python version to use'
         required: false
         type: string
@@ -36,7 +38,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.14.7'
+        default: '3.14.6'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.14.7'
+        default: '3.14.6'
         description: 'Python version to use'
         required: false
         type: string


### PR DESCRIPTION
#### Reason for change

Resolves #2553 

CPython 3.14.7 on windows bundles Tcl/Tk 9 which crashes when the DQC plugin is enabled. [3.14.6 still bundles 8.6](https://github.com/Arelle/Arelle/actions/runs/32068514802). I've opened a PR in the xule repo (https://github.com/xbrlus/xule/pull/46). Once that's released and EDGAR 26.3 (https://github.com/Arelle/EDGAR/pull/67) is merged we can officially support Tcl/Tk 9.

#### Description of change

Switch Windows build from Python 3.14.7 to 3.14.6 (this still includes a newer OpenSSL to resolve the CVE in #2531)

#### Steps to Test

* [x] test DQC plugin on windows build with python 3.14.6

**review**:
@Arelle/arelle
