### PR TITLE
Preprocessing function for conformance suite configs

### DIFF
--- a/tests/integration_tests/validation/conformance_suite_config.py
+++ b/tests/integration_tests/validation/conformance_suite_config.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Callable
 
 from tests.integration_tests.github import OS_CORES
 
@@ -214,6 +214,7 @@ class ConformanceSuiteConfig:
     expected_missing_testcases: frozenset[str] = frozenset()
     membership_url: str | None = None
     plugins: frozenset[str] = frozenset()
+    preprocessing_func: Callable[[ConformanceSuiteConfig], None] | None = None
     shards: int = 1
     strict_testcase_index: bool = True
     required_locale_by_ids: dict[str, re.Pattern[str]] = field(default_factory=dict)

--- a/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/esef_ixbrl_2023.py
@@ -5,6 +5,23 @@ from tests.integration_tests.validation.conformance_suite_config import (
     ConformanceSuiteConfig, ConformanceSuiteAssetConfig, AssetSource
 )
 
+
+def _preprocessing_func(config: ConformanceSuiteConfig) -> None:
+    with open(
+            config.entry_point_root /
+            "tests/inline_xbrl/G2-6-1_3/index.xml",
+            "r+"
+    ) as f:
+        content = f.read()
+        # Test case references TC2_invalid.zip, but actual file in suite has .xbr extension.
+        content = content.replace("TC2_invalid.zip", "TC2_invalid.xbr")
+        # Test case references TC3_invalid.zip, but actual file in suite has .xbri extension.
+        content = content.replace("TC3_invalid.zip", "TC3_invalid.xbri")
+        f.seek(0)
+        f.write(content)
+        f.truncate()
+
+
 ZIP_PATH = Path("esef_conformance_suite_2023.zip")
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 config = ConformanceSuiteConfig(
@@ -25,9 +42,6 @@ config = ConformanceSuiteConfig(
     expected_failure_ids=frozenset(f"tests/inline_xbrl/{s}" for s in [
         # Test report uses older domain item type (http://www.xbrl.org/dtr/type/non-numeric) forbidden by ESEF.3.2.2.
         "G3-1-2/index.xml:TC2_valid",
-        # These tests reference zip files, which do not exist in the conformance suite.
-        "G2-6-1_3/index.xml:TC2_invalid",
-        "G2-6-1_3/index.xml:TC3_invalid",
         # The following test case fails because of the `tech_duplicated_facts1` formula, which incorrectly fires.
         # It does not take into account the language attribute on the fact.
         # Facts are not duplicates if their language attributes are different.
@@ -36,6 +50,7 @@ config = ConformanceSuiteConfig(
     info_url="https://www.esma.europa.eu/document/esef-conformance-suite-2023",
     name=PurePath(__file__).stem,
     plugins=frozenset({"validate/ESEF"}),
+    preprocessing_func=_preprocessing_func,
     shards=8,
     test_case_result_options="match-any",
 )

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -6,6 +6,22 @@ from tests.integration_tests.validation.conformance_suite_config import (
 )
 
 
+def _preprocessing_func(config: ConformanceSuiteConfig) -> None:
+    with open(
+            config.entry_point_root /
+            "tests/FRC/FRC_09/index.xml",
+            "r+"
+    ) as f:
+        content = f.read()
+        # Test case references TC2_valid.zip, but actual file in suite has .xbri extension.
+        content = content.replace("TC2_valid.zip", "TC2_valid.xbri")
+        # Test case references TC3_valid.zip, but actual file in suite has .xbri extension.
+        content = content.replace("TC3_valid.zip", "TC3_valid.xbri")
+        f.seek(0)
+        f.write(content)
+        f.truncate()
+
+
 ZIP_PATH = Path("uksef-conformance-suite-v2.0.zip")
 EXTRACTED_PATH = Path(ZIP_PATH.stem)
 EXTRACTED_ZIP_PATH = EXTRACTED_PATH / "uksef-conformance-suite-v2.0" / "uksef-conformance-suite-v2.0.zip"
@@ -44,17 +60,8 @@ config = ConformanceSuiteConfig(
             # Testcase does not specify count (1 is default), so 19 additional occurrences
             "xmlSchema:elementUnexpected": 19,
         },
-        # Test case references TC2_valid.zip, but actual file in suite has .xbri extension.
-        "FRC_09/index.xml:TC2_valid": {
-            "FileSourceError": 1,
-            "tpe:invalidArchiveFormat": 1
-        },
-        # Test case references TC3_valid.zip, but actual file in suite has .xbri extension.
-        "FRC_09/index.xml:TC3_valid": {
-            "FileSourceError": 1,
-            "tpe:invalidArchiveFormat": 1
-        },
         # Report package uses CR document type URI instead of rec URI.
+        "FRC_09/index.xml:TC2_valid": {"rpe:unsupportedReportPackageVersion": 1},
         "FRC_09/index.xml:TC4_valid": {"rpe:unsupportedReportPackageVersion": 1},
     }.items()},
     expected_failure_ids=frozenset({f"tests/FRC/{s}" for s in [
@@ -102,5 +109,6 @@ config = ConformanceSuiteConfig(
     name=PurePath(__file__).stem,
     disclosure_system="uksef-only-2025",
     plugins=frozenset({"inlineXbrlDocumentSet", "validate/ESEF"}),
+    preprocessing_func=_preprocessing_func,
     shards=4,
 )

--- a/tests/integration_tests/validation/run_conformance_suites.py
+++ b/tests/integration_tests/validation/run_conformance_suites.py
@@ -147,6 +147,9 @@ def run_conformance_suites(
         download_assets(unique_assets, download_option == DOWNLOAD_OVERWRITE, download_cache, download_private)
     else:
         verify_assets(unique_assets)
+    for config in conformance_suite_configs:
+        if config.preprocessing_func is not None:
+            config.preprocessing_func(config)
     all_results = []
     if test_option:
         for config in conformance_suite_configs:


### PR DESCRIPTION
#### Reason for change
Some conformance suites references non-existent files, but the intent is clear. We can directly manipulate the file so we can still run the intended test.

#### Description of change
Add an optional `preprocessing_func` to conformance suite configurations.

#### Steps to Test
CI

**review**:
@Arelle/arelle
