### PR TITLE
Preview Builds Dispatch Workflow

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Define artifact names
         id: define-artifact-names
         run: |
-          [[ $(echo dist/*.tgz) =~ -([0-9]+\.[0-9]+\.[0-9]+)\.tgz$ ]] && echo "artifact_versioned_name=arelle-ubuntu-${BASH_REMATCH[1]}.tgz" >> $GITHUB_OUTPUT
+          echo "artifact_versioned_name=$(basename dist/*.tgz)" >> $GITHUB_OUTPUT
           echo "BUILD_ARTIFACT_PATH=$(echo dist/*.tgz)" >> $GITHUB_ENV
           echo "uploaded_artifact_name=ubuntu distribution" >> $GITHUB_OUTPUT
       - name: Capture build env

--- a/.github/workflows/build-previews.yml
+++ b/.github/workflows/build-previews.yml
@@ -1,0 +1,165 @@
+name: Build Previews
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: 'Public label for the preview builds (e.g. 25.2-edgar, xt-1234)'
+        required: true
+        type: string
+      edgar_ref:
+        description: 'Arelle/EDGAR branch, tag or SHA to checkout (blank for default)'
+        required: false
+        type: string
+      xule_ref:
+        description: 'xbrlus/xule branch, tag or SHA to checkout (blank for default)'
+        required: false
+        type: string
+
+run-name: Build Previews ${{ inputs.label }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.label }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build-linux:
+    name: Build Linux
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      edgar_ref: ${{ inputs.edgar_ref }}
+      xule_ref: ${{ inputs.xule_ref }}
+
+  build-macos-arm64:
+    name: Build macOS arm64
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      edgar_ref: ${{ inputs.edgar_ref }}
+      xule_ref: ${{ inputs.xule_ref }}
+    secrets: inherit
+
+  build-macos-x64:
+    name: Build macOS x64
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      edgar_ref: ${{ inputs.edgar_ref }}
+      xule_ref: ${{ inputs.xule_ref }}
+      macos_version: 15-intel
+      python_architecture: x64
+    secrets: inherit
+
+  build-windows:
+    name: Build Windows
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      edgar_ref: ${{ inputs.edgar_ref }}
+      xule_ref: ${{ inputs.xule_ref }}
+
+  publish:
+    name: Publish
+    needs:
+      - build-linux
+      - build-macos-arm64
+      - build-macos-x64
+      - build-windows
+    if: github.repository == 'Arelle/Arelle'
+    environment: release
+    permissions:
+      id-token: write
+    runs-on: ubuntu-24.04
+    env:
+      UBUNTU_PREVIEW_NAME: arelle-ubuntu-${{ inputs.label }}-preview.tgz
+      MACOS_ARM64_PREVIEW_NAME: arelle-macos-arm64-${{ inputs.label }}-preview.dmg
+      MACOS_X64_PREVIEW_NAME: arelle-macos-x64-${{ inputs.label }}-preview.dmg
+      WINDOWS_INSTALLER_PREVIEW_NAME: arelle-win-${{ inputs.label }}-preview.exe
+      WINDOWS_ZIP_PREVIEW_NAME: arelle-win-${{ inputs.label }}-preview.zip
+    steps:
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ${{ needs.build-linux.outputs.uploaded_artifact_name }}
+      - name: Download macOS arm64 artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ${{ needs.build-macos-arm64.outputs.uploaded_artifact_name }}
+      - name: Download macOS x64 artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ${{ needs.build-macos-x64.outputs.uploaded_artifact_name }}
+      - name: Download Windows installer artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ${{ needs.build-windows.outputs.exe_uploaded_artifact_name }}
+      - name: Download Windows zip artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ${{ needs.build-windows.outputs.zip_uploaded_artifact_name }}
+
+      - name: Rename artifacts to preview object names
+        run: |
+          mv "${{ needs.build-linux.outputs.artifact_versioned_name }}" "$UBUNTU_PREVIEW_NAME"
+          mv "${{ needs.build-macos-arm64.outputs.artifact_versioned_name }}" "$MACOS_ARM64_PREVIEW_NAME"
+          mv "${{ needs.build-macos-x64.outputs.artifact_versioned_name }}" "$MACOS_X64_PREVIEW_NAME"
+          mv "${{ needs.build-windows.outputs.exe_artifact_versioned_name }}" "$WINDOWS_INSTALLER_PREVIEW_NAME"
+          mv "${{ needs.build-windows.outputs.zip_artifact_versioned_name }}" "$WINDOWS_ZIP_PREVIEW_NAME"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::494047596077:role/GitHubActionsArelleS3Upload
+          aws-region: us-west-1
+      - name: Upload previews to AWS S3
+        run: |
+          aws s3 cp --acl public-read "$UBUNTU_PREVIEW_NAME" "s3://arelle-us/$UBUNTU_PREVIEW_NAME"
+          aws s3 cp --acl public-read "$MACOS_ARM64_PREVIEW_NAME" "s3://arelle-us/$MACOS_ARM64_PREVIEW_NAME"
+          aws s3 cp --acl public-read "$MACOS_X64_PREVIEW_NAME" "s3://arelle-us/$MACOS_X64_PREVIEW_NAME"
+          aws s3 cp --acl public-read "$WINDOWS_INSTALLER_PREVIEW_NAME" "s3://arelle-us/$WINDOWS_INSTALLER_PREVIEW_NAME"
+          aws s3 cp --acl public-read "$WINDOWS_ZIP_PREVIEW_NAME" "s3://arelle-us/$WINDOWS_ZIP_PREVIEW_NAME"
+      - name: Configure Ali Cloud credentials
+        uses: yizhoumo/setup-ossutil@v2.0.0
+        with:
+          endpoint: oss-cn-shenzhen.aliyuncs.com
+          access-key-id: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          access-key-secret: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+      - name: Upload previews to Ali Cloud
+        run: |
+          ossutil cp -f "$UBUNTU_PREVIEW_NAME" "oss://arelle-cn/$UBUNTU_PREVIEW_NAME"
+          ossutil cp -f "$MACOS_ARM64_PREVIEW_NAME" "oss://arelle-cn/$MACOS_ARM64_PREVIEW_NAME"
+          ossutil cp -f "$MACOS_X64_PREVIEW_NAME" "oss://arelle-cn/$MACOS_X64_PREVIEW_NAME"
+          ossutil cp -f "$WINDOWS_INSTALLER_PREVIEW_NAME" "oss://arelle-cn/$WINDOWS_INSTALLER_PREVIEW_NAME"
+          ossutil cp -f "$WINDOWS_ZIP_PREVIEW_NAME" "oss://arelle-cn/$WINDOWS_ZIP_PREVIEW_NAME"
+
+      - name: Write tester URL summary
+        env:
+          ARELLE_REF: ${{ github.ref_name }}
+          EDGAR_REF: ${{ inputs.edgar_ref }}
+          XULE_REF: ${{ inputs.xule_ref }}
+        run: |
+          {
+            echo "Windows Installer:"
+            echo "USA: https://arelle-us.s3-us-west-1.amazonaws.com/$WINDOWS_INSTALLER_PREVIEW_NAME"
+            echo "Europe: https://arelle-eu.s3.eu-central-1.amazonaws.com/$WINDOWS_INSTALLER_PREVIEW_NAME"
+            echo "China: https://arelle-cn.oss-cn-shenzhen.aliyuncs.com/$WINDOWS_INSTALLER_PREVIEW_NAME"
+            echo
+            echo "Windows Zip:"
+            echo "USA: https://arelle-us.s3-us-west-1.amazonaws.com/$WINDOWS_ZIP_PREVIEW_NAME"
+            echo "Europe: https://arelle-eu.s3.eu-central-1.amazonaws.com/$WINDOWS_ZIP_PREVIEW_NAME"
+            echo "China: https://arelle-cn.oss-cn-shenzhen.aliyuncs.com/$WINDOWS_ZIP_PREVIEW_NAME"
+            echo
+            echo "macOS arm64:"
+            echo "USA: https://arelle-us.s3-us-west-1.amazonaws.com/$MACOS_ARM64_PREVIEW_NAME"
+            echo "Europe: https://arelle-eu.s3.eu-central-1.amazonaws.com/$MACOS_ARM64_PREVIEW_NAME"
+            echo "China: https://arelle-cn.oss-cn-shenzhen.aliyuncs.com/$MACOS_ARM64_PREVIEW_NAME"
+            echo
+            echo "macOS x64:"
+            echo "USA: https://arelle-us.s3-us-west-1.amazonaws.com/$MACOS_X64_PREVIEW_NAME"
+            echo "Europe: https://arelle-eu.s3.eu-central-1.amazonaws.com/$MACOS_X64_PREVIEW_NAME"
+            echo "China: https://arelle-cn.oss-cn-shenzhen.aliyuncs.com/$MACOS_X64_PREVIEW_NAME"
+            echo
+            echo "Ubuntu:"
+            echo "USA: https://arelle-us.s3-us-west-1.amazonaws.com/$UBUNTU_PREVIEW_NAME"
+            echo "Europe: https://arelle-eu.s3.eu-central-1.amazonaws.com/$UBUNTU_PREVIEW_NAME"
+            echo "China: https://arelle-cn.oss-cn-shenzhen.aliyuncs.com/$UBUNTU_PREVIEW_NAME"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tests/integration_tests/scripts/script_util.py
+++ b/tests/integration_tests/scripts/script_util.py
@@ -7,11 +7,11 @@ import subprocess
 import sys
 import time
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from os import linesep
 from pathlib import Path
-from typing import cast, Any, Generator
+from typing import Any, cast
 
 import regex
 from lxml import etree

--- a/tests/integration_tests/scripts/script_util.py
+++ b/tests/integration_tests/scripts/script_util.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import os
 import shlex
+import socket
 import subprocess
 import sys
 import time
@@ -148,6 +149,30 @@ def run_arelle(
     assert result.returncode == 0, result.stderr.decode().strip()
 
 
+def wait_for_localhost_port(
+    port: int,
+    proc: subprocess.Popen[bytes],
+    timeout: float = 120,
+) -> None:
+    """Block until localhost accepts a TCP connection on *port*."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"Arelle webserver exited with code {proc.returncode} "
+                f"before listening on port {port}."
+            )
+        try:
+            with socket.create_connection(("localhost", port), timeout=0.1):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise TimeoutError(
+        f"Arelle webserver did not accept connections on port {port} "
+        f"within {timeout} seconds."
+    )
+
+
 @contextmanager
 def run_arelle_webserver(
     arelle_command: str,
@@ -162,8 +187,8 @@ def run_arelle_webserver(
     try:
         print(f"Starting web server on port {port}...")
         proc = subprocess.Popen(args)
-        print("Waiting 2 seconds for web server to be ready...")
-        time.sleep(2)  # TODO: capture process output and wait for "Listening" message
+        print(f"Waiting for web server on port {port}...")
+        wait_for_localhost_port(port, proc)
         print("Web server ready.")
         yield proc
     finally:


### PR DESCRIPTION
#### Reason for change

Create GitHub workflow to help automate publishing preview builds. Can be used for EDGAR previews.

#### Description of change

New dispatch workflow to build and upload preview builds.

#### Steps to Test

* [x] use [workflow](https://github.com/Arelle/Arelle/actions/runs/32595951459) to build and publish EDGAR 26.3 preview builds.

**review**:
@Arelle/arelle
