### PR TITLE
Fix importSchemaLocationBasename check

### DIFF
--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -1082,7 +1082,7 @@ class ModelDocument(ModelDocumentBase):
                         messageCodes=("EFM.6.22.02", "GFM.1.1.3", "SBR.NL.2.1.0.06", "SBR.NL.2.2.0.17"))
                 return
             doc = None
-            importSchemaLocationBasename = os.path.basename(importNamespace)
+            importSchemaLocationBasename = os.path.basename(importSchemaLocation)
             # is there an exact match for importNamespace and uri?
             for otherDoc in self.modelXbrl.namespaceDocs[importNamespace]:
                 doc = otherDoc

--- a/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
+++ b/tests/integration_tests/validation/conformance_suite_configurations/uksef.py
@@ -80,10 +80,6 @@ config = ConformanceSuiteConfig(
             "multipleIdentifiers": 1,
             "segmentUsed": 1,
         },
-        "FRC_02/index.xml:TC3_invalid": {
-            "info:duplicatedSchema": 1,
-            "xbrl:multipleTopLevelSchemasForNamespace": 1,
-        },
         "FRC_07/index.xml:TC2_invalid": {
             # By the same logic that FRC_06:TC2 fires multipleIdentifiers, so should FRC_07:TC2
             "multipleIdentifiers": 1,


### PR DESCRIPTION
#### Reason for change
The intent of [this block](https://github.com/Arelle/Arelle/blob/1dbd0b365a7529ae3f7f1d461bb99617d849debf/arelle/ModelDocument.py#L1084-L1094) is to avoid importing the same document as two separate `ModelDocument` instances, and consolidate them instead.

To achieve this, it compares each previously loaded document with the same target namespace. If it finds one with an exact URI match, it considers it a match and prevents full re-loading. In the absence of an exact URI match, it confirms that the other document at least has the same filename/basename to consider it a match.

The problem lies where the code incorrectly retrieves the *namespace* basename rather than the *schema location* basename, causing the subsequent check to essentially always fire and classify an otherwise matching document as a different file.

This causes issues primarily when a single document is retrievable via distinct URIs. For example, whenever Arelle allows `http` and `https` schemes to be used interchangeably, as it does when referencing a file in the built-in cache (`arelle/resources`).

#### Description of change
The ideal solution might be comparing the actual resolved filepaths rather than URIs, but the original intent may have been to allow the same file to be referenced from different file locations and a matching target namespace + filename was the heuristic to consider them the "same". Regardless, that would be a larger scope and higher risk change. Instead, I've corrected the incorrect variable use as a low risk but effective fix.

#### Steps to Test
Run this options file (with empty HTTP cache): [uksef.json](https://github.com/user-attachments/files/32116896/uksef.json)
The referenced package ultimately attempts to load the `http://www.xbrl.org/dtr/type/2020-01-21` namespace using `http` in one place and `https` in another.
Without these changes, expect:
```
[info:duplicatedSchema] Schema file with same targetNamespace http://www.xbrl.org/dtr/type/2020-01-21 loaded from arelle/arelle/resources/cache/https/www.xbrl.org/dtr/type/2020-01-21/types.xsd and https://www.xbrl.org/dtr/type/2020-01-21/types.xsd - http://www.abc.com/xbrl/2021/abc-2021-12-31.xsd 50
[xbrl:multipleTopLevelSchemasForNamespace] Schemas for namespace http://www.xbrl.org/dtr/type/2020-01-21 are not fully connected via xs:include: arelle/arelle/resources/cache/https/www.xbrl.org/dtr/type/2020-01-21/types.xsd, https://www.xbrl.org/dtr/type/2020-01-21/types.xsd. All schemas for a namespace must form a single connected group of xs:include links with at most one top-level (non-included) schema. - https://www.xbrl.org/dtr/type/2020-01-21/types.xsd 
```
With these changes, those errors will not appear.


**review**:
@Arelle/arelle
