### PR TITLE
Add IRD to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,7 @@ tests/resources/conformance_suites/*
 !tests/resources/conformance_suites/dba_*
 !tests/resources/conformance_suites/edinet/
 !tests/resources/conformance_suites/HMRC/
+!tests/resources/conformance_suites/ird/
 !tests/resources/conformance_suites/nl_*/
 !tests/resources/conformance_suites/ros/
 tests/resources/packages/


### PR DESCRIPTION
#### Reason for change

The IRD conformance suite was added to .gitignore but not .dockerignore. This caused tagged Linux Docker builds to appear dirty and [broke release version detection](https://github.com/Arelle/Arelle/actions/runs/33775909767/job/100776798367) (`VERSION=2.44.8.dev0+g3b0674643.d20260903` instead of `VERSION=2.44.7`) in scripts/buildLinuxDist.sh.

#### Description of change

Add new IRD conformance suite exception gitignore entry to dockerignore.

#### Steps to Test

* CI

**review**:
@Arelle/arelle
