### PR TITLE
Add legacy website URL aliases

### DIFF
--- a/docs/website/content/_index.md
+++ b/docs/website/content/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Arelle
 description: A free and open source platform for validating, exploring, and extracting XBRL data.
+aliases:
+  - /arelle/
 ---
 
 Arelle is a free and open source platform for validating, exploring, and extracting XBRL data.

--- a/docs/website/content/updates/_index.md
+++ b/docs/website/content/updates/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Project updates
 description: Updates from the Arelle team.
+aliases:
+  - /arelle/blog/
 outputs:
   - HTML
   - RSS


### PR DESCRIPTION
#### Reason for change

Google still has the old homepage and blog path in search results.

#### Description of change

Add missing aliases so users are redirected.

#### Steps to Test

* ci
* download `website` ci artifact from build website workflow
* extract archive
* `python -m http.server -d <extracted-artifact>`
* verify aliased redirects work:
  * <http://[::]:8000/arelle/>
  * <http://[::]:8000/arelle/blog/>

**review**:
@Arelle/arelle
