### PR TITLE
Table linkbase: positional dimensions

### DIFF
--- a/arelle/ModelRenderingObject.py
+++ b/arelle/ModelRenderingObject.py
@@ -970,6 +970,20 @@ class DefnMdlTable(ModelFormulaResource):
         return parentChildOrder(self)
 
     @property
+    def positionalDimensionsOnly(self) -> bool:
+        """Whether dimensions the table does not address constrain its cells.
+
+        When true, a dimension which none of the table's breakdowns identifies
+        places no constraint on a cell, and facts are selected irrespective of
+        whether they report it.  The dimensions the table does address -- its
+        positional dimensions -- are unaffected: they are constrained in every
+        cell already, either explicitly or by the inference drawn for aspects
+        participating in a breakdown, so relaxing this cannot weaken them.
+        """
+        return any(self.get(clarkName) in ("true", "1")
+                   for clarkName in XbrlConst.cnTablePositionalDimensionsOnly)
+
+    @property
     def descendantArcroles(self) -> tuple[str, ...]:  # type: ignore[override]
         return (XbrlConst.tableFilter, XbrlConst.tableFilterMMDD,
                 XbrlConst.tableBreakdown, XbrlConst.tableBreakdownMMDD,

--- a/arelle/XbrlConst.py
+++ b/arelle/XbrlConst.py
@@ -651,6 +651,22 @@ qnTableConceptRelationshipNodeMMDD = qname("{http://xbrl.org/PWD/2017-07-12/tabl
 qnTableDimensionRelationshipNodeMMDD = qname("{http://xbrl.org/PWD/2017-07-12/table-1.1}table:dimensionRelationshipNode")
 qnTableAspectNodeMMDD = qname("{http://xbrl.org/PWD/2017-07-12/table-1.1}table:aspectNode")
 
+# Positional dimensions (table linkbase 1.0 addition, work item #37).
+# The attribute rides the anyAttribute wildcard on table:table.type, so it needs
+# no change to the REC'd table schema and is ignored by processors without it.
+# The namespace carries the table specification's own status date URI rather than
+# a date of its own, so the conformance suite templates it with the same token it
+# uses everywhere else.  Production and pre-production forms are both recognised,
+# as for the extensible enumerations above.
+tablePositionals = frozenset({
+    "http://xbrl.org/2014/table-positional",
+    "http://xbrl.org/WGWD/YYYY-MM-DD/table-positional",
+})
+cnTablePositionalDimensionsOnly = frozenset(  # clark names
+    "{{{}}}positionalDimensionsOnly".format(namespace)
+    for namespace in tablePositionals
+)
+
 booleanValueTrue = "true"
 booleanValueFalse = "false"
 

--- a/arelle/rendering/RenderingLayout.py
+++ b/arelle/rendering/RenderingLayout.py
@@ -395,6 +395,12 @@ def bodyCells(view, row, yStrctNodes, xStrctNodes, zAspectStrctNodes, lytMdlYCel
     hasRows = False
     if True: # yParentStrctNode is not None:
         dimDefaults = view.modelXbrl.qnameDimensionDefaults
+        # A table may declare that only the dimensions it addresses constrain its
+        # cells.  The two tests below are what make a dimension the table never
+        # mentions exclude a fact, so they are the ones this disables; the
+        # dimensions the table does address are matched through matchableAspects
+        # either way, and are unaffected.
+        positionalDimensionsOnly = view.defnMdlTable.positionalDimensionsOnly
         for yStrctNode in yStrctNodes: # yParentStrctNode.strctMdlChildNodes: # strctMdlEffectiveChildNodes:
             #row = view.bodyCells(row, yStrctNode, xStrctNodes, zAspectStrctNodes)
             if not (yStrctNode.isAbstract or
@@ -467,9 +473,10 @@ def bodyCells(view, row, yStrctNodes, xStrctNodes, zAspectStrctNodes, lytMdlYCel
                         for fact in sorted(facts, key=lambda f:f.objectIndex):
                             if (all(aspectMatches(view.rendrCntx, fact, fp, aspect)
                                     for aspect in matchableAspects) and
-                                all(fact.context.dimMemberQname(dim,includeDefaults=True) in (dimDefaults[dim], None)
-                                    for dim in cellDefaultedDims) and
-                                    len(fp.context.qnameDims) == len(fact.context.qnameDims)):
+                                (positionalDimensionsOnly or
+                                 (all(fact.context.dimMemberQname(dim,includeDefaults=True) in (dimDefaults[dim], None)
+                                      for dim in cellDefaultedDims) and
+                                  len(fp.context.qnameDims) == len(fact.context.qnameDims)))):
                                 if yStrctNode.hasValueExpression(xStrctNode):
                                     value = yStrctNode.evalValueExpression(fact, xStrctNode)
                                 else:


### PR DESCRIPTION
A table may carry tp:positionalDimensionsOnly, in which case a dimension which none of its breakdowns identifies places no constraint on a cell, and facts are selected irrespective of whether they report it.

The dimensions the table does address are unaffected. A table may have only one breakdown per aspect, and every leaf node of that breakdown carries a value for it, so those dimensions are constrained in every cell already and matched through matchableAspects either way. What this disables is the pair of tests in bodyCells that make a dimension the table never mentions exclude a fact.

#### Reason for change
[TLB WG Work Item](https://gitlab.xbrl.org/rendering/table-linkbase/-/work_items/37#topl)
[TLB MR Positional Dimensions](https://gitlab.xbrl.org/rendering/table-linkbase/-/merge_requests/42)

#### Description of change
Adds positional dimensions support to TLB 1.0 implementation 

#### Steps to Test
[TLB MR test suite](https://gitlab.xbrl.org/rendering/table-linkbase/-/tree/37-positional-dimensions/conf)

**review**:
@Arelle/arelle
