### PR TITLE
Rss fix

### DIFF
--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -1221,11 +1221,16 @@ class CntlrWinMain(Cntlr.Cntlr):
         # rssItems, etc.). Only worth refusing when the watch has a validate/alert/plugin action
         # checked - that's when watchCycle spends real time loading and processing each item and
         # the race window is significant; with nothing checked it just refreshes the feed listing.
+        # Also skip watches that already have a stop requested: stop() only sets a flag, so a
+        # watch sleeping between polls (up to 10 minutes) still reports its thread as alive even
+        # though it won't touch the model again - checking stopRequested lets Validate proceed
+        # right after Stop is clicked instead of waiting out the rest of that sleep.
         from arelle.WatchRss import hasWatchAction
         watchingModelXbrl = next(
             (modelXbrl for modelXbrl in self.modelManager.loadedModelXbrls
              if (watchRss := getattr(modelXbrl, "watchRss", None)) is not None
              and watchRss.thread is not None and watchRss.thread.is_alive()
+             and not watchRss.stopRequested
              and hasWatchAction(self, self.modelManager.rssWatchOptions)),
             None)
         if watchingModelXbrl is not None:

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -1215,6 +1215,27 @@ class CntlrWinMain(Cntlr.Cntlr):
                 parent=self.parent,
             )
             return
+        # RSS Watch reloads and mutates a loaded RSS feed's ModelXbrl on its own background thread
+        # (see WatchRss.watchCycle); running Validate on the same feed concurrently corrupts both,
+        # since they share and separately reset the same ModelXbrl state (modelObjects, contexts,
+        # rssItems, etc.). Only worth refusing when the watch has a validate/alert/plugin action
+        # checked - that's when watchCycle spends real time loading and processing each item and
+        # the race window is significant; with nothing checked it just refreshes the feed listing.
+        from arelle.WatchRss import hasWatchAction
+        watchingModelXbrl = next(
+            (modelXbrl for modelXbrl in self.modelManager.loadedModelXbrls
+             if (watchRss := getattr(modelXbrl, "watchRss", None)) is not None
+             and watchRss.thread is not None and watchRss.thread.is_alive()
+             and hasWatchAction(self, self.modelManager.rssWatchOptions)),
+            None)
+        if watchingModelXbrl is not None:
+            tkinter.messagebox.showwarning(
+                _("arelle - Warning"),
+                _("RSS Watch is currently running on {0}. Stop RSS Watch before running Validate; "
+                  "running both at once on the same feed corrupts results.").format(watchingModelXbrl.modelDocument.basename),
+                parent=self.parent,
+            )
+            return
         threading.Thread(target=self.backgroundValidate, daemon=True).start()
 
     def backgroundValidate(self) -> None:

--- a/arelle/ModelRssItem.py
+++ b/arelle/ModelRssItem.py
@@ -96,6 +96,17 @@ class ModelRssItem(ModelObject):
         self.edgrSequence = edgrPrefix + "sequence"
         self.edgrType = edgrPrefix + "type"
         self.edgrUrl = edgrPrefix + "url"
+        # Restore validation results captured for this item on a prior cycle. ModelRssItem objects
+        # are lxml element proxies, and RSS watch reloads the feed (new ModelRssObject and fresh
+        # proxies) on every poll, so results are kept on the persistent ModelXbrl keyed by accession
+        # number and restored here - otherwise already-tested rows revert to "not tested" on refresh.
+        rssModelXbrl = getattr(modelDocument, "modelXbrl", None)
+        priorResults = getattr(rssModelXbrl, "rssItemResults", {}).get(self.accessionNumber or "")
+        if priorResults is not None:
+            self.status = priorResults["status"]
+            self.results = priorResults["results"]
+            self.assertions = priorResults["assertions"]
+            self.assertionUnsuccessful = priorResults["assertionUnsuccessful"]
 
 
     @property
@@ -245,6 +256,18 @@ class ModelRssItem(ModelObject):
                 self.results.append(error)
                 self.status = "fail"  # error code
         self.results.sort()
+        # Persist on the persistent ModelXbrl (survives RSS watch feed reloads, which replace the
+        # ModelRssObject and every ModelRssItem proxy) so this result is restored in init().
+        rssModelXbrl = self.modelXbrl
+        if rssModelXbrl is not None and self.accessionNumber:
+            if not hasattr(rssModelXbrl, "rssItemResults"):
+                rssModelXbrl.rssItemResults = {}
+            rssModelXbrl.rssItemResults[self.accessionNumber] = {
+                "status": self.status,
+                "results": list(self.results),
+                "assertions": self.assertions,
+                "assertionUnsuccessful": self.assertionUnsuccessful,
+            }
 
     @property
     def propertyView(self) -> tuple[tuple[str, Any], ...]:

--- a/arelle/ModelRssItem.py
+++ b/arelle/ModelRssItem.py
@@ -17,6 +17,11 @@ if TYPE_CHECKING:
 
 _: TypeGetText
 
+# Statuses (see ModelRssItem.setResults) that mean an item was already fully validated on a
+# prior run - shared by Validate.validateRssFeed and WatchRss.watchCycle so both agree on
+# whether an item needs to be re-downloaded and re-validated.
+rssItemAlreadyValidatedStatuses = frozenset(("pass", "fail", "unsuccessful"))
+
 
 def _descendantText(
     element: ModelObject,

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -63,6 +63,10 @@ class ValidationException(Exception):
 
 commaSpaceSplitPattern = re.compile(r",\s*")
 
+# RSS item statuses (see ModelRssItem.setResults) that mean the item was already fully validated
+# on a prior run; validateRssFeed skips re-downloading and re-validating these.
+rssItemAlreadyValidatedStatuses = frozenset(("pass", "fail", "unsuccessful"))
+
 class Validate:
     """Validation operations are separated from the objects that are validated, because the operations are
     complex, interwoven, and factored quite differently than the objects being validated.
@@ -193,6 +197,11 @@ class Validate:
             if getattr(rssItem, "skipRssItem", False):
                 self.modelXbrl.info("info", _("skipping RSS Item %(accessionNumber)s %(formType)s %(companyName)s %(period)s"),
                     modelObject=rssItem, accessionNumber=rssItem.accessionNumber, formType=rssItem.formType, companyName=rssItem.companyName, period=rssItem.period)  # type: ignore[union-attr]
+                continue
+            if getattr(rssItem, "status", None) in rssItemAlreadyValidatedStatuses:
+                self.modelXbrl.info("info", _("skipping already validated RSS Item %(accessionNumber)s %(formType)s %(companyName)s %(period)s, status %(status)s"),
+                    modelObject=rssItem, accessionNumber=rssItem.accessionNumber, formType=rssItem.formType, companyName=rssItem.companyName,  # type: ignore[union-attr]
+                    period=rssItem.period, status=rssItem.status)  # type: ignore[union-attr]
                 continue
             self.modelXbrl.info("info", _("RSS Item %(accessionNumber)s %(formType)s %(companyName)s %(period)s"),
                 modelObject=rssItem, accessionNumber=rssItem.accessionNumber, formType=rssItem.formType, companyName=rssItem.companyName, period=rssItem.period)  # type: ignore[union-attr]

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -20,6 +20,7 @@ from arelle import (
     ValidateInfoset, ViewFileRenderedLayout, UrlUtil,
     )
 from arelle.CompareInstance import compareInstance
+from arelle.ModelRssItem import rssItemAlreadyValidatedStatuses
 from arelle.ModelRssObject import ModelRssObject
 from arelle.PythonUtil import isLegacyAbs
 from arelle.ValidateFileSource import ValidateFileSource
@@ -62,10 +63,6 @@ class ValidationException(Exception):
         return "{0}({1})={2}".format(self.code,self.severity,self.message)
 
 commaSpaceSplitPattern = re.compile(r",\s*")
-
-# RSS item statuses (see ModelRssItem.setResults) that mean the item was already fully validated
-# on a prior run; validateRssFeed skips re-downloading and re-validating these.
-rssItemAlreadyValidatedStatuses = frozenset(("pass", "fail", "unsuccessful"))
 
 class Validate:
     """Validation operations are separated from the objects that are validated, because the operations are

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -160,6 +160,25 @@ class Validate:
                     exc_info=True)
         self.close()
 
+    def _closeRssItemModelXbrl(self, modelXbrl: ModelXbrl | None) -> None:
+        # An RSS item that is an inline filing with separate IXDS targets (e.g. an EX-FILING FEES
+        # exhibit) causes inlineXbrlDocumentSet to publish its secondary-target modelXbrls into
+        # modelManager.loadedModelXbrls, sharing the primary item's parsed html elements. Close and
+        # unregister those together with the item so a later loadedModelXbrls sweep (such as the GUI
+        # backgroundValidate loop) does not validate a model whose parser points at the now-closed
+        # primary (which would raise AttributeError on qnameConcepts and similar).
+        if modelXbrl is None:
+            return
+        loadedModelXbrls = self.modelXbrl.modelManager.loadedModelXbrls
+        for supplementalModelXbrl in getattr(modelXbrl, "supplementalModelXbrls", ()):
+            try:
+                while supplementalModelXbrl in loadedModelXbrls:
+                    loadedModelXbrls.remove(supplementalModelXbrl)
+                supplementalModelXbrl.close()
+            except Exception:
+                pass
+        modelXbrl.close()
+
     def validateRssFeed(self) -> None:
         self.modelXbrl.info("info", "RSS Feed", modelDocument=self.modelXbrl)
         reloadCache = getattr(self.modelXbrl, "reloadCache", False)
@@ -205,7 +224,7 @@ class Validate:
                 for pluginXbrlMethod in modelXbrl.modelManager.cntlr.plugins.hooks("RssItem.Xbrl.Loaded"):
                     pluginXbrlMethod(modelXbrl, {}, rssItem)
                 if getattr(rssItem, "doNotProcessRSSitem", False) or modelXbrl.modelDocument is None:
-                    modelXbrl.close()
+                    self._closeRssItemModelXbrl(modelXbrl)
                     continue # skip entry based on processing criteria
                 self.instValidator.validate(modelXbrl, self.modelXbrl.modelManager.formulaOptions.typedParameters(self.modelXbrl.prefixedNamespaces))
                 self.instValidator.close()
@@ -213,7 +232,7 @@ class Validate:
                 self.modelXbrl.modelManager.viewModelObject(self.modelXbrl, rssItem.objectId())  # type: ignore[union-attr]
                 for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.plugins.hooks("Validate.RssItem"):
                     pluginXbrlMethod(self, modelXbrl, rssItem)
-                modelXbrl.close()
+                self._closeRssItemModelXbrl(modelXbrl)
             except Exception as err:
                 self.modelXbrl.error("exception:" + type(err).__name__,
                     _("RSS item validation exception: %(error)s, instance: %(instance)s"),
@@ -222,8 +241,7 @@ class Validate:
                     exc_info=True)
                 try:
                     self.instValidator.close()
-                    if modelXbrl is not None:
-                        modelXbrl.close()
+                    self._closeRssItemModelXbrl(modelXbrl)
                 except Exception as err:
                     pass
             del modelXbrl  # completely dereference

--- a/arelle/ViewWinRssFeed.py
+++ b/arelle/ViewWinRssFeed.py
@@ -118,7 +118,9 @@ class ViewRssFeed(ViewWinTree.ViewTree):
     def treeviewSelect(self, *args: Any) -> None:
         if self.blockSelectEvent == 0 and self.blockViewModelObject == 0:
             self.blockViewModelObject += 1
-            self.modelXbrl.viewModelObject(self.treeView.selection()[0])
+            selection = self.treeView.selection()
+            if selection is not None and len(selection) > 0:
+                self.modelXbrl.viewModelObject(selection[0])
             self.blockViewModelObject -= 1
 
     def viewModelObject(self, rssItem: ModelRssItem) -> None:

--- a/arelle/WatchRss.py
+++ b/arelle/WatchRss.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import regex as re
 import threading
+from typing import Any
 
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.ModelXbrl import ModelXbrl, load as ModelXbrlLoad
@@ -12,6 +13,7 @@ from arelle.ModelDocument import load as ModelDocumentLoad
 from arelle.XmlUtil import datetimeValue
 from arelle.formula import ValidateFormula
 from arelle.FileSource import openFileSource
+from arelle.utils.EntryPointDetection import filesourceEntrypointFiles
 from arelle.typing import TypeGetText
 
 _: TypeGetText
@@ -19,6 +21,21 @@ _: TypeGetText
 
 def initializeWatcher(modelXbrl: ModelXbrl) -> WatchRss:
     return WatchRss(modelXbrl)
+
+
+def hasWatchAction(cntlr: Any, rssWatchOptions: dict[str, Any]) -> bool:
+    # True if the RSS Watch options configured on cntlr have anything checked that makes
+    # watchCycle load and process each new filing (validate, alert-on-match, or a plugin
+    # action) rather than just refreshing the feed listing.
+    return bool(
+        rssWatchOptions.get("validateDisclosureSystemRules") or
+        rssWatchOptions.get("validateXbrlRules") or
+        rssWatchOptions.get("validateCalcs") or
+        rssWatchOptions.get("validateFormulaAssertions") or
+        rssWatchOptions.get("alertMatchedFactText") or
+        any(pluginXbrlMethod(rssWatchOptions)
+            for pluginXbrlMethod in cntlr.plugins.hooks("RssWatch.HasWatchAction"))
+    )
 
 
 class ValidationException(Exception):
@@ -70,6 +87,25 @@ class WatchRss:
         if self.thread and self.thread.is_alive():
             self.stopRequested = True
 
+    def _closeRssItemModelXbrl(self, modelXbrl: ModelXbrl | None) -> None:
+        # A watched item that is an inline filing with separate IXDS targets (e.g. an EX-FILING
+        # FEES exhibit) causes inlineXbrlDocumentSet to publish secondary-target modelXbrls into
+        # modelManager.loadedModelXbrls, sharing this item's parsed html elements. Close and
+        # unregister those together with the item so a later loadedModelXbrls sweep (such as the
+        # GUI's Validate command) does not process a model whose parser points at this now-closed
+        # item (which would raise AttributeError on qnameConcepts and similar).
+        if modelXbrl is None:
+            return
+        loadedModelXbrls = self.rssModelXbrl.modelManager.loadedModelXbrls
+        for supplementalModelXbrl in getattr(modelXbrl, "supplementalModelXbrls", ()):
+            try:
+                while supplementalModelXbrl in loadedModelXbrls:
+                    loadedModelXbrls.remove(supplementalModelXbrl)
+                supplementalModelXbrl.close()
+            except Exception:
+                pass
+        modelXbrl.close()
+
     def watchCycle(self) -> None:
         logFile = self.rssModelXbrl.modelManager.rssWatchOptions.get("logFileUri")
         if logFile:
@@ -108,20 +144,19 @@ class WatchRss:
             postLoadAction = ", ".join(postLoadActions)
 
             # anything to check new filings for
-            if (rssWatchOptions.get("validateDisclosureSystemRules") or
-                rssWatchOptions.get("validateXbrlRules") or
-                rssWatchOptions.get("validateCalcs") or
-                rssWatchOptions.get("validateFormulaAssertions") or
-                rssWatchOptions.get("alertMatchedFactText") or
-                any(pluginXbrlMethod(rssWatchOptions)
-                    for pluginXbrlMethod in self.cntlr.plugins.hooks("RssWatch.HasWatchAction"))
-                ):
+            if hasWatchAction(self.cntlr, rssWatchOptions):
                 # form keys in ascending order of pubdate
                 pubDateRssItems = []
                 for rssItem in self.rssModelXbrl.modelDocument.rssItems:  # type: ignore[union-attr]
                     pubDateRssItems.append((rssItem.pubDate, rssItem.objectId()))
 
-                for pubDate, rssItemObjectId in sorted(pubDateRssItems):
+                # sort by pubDate ascending; items whose pubDate failed to parse (None) sort first
+                # via the leading flag so None is never compared against a datetime, which would
+                # otherwise raise and abort the whole watch cycle
+                validatedSinceViewRefresh = 0
+                for pubDate, rssItemObjectId in sorted(
+                        pubDateRssItems,
+                        key=lambda i: (i[0] is not None, i[0] if i[0] is not None else "", i[1])):
                     rssItem = self.rssModelXbrl.modelObject(rssItemObjectId)
                     # update ui thread via modelManager (running in background here)
                     self.rssModelXbrl.modelManager.viewModelObject(self.rssModelXbrl, rssItem.objectId())  # type: ignore[union-attr]
@@ -131,13 +166,23 @@ class WatchRss:
                     if (latestPubDate and
                         rssItem.pubDate < latestPubDate):  # type: ignore[union-attr]
                         continue
+                    modelXbrl = None
                     try:
                         # try zipped URL if possible, else expanded instance document
-                        modelXbrl = ModelXbrlLoad(self.rssModelXbrl.modelManager,
-                                                   openFileSource(rssItem.zippedUrl, self.cntlr),  # type: ignore[union-attr]
-                                                   postLoadAction)
+                        filesource = openFileSource(rssItem.zippedUrl, self.cntlr)  # type: ignore[union-attr]
+                        if filesource and not filesource.selection and filesource.isArchive:
+                            # a filing zip usually holds multiple files (instance, schema,
+                            # linkbases, htm docs, ...); without selecting the actual entry
+                            # point document here, ModelDocument.load would try to parse the
+                            # raw zip bytes as XML and fail with a UnicodeDecodeError
+                            entrypoints = filesourceEntrypointFiles(filesource)
+                            if entrypoints:
+                                for pluginXbrlMethod in self.cntlr.plugins.hooks("ModelTestcaseVariation.ArchiveIxds"):
+                                    pluginXbrlMethod(self.rssModelXbrl, filesource, entrypoints)
+                                filesource.select(entrypoints[0].get("file", None))
+                        modelXbrl = ModelXbrlLoad(self.rssModelXbrl.modelManager, filesource, postLoadAction)
                         if self.stopRequested:
-                            modelXbrl.close()
+                            self._closeRssItemModelXbrl(modelXbrl)
                             break
 
                         emailAlert = False
@@ -153,7 +198,7 @@ class WatchRss:
                                 pluginXbrlMethod(modelXbrl, rssWatchOptions, rssItem)
                             # validate schema, linkbase, or instance
                             if self.stopRequested:
-                                modelXbrl.close()
+                                self._closeRssItemModelXbrl(modelXbrl)
                                 break
                             if self.instValidator:
                                 self.instValidator.validate(modelXbrl, modelXbrl.modelManager.formulaOptions.typedParameters(modelXbrl.prefixedNamespaces))
@@ -185,8 +230,17 @@ class WatchRss:
                                 ValidateFormula.validate(self.instValidator)
 
                         rssItem.setResults(modelXbrl)  # type: ignore[union-attr]
-                        modelXbrl.close()
+                        self._closeRssItemModelXbrl(modelXbrl)
                         del modelXbrl  # completely dereference
+                        # Refresh the feed views periodically so statuses appear as the run
+                        # progresses. The targeted viewModelObject update below is unreliable once
+                        # the feed has been reloaded (its tree nodes are rebuilt from fresh element
+                        # proxies), so a full rebuild - which reads each item's persisted result -
+                        # is the dependable path; throttle it to keep the UI thread responsive.
+                        validatedSinceViewRefresh += 1
+                        if validatedSinceViewRefresh >= 5:
+                            validatedSinceViewRefresh = 0
+                            self.rssModelXbrl.modelManager.reloadViews(self.rssModelXbrl)
                         self.rssModelXbrl.modelManager.viewModelObject(self.rssModelXbrl, rssItem.objectId())  # type: ignore[union-attr]
                         if rssItem.assertionUnsuccessful and rssWatchOptions.get("alertAssertionUnsuccessful"):  # type: ignore[union-attr]
                             emailAlert = True
@@ -239,7 +293,15 @@ class WatchRss:
                                                 modelXbrl=self.rssModelXbrl, company=rssItem.companyName,  # type: ignore[union-attr]
                                                 form=rssItem.formType, date=rssItem.filingDate, error=err,  # type: ignore[union-attr]
                                                 exc_info=True)
+                        try:
+                            self._closeRssItemModelXbrl(modelXbrl)
+                        except Exception:
+                            pass
                     if self.stopRequested: break
+                # rebuild the feed views so this cycle's freshly validated items show their status
+                # now, rather than only after the next poll reloads the feed
+                if not self.stopRequested:
+                    self.rssModelXbrl.modelManager.reloadViews(self.rssModelXbrl)
             if self.stopRequested:
                 self.cntlr.showStatus(_("RSS watch, stop requested"), 10000)
                 # reset prior options for calc and formula running

--- a/arelle/WatchRss.py
+++ b/arelle/WatchRss.py
@@ -10,6 +10,7 @@ from typing import Any
 from arelle.ValidateXbrl import ValidateXbrl
 from arelle.ModelXbrl import ModelXbrl, load as ModelXbrlLoad
 from arelle.ModelDocument import load as ModelDocumentLoad
+from arelle.ModelRssItem import rssItemAlreadyValidatedStatuses
 from arelle.XmlUtil import datetimeValue
 from arelle.formula import ValidateFormula
 from arelle.FileSource import openFileSource
@@ -159,13 +160,16 @@ class WatchRss:
                         key=lambda i: (i[0] is not None, i[0] if i[0] is not None else "", i[1])):
                     if self.stopRequested:
                         break
+                    rssItem = self.rssModelXbrl.modelObject(rssItemObjectId)
                     latestPubDate = datetimeValue(rssWatchOptions.get("latestPubDate"))
-                    if latestPubDate and pubDate is not None and pubDate < latestPubDate:
-                        # already processed on a prior poll - skip without moving the
+                    if ((latestPubDate and pubDate is not None and pubDate < latestPubDate) or
+                            getattr(rssItem, "status", None) in rssItemAlreadyValidatedStatuses):
+                        # already processed - by an earlier poll (pubDate watermark) or by a
+                        # manual Validate run since (status already pass/fail/unsuccessful,
+                        # see ModelRssItem.setResults) - skip without moving the
                         # selection/view onto it, so watching a refresh only visits items
                         # that are actually "not tested"
                         continue
-                    rssItem = self.rssModelXbrl.modelObject(rssItemObjectId)
                     # update ui thread via modelManager (running in background here)
                     self.rssModelXbrl.modelManager.viewModelObject(self.rssModelXbrl, rssItem.objectId())  # type: ignore[union-attr]
                     if self.stopRequested:

--- a/arelle/WatchRss.py
+++ b/arelle/WatchRss.py
@@ -157,15 +157,19 @@ class WatchRss:
                 for pubDate, rssItemObjectId in sorted(
                         pubDateRssItems,
                         key=lambda i: (i[0] is not None, i[0] if i[0] is not None else "", i[1])):
+                    if self.stopRequested:
+                        break
+                    latestPubDate = datetimeValue(rssWatchOptions.get("latestPubDate"))
+                    if latestPubDate and pubDate is not None and pubDate < latestPubDate:
+                        # already processed on a prior poll - skip without moving the
+                        # selection/view onto it, so watching a refresh only visits items
+                        # that are actually "not tested"
+                        continue
                     rssItem = self.rssModelXbrl.modelObject(rssItemObjectId)
                     # update ui thread via modelManager (running in background here)
                     self.rssModelXbrl.modelManager.viewModelObject(self.rssModelXbrl, rssItem.objectId())  # type: ignore[union-attr]
                     if self.stopRequested:
                         break
-                    latestPubDate = datetimeValue(rssWatchOptions.get("latestPubDate"))
-                    if (latestPubDate and
-                        rssItem.pubDate < latestPubDate):  # type: ignore[union-attr]
-                        continue
                     modelXbrl = None
                     try:
                         # try zipped URL if possible, else expanded instance document


### PR DESCRIPTION
#### Reason for change
The RSS feed contained various bugs which made it unusable. This PR aims to resolve these issues. Note we also have some additional changes on the EDGAR plugin side.

#### Description of change
Validate.py — validateRssFeed now closes and unregisters an RSS item's secondary IXDS models (_closeRssItemModelXbrl) instead of leaving them in modelManager.loadedModelXbrls, where a later sweep (GUI Validate, or the RSS feed run itself) would hit a closed model's parser and crash with AttributeError: qnameConcepts. Also skips items already validated on a prior run (pass/fail/unsuccessful status) instead of re‑downloading and re‑validating the whole feed every time.

WatchRss.py — the watch loop's item loader never selected an entry point inside a filing's zip, so it tried to parse the raw zip bytes as XML and failed with a UnicodeDecodeError on every item; now mirrors validateRssFeed's archive entry‑point discovery.

ModelRssItem.py — RSS item results (status/results/assertions) are lxml‑proxy attributes that get lost whenever the feed is reloaded (every watch poll rebuilds the whole document); results are now persisted on the long‑lived ModelXbrl and restored per item on reload, so previously‑validated rows don't revert to "not tested". Also the home for the shared rssItemAlreadyValidatedStatuses set used by both Validate.py and WatchRss.py.

ViewWinRssFeed.py — guard against an empty tree selection in treeviewSelect (IndexError when nothing is selected).

CntlrWinMain.py — refuse to run Validate while RSS Watch is actively processing the same feed (they mutate the same ModelXbrl concurrently otherwise), but only when the watch actually has a validate/alert action configured and hasn't already been asked to stop.

#### Steps to Test

**review**:
@Arelle/arelle
